### PR TITLE
docs(kaizen): sixteen research tickets from 2026 arxiv dogfood round 2

### DIFF
--- a/docs/kaizen-tickets/KAIZEN-0001.md
+++ b/docs/kaizen-tickets/KAIZEN-0001.md
@@ -1,0 +1,32 @@
+# KAIZEN-0001: Sanitize pmat MCP tool descriptions via the "smell" taxonomy
+
+**Source paper:** arxiv:2602.14878 — "Model Context Protocol (MCP) Tool Descriptions Are Smelly! Towards Improving AI Agent Efficiency with Augmented MCP Tool Descriptions" (Hasan et al., 2026)
+**Category:** sub-agent-behavior
+**Priority:** high
+**Effort:** S
+
+## Problem
+Hasan et al. empirically found 97.1% of public MCP tool descriptions have quality "smells" (ambiguous parameters, missing examples, inconsistent units, unbounded return shape). pmat's MCP server exposes ~20 tools (`pmat_query_code`, `pmat_get_function`, `pmat_find_similar`, `pmat_index_stats`, etc.) whose descriptions were written iteratively and have not been audited against a canonical checklist. Sub-agents that see these schemas pay a token tax and sometimes mis-parameterize calls (e.g., passing globs where regexes are expected on `--exclude-file` vs `--exclude`).
+
+## Proposed improvement
+Apply the paper's augmentation pattern to every `#[tool]` description in `server/src/mcp_pmcp/`:
+1. Enforce a standard preamble: *purpose*, *when-to-use*, *when-not-to-use*, *output-shape*, *failure-mode*.
+2. Add one canonical JSON example per tool (paper shows +18% first-call success).
+3. Explicit parameter units (e.g., `limit: number of functions, 1..200, default 10` not just `limit: number`).
+4. Add a `cost_hint` field ("cheap" / "expensive") so orchestrators can budget.
+
+## Impact
+- Paper reports 6x token reduction on initial tool overhead for capable agents and measurable increase in tool-call correctness.
+- pmat agents today spend 2–4k tokens just on tool discovery; projected savings ~1.5k tokens per session.
+
+## Implementation sketch
+1. Audit every tool in `server/src/mcp_pmcp/tools/*.rs` — produce a smell report.
+2. Update doc comments (these become MCP descriptions via pmcp macros).
+3. Add a `mcp-lint` subcommand that re-checks descriptions against the smell taxonomy on CI.
+4. Add golden test: snapshot the JSON schema emitted to MCP clients and regress on diff.
+
+## Acceptance criteria
+- `pmat mcp-lint` reports 0 smells across all exposed tools.
+- Each tool has ≥1 in-description example and explicit parameter units/bounds.
+- MCP schema snapshot test passes; diff reviewed in PR.
+- **Requires MCP tool schema changes — flagged for client compatibility review.**

--- a/docs/kaizen-tickets/KAIZEN-0002.md
+++ b/docs/kaizen-tickets/KAIZEN-0002.md
@@ -1,0 +1,31 @@
+# KAIZEN-0002: Pointer-based large-result returns from pmat MCP tools
+
+**Source paper:** arxiv:2511.22729 — "Solving Context Window Overflow in AI Agents" (Labate, Nov 2025)
+**Category:** sub-agent-behavior
+**Priority:** high
+**Effort:** M
+
+## Problem
+`pmat query --include-source --limit 30` or `pmat context --format llm-optimized` can return 50–300 KB of text per call. When a sub-agent triggers this from its parent's conversation, the result is either truncated (lossy) or blows the context window (OOM). Today pmat's MCP tools return raw blobs; agents must then stream them through their own context.
+
+## Proposed improvement
+Adopt the paper's *pointer-to-value* pattern. Any MCP tool whose result exceeds a configurable threshold (e.g., 8 KB) should:
+1. Persist the full payload to `.pmat/mcp-artifacts/<uuid>.json` (or `.md`).
+2. Return a compact summary `{"artifact_id": "...", "preview": "first 40 lines", "size_bytes": N, "row_count": N, "fetch_tool": "pmat_read_artifact"}`.
+3. Add companion `pmat_read_artifact` and `pmat_slice_artifact(start, end)` MCP tools so agents can request just what they need.
+
+## Impact
+- The paper demonstrates lossless handling of arbitrary-size tool responses.
+- Projected: 30–50% context-window savings on deep-context / large-query workloads. Enables agents to `pmat context` on monorepos (currently unusable because output >1 MB).
+
+## Implementation sketch
+1. New crate module `server/src/mcp_pmcp/artifacts.rs` with artifact store (file-backed, LRU eviction at 500 MB).
+2. Wrap every `Tool::call()` result in `maybe_spill_to_artifact(result, threshold)`.
+3. Add `pmat_read_artifact {id, offset?, limit?}` and `pmat_slice_artifact {id, jsonpath}` tools.
+4. Configure threshold via `.pmat/mcp-config.toml`.
+
+## Acceptance criteria
+- Any tool result >8 KB is spilled; preview+id returned.
+- `pmat_read_artifact` round-trip passes integration test.
+- Benchmark: running `pmat context` via MCP no longer truncates or fails on a 50 KLOC repo.
+- **Requires MCP tool schema changes — two new tools added (additive, non-breaking).**

