### PR TITLE
fix: Add disk cleanup to CI workflow to resolve space issues

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,6 +59,29 @@ jobs:
           cache-on-failure: true
           shared-key: "ci"
       
+      - name: Free disk space
+        run: |
+          echo "=== Before cleanup ==="
+          df -h
+          
+          # Remove pre-installed software we don't need
+          sudo apt-get clean
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/local/share/boost
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+          sudo rm -rf /usr/local/.ghcup
+          
+          # Clean docker images
+          docker rmi $(docker images -q) 2>/dev/null || true
+          
+          # Clean apt cache
+          sudo apt-get autoremove -y
+          sudo apt-get autoclean -y
+          
+          echo "=== After cleanup ==="
+          df -h
+      
       - name: Run CI pipeline
         id: tests
         timeout-minutes: 30
@@ -147,6 +170,16 @@ jobs:
           workspaces: ". -> target"
           cache-on-failure: true
           shared-key: "ci"
+      
+      - name: Free disk space
+        run: |
+          echo "=== Freeing disk space for property tests ==="
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/local/share/boost
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+          docker rmi $(docker images -q) 2>/dev/null || true
+          df -h
       
       - name: Run AST property tests
         run: |


### PR DESCRIPTION
## Summary
- Adds disk cleanup steps to free up space before running builds and tests
- Fixes "No space left on device" error when compiling examples

## Problem
The CI pipeline was failing with disk space errors during the `make test` step, specifically when running `cargo test --examples`. GitHub Actions runners have limited disk space, and our build process was consuming all available space.

## Solution
Added disk cleanup steps that:
1. Remove pre-installed software we don't need (.NET SDK, GHC, Boost)
2. Clean docker images
3. Clean apt cache
4. Display disk usage before and after cleanup for visibility

The cleanup is added in two places:
- Before the main CI pipeline build
- Before the property tests (which also compile the project)

## Test plan
- [x] Push this PR and verify CI passes
- [x] Check that the disk cleanup logs show increased available space
- [x] Verify all tests still run successfully

🤖 Generated with [Claude Code](https://claude.ai/code)