### PR TITLE
docs(examples): CB-16xx round 2 — CB-1617/1618/1619/1645 lifecycle demos

### DIFF
--- a/examples/cb16xx_completion_target.rs
+++ b/examples/cb16xx_completion_target.rs
@@ -1,0 +1,240 @@
+//! CB-16xx Completion Level vs. Target Demo — CB-1619.
+//!
+//! Component 28 of the CB-16xx spec enforces that a ticket's recorded
+//! `achieved_level` (what was actually verified) matches the `target_level`
+//! declared in its contract. The two live together in
+//! `.pmat-work/<ID>/verification-report.json`:
+//!
+//!   {"target_level": "L3", "achieved_level": "L3"}   ← ok
+//!   {"target_level": "L4", "achieved_level": "L2"}   ← silent downgrade
+//!
+//! CB-1619 fails the second shape because a ticket that aimed for L4 Kani
+//! verification but shipped with only L2 DbC evidence has drifted from its
+//! stated contract. Closing tickets below target is the most common way
+//! obligations get silently dropped — CB-1619 catches it at the gate.
+//!
+//! This example synthesises three tickets side-by-side and marches the same
+//! repository through three phases to show how CB-1619 ratchets from Skip
+//! to Pass to Fail:
+//!
+//!   Phase 1 — Tickets have contracts but no verification-report.json yet:
+//!             CB-1619 Skip.
+//!   Phase 2 — Each ticket reports achieved == target: CB-1619 Pass.
+//!   Phase 3 — Mutate COMPLETE-003's report to claim target=L4, achieved=L2
+//!             (a typical "kani slipped, we shipped anyway" signal):
+//!             CB-1619 Fail listing COMPLETE-003.
+//!
+//! Run with: `cargo run --example cb16xx_completion_target`
+
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+const TICKETS: &[(&str, &str)] = &[
+    ("COMPLETE-001", "L1"),
+    ("COMPLETE-002", "L3"),
+    ("COMPLETE-003", "L4"),
+];
+
+fn main() {
+    println!("=== PMAT Comply — CB-1619 Achieved-Level == Target Demo ===\n");
+
+    let tmp = tempfile::tempdir().expect("create tempdir");
+    let root = tmp.path();
+    println!("Synthesizing project tree at {}\n", root.display());
+
+    write_min_project_files(root);
+    for (id, lvl) in TICKETS {
+        write_work_contract(root, id, lvl);
+    }
+
+    // ── Phase 1: contracts exist, no reports — CB-1619 Skip ──────────────────
+    println!("── Phase 1: contracts only, no verification-report.json (Skip) ──");
+    run_and_filter(root, 1619);
+
+    // ── Phase 2: each ticket achieved its target — CB-1619 Pass ──────────────
+    println!("\n── Phase 2: write matching reports (achieved == target) (Pass) ──");
+    for (id, lvl) in TICKETS {
+        write_verification_report(root, id, lvl, lvl);
+    }
+    run_and_filter(root, 1619);
+
+    // ── Phase 3: COMPLETE-003 downgrades silently — CB-1619 Fail ─────────────
+    println!("\n── Phase 3: mutate COMPLETE-003 to achieved=L2 (Fail) ──");
+    write_verification_report(root, "COMPLETE-003", "L4", "L2");
+    run_and_filter(root, 1619);
+
+    println!("\n=== Completion-Target Semantics ===");
+    print_notes();
+}
+
+fn write_min_project_files(root: &Path) {
+    fs::write(
+        root.join("Cargo.toml"),
+        "[package]\nname = \"cb16xx-complete\"\nversion = \"0.0.1\"\nedition = \"2021\"\n",
+    )
+    .expect("write Cargo.toml");
+    let src = root.join("src");
+    fs::create_dir_all(&src).expect("mkdir src");
+    fs::write(src.join("lib.rs"), "pub fn finish() -> bool { true }\n").expect("write lib.rs");
+}
+
+/// Write `.pmat-work/<ticket>/contract.json` at the given target level. The
+/// contract is fully serde-compatible: `thresholds` and `baseline_file_manifest`
+/// are populated because serde_json rejects short-form `{}` for either.
+fn write_work_contract(root: &Path, ticket: &str, level: &str) {
+    let contract = serde_json::json!({
+        "version": "5.0",
+        "work_item_id": ticket,
+        "created_at": "2026-04-18T00:00:00Z",
+        "baseline_commit": "0".repeat(40),
+        "baseline_tdg": 95.0,
+        "baseline_coverage": 95.0,
+        "baseline_rust_score": null,
+        "baseline_file_manifest": manifest_stub(),
+        "thresholds": thresholds_stub(),
+        "verification_level": level,
+        "iteration": 1,
+        "claims": [],
+        "implements": [],
+    });
+    let dir = root.join(".pmat-work").join(ticket);
+    fs::create_dir_all(&dir).expect("mkdir ticket");
+    fs::write(
+        dir.join("contract.json"),
+        serde_json::to_vec_pretty(&contract).unwrap(),
+    )
+    .expect("write contract.json");
+}
+
+/// Write `.pmat-work/<ticket>/verification-report.json`. Only `target_level`
+/// and `achieved_level` are load-bearing — CB-1619 ignores other fields. The
+/// level strings must parse via `VerificationLevel::parse_strict`, i.e. `L0`
+/// through `L5` with no trailing whitespace.
+fn write_verification_report(root: &Path, ticket: &str, target: &str, achieved: &str) {
+    let report = serde_json::json!({
+        "target_level":   target,
+        "achieved_level": achieved,
+        "completed_at":   "2026-04-18T18:00:00Z",
+        "notes": if target == achieved {
+            format!("{}: achieved target {}", ticket, target)
+        } else {
+            format!("{}: slipped {} → {}", ticket, target, achieved)
+        },
+    });
+    let path = root
+        .join(".pmat-work")
+        .join(ticket)
+        .join("verification-report.json");
+    fs::write(path, serde_json::to_vec_pretty(&report).unwrap())
+        .expect("write verification-report.json");
+}
+
+fn thresholds_stub() -> serde_json::Value {
+    serde_json::json!({
+        "min_coverage_pct": 95.0,
+        "min_per_file_coverage_pct": 95.0,
+        "max_tdg_regression": 0.0,
+        "max_function_complexity": 20,
+        "max_file_lines": 500,
+        "min_spec_score": 95,
+        "require_github_sync": false,
+        "require_spec_update": false,
+        "require_roadmap_update": false,
+        "block_on_new_satd": false,
+        "block_on_new_dead_code": false,
+        "require_lint_pass": false
+    })
+}
+
+fn manifest_stub() -> serde_json::Value {
+    serde_json::json!({
+        "files": {},
+        "coverage_required": [],
+        "manifest_hash": "stub"
+    })
+}
+
+/// Run `pmat comply check` on `root` and echo CB-<cb_id> rows only. Missing
+/// `pmat` is non-fatal — the notes still print as a documentation fallback.
+fn run_and_filter(root: &Path, cb_id: u32) {
+    let binary = option_env!("CARGO_BIN_EXE_pmat").unwrap_or("pmat");
+    let out = Command::new(binary)
+        .args(["comply", "check", "-p"])
+        .arg(root)
+        .args(["-f", "text"])
+        .output();
+
+    let output = match out {
+        Ok(o) => o,
+        Err(e) => {
+            println!("  (pmat not found on PATH: {e}; skipping run)");
+            return;
+        }
+    };
+    println!("  exit status: {}", output.status);
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let needle = format!("CB-{}:", cb_id);
+    let rows: Vec<&str> = stdout
+        .lines()
+        .chain(stderr.lines())
+        .filter(|l| l.contains(&needle))
+        .collect();
+    if rows.is_empty() {
+        println!(
+            "  (no CB-{} row — likely a pmat build predating PR #302)",
+            cb_id
+        );
+    } else {
+        for line in rows {
+            println!("    {}", line.trim_start());
+        }
+    }
+}
+
+fn print_notes() {
+    println!(
+        "\
+CB-1619 is the closing gate of the work-verification ladder. Target level is
+declared at bind time (the contract's `verification_level`); achieved level
+is declared at completion time (`verification-report.json:achieved_level`).
+The two must match — silent downgrade between bind and close is exactly the
+scope erosion that the CB-16xx ratchet is designed to prevent.
+
+Decision table:
+
+  target_level missing or unparseable    → this ticket is skipped silently
+  achieved_level missing or unparseable  → this ticket is skipped silently
+  achieved == target                     → counted as Pass
+  achieved <  target                     → counted as Fail row
+  achieved >  target  (over-achievement) → counted as Pass (no ratchet)
+
+When every ticket has been skipped (no readable report yet), CB-1619 itself
+reports Skip for the whole project, because there's nothing to judge. This
+is the intended migration behaviour for repos mid-adoption.
+
+Related ladder checks (all activate under the L3+ profile):
+
+  CB-1610  ticket's verification_level parses as L0..L5
+  CB-1611  ticket's verification_level ≤ binding's max attainable level
+  CB-1617  downgrade ledger reasons are non-empty
+  CB-1618  per-ticket checkpoint level is monotone (or audited)
+
+Fix pattern when CB-1619 fires: either re-run the L4 verification (so
+achieved catches up), or explicitly downgrade the contract's target with a
+ledger entry — which lifts the bar CB-1619 is comparing against. Never just
+blank the `achieved_level` field to silence the check; CB-1619 reads the
+report, not the absence of one.
+"
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn main_runs() {
+        super::main();
+    }
+}

--- a/examples/cb16xx_derived_yaml_obligations.rs
+++ b/examples/cb16xx_derived_yaml_obligations.rs
@@ -1,0 +1,240 @@
+//! CB-16xx Derived YAML Obligations Demo — CB-1645.
+//!
+//! Component 31 of the CB-16xx spec (Chain-of-Thought proof + evidence)
+//! requires that every ticket's `.pmat-work/<ID>/contract.json` have a
+//! matching *derived* YAML at `contracts/work/<sanitized-id>.yaml` whose
+//! preconditions/postconditions mirror the contract's `require`/`ensure`
+//! clauses.
+//!
+//! The derived YAML is the machine-readable obligation surface that other
+//! tools (Kani harness scaffolders, mutation generators) consume. If it
+//! drifts from the contract.json — because someone edited the contract
+//! without running `pmat comply refresh-bindings` — downstream artifacts
+//! silently bind to yesterday's obligations. CB-1645 catches exactly that.
+//!
+//! This example walks through five phases on one ticket `DERIVE-001`:
+//!
+//!   Phase 1 — No `.pmat-work/` tickets at all: CB-1645 Skip.
+//!   Phase 2 — Ticket exists but contract.json has no `require`/`ensure`
+//!             (nothing to derive): CB-1645 Skip.
+//!   Phase 3 — contract.json has clauses but `contracts/work/` is empty:
+//!             CB-1645 Fail ("missing derived").
+//!   Phase 4 — Derived YAML exists and mentions every clause: CB-1645 Pass.
+//!   Phase 5 — Contract adds a new postcondition without rederiving the
+//!             YAML: CB-1645 Fail ("stale").
+//!
+//! Run with: `cargo run --example cb16xx_derived_yaml_obligations`
+
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+const TICKET: &str = "DERIVE-001";
+
+fn main() {
+    println!("=== PMAT Comply — CB-1645 Derived YAML Obligations Demo ===\n");
+
+    let tmp = tempfile::tempdir().expect("create tempdir");
+    let root = tmp.path();
+    println!("Synthesizing project tree at {}\n", root.display());
+
+    write_min_project_files(root);
+
+    // ── Phase 1: no tickets — Skip ───────────────────────────────────────────
+    println!("── Phase 1: no tickets (expect Skip) ──");
+    run_and_filter(root, 1645);
+
+    // ── Phase 2: ticket exists but no derivable clauses — Skip ───────────────
+    println!("\n── Phase 2: contract.json without require/ensure (Skip) ──");
+    write_contract(root, TICKET, serde_json::json!({ "work_item_id": TICKET }));
+    run_and_filter(root, 1645);
+
+    // ── Phase 3: contract has clauses but no derived YAML — Fail ─────────────
+    println!("\n── Phase 3: add require/ensure but no derived YAML (Fail) ──");
+    write_contract(
+        root,
+        TICKET,
+        serde_json::json!({
+            "work_item_id": TICKET,
+            "require": ["input is a non-empty slice of u32"],
+            "ensure":  ["result is sorted ascending", "result preserves length"],
+        }),
+    );
+    run_and_filter(root, 1645);
+
+    // ── Phase 4: write derived YAML that mentions every clause — Pass ────────
+    println!("\n── Phase 4: write matching contracts/work/DERIVE-001.yaml (Pass) ──");
+    write_derived_yaml(
+        root,
+        TICKET,
+        "name: \"DERIVE-001\"\n\
+         preconditions:\n\
+         \x20 - \"input is a non-empty slice of u32\"\n\
+         postconditions:\n\
+         \x20 - \"result is sorted ascending\"\n\
+         \x20 - \"result preserves length\"\n",
+    );
+    run_and_filter(root, 1645);
+
+    // ── Phase 5: add a new postcondition to contract.json, YAML stale — Fail ─
+    println!("\n── Phase 5: contract gains a new postcondition, YAML goes stale (Fail) ──");
+    write_contract(
+        root,
+        TICKET,
+        serde_json::json!({
+            "work_item_id": TICKET,
+            "require": ["input is a non-empty slice of u32"],
+            "ensure":  [
+                "result is sorted ascending",
+                "result preserves length",
+                "result is a permutation of input",
+            ],
+        }),
+    );
+    run_and_filter(root, 1645);
+
+    println!("\n=== Derivation Semantics ===");
+    print_notes();
+}
+
+fn write_min_project_files(root: &Path) {
+    fs::write(
+        root.join("Cargo.toml"),
+        "[package]\nname = \"cb16xx-derive\"\nversion = \"0.0.1\"\nedition = \"2021\"\n",
+    )
+    .expect("write Cargo.toml");
+    let src = root.join("src");
+    fs::create_dir_all(&src).expect("mkdir src");
+    fs::write(
+        src.join("lib.rs"),
+        "pub fn sort(v: &mut [u32]) { v.sort(); }\n",
+    )
+    .expect("write lib.rs");
+    // contracts/work/ is the directory CB-1645 scans — we pre-create it so
+    // Phase 3's Fail message says "missing derived <ID>.yaml" rather than
+    // "missing contracts/work/ directory" (both Fail, but the message
+    // differs).
+    fs::create_dir_all(root.join("contracts").join("work")).expect("mkdir contracts/work");
+}
+
+/// Write `.pmat-work/<ticket>/contract.json` with the given JSON value. The
+/// check only reads `require` (array of strings) and `ensure` (array of
+/// strings); the other fields are tolerated but ignored.
+fn write_contract(root: &Path, ticket: &str, contract: serde_json::Value) {
+    let dir = root.join(".pmat-work").join(ticket);
+    fs::create_dir_all(&dir).expect("mkdir ticket");
+    fs::write(
+        dir.join("contract.json"),
+        serde_json::to_vec_pretty(&contract).unwrap(),
+    )
+    .expect("write contract.json");
+}
+
+/// Write `contracts/work/<sanitized_id>.yaml`. The sanitizer replaces any
+/// non-alphanumeric/underscore/dash characters with '_', matching the
+/// generator in `check_commit_enforcement_p8::generate_work_contract_yamls`
+/// and therefore CB-1645's lookup. `DERIVE-001` stays literal because '-'
+/// is preserved.
+fn write_derived_yaml(root: &Path, ticket: &str, body: &str) {
+    let safe = sanitize_work_id(ticket);
+    let path = root
+        .join("contracts")
+        .join("work")
+        .join(format!("{}.yaml", safe));
+    fs::write(path, body).expect("write derived yaml");
+}
+
+/// Same sanitization rule CB-1645 uses: alnum, `-`, `_` survive; everything
+/// else becomes `_`. Kept here so the example's filenames match the check's
+/// lookup without depending on pmat internals.
+fn sanitize_work_id(id: &str) -> String {
+    id.chars()
+        .map(|c| {
+            if c.is_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+/// Run `pmat comply check` on `root` and echo lines mentioning `CB-<cb_id>:`.
+/// Missing `pmat` binary is non-fatal — the walkthrough text is the primary
+/// payload, the check output is validation.
+fn run_and_filter(root: &Path, cb_id: u32) {
+    let binary = option_env!("CARGO_BIN_EXE_pmat").unwrap_or("pmat");
+    let out = Command::new(binary)
+        .args(["comply", "check", "-p"])
+        .arg(root)
+        .args(["-f", "text"])
+        .output();
+
+    let output = match out {
+        Ok(o) => o,
+        Err(e) => {
+            println!("  (pmat not found on PATH: {e}; skipping run)");
+            return;
+        }
+    };
+    println!("  exit status: {}", output.status);
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let needle = format!("CB-{}:", cb_id);
+    let rows: Vec<&str> = stdout
+        .lines()
+        .chain(stderr.lines())
+        .filter(|l| l.contains(&needle))
+        .collect();
+    if rows.is_empty() {
+        println!(
+            "  (no CB-{} row — likely a pmat build predating PR #302)",
+            cb_id
+        );
+    } else {
+        for line in rows {
+            println!("    {}", line.trim_start());
+        }
+    }
+}
+
+fn print_notes() {
+    println!(
+        "\
+CB-1645 treats `contracts/work/<ID>.yaml` as a materialized view over
+`.pmat-work/<ID>/contract.json`. The two must stay coherent:
+
+  contract.json `require` → YAML `preconditions:`
+  contract.json `ensure`  → YAML `postconditions:`
+
+Neither file is the ground truth alone — the ticket's contract.json is what
+reviewers edit, but downstream tools (Kani harness scaffolder, mutation
+roster generator) read the YAML. Drift between them is silent scope
+reduction of the obligation surface.
+
+Fix pattern when CB-1645 fails:
+  pmat comply refresh-bindings --ticket DERIVE-001
+which regenerates the YAML from the current contract.json. For bulk repair,
+drop `--ticket` and let it rebuild every ticket in `.pmat-work/`.
+
+Related checks in the Component 31 family:
+
+  CB-1640  ChainOfThought assumption references resolve to a prior step
+  CB-1641  ChainOfThought evidence references exist on disk
+  CB-1643  L3 ProvableContract expressions have structured `expr:` field
+  CB-1647  Orphan derived YAMLs (YAML without matching contract.json)
+
+Together these form the chain-of-thought coherence ring: every claim links
+back to ground truth and every derived artifact stays synchronised.
+"
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn main_runs() {
+        super::main();
+    }
+}

--- a/examples/cb16xx_downgrade_monotonicity.rs
+++ b/examples/cb16xx_downgrade_monotonicity.rs
@@ -1,0 +1,209 @@
+//! CB-16xx Downgrade + Monotonicity Audit Demo — CB-1617 and CB-1618.
+//!
+//! Component 28 of the CB-16xx spec introduces a *downgrade audit ledger* at
+//! `.pmat-work/ledger/downgrades.json` and requires that every verification-
+//! level regression in a ticket's per-checkpoint timeline be matched by an
+//! audit entry. Two checks work in tandem to enforce this:
+//!
+//!   * **CB-1617** — every entry in the downgrade ledger must carry a
+//!     non-empty `reason` field. An empty reason is silent scope reduction.
+//!   * **CB-1618** — a ticket's `verification_level` across its
+//!     `.pmat-work/<ID>/checkpoints/*.json` files must be non-decreasing,
+//!     unless the ticket appears in the downgrade ledger. Presence alone
+//!     satisfies CB-1618; CB-1617 independently checks the `reason`.
+//!
+//! This example walks through four phases on a single ticket `AUDIT-001` to
+//! show the full Skip → Pass → Fail → Pass lifecycle of both checks.
+//!
+//!   Phase 1 — No checkpoints, no ledger: both checks Skip.
+//!   Phase 2 — Monotonic ascending checkpoints (L1 → L3 → L4) without ledger:
+//!             CB-1618 Pass, CB-1617 still Skip (ledger absent).
+//!   Phase 3 — Add a regressing checkpoint (L4 → L2) with NO ledger entry:
+//!             CB-1618 Fail ("unaudited regression"), CB-1617 still Skip.
+//!   Phase 4 — Write a ledger entry that cites the regression AND has a
+//!             real reason string: CB-1618 Pass, CB-1617 Pass.
+//!   Phase 5 — Mutate that ledger entry to blank the reason: CB-1617 Fail
+//!             (CB-1618 still Pass because presence alone is enough for it).
+//!
+//! Run with: `cargo run --example cb16xx_downgrade_monotonicity`
+
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+fn main() {
+    println!("=== PMAT Comply — CB-1617 + CB-1618 Downgrade/Monotonicity Demo ===\n");
+
+    let tmp = tempfile::tempdir().expect("create tempdir");
+    let root = tmp.path();
+    println!("Synthesizing project tree at {}\n", root.display());
+
+    write_min_project_files(root);
+
+    // ── Phase 1: no checkpoints, no ledger — both Skip ───────────────────────
+    println!("── Phase 1: no checkpoints, no ledger (both Skip) ──");
+    run_and_filter(root, &[1617, 1618]);
+
+    // ── Phase 2: monotonic ascending L1 → L3 → L4 — CB-1618 Pass, 1617 Skip ──
+    println!("\n── Phase 2: monotonic L1 → L3 → L4 (CB-1618 Pass, CB-1617 Skip) ──");
+    write_checkpoint(root, "AUDIT-001", "a.json", "2026-04-18T09:00:00Z", "L1");
+    write_checkpoint(root, "AUDIT-001", "b.json", "2026-04-18T10:00:00Z", "L3");
+    write_checkpoint(root, "AUDIT-001", "c.json", "2026-04-18T11:00:00Z", "L4");
+    run_and_filter(root, &[1617, 1618]);
+
+    // ── Phase 3: regress to L2 without ledger — CB-1618 Fail, 1617 Skip ──────
+    println!("\n── Phase 3: regress L4 → L2 without ledger (CB-1618 Fail) ──");
+    write_checkpoint(root, "AUDIT-001", "d.json", "2026-04-18T12:00:00Z", "L2");
+    run_and_filter(root, &[1617, 1618]);
+
+    // ── Phase 4: ledger entry with real reason — both Pass ───────────────────
+    println!("\n── Phase 4: add ledger entry with reason (both Pass) ──");
+    write_downgrade_ledger(
+        root,
+        &[ledger_entry(
+            "AUDIT-001",
+            "kani runner offline — reviewer agreed to defer L4 to next sprint",
+        )],
+    );
+    run_and_filter(root, &[1617, 1618]);
+
+    // ── Phase 5: blank the reason — CB-1617 Fail ─────────────────────────────
+    println!("\n── Phase 5: blank the ledger reason (CB-1617 Fail) ──");
+    write_downgrade_ledger(root, &[ledger_entry("AUDIT-001", "")]);
+    run_and_filter(root, &[1617, 1618]);
+
+    println!("\n=== Downgrade/Monotonicity Semantics ===");
+    print_notes();
+}
+
+fn write_min_project_files(root: &Path) {
+    fs::write(
+        root.join("Cargo.toml"),
+        "[package]\nname = \"cb16xx-downgrade\"\nversion = \"0.0.1\"\nedition = \"2021\"\n",
+    )
+    .expect("write Cargo.toml");
+    let src = root.join("src");
+    fs::create_dir_all(&src).expect("mkdir src");
+    fs::write(src.join("lib.rs"), "pub fn audit() {}\n").expect("write lib.rs");
+    // `.pmat-work/` must exist so CB-1618's first tier gate opens; we leave
+    // `ledger/` unmaterialized until Phase 4 so Phase 1-3 exercise the Skip
+    // branch in CB-1617.
+    fs::create_dir_all(root.join(".pmat-work")).expect("mkdir .pmat-work");
+}
+
+/// Append one checkpoint at `.pmat-work/<ticket>/checkpoints/<filename>`.
+/// CB-1618 sorts checkpoints by the `timestamp` field, not by filename, so
+/// filenames can be anything valid — we use `a.json`..`d.json` for clarity.
+fn write_checkpoint(root: &Path, ticket: &str, filename: &str, ts: &str, level: &str) {
+    let dir = root.join(".pmat-work").join(ticket).join("checkpoints");
+    fs::create_dir_all(&dir).expect("mkdir checkpoints");
+    let body = serde_json::json!({
+        "timestamp": ts,
+        "verification_level": level,
+    });
+    fs::write(
+        dir.join(filename),
+        serde_json::to_vec_pretty(&body).unwrap(),
+    )
+    .expect("write checkpoint");
+}
+
+/// Write `.pmat-work/ledger/downgrades.json` from the given entries. The
+/// file must be a JSON array at the top level — anything else trips the
+/// structural Fail branch of CB-1617.
+fn write_downgrade_ledger(root: &Path, entries: &[serde_json::Value]) {
+    let dir = root.join(".pmat-work").join("ledger");
+    fs::create_dir_all(&dir).expect("mkdir ledger");
+    let body = serde_json::Value::Array(entries.to_vec());
+    fs::write(
+        dir.join("downgrades.json"),
+        serde_json::to_vec_pretty(&body).unwrap(),
+    )
+    .expect("write downgrades.json");
+}
+
+/// One downgrade ledger entry. Only `ticket` and `reason` are load-bearing —
+/// CB-1617 scans for empty `reason` strings; CB-1618 uses `ticket` membership
+/// as its "this regression has been audited" predicate.
+fn ledger_entry(ticket: &str, reason: &str) -> serde_json::Value {
+    serde_json::json!({
+        "ticket": ticket,
+        "reason": reason,
+        "from_level": "L4",
+        "to_level": "L2",
+        "timestamp": "2026-04-18T12:30:00Z",
+    })
+}
+
+/// Run `pmat comply check` on `root` and echo only lines that mention the
+/// given CB numeric ids. Missing `pmat` isn't fatal — we still print the
+/// notes so the example is useful as documentation even without a build.
+fn run_and_filter(root: &Path, cb_ids: &[u32]) {
+    let binary = option_env!("CARGO_BIN_EXE_pmat").unwrap_or("pmat");
+    let out = Command::new(binary)
+        .args(["comply", "check", "-p"])
+        .arg(root)
+        .args(["-f", "text"])
+        .output();
+
+    let output = match out {
+        Ok(o) => o,
+        Err(e) => {
+            println!("  (pmat not found on PATH: {e}; skipping run)");
+            return;
+        }
+    };
+    println!("  exit status: {}", output.status);
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    let targets: Vec<String> = cb_ids.iter().map(|n| format!("CB-{}:", n)).collect();
+    let rows: Vec<&str> = stdout
+        .lines()
+        .chain(stderr.lines())
+        .filter(|l| targets.iter().any(|t| l.contains(t)))
+        .collect();
+    if rows.is_empty() {
+        println!("  (no matching CB rows — likely a pmat build predating PR #302)");
+    } else {
+        for line in rows {
+            println!("    {}", line.trim_start());
+        }
+    }
+}
+
+fn print_notes() {
+    println!(
+        "\
+The downgrade ledger is the narrow audit surface for every verification-level
+regression. CB-1617 and CB-1618 divide its enforcement:
+
+  CB-1617  ledger entry well-formed       → every `reason` non-empty
+  CB-1618  ledger entry present per ticket → regressions are audited
+
+Together they form a ratchet: once a ticket has climbed to L4, any slide back
+down to L2 requires a ledger row with a human-readable explanation. Silent
+regressions (no entry OR empty reason) fail the gate.
+
+Related surfaces:
+
+  .pmat-work/<ID>/checkpoints/*.json  — the per-ticket timeline CB-1618 reads
+  .pmat-work/ledger/downgrades.json   — the audit trail CB-1617 validates
+  .pmat-work/ledger/unbinds.json      — CB-1602 chain-of-custody for unbinds
+  .pmat-work/ledger/roster-mutations.json — CB-1624 audit for manual deletes
+
+Fix pattern when CB-1618 fires: add a row to downgrades.json with a real
+`reason`, then re-run `pmat comply check` — both checks should flip to Pass.
+Never blank the reason to appease the gate — CB-1617 will still flag it.
+"
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn main_runs() {
+        super::main();
+    }
+}


### PR DESCRIPTION
## Summary

Three standalone runnable examples covering CB-16xx compliance checks NOT already exercised by PR #304 (`comply_cb16xx`) or PR #325 (ladder + drift + unbind triptych).

- **`examples/cb16xx_downgrade_monotonicity.rs`** — five-phase Skip → Pass → Fail → Pass → Fail demo of CB-1617 (downgrade reason audit) and CB-1618 (per-ticket checkpoint level monotonicity) working in tandem on `.pmat-work/AUDIT-001/`.
- **`examples/cb16xx_derived_yaml_obligations.rs`** — five-phase demo of CB-1645 (derived `contracts/work/<ID>.yaml` must mirror `contract.json`'s `require` / `ensure`). Walks Skip (no tickets) → Skip (no clauses) → Fail (missing derived) → Pass (matching YAML) → Fail (stale after contract edit).
- **`examples/cb16xx_completion_target.rs`** — three-phase demo of CB-1619 (on completion, `achieved_level` must equal `target_level`). Three tickets go from Skip → Pass → Fail after mutating `COMPLETE-003` to report a silent L4→L2 downgrade.

All examples self-contained via `tempfile::tempdir()`, use the `option_env!("CARGO_BIN_EXE_pmat").unwrap_or("pmat")` subprocess pattern established by PR #304, and are documentation-first — semantic notes at the tail of each example print even when `pmat` isn't on PATH.

## Test plan

- [x] `cargo build --examples` — clean (no warnings)
- [x] `cargo fmt --check` — clean
- [x] `cargo run --example cb16xx_downgrade_monotonicity` — all 5 phases produce expected Skip/Pass/Fail rows matching `pmat comply check` output
- [x] `cargo run --example cb16xx_derived_yaml_obligations` — all 5 phases produce expected rows; derivation stale-drift path exercised
- [x] `cargo run --example cb16xx_completion_target` — all 3 phases correct; silent-downgrade detection verified

Example run excerpts (downgrade+monotonicity):

```
── Phase 2: monotonic L1 → L3 → L4 (CB-1618 Pass, CB-1617 Skip) ──
    - CB-1617: Downgrade Reason Audit: No downgrade ledger at .pmat-work/ledger/downgrades.json
    ✓ CB-1618: Level Monotonicity: 1 ticket(s) monotonic across checkpoints
── Phase 3: regress L4 → L2 without ledger (CB-1618 Fail) ──
    ✗ CB-1618: Level Monotonicity: 1 ticket(s) regressed without audit:
── Phase 4: add ledger entry with reason (both Pass) ──
    ✓ CB-1617: Downgrade Reason Audit: 1 downgrade(s) carry a recorded reason
    ✓ CB-1618: Level Monotonicity: 1 ticket(s) monotonic across checkpoints
── Phase 5: blank the ledger reason (CB-1617 Fail) ──
    ✗ CB-1617: Downgrade Reason Audit: 1 downgrade(s) lack a `reason`:
```

## Coverage (CB-16xx checks now exercised by runnable examples)

After this PR merges, the runnable-example coverage of CB-16xx becomes:

| CB | Check | Example |
|----|-------|---------|
| CB-1610..1616 | L0..L5 ladder | `cb16xx_ladder_walkthrough.rs` (PR #325) |
| CB-1615 | Kani harness SHA drift | `cb16xx_drift_detection.rs` (PR #325) |
| CB-1617 | Downgrade reason audit | `cb16xx_downgrade_monotonicity.rs` (this PR) |
| CB-1618 | Level monotonicity | `cb16xx_downgrade_monotonicity.rs` (this PR) |
| CB-1619 | Achieved == target | `cb16xx_completion_target.rs` (this PR) |
| CB-1621 | ProvableContract expected drift | `cb16xx_drift_detection.rs` (PR #325) |
| CB-1624 | Manual-deletion audit | `cb16xx_unbind_ledger.rs` (PR #325) |
| CB-1645 | Derived YAML obligations | `cb16xx_derived_yaml_obligations.rs` (this PR) |

Branch is published as `docs/cb16xx-examples-round2-b` (the un-suffixed name was already taken by an unrelated remote tip).

Robot Generated with [Claude Code](https://claude.com/claude-code)