--- a/docs/kaizen-tickets/KAIZEN-0003.md
+++ b/docs/kaizen-tickets/KAIZEN-0003.md
@@ -1,0 +1,36 @@
+# KAIZEN-0003: Citation-grounded query results to prevent sub-agent hallucination
+
+**Source paper:** arxiv:2512.12117 — "Citation-Grounded Code Comprehension: Preventing LLM Hallucination Through Hybrid Retrieval and Graph-Augmented Context" (Dec 2025)
+**Category:** sub-agent-behavior
+**Priority:** high
+**Effort:** M
+
+## Problem
+The paper measures that 100% of fabricated "cite non-existent file" or "invalid line range" errors can be prevented by mechanical verification. Sub-agents using pmat today sometimes synthesize plausible-but-wrong claims ("this function calls X") after reading pmat output, because results lack a machine-checkable, structured citation block. `pmat query --include-source` gives file/line but agents paraphrase and drift.
+
+## Proposed improvement
+Augment every pmat query result with a structured `citations` block:
+```json
+{
+  "citations": [
+    {"file": "server/src/foo.rs", "start_line": 123, "end_line": 160, "sha": "b6d7be...", "content_hash": "sha256:..."}
+  ]
+}
+```
+Add `pmat verify-citation --file F --start S --end E --sha H` that returns the exact bytes or a cryptographic mismatch, so downstream agents (or a second verifier agent) can mechanically check that a synthesized claim refers to real code at a known revision.
+
+## Impact
+- Paper reports 92% citation accuracy vs. 74–78% baseline, and prevents 100% of "hallucinated file" errors.
+- Enables a two-phase agent workflow: (1) query pmat → receive cited snippets, (2) verify cited ranges before committing to a plan.
+
+## Implementation sketch
+1. Add `Citation` struct to `QueryResult`; populate via existing AST index offsets (we already have these).
+2. Add `--with-citations` flag (on by default for MCP callers).
+3. Implement `pmat verify-citation` using git blob lookup when `sha` is set.
+4. Extend `pmat-book` chapter on "Agent Workflows" to show citation-verify pattern.
+
+## Acceptance criteria
+- Every `pmat query` result with `--include-source` emits a `citations[]` array.
+- `pmat verify-citation` returns byte-exact match or specific failure (`file_missing | sha_mismatch | range_outside_file | content_hash_mismatch`).
+- Book chapter 15 (agent workflows) shows end-to-end example.
+- **MCP schema change — new optional `citations` field on query-result tools (additive).**

--- a/docs/kaizen-tickets/KAIZEN-0004.md
+++ b/docs/kaizen-tickets/KAIZEN-0004.md
@@ -1,0 +1,39 @@
+# KAIZEN-0004: Sub-agent "budget hint" headers on pmat tool responses
+
+**Source paper:** arxiv:2511.03728 — "Efficient On-Device Agents via Adaptive Context Management" (Nov 2025) + arxiv:2508.21433 — "The Complexity Trap: Simple Observation Masking Is as Efficient as LLM Summarization"
+**Category:** sub-agent-behavior
+**Priority:** medium
+**Effort:** S
+
+## Problem
+Orchestrator agents (Claude Code main loop, CAID dispatcher) need to decide whether to keep or discard a tool observation to stay under context budget. Today pmat results have no metadata hinting at their "value density" — a 20 KB `pmat query --coverage-gaps` is full of signal, while a 20 KB `pmat scaffold-agent` is mostly boilerplate. Agents default to keeping everything, then hit the 200k window.
+
+## Proposed improvement
+Every MCP tool response emits a `meta` envelope:
+```json
+{
+  "meta": {
+    "tokens_estimate": 4821,
+    "value_density": 0.82,        // signal:noise heuristic
+    "safe_to_mask_after": 5,      // turns — paper's observation-masking cue
+    "summary_one_line": "Found 12 uncovered functions; top impact: tokenize() 42 lines",
+    "persistent_key": "coverage-gaps-2026-04-18"
+  }
+}
+```
+Orchestrators can then drop or summarize results once `safe_to_mask_after` turns have passed.
+
+## Impact
+- The complexity-trap paper shows simple observation-masking matches LLM-summarization at a fraction of cost. Giving agents the mask hint converts a reactive strategy into a proactive one.
+- Projected 15–25% context savings in long sessions (>50 turns) observed in the cited paper.
+
+## Implementation sketch
+1. Compute `tokens_estimate` via tiktoken-rs (already a transitive dep).
+2. Emit `summary_one_line` from the existing result formatter (pick top-1 finding).
+3. Populate `safe_to_mask_after` per tool (e.g., 2 for `query`, ∞ for `verify-citation`).
+4. Document semantics in `docs/claude-integration-final.md`.
+
+## Acceptance criteria
+- Every MCP tool response has `meta` envelope.
+- Integration test: orchestrator can mask past results based on `safe_to_mask_after` and still resume work via `persistent_key`.
+- **MCP schema additive change — new optional `meta` envelope on every response.**

