### PR TITLE
fix: remove coverage_nightly cfg from build.rs (breaks stable CI)

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -21,11 +21,6 @@ fn main() {
     println!("cargo:rustc-check-cfg=cfg(cargo_publish)");
     println!("cargo:rustc-check-cfg=cfg(coverage)");
 
-    // Enable coverage(off) source-level exclusions during coverage builds
-    if env::var("CARGO_LLVM_COV").is_ok() {
-        println!("cargo:rustc-cfg=coverage_nightly");
-    }
-
     // Fast build mode for development - skip heavy operations but generate stubs
     if env::var("PMAT_FAST_BUILD").is_ok() {
         println!("cargo:warning=Fast build mode enabled - skipping heavy build operations");


### PR DESCRIPTION
## Summary
- Removes build.rs lines that inject `--cfg coverage_nightly` when `CARGO_LLVM_COV` is present
- This caused `#![feature(coverage_attribute)]` to activate on stable Rust, failing CI
- `cargo-llvm-cov` handles this cfg natively on nightly — build.rs shouldn't duplicate it

## Five-Whys
1. CI fails: `#![feature] may not be used on the stable release channel`
2. `#![cfg_attr(coverage_nightly, feature(...))]` activates
3. build.rs sets `coverage_nightly` cfg when `CARGO_LLVM_COV` env exists
4. sovereign-ci container runs stable 1.94, not nightly
5. build.rs doesn't respect `--no-cfg-coverage-nightly` flag

## Test plan
- [ ] CI coverage job passes on stable

🤖 Generated with [Claude Code](https://claude.com/claude-code)