### PR TITLE
fix: resolve 6 dogfood bugs in new sprint commands

### DIFF
--- a/src/cli/handlers/bottleneck_handler.rs
+++ b/src/cli/handlers/bottleneck_handler.rs
@@ -7,6 +7,9 @@ use anyhow::Result;
 use std::collections::HashMap;
 use std::path::Path;
 
+/// Git churn data: (file touch counts, commit file groups, total commits)
+type GitChurnData = (HashMap<String, usize>, Vec<Vec<String>>, usize);
+
 /// A detected bottleneck file
 #[derive(Debug, serde::Serialize)]
 struct BottleneckFile {
@@ -89,6 +92,7 @@ fn analyze_bottlenecks(path: &Path, period: u32, threshold: usize) -> Result<Bot
         .iter()
         .filter(|(_, &count)| count >= threshold)
         .filter(|(path, _)| !is_generated_file(path))
+        .filter(|(file_path, _)| file_sizes.contains_key(file_path.as_str()))
         .map(|(file_path, &touches)| {
             let lines = file_sizes.get(file_path.as_str()).copied().unwrap_or(0);
             let authors = file_authors.get(file_path.as_str()).copied().unwrap_or(1);
@@ -132,7 +136,7 @@ fn analyze_bottlenecks(path: &Path, period: u32, threshold: usize) -> Result<Bot
 fn get_git_churn(
     path: &Path,
     period: u32,
-) -> Result<(HashMap<String, usize>, Vec<Vec<String>>, usize)> {
+) -> Result<GitChurnData> {
     let output = std::process::Command::new("git")
         .args([
             "log",

--- a/src/cli/handlers/comply_handlers/check_handlers/check_provable_contracts.rs
+++ b/src/cli/handlers/comply_handlers/check_handlers/check_provable_contracts.rs
@@ -84,7 +84,7 @@ fn find_contract_files(contracts_dir: &Path) -> Vec<String> {
         if path.is_file()
             && (path
                 .extension()
-                .map_or(false, |e| e == "yaml" || e == "yml"))
+                .is_some_and(|e| e == "yaml" || e == "yml"))
             && !is_binding_file(path)
         {
             // Quick check: does it look like a provable-contract file?
@@ -107,7 +107,7 @@ fn find_contract_files(contracts_dir: &Path) -> Vec<String> {
 /// Check if a YAML file is a binding registry (not a contract)
 fn is_binding_file(path: &Path) -> bool {
     path.file_name()
-        .map_or(false, |n| n.to_string_lossy().contains("binding"))
+        .is_some_and(|n| n.to_string_lossy().contains("binding"))
 }
 
 /// Run `pv lint` and parse the result
@@ -387,7 +387,7 @@ fn build_provable_contracts_result(
 
     // Lint results
     if lint.passed {
-        parts.push(format!("{}", c::pass("lint passed")));
+        parts.push(c::pass("lint passed").to_string());
     } else {
         has_errors = true;
         parts.push(format!(

--- a/src/cli/handlers/split_auto_handler.rs
+++ b/src/cli/handlers/split_auto_handler.rs
@@ -285,7 +285,7 @@ fn estimate_splits(line_count: usize, max_lines: usize) -> usize {
     }
     // Number of splits = ceil(line_count / max_lines) - 1
     // (the original file stays, everything else is extracted)
-    let chunks = (line_count + max_lines - 1) / max_lines;
+    let chunks = line_count.div_ceil(max_lines);
     if chunks > 1 {
         chunks - 1
     } else {
@@ -325,7 +325,7 @@ fn is_top_level_item(line: &str) -> Option<(&str, &str)> {
     ];
 
     for kw in &keywords {
-        if after_vis.starts_with(kw) {
+        if let Some(rest) = after_vis.strip_prefix(kw) {
             let kind = kw.split_whitespace().next().unwrap_or(kw.trim());
             // Normalize "async fn" to "fn" and "impl<" to "impl"
             let kind = match kind {
@@ -333,7 +333,6 @@ fn is_top_level_item(line: &str) -> Option<(&str, &str)> {
                 "macro_rules!" => "macro",
                 _ => kind.trim_end_matches('<'),
             };
-            let rest = &after_vis[kw.len()..];
             let name = extract_item_name(rest);
             return Some((kind, name));
         }
@@ -475,17 +474,15 @@ fn find_split_points(content: &str) -> Vec<TopLevelItem> {
         }
 
         // Detect top-level item start (only when at brace depth 0 or about to enter)
-        if brace_depth == 0 || (brace_depth == 1 && current_item.is_none()) {
-            if current_item.is_some() && brace_depth == 0 {
-                // Close the current item
-                if let Some((kind, name, start)) = current_item.take() {
-                    items.push(TopLevelItem {
-                        kind,
-                        name,
-                        start_line: start,
-                        end_line: line_num,
-                    });
-                }
+        if brace_depth == 0 && current_item.is_some() {
+            // Close the current item
+            if let Some((kind, name, start)) = current_item.take() {
+                items.push(TopLevelItem {
+                    kind,
+                    name,
+                    start_line: start,
+                    end_line: line_num,
+                });
             }
         }
 

--- a/src/cli/handlers/stack_scaffold_handler.rs
+++ b/src/cli/handlers/stack_scaffold_handler.rs
@@ -27,7 +27,8 @@ pub struct ScaffoldResult {
 
 pub fn get_scaffold_files(template: &str) -> Vec<ScaffoldFile> {
     match template {
-        "sqi-a-minus" | _ => get_sqi_a_minus_files(),
+        "sqi-a-minus" => get_sqi_a_minus_files(),
+        _ => get_sqi_a_minus_files(),
     }
 }
 

--- a/src/cli/handlers/stack_sync_handler.rs
+++ b/src/cli/handlers/stack_sync_handler.rs
@@ -530,11 +530,11 @@ fn print_status_table(
 
             if is_outdated {
                 println!(
-                    "    {} {} {} -> {}",
+                    "    {} {} {} -> {latest}{}",
                     c::fail(&dep.name),
                     c::dim(current),
                     c::BOLD_GREEN,
-                    format!("{latest}{}", c::RESET),
+                    c::RESET,
                 );
             } else {
                 println!("    {} {}", c::pass(&dep.name), c::dim(current),);
@@ -704,7 +704,7 @@ pub async fn handle_stack_sync(apply: bool, dry_run: bool) -> Result<()> {
         for mismatch in mismatches {
             // Simple text replacement for version strings
             // Handle both `crate = "version"` and `crate = { version = "version", ... }`
-            let old_patterns = vec![
+            let old_patterns = [
                 format!("{} = \"{}\"", mismatch.crate_name, mismatch.current_version),
                 format!("version = \"{}\"", mismatch.current_version),
             ];

--- a/src/cli/handlers/test_stability_handler.rs
+++ b/src/cli/handlers/test_stability_handler.rs
@@ -46,17 +46,20 @@ pub async fn handle_test_stability(
     output: Option<&Path>,
 ) -> Result<()> {
     use crate::cli::colors as c;
+    let is_json = matches!(format, crate::cli::enums::OutputFormat::Json);
 
-    println!("{}\n", c::header("Test Stability Analysis"));
-    println!(
-        "  {}Runs:{} {}  {}Filter:{} {}\n",
-        c::BOLD,
-        c::RESET,
-        c::number(&runs.to_string()),
-        c::BOLD,
-        c::RESET,
-        c::dim(filter.unwrap_or("(all)")),
-    );
+    if !is_json {
+        println!("{}\n", c::header("Test Stability Analysis"));
+        println!(
+            "  {}Runs:{} {}  {}Filter:{} {}\n",
+            c::BOLD,
+            c::RESET,
+            c::number(&runs.to_string()),
+            c::BOLD,
+            c::RESET,
+            c::dim(filter.unwrap_or("(all)")),
+        );
+    }
 
     let start = Instant::now();
     let analysis = run_stability_analysis(path, runs, filter)?;
@@ -207,55 +210,41 @@ fn run_test_suite(path: &Path, filter: Option<&str>) -> Result<Vec<(String, bool
     let mut args = vec![
         "test".to_string(),
         "--lib".to_string(),
-        "--".to_string(),
-        "--test-threads=4".to_string(),
-        "-Z".to_string(),
-        "unstable-options".to_string(),
-        "--format=json".to_string(),
     ];
 
     if let Some(f) = filter {
-        // Insert filter before --
-        args.insert(2, f.to_string());
+        args.push(f.to_string());
     }
 
+    args.push("--".to_string());
+    args.push("--test-threads=4".to_string());
+
+    let start = std::time::Instant::now();
     let output = std::process::Command::new("cargo")
         .args(&args)
         .current_dir(path)
         .env("RUST_MIN_STACK", "8388608")
         .output()?;
+    let elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
 
     let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
     let mut results = Vec::new();
 
-    for line in stdout.lines() {
-        // Parse JSON test events
-        if let Ok(event) = serde_json::from_str::<serde_json::Value>(line) {
-            if event.get("type").and_then(|t| t.as_str()) == Some("test")
-                && event.get("event").and_then(|e| e.as_str()).is_some()
-            {
-                let name = event
-                    .get("name")
-                    .and_then(|n| n.as_str())
-                    .unwrap_or("")
-                    .to_string();
-                let event_type = event.get("event").and_then(|e| e.as_str()).unwrap_or("");
-                let exec_time = event
-                    .get("exec_time")
-                    .and_then(|t| t.as_f64())
-                    .unwrap_or(0.0)
-                    * 1000.0; // convert to ms
+    // Parse text test output (stable Rust compatible)
+    parse_text_test_output(&stdout, &mut results);
 
-                if event_type == "ok" || event_type == "failed" {
-                    results.push((name, event_type == "ok", exec_time));
-                }
-            }
-        }
+    // Also check stderr (cargo test puts some output there)
+    if results.is_empty() {
+        parse_text_test_output(&stderr, &mut results);
     }
 
-    // Fallback: if JSON parsing yielded nothing, parse text output
-    if results.is_empty() {
-        parse_text_test_output(&stdout, &mut results);
+    // If we got results but no timing, estimate from total elapsed
+    if !results.is_empty() && results.iter().all(|(_, _, d)| *d == 0.0) {
+        let per_test = elapsed_ms / results.len() as f64;
+        for r in &mut results {
+            r.2 = per_test;
+        }
     }
 
     Ok(results)


### PR DESCRIPTION
## Summary
- **bottleneck**: Filter deleted/renamed files showing Lines: 0 with infinite churn ratio
- **test-stability**: Remove unstable `-Z` JSON format flag causing 0 tests on stable Rust; use text parser instead
- **test-stability**: Guard header output behind is_json check to prevent stdout contamination in JSON mode
- **clippy**: Fix type_complexity, div_ceil, strip_prefix, collapsible_if, format_in_format_args, useless_vec, wildcard_in_or_patterns, is_some_and across 6 handler files

## Test plan
- [x] `cargo check` — clean compile
- [x] `cargo clippy` — 0 warnings in new handler files  
- [x] `cargo test --lib` — 21,603 passed, 0 failed
- [x] `pmat analyze bottleneck` — no more Lines: 0 entries
- [x] `pmat test-stability --runs 1 --filter bottleneck` — 23 tests detected (was 0)
- [x] `pmat test-stability --runs 1` — 21,603 tests detected
- [x] `pmat test-stability --format json` — clean JSON output
- [x] `pmat analyze bottleneck --format json` — clean JSON output

🤖 Generated with [Claude Code](https://claude.com/claude-code)