--- a/docs/kaizen-tickets/KAIZEN-0005.md
+++ b/docs/kaizen-tickets/KAIZEN-0005.md
@@ -1,0 +1,34 @@
+# KAIZEN-0005: `pmat sub-agent delegate` primitive for isolated task contexts
+
+**Source paper:** arxiv:2603.05344 — "Building AI Coding Agents for the Terminal: Scaffolding, Harness, Context Engineering, and Lessons Learned" (Mar 2026) + arxiv:2601.07577 — "Beyond Entangled Planning: Task-Decoupled Planning for Long-Horizon Agents"
+**Category:** sub-agent-behavior
+**Priority:** high
+**Effort:** L
+
+## Problem
+Sub-agent delegation is today an *implicit* capability of the client (e.g., Claude Code's Task tool) — pmat has no first-class way to scope *which tools* a sub-agent may call, nor to persist/resume its contract state when invoked. Agents that use pmat as an orchestrator end up re-reading the same context.idx on every invocation.
+
+## Proposed improvement
+Add `pmat sub-agent delegate --contract-id <id> --tools <allowlist> --read-only` that:
+1. Opens a scoped MCP session with only the listed tools available (least-privilege).
+2. Loads the contract's *prior observations* from `.pmat-work/<id>/observations.jsonl` so the sub-agent resumes with warm context.
+3. Streams new observations back and closes the session, appending a compact summary to the parent contract.
+
+This mirrors the "Subagent Orchestration" pattern from the arxiv:2603.05344 paper (Claude Code scaffolding).
+
+## Impact
+- The paper shows isolated sub-agents with filtered tool access dramatically reduce context pollution in the parent.
+- Enables pmat as a *delegation primitive* — a competitive alternative to bespoke agent frameworks.
+
+## Implementation sketch
+1. New CLI: `pmat sub-agent delegate` — spawns a constrained MCP server as a child process.
+2. Tool allowlist enforced at the MCP transport layer (reject unlisted tool-call requests).
+3. Observation log at `.pmat-work/<id>/observations.jsonl`, replayable on resume.
+4. MCP tool `pmat_delegate_task` so parent agents can programmatically spawn.
+5. Contract-file format (extend `.pmat-work/<id>/contract.json`) to record sub-agent lineage.
+
+## Acceptance criteria
+- `pmat sub-agent delegate --contract-id X --tools pmat_query_code,pmat_get_function` succeeds; calling an excluded tool returns `PermissionDenied`.
+- Sub-agent observations are appended to the contract and visible in `pmat work show X`.
+- `pmat_delegate_task` MCP tool works with Claude Code.
+- **New MCP tool added (`pmat_delegate_task`) — additive schema change.**

--- a/docs/kaizen-tickets/KAIZEN-0006.md
+++ b/docs/kaizen-tickets/KAIZEN-0006.md
@@ -1,0 +1,34 @@
+# KAIZEN-0006: Graph-native navigation tool for agents (CSR + structural edges)
+
+**Source paper:** arxiv:2602.20048 — "The Navigation Paradox in Large-Context Agentic Coding: Graph-Structured Dependency Navigation Outperforms Retrieval" (Feb 2026) + arxiv:2603.27277 — "Codebase-Memory: Tree-Sitter-Based Knowledge Graphs for LLM Code Exploration via MCP"
+**Category:** sub-agent-behavior
+**Priority:** high
+**Effort:** M
+
+## Problem
+The "Navigation Paradox" paper empirically shows graph-navigation (IMPORTS / INHERITS / INSTANTIATES edges) beats dense-retrieval semantic search on architecture-heavy tasks. Codebase-Memory reports 10x fewer tokens and 2.1x fewer tool calls vs file-exploration agents. pmat already has a trueno-graph CSR graph backing `pmat query` but does **not expose structural-edge queries** to agents — they must fall back to semantic search for every navigation step.
+
+## Proposed improvement
+Expose three new MCP tools:
+1. `pmat_graph_neighbors {node, edge_kind, direction, depth}` — O(1) lookup of IMPORTS / CALLS / INHERITS / DEFINES edges.
+2. `pmat_graph_path {from, to, max_depth}` — shortest reachability path.
+3. `pmat_graph_subgraph {seed, radius, edge_filter}` — return a focused subgraph as compact DOT/JSON.
+
+These already exist internally via `trueno-graph`; this ticket surfaces them through MCP with a compact JSON schema.
+
+## Impact
+- Paper: 10x fewer tokens, 2.1x fewer tool calls on architecture tasks.
+- pmat is uniquely positioned — we already build the graph every index cycle.
+- Turns a latent capability into a competitive differentiator for agent workflows.
+
+## Implementation sketch
+1. Add `server/src/mcp_pmcp/tools/graph.rs` with three handlers.
+2. Use existing `context_graph.rs` and `tdg_graph.rs` as backing stores.
+3. Return compact shape: arrays of `{id, name, file:line}` tuples; no full function bodies.
+4. Document the "when to use graph vs semantic search" guidance in book ch 14.
+
+## Acceptance criteria
+- Three new MCP tools callable from Claude Code.
+- Benchmark: traversing a 50-node CALLS subgraph <50 ms.
+- Book chapter updated with decision tree: graph navigation vs semantic search.
+- **3 new MCP tools added — additive schema change.**

--- a/docs/kaizen-tickets/KAIZEN-0007.md
+++ b/docs/kaizen-tickets/KAIZEN-0007.md
@@ -1,0 +1,34 @@
+# KAIZEN-0007: Experiential heuristics memory for pmat work contracts
+
+**Source paper:** arxiv:2603.24639 — "Experiential Reflective Learning" (ICLR 2026 MemAgents Workshop) + arxiv:2512.12818 — "Hindsight is 20/20: Building Agent Memory that Retains, Recalls, and Reflects"
+**Category:** sub-agent-behavior
+**Priority:** medium
+**Effort:** M
+
+## Problem
+Each `pmat work` contract starts fresh. When an agent (or human) closes a CB-xxxx with a root-cause-and-fix, the learning is lost — the next similar bug re-runs the same Five-Whys from scratch. The ERL paper shows agents that reflect into a *structured heuristic bank* (trigger conditions + recommended action) self-improve on repeat tasks.
+
+## Proposed improvement
+On contract closure, `pmat work close` automatically:
+1. Runs a reflection template over the contract's Five-Whys output + fix diff.
+2. Emits a `Heuristic {trigger_condition, recommended_action, evidence_contract_ids[], confidence}`.
+3. Appends it to `.pmat/heuristics.jsonl`.
+4. On new contract creation, `pmat work new` runs `pmat heuristics query --topic <title>` and surfaces the top-3 relevant heuristics as a *starter prompt* for the agent.
+
+## Impact
+- The ERL paper reports measurable compounding improvement on repeat tasks.
+- pmat already captures Five-Whys + falsification claims; heuristics is the natural next artifact.
+- Closes the loop between Toyota Way root-cause-analysis and future prevention.
+
+## Implementation sketch
+1. `pmat/heuristics/` module: schema + JSONL storage + embed-index (reuse aprender embeddings).
+2. Hook into `work.close()` to trigger reflection.
+3. New CLI: `pmat heuristics list | query | prune`.
+4. Integrate with `pmat work new` to pre-seed relevant heuristics.
+5. MCP tool `pmat_heuristics_query` so sub-agents can self-retrieve.
+
+## Acceptance criteria
+- Closing a contract emits one heuristic JSONL line.
+- `pmat heuristics query "stack overflow"` returns ranked prior heuristics.
+- `pmat work new` surfaces top-3 related heuristics in the contract scaffold.
+- **New MCP tool `pmat_heuristics_query` — additive.**

--- a/docs/kaizen-tickets/KAIZEN-0008.md
+++ b/docs/kaizen-tickets/KAIZEN-0008.md
@@ -1,0 +1,34 @@
+# KAIZEN-0008: Multi-persona Five Whys (MAR-style)
+
+**Source paper:** arxiv:2512.20845 — "MAR: Multi-Agent Reflexion Improves Reasoning Abilities in LLMs" + arxiv:2602.09937 — "Why Do AI Agents Systematically Fail at Cloud Root Cause Analysis?"
+**Category:** sub-agent-behavior
+**Priority:** medium
+**Effort:** M
+
+## Problem
+The AI-RCA-failure paper (2602.09937) shows single-agent Reflexion loops (one model acting + judging + reflecting) produce *repeated reasoning errors and confirmation bias*. Today `pmat five-whys` issues a single LLM prompt with an optional `--auto-analyze` pass — it is structurally a single-agent loop and shares this weakness. Questions like "why is memory growing" tend to converge too early on the first plausible chain.
+
+## Proposed improvement
+Add `pmat five-whys --multi-persona` that runs the MAR pattern:
+- **Analyst** persona: collects evidence (complexity, TDG, churn — the existing weighted signals).
+- **Skeptic** persona: challenges the leading hypothesis with counter-evidence.
+- **Architect** persona: proposes structural root cause.
+- **Judge** synthesizes and outputs a final Five-Whys chain with disagreement markers.
+
+Each persona gets *scoped evidence* (not the full conversation) — analogue to paper's "separated acting, diagnosing, critiquing, aggregating".
+
+## Impact
+- MAR paper reports substantial reasoning-quality lift on multi-step diagnosis.
+- Converts Five-Whys from one-shot into an adversarial dialogue, which matches Toyota Way's team-based genba practice.
+
+## Implementation sketch
+1. Extend `five_whys` module with `Persona` enum + per-persona prompt template.
+2. Evidence gating: each persona sees only task-relevant evidence slices.
+3. Final output format adds `disagreements[]` alongside the Five-Whys chain.
+4. Feature-flag behind `--multi-persona` to keep single-agent mode as default.
+
+## Acceptance criteria
+- `pmat five-whys --multi-persona "stack overflow"` runs 4 personas and emits a synthesized report + disagreements section.
+- Integration test: on a known red-herring input, multi-persona produces a different and better root cause than single-persona.
+- Book chapter updated.
+- **No MCP schema change** — CLI flag only; existing MCP tool returns richer report when flag is set in args.

--- a/docs/kaizen-tickets/KAIZEN-0009.md
+++ b/docs/kaizen-tickets/KAIZEN-0009.md
@@ -1,0 +1,31 @@
+# KAIZEN-0009: Attention-probe-style scalable fault localization signal
+
+**Source paper:** arxiv:2502.13966 — "Where's the Bug? Attention Probing for Scalable Fault Localization" (Feb 2025) + arxiv:2501.18005 — "Fault Localization via Fine-tuning LLMs with Mutation Generated Stack Traces"
+**Category:** other
+**Priority:** medium
+**Effort:** L
+
+## Problem
+pmat's current fault-annotation (`--faults`) is rule-based: unwrap / panic / unsafe counts. This catches *potential* fault sites but not *likely* fault sites. The Bug-Attention-Probe paper learns scalable fault-localization without direct labels and outperforms prompting of large LLMs. The mutation-stack-trace paper achieves 66.9% localization accuracy on HANA crashes via fine-tuning on 4.1M mutants.
+
+## Proposed improvement
+Add a `--probe-faults` flag that, on top of rule-based faults, emits a *learned* fault-likelihood score per function using a lightweight attention-probe trained on pmat's own `.pmat-work/*/contract.json` bug-history + fix-diffs. Because we already track "which function was changed to close CB-xxxx", we have free training data.
+
+## Impact
+- Paper reports SOTA fault localization without labels, outperforming LLM prompting.
+- pmat's contract history is an untapped supervised signal — this converts it into a first-class prediction.
+
+## Implementation sketch
+1. Mine fix-commits from `.pmat-work/*/contract.json` → `(function_id, was_root_cause: bool)` pairs.
+2. Train a simple probe (aprender linear classifier) over pmat's existing function-level features: complexity, churn, duplicates, entropy, centrality, existing faults.
+3. Serve predictions via `pmat query --probe-faults` and the existing MCP tools.
+4. Nightly retrain when ≥10 new contracts closed.
+
+## Impact (quantified)
+- If probe reaches paper's 66–74% top-1 accuracy, the current rule-based unwrap count (which has ~20% precision for real bugs per informal review) becomes a minor contributor.
+
+## Acceptance criteria
+- `pmat query "X" --probe-faults` adds `probe_fault_score ∈ [0,1]` per result.
+- Precision-at-10 on held-out contracts ≥50% on pmat itself (dogfood baseline).
+- Probe artifact <1 MB, loadable in <100 ms.
+- **No MCP schema change** — `probe_fault_score` is an additive optional field on existing query results.

--- a/docs/kaizen-tickets/KAIZEN-0010.md
+++ b/docs/kaizen-tickets/KAIZEN-0010.md
@@ -1,0 +1,34 @@
+# KAIZEN-0010: Commit-intent index with semantic drift detection
+
+**Source paper:** arxiv:2511.19875 — "CodeFuse-CommitEval: Towards Benchmarking LLM's Power on Commit Message and Code Change Inconsistency Detection" + arxiv:2603.15566 — "Lore: Repurposing Git Commit Messages as a Structured Knowledge Protocol for AI Coding Agents"
+**Category:** provable-contracts
+**Priority:** medium
+**Effort:** M
+
+## Problem
+pmat has a `CommitEmbedder` (TF-IDF, 128-dim) for `-G` git-history search. But we do not *validate* that a commit message actually describes the diff. CodeFuse-CommitEval shows many commit messages are semantically inconsistent with their diffs — which means `-G` sometimes surfaces misleading results (commit promises X, diff does Y). Lore argues commit messages are a *structured knowledge protocol*; that only works if they're accurate.
+
+## Proposed improvement
+Add `pmat git-verify --range master..HEAD` that:
+1. For each commit, computes (embedding(message), embedding(diff_summary)).
+2. Flags commits where cosine similarity < threshold as *inconsistent*.
+3. Optionally runs in pre-push hook (behind `PMAT_VERIFY_COMMITS=1`) to block drift.
+
+Additionally surface the consistency score as a field on `pmat query -G` results so agents can down-weight suspicious history.
+
+## Impact
+- Paper shows LLMs struggle to detect inconsistency (baseline ~60% accuracy); a dedicated signal is useful context for agents.
+- Improves the `-G` search precision by penalizing mis-labeled history.
+
+## Implementation sketch
+1. Extend `git_history_index` with `diff_embedding` column (SQLite schema migration).
+2. Add `pmat git-verify` CLI.
+3. Expose `commit_consistency_score` on `-G` search results.
+4. Document in book: pmat gives agents *calibrated* git signals.
+
+## Acceptance criteria
+- `pmat git-verify` outputs per-commit score + overall drift report.
+- Schema migration is backward compatible (v2.1 bumps).
+- `pmat query -G "fix memory leak"` returns results with `commit_consistency_score` field.
+- Pre-push hook opt-in documented.
+- **No MCP schema break** — additive field on existing git-history results.

--- a/docs/kaizen-tickets/KAIZEN-0011.md
+++ b/docs/kaizen-tickets/KAIZEN-0011.md
@@ -1,0 +1,32 @@
+# KAIZEN-0011: Mutation-prioritized coverage-gap targeting
+
+**Source paper:** arxiv:2505.05584 — "PRIMG: Efficient LLM-driven Test Generation Using Mutant Prioritization" (May 2025) + arxiv:2403.16218 — "CoverUp: Coverage-Guided LLM-Based Test Generation"
+**Category:** other
+**Priority:** medium
+**Effort:** M
+
+## Problem
+`pmat query --coverage-gaps --rank-by impact` ranks by `missed_lines * pagerank / complexity`. That's a static proxy for "how important is this to test"; it doesn't distinguish between "uncovered trivial getter" and "uncovered branch that, if mutated, survives". PRIMG shows mutant-based prioritization produces smaller, higher-impact test suites.
+
+## Proposed improvement
+Add `--rank-by mutation-impact` that scores uncovered functions by:
+1. How many *surviving mutants* they'd produce if tested (estimated from line count × operator kinds).
+2. How many downstream callers would be protected (PageRank on CALLS graph).
+
+Integrate with a new `pmat test-plan` that emits a ranked to-do list for LLM-driven test-generation tools (e.g., "write tests for fn X covering branch B; kill mutants M1, M2").
+
+## Impact
+- PRIMG reports significantly smaller test suites at equivalent mutation coverage.
+- Converts pmat from "here are gaps" into "here's the optimal test-writing plan for an agent".
+
+## Implementation sketch
+1. Lightweight mutation-operator estimator in aprender (no need for actual mutation-testing execution — estimate survivor count).
+2. New ranking function in `query_handler` behind `--rank-by mutation-impact`.
+3. New `pmat test-plan` command + MCP tool `pmat_test_plan {target, budget}`.
+4. Integration guide: Claude Code → pmat_test_plan → test-writing sub-agent.
+
+## Acceptance criteria
+- `--rank-by mutation-impact` works and differs from `impact`.
+- `pmat test-plan --budget 20` returns a ranked plan of ≤20 items with reasoning.
+- Book chapter: "Generating tests with sub-agents".
+- **One new MCP tool `pmat_test_plan` — additive.**

--- a/docs/kaizen-tickets/KAIZEN-0012.md
+++ b/docs/kaizen-tickets/KAIZEN-0012.md
@@ -1,0 +1,33 @@
+# KAIZEN-0012: Refinement-type contract synthesis for pmat-verified functions
+
+**Source paper:** arxiv:2510.25015 — "VeriStruct: AI-assisted Automated Verification of Data-Structure Modules in Verus" (Mar 2026) + arxiv:2602.02881 — "Learning-Infused Formal Reasoning: From Contract Synthesis to Artifact Reuse"
+**Category:** provable-contracts
+**Priority:** low
+**Effort:** L
+
+## Problem
+pmat's `pmat work` contract system tracks *work items* (CB-xxxx) but not *function-level specifications*. VeriStruct and the learning-infused-formal-reasoning vision paper argue that lightweight AI-assisted spec synthesis (pre/post-conditions, invariants) is now tractable for real Rust code.
+
+## Proposed improvement
+Add `pmat spec synthesize --function <path>::<name>` that:
+1. Extracts the function's signature + body + callers + tests.
+2. Runs a constrained LLM prompt to propose Verus-compatible `requires` / `ensures` / invariant clauses.
+3. Optionally invokes Verus (if present on PATH) to verify; records results in `.pmat/specs/<function_id>.verus`.
+4. Surfaces in `pmat query` as `spec_coverage: 0..1` — fraction of call sites with a verified contract.
+
+## Impact
+- Paper demonstrates practical Verus contract synthesis on real data structures.
+- Gives pmat a novel metric (`spec_coverage`) orthogonal to line coverage — measures *semantic* coverage.
+- Aligns with pmat's existing "contract-first enforcement" principle.
+
+## Implementation sketch
+1. `pmat/specs/` module: storage + render to Verus syntax.
+2. External process integration with `verus` binary (graceful fallback if absent).
+3. Aggregation: `pmat analyze spec-coverage` reports spec_coverage per file/module.
+4. Intentionally scope to Rust only in v1.
+
+## Acceptance criteria
+- `pmat spec synthesize` produces a syntactically valid Verus stub in ≥50% of trivial pure functions on pmat itself.
+- `pmat analyze spec-coverage` reports aggregate.
+- Documented limitation: non-Rust, non-pure, IO-heavy functions unsupported.
+- **No MCP schema change in v1** — CLI only.

--- a/docs/kaizen-tickets/KAIZEN-0013.md
+++ b/docs/kaizen-tickets/KAIZEN-0013.md
@@ -1,0 +1,31 @@
+# KAIZEN-0013: Cross-phase AST cache to eliminate redundant syn::parse_file()
+
+**Source paper:** arxiv:2506.15655 — "cAST: Enhancing Code Retrieval-Augmented Generation with Structural Chunking via AST" (2025)
+**Category:** performance
+**Priority:** medium
+**Effort:** M
+
+## Problem
+PMAT project memory (MEMORY.md, "Memory Profiling" section) records: *"deep context path: 8.7 GB total allocs, 104 MB peak — dominated by syn::parse_file() across parallel analysis phases"*. We already know the fix: a cross-phase AST cache. The cAST paper validates AST reuse as a first-class primitive for code-serving systems.
+
+## Proposed improvement
+Add `AstCache` keyed by `(file_path, mtime, content_hash)` that:
+1. Parses each Rust file at most once per `analyze_project` call (across AST / complexity / dead-code / duplicate / context phases).
+2. Survives across contract-validation runs via memory-mapped cache at `.pmat/ast-cache/`.
+3. Chunks on AST boundaries (cAST's split-then-merge) for downstream consumers.
+
+## Impact
+- Direct line to the known 8.7 GB allocation bottleneck. Target: 3–4x reduction.
+- cAST paper reports substantial retrieval quality gains from AST-aligned chunks.
+
+## Implementation sketch
+1. `server/src/services/ast_cache.rs` — Arc<HashMap<AstKey, Arc<syn::File>>>.
+2. Plumb through `analyze_project` phases; refactor each phase to accept `&dyn AstProvider`.
+3. Optional disk-backed cache for cross-process reuse (bincode + mmap).
+4. Benchmark script in `examples/bench_ast_cache.rs`.
+
+## Acceptance criteria
+- dhat allocations on `context` mode drop by ≥3x.
+- All existing tests pass; no regression in analysis fidelity.
+- Benchmark in CI compares before/after.
+- **No MCP schema change.**

--- a/docs/kaizen-tickets/KAIZEN-0014.md
+++ b/docs/kaizen-tickets/KAIZEN-0014.md
@@ -1,0 +1,27 @@
+# KAIZEN-0014: Re-ranking BM25 query results with graph-adjacency boost
+
+**Source paper:** arxiv:2510.04905 — "Retrieval-Augmented Code Generation: A Survey with Focus on Repository-Level Approaches" (Oct 2025) + Dropstone blog on 40-language tree-sitter scaling (2025)
+**Category:** performance
+**Priority:** low
+**Effort:** S
+
+## Problem
+`pmat query` uses FTS5 BM25 (KAIZEN-era SQLite migration) for lexical ranking, plus semantic embeddings for ranking. The RAG survey observes that *repository-level* systems benefit from combining BM25 with a structural-adjacency bonus (how reachable is the result from the seed term's symbol graph?). Our current re-rank does not exploit the graph.
+
+## Proposed improvement
+After BM25 + embedding fusion, apply a graph-adjacency re-rank: boost results whose symbol is within `k` CALLS-graph hops of any term matched literally in the query (e.g., if the query is "tokenize" and we BM25-match `Tokenizer::new`, then `Tokenizer::feed` gets a boost).
+
+## Impact
+- RAG survey cites 5–15% precision lift on repo-level queries from hybrid-rank approaches.
+- Inherits natively from trueno-graph's O(1) adjacency lookup.
+
+## Implementation sketch
+1. Identify *anchor symbols* in the query (literal-matched function names).
+2. Expand `k=2` hops in CALLS graph, produce `boost_set`.
+3. Multiply final score by `1 + 0.15` if result is in `boost_set`, `1 + 0.05` at k=2.
+4. Feature-flag behind `--graph-rerank` initially.
+
+## Acceptance criteria
+- `pmat query "tokenize" --graph-rerank` shifts results; informal dogfood A/B shows preferred ordering.
+- Performance: re-rank adds <20 ms to typical queries (graph adjacency is already O(1)).
+- **No MCP schema change** — internal ranking only.

--- a/docs/kaizen-tickets/KAIZEN-0015.md
+++ b/docs/kaizen-tickets/KAIZEN-0015.md
@@ -1,0 +1,31 @@
+# KAIZEN-0015: `pmat_index_stats_incremental` streaming tool for responsive agents
+
+**Source paper:** arxiv:2604.11462 — "Escaping the Context Bottleneck: Active Context Curation for LLM Agents via Reinforcement Learning" + arxiv:2604.08224 — "Externalization in LLM Agents: A Unified Review of Memory, Skills, Protocols and Harness Engineering"
+**Category:** sub-agent-behavior
+**Priority:** low
+**Effort:** S
+
+## Problem
+When an agent runs `pmat index rebuild` on a large monorepo, the tool blocks for 10–30 s with no feedback. Modern harnesses (per the "Externalization" survey) reward *streaming progress updates* — the agent can plan next steps while indexing runs. Today pmat returns one big reply at the end.
+
+## Proposed improvement
+Add MCP streaming protocol support for long-running tools. Specifically:
+1. `pmat_index_rebuild` emits progress events: `{phase: "parsing", files_done: 120, total: 5000, eta_seconds: 18}`.
+2. `pmat_query` for very large corpora emits partial result batches.
+3. Leverage MCP's optional `progress` notification channel.
+
+Per the "Active Context Curation" paper, agents that observe progress can decide to kill long-running calls and re-plan — critical for sub-agent delegation.
+
+## Impact
+- Better agent ergonomics on monorepos: fewer timeouts, actionable progress.
+- Unblocks sub-agent patterns where the parent wants to dispatch other work in parallel.
+
+## Implementation sketch
+1. Add `ProgressReporter` trait; wire into `save()` / `load()` / `rebuild()` in agent-context-index.
+2. Use pmcp SDK's notification API (already supported; not currently wired).
+3. Document required client support in MCP integration docs.
+
+## Acceptance criteria
+- `pmat index rebuild` via MCP emits ≥3 progress events on a typical session.
+- Cancellable mid-flight (agent-side timeout → clean cancel).
+- **MCP protocol usage change — additive notifications, but requires client to handle them (graceful degradation for non-supporting clients).**

--- a/docs/kaizen-tickets/KAIZEN-0016.md
+++ b/docs/kaizen-tickets/KAIZEN-0016.md
@@ -1,0 +1,32 @@
+# KAIZEN-0016: Asynchronous isolated delegation (CAID) for pmat work pipelines
+
+**Source paper:** arxiv:2603.21489 — "Effective Strategies for Asynchronous Software Engineering Agents" (Mar 2026)
+**Category:** sub-agent-behavior
+**Priority:** low
+**Effort:** L
+
+## Problem
+CAID (Centralized Asynchronous Isolated Delegation) is the paper's SOTA coordination paradigm: a central manager constructs dependency-aware task plans, dispatches subtasks to *concurrent isolated workspaces*, and consolidates via test-based verification. pmat's `pmat work` is sequential and single-branch; concurrent contracts trample each other in a shared checkout.
+
+## Proposed improvement
+Add `pmat work parallel --contracts CB-001,CB-002,CB-003` that:
+1. Creates a git worktree per contract in `.pmat-work/<id>/worktree/`.
+2. Dispatches each to an isolated agent (or manual agent via a slot).
+3. On completion, runs cross-contract verifier: merges to staging branch, runs `cargo test` across the union.
+4. Only unblocks `work close` if the union passes.
+
+## Impact
+- Paper reports substantial throughput lift on multi-task batches without loss of quality.
+- Enables pmat to orchestrate *fleets* of sub-agents against a backlog.
+
+## Implementation sketch
+1. Worktree-per-contract in `work.rs`.
+2. New subcommand `pmat work parallel`.
+3. Staging-branch merge + cross-verify step.
+4. Compatibility: reject non-independent contracts (file-overlap check) up-front.
+
+## Acceptance criteria
+- `pmat work parallel CB-a,CB-b` creates two worktrees and surfaces status.
+- File-overlap detection warns when contracts touch same files.
+- On success, a staging branch contains a merged result verified by test suite.
+- **No MCP tool changes** — pmat_work_* tools remain; parallel is an orchestration layer around them.


### PR DESCRIPTION
## Summary
Research sweep of 26 arxiv papers (Q4-2025..Q1-2026) surfaced 16 actionable kaizen tickets focused on sub-agent behavior (8), performance (2), provable-contracts (2), fault-localization (1), testing (2), and formal verification (1). Emphasis on advanced Claude Code integration and sub-agent delegation primitives.

**Top 3 by impact**
- **KAIZEN-0002**: pointer-based large-result returns from MCP tools (arxiv:2511.22729) — replaces lossy truncation with addressable artifacts. Unblocks `pmat context` on monorepos + multi-30KB result workflows.
- **KAIZEN-0006**: graph-native navigation MCP tools (arxiv:2602.20048, 2603.27277). Paper reports **10x token reduction, 2.1x fewer tool calls**. pmat already has the trueno-graph CSR — just needs to expose it as MCP tools.
- **KAIZEN-0005**: `pmat sub-agent delegate` primitive (arxiv:2603.05344) — scoped tool allowlists + contract-warm context resume. Makes pmat a first-class delegation tool.

**Other research themes**
- Tool-description smells (arxiv:2602.14878) — 97% of public MCP descriptions fail quality audits.
- Pointer-over-value context management (arxiv:2511.22729).
- Multi-persona reflection fixes single-agent RCA bias (arxiv:2512.20845).
- Mechanical citation grounding (arxiv:2512.12117) — 100% of "cite non-existent file" errors are mechanically preventable.
- Heuristic memory banks from ERL (arxiv:2603.24639, ICLR 2026) — contracts should emit reusable post-mortems.

**MCP schema changes** (all additive, no breaking changes):
KAIZEN-0001 (revised descriptions), 0002 (2 new pointer tools), 0003 (citations field), 0004 (meta envelope), 0005 (`pmat_delegate_task`), 0006 (3 graph tools), 0007 (`heuristics_query`), 0011 (`pmat_test_plan`), 0015 (progress notifications). KAIZEN-0001 requires a schema-snapshot regression test.

**Meta-observations — where pmat lags vs SOTA**
1. MCP tools are opaque — no `tokens_estimate`, no `safe_to_mask`, no summaries. SOTA is moving toward self-describing tool results.
2. pmat builds excellent structural graphs (trueno-graph CSR) but does NOT expose graph-navigation as MCP tools — latent 10x token-saving capability.
3. No formal citation contract — sub-agents must "trust" pmat output. Cryptographic verification is cheap and eliminates a hallucination class.
4. Single-agent RCA (`pmat five-whys`) is structurally vulnerable to confirmation bias per the RCA-failure paper.
5. Contract system (`pmat work`) doesn't learn — every bug is fresh. ERL heuristic banks are the obvious next step.

## Test plan
- [ ] KAIZEN-0001..0016 markdown files render correctly on GitHub.
- [ ] Cross-link tickets to existing CB-17xx / CB-18xx umbrellas (#328, #329) in follow-up comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)