### PR TITLE
feat(ci): add cargo-mutants job for post-merge mutation testing (GH-275)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,27 @@ jobs:
             exit 1
           fi
           echo "All required jobs passed"
+
+  # GH-275: Post-merge mutation testing for RPS Rust Tooling score.
+  # Runs only on push to master (never on PRs — takes 30-120 min).
+  # `continue-on-error: true` keeps this informational, not blocking.
+  mutants:
+    runs-on: [self-hosted, X64, Linux]
+    continue-on-error: true
+    container:
+      image: localhost:5000/sovereign-ci:stable
+    timeout-minutes: 120
+    needs: [gate]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install cargo-mutants
+        run: cargo install cargo-mutants --locked
+      - name: Run mutation testing
+        run: cargo mutants --no-times --timeout 300 --in-place -- --lib
+        continue-on-error: true
+      - name: Upload mutation results
+        uses: actions/upload-artifact@v7
+        with:
+          name: mutation-results
+          path: mutants.out/


### PR DESCRIPTION
## Summary

Addresses GH-275: the RPS Rust Tooling score sits at ~53.8%, with the gap being mutation testing. Adds a `cargo-mutants` CI job mirroring the pattern already landed in paiml/aprender so both repos contribute mutation coverage signal to RPS.

- Runs only on `push` to `master` (never on PRs — mutation runs take 30-120 min)
- `continue-on-error: true` at the job level keeps it informational, not blocking
- `needs: [gate]` waits for the CI gate (PR #296) to pass first
- Uploads `mutants.out/` as a workflow artifact for inspection

Surgical: touches only `.github/workflows/ci.yml`. The existing `ci` + `gate` jobs are unchanged.

## Test plan

- [x] YAML parses: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"`
- [ ] First post-merge run to master exercises the new job
- [ ] Artifact `mutation-results` appears on the workflow run and contains `mutants.out/`
- [ ] `needs: [gate]` gating verified — mutants skipped on PR runs

Closes #275

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>