### PR TITLE
fix(hooks): GH-301 harden pre-commit against worktree Makefile sweeps

### DIFF
--- a/src/cli/handlers/hooks_command_handlers/hook_generation.rs
+++ b/src/cli/handlers/hooks_command_handlers/hook_generation.rs
@@ -65,6 +65,11 @@ echo "================================"
     }
 
     /// Generate environment variables section
+    ///
+    /// GH-301: `PMAT_PRECOMMIT_EXCLUDE_DIRS` is an escape hatch for directory patterns
+    /// that must never be scanned by the hook. Space-separated path prefixes. The
+    /// hook defaults cover Claude/Cursor ephemeral worktrees and common build/cache
+    /// directories so agent sessions don't balloon pre-commit time.
     fn generate_env_vars(&self, config: &PmatConfig) -> String {
         format!(
             r#"# Load current configuration dynamically
@@ -73,6 +78,9 @@ export PMAT_MAX_COGNITIVE_COMPLEXITY={}
 export PMAT_MIN_TEST_COVERAGE={}
 export PMAT_MAX_SATD_COMMENTS=5
 export PMAT_TASK_ID_PATTERN="PMAT-[0-9]{{4}}"
+# GH-301: directories excluded from any hook filesystem scan.
+# Override with: PMAT_PRECOMMIT_EXCLUDE_DIRS=".claude/worktrees target ..." git commit
+export PMAT_PRECOMMIT_EXCLUDE_DIRS="${{PMAT_PRECOMMIT_EXCLUDE_DIRS:-.claude/worktrees .cursor/worktrees target node_modules .venv}}"
 "#,
             config.quality.max_complexity,
             config.quality.max_cognitive_complexity,
@@ -117,9 +125,37 @@ fi
 
 echo "📊 Running quality gate checks..."
 
+# GH-301: helper that strips PMAT_PRECOMMIT_EXCLUDE_DIRS prefixes from a stream
+# of git-tracked paths. Never call `find` here — `find` traverses .gitignore'd
+# paths (like .claude/worktrees/*) which blows up pre-commit time on monorepos
+# with many agent worktrees and can even invoke nested Makefiles.
+_pmat_filter_excluded() {
+    if [ -z "$PMAT_PRECOMMIT_EXCLUDE_DIRS" ]; then cat; return; fi
+    awk -v excl="$PMAT_PRECOMMIT_EXCLUDE_DIRS" '
+        BEGIN { n = split(excl, a, " ") }
+        {
+            skip = 0
+            for (i = 1; i <= n; i++) {
+                if (a[i] != "" && index($0, a[i] "/") == 1) { skip = 1; break }
+            }
+            if (!skip) print
+        }
+    '
+}
+
 # Detect if this repo has any source files at all (not just staged ones).
 # Non-code repos (docs, configs, YAML, contracts) get a fast pass.
-HAS_SOURCE_FILES=$(find . -maxdepth 4 -type f \( -name '*.rs' -o -name '*.py' -o -name '*.ts' -o -name '*.tsx' -o -name '*.js' -o -name '*.jsx' -o -name '*.go' -o -name '*.c' -o -name '*.cpp' -o -name '*.lua' -o -name '*.php' -o -name '*.swift' \) -not -path './.git/*' -not -path '*/target/*' -not -path '*/node_modules/*' -print -quit 2>/dev/null)
+# Uses `git ls-files` (GH-301) so .gitignore'd directories — including
+# .claude/worktrees/, target/, node_modules/ — are never scanned. Outside a
+# git worktree we fall back to a bounded find with explicit prunes.
+if git rev-parse --git-dir > /dev/null 2>&1; then
+    HAS_SOURCE_FILES=$(git ls-files -- \
+        '*.rs' '*.py' '*.ts' '*.tsx' '*.js' '*.jsx' \
+        '*.go' '*.c' '*.cpp' '*.lua' '*.php' '*.swift' 2>/dev/null \
+        | _pmat_filter_excluded | head -n 1)
+else
+    HAS_SOURCE_FILES=$(find . -maxdepth 4 -type f \( -name '*.rs' -o -name '*.py' -o -name '*.ts' -o -name '*.tsx' -o -name '*.js' -o -name '*.jsx' -o -name '*.go' -o -name '*.c' -o -name '*.cpp' -o -name '*.lua' -o -name '*.php' -o -name '*.swift' \) -not -path './.git/*' -not -path '*/target/*' -not -path '*/node_modules/*' -not -path '*/.claude/worktrees/*' -not -path '*/.cursor/worktrees/*' -print -quit 2>/dev/null)
+fi
 
 if [ -z "$HAS_SOURCE_FILES" ]; then
     echo "  Project type: non-code (docs/configs/YAML)"

--- a/src/cli/handlers/hooks_command_handlers/mod.rs
+++ b/src/cli/handlers/hooks_command_handlers/mod.rs
@@ -33,3 +33,10 @@ pub use types::{
 #[cfg(test)]
 #[path = "../hooks_command_handlers_tests.rs"]
 mod tests;
+
+// GH-301 regression tests live in a dedicated small file so future growth of
+// hooks_command_handlers_tests.rs (already near the CB-040 ratchet) does not
+// block the fix from landing.
+#[cfg(test)]
+#[path = "../hooks_tests_gh301_makefile_scan.rs"]
+mod gh301_makefile_scan_tests;

--- a/src/cli/handlers/hooks_tests_gh301_makefile_scan.rs
+++ b/src/cli/handlers/hooks_tests_gh301_makefile_scan.rs
@@ -1,0 +1,146 @@
+//! Regression tests for GH-301: hook generator must never scan for Makefiles
+//! recursively with `find` nor invoke `make -C $dir all`.
+//!
+//! Context: on monorepos with many Claude Code / Cursor agent worktrees under
+//! `.claude/worktrees/*`, a `find . -name "Makefile"` sweep walks gitignored
+//! trees and a `make -C $dir all` loop can block a single `git commit` for
+//! minutes to hours. The PMAT hook generator therefore uses `git ls-files`
+//! and must not emit either pattern.
+//!
+//! Issue: https://github.com/paiml/paiml-mcp-agent-toolkit/issues/301
+
+// This file is included via `#[path]` from hooks_command_handlers/mod.rs,
+// so `super::` resolves to the hooks_command_handlers module.
+use super::HooksCommand;
+
+/// Fetch the generated pre-commit content via the same production code path
+/// that `pmat hooks install` uses. If either async generation or the runtime
+/// is unavailable, fall back to the deterministic sync fragments that do not
+/// need config loading.
+fn generated_hook_fragments() -> String {
+    // generate_quality_checks and generate_hook_header are sync and
+    // contract-verified — together they cover the body that was historically
+    // most likely to contain a bad `find Makefile` sweep.
+    let cmd = HooksCommand::default_for_tests();
+    let mut out = String::new();
+    out.push_str(&cmd.generate_hook_header());
+    out.push('\n');
+    out.push_str(&cmd.generate_quality_checks());
+    out
+}
+
+impl HooksCommand {
+    /// Test helper: construct a HooksCommand pointing at bogus paths. Only
+    /// sync methods that don't touch the filesystem are safe to call on the
+    /// returned instance.
+    fn default_for_tests() -> Self {
+        HooksCommand::new(
+            std::path::PathBuf::from("/tmp/pmat-gh301-hooks"),
+            std::path::PathBuf::from("/tmp/pmat-gh301-config.toml"),
+        )
+    }
+}
+
+#[test]
+fn gh301_generated_hook_never_finds_makefiles_recursively() {
+    let hook = generated_hook_fragments();
+
+    // The reported pathological snippet — any variant MUST NOT appear.
+    assert!(
+        !hook.contains(r#"find . -name "Makefile""#),
+        "GH-301 regression: hook contains `find . -name \"Makefile\"` sweep"
+    );
+    assert!(
+        !hook.contains("-name Makefile"),
+        "GH-301 regression: hook contains `-name Makefile` filter"
+    );
+}
+
+#[test]
+fn gh301_generated_hook_never_runs_make_all_in_subdirs() {
+    let hook = generated_hook_fragments();
+
+    assert!(
+        !hook.contains(r#"make -C "$dir" all"#),
+        "GH-301 regression: hook shells out to `make -C $dir all`"
+    );
+    assert!(
+        !hook.contains("make -C $dir all"),
+        "GH-301 regression: hook shells out to `make -C $dir all`"
+    );
+    assert!(
+        !hook.contains("MAKEFILE_DIRS="),
+        "GH-301 regression: hook defines MAKEFILE_DIRS variable"
+    );
+}
+
+#[test]
+fn gh301_any_makefile_discovery_uses_git_ls_files_not_find() {
+    let hook = generated_hook_fragments();
+
+    // Inspect only executable shell lines — strip `#` comments — then look
+    // for any combination that discovers Makefiles via `find`.
+    let executable: String = hook
+        .lines()
+        .map(|line| match line.split_once('#') {
+            Some((code, _comment)) => code,
+            None => line,
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let executable_lower = executable.to_lowercase();
+    if executable_lower.contains("makefile") {
+        let uses_find_for_makefile =
+            executable.contains("find ") && executable.contains("Makefile");
+        assert!(
+            !uses_find_for_makefile,
+            "GH-301 regression: Makefile discovery must use `git ls-files`, not `find`:\n{executable}"
+        );
+    }
+}
+
+#[test]
+fn gh301_source_file_detection_prefers_git_ls_files() {
+    let hook = generated_hook_fragments();
+
+    // The HAS_SOURCE_FILES probe in generate_quality_checks must route
+    // through git ls-files when inside a worktree so gitignored trees
+    // (including .claude/worktrees) are never walked.
+    assert!(
+        hook.contains("git ls-files"),
+        "GH-301 hardening: generated hook must use `git ls-files` for source discovery"
+    );
+}
+
+#[test]
+fn gh301_exposes_exclude_dirs_escape_hatch() {
+    let cmd = HooksCommand::default_for_tests();
+
+    // The header/checks are sync, but env vars require config resolution. We
+    // approximate by checking the full content a user gets on install via a
+    // runtime — but keep the test hermetic by only asserting the literal
+    // `PMAT_PRECOMMIT_EXCLUDE_DIRS` token lives somewhere in the module
+    // source output path, which is easiest to probe through a direct runtime
+    // call on `generate_hook_content`.
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("tokio runtime");
+    let hook: String = runtime
+        .block_on(async { cmd.generate_hook_content().await })
+        .expect("hook content");
+
+    assert!(
+        hook.contains("PMAT_PRECOMMIT_EXCLUDE_DIRS"),
+        "GH-301: generated hook must declare PMAT_PRECOMMIT_EXCLUDE_DIRS env var"
+    );
+    assert!(
+        hook.contains(".claude/worktrees"),
+        "GH-301: default exclude list must cover .claude/worktrees"
+    );
+    assert!(
+        hook.contains(".cursor/worktrees"),
+        "GH-301: default exclude list must cover .cursor/worktrees"
+    );
+}


### PR DESCRIPTION
## Summary

Closes #301. Defense-in-depth hardening of the PMAT pre-commit hook generator so it can never emit a `find . -name "Makefile" … make -C "\$dir" all` sweep (the pathological pattern reported in the issue).

Audit found no such snippet in any of PMAT's current generators (`git log -S 'MAKEFILE_DIRS'` + grep on `src/`, `templates/`, `prompts/` all empty) — the reporter is on a custom or stale hook. So this PR is a regression guard plus sensible escape hatches for monorepos that *do* have that pattern in their legacy hooks.

## Changes

- **`hook_generation.rs` — `generate_env_vars`**: emits `PMAT_PRECOMMIT_EXCLUDE_DIRS` with default `.claude/worktrees .cursor/worktrees target node_modules .venv`, overridable via env and consumed by the `_pmat_filter_excluded` helper.
- **`hook_generation.rs` — `generate_quality_checks`**: the `HAS_SOURCE_FILES` probe now prefers `git ls-files` when inside a worktree, so gitignored trees (including `.claude/worktrees/*`) are never walked. The `find` fallback retained for non-git contexts now also prunes `.claude/worktrees/*` and `.cursor/worktrees/*`.
- **`hooks_tests_gh301_makefile_scan.rs` (new, 5 tests)**: regression guards asserting the generated hook content never contains `find . -name "Makefile"`, `make -C "\$dir" all`, or `MAKEFILE_DIRS=`, that any Makefile discovery uses `git ls-files`, and that the exclude-dirs env var is present with the expected default list.

## Related recommendation (not in this PR)

The biggest single source of **current** pre-commit slowness on this repo (per audit) is the unconditional `pmat analyze satd` full-project scan (~420ms on pmat itself, linear with repo size). Scoping it to staged files — or batching the 20× per-file complexity spawn — would cut commit time by ~90%. Filed separately because it's a semantic change, not a regression guard.

## Test plan

- [x] `cargo test --lib gh301` — 5/5 passing
- [x] `cargo test --lib hooks_` — 184 passing
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean (via pre-push gate)
- [ ] CI `ci/gate` passes
- [ ] CI `workspace-test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)