### PR TITLE
chore(deps): pmcp 1.10 → 2.3 upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -362,7 +362,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a8b66b44e8f05dee829f5a9bd2140b58c73fe7d32099b9312fb116144ba5ab"
 dependencies = [
  "apr-cli",
- "aprender-core 0.29.3",
+ "aprender-core 0.30.0",
 ]
 
 [[package]]
@@ -482,7 +482,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml_ng",
- "sha2",
+ "sha2 0.10.9",
  "tempfile",
  "trueno 0.17.0",
  "trueno-quant",
@@ -698,7 +698,7 @@ dependencies = [
  "rmp-serde",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "static_assertions",
  "thiserror 2.0.18",
  "tokio",
@@ -818,7 +818,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "serde_yaml_ng",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 2.0.18",
  "toml 0.8.23",
  "trueno 0.17.0",
@@ -1745,6 +1745,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2024,7 +2033,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.6",
  "inout",
 ]
 
@@ -2252,6 +2261,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "const-random"
@@ -2529,6 +2544,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "csv"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2569,7 +2593,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -2709,7 +2733,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -2810,10 +2834,21 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.6",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.1",
 ]
 
 [[package]]
@@ -2909,7 +2944,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -2936,7 +2971,7 @@ dependencies = [
  "ed25519",
  "rand_core 0.6.4",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -2955,7 +2990,7 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
@@ -3030,7 +3065,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "serde_yaml_ng",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 2.0.18",
  "toml 0.8.23",
  "trueno 0.17.0",
@@ -4024,7 +4059,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -4148,6 +4183,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7"
 dependencies = [
  "libm",
+]
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+dependencies = [
+ "typenum",
 ]
 
 [[package]]
@@ -4703,7 +4747,7 @@ dependencies = [
  "rsa",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "signature",
  "simple_asn1",
 ]
@@ -5131,7 +5175,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -5925,7 +5969,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -5937,7 +5981,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -6083,7 +6127,7 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "hmac",
 ]
 
@@ -6369,7 +6413,7 @@ dependencies = [
  "serde_json",
  "serde_yaml_ng",
  "serial_test",
- "sha2",
+ "sha2 0.10.9",
  "shell-words",
  "sourcemap",
  "swc_common",
@@ -6431,9 +6475,9 @@ dependencies = [
 
 [[package]]
 name = "pmcp"
-version = "1.20.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f05b254860781fb855f89676afdc1b682cfb71e5c3d3696ab5724033df213b"
+checksum = "55682be7f9bc2e1603f560279c83551b5ae3bf614a3c39042b8b4f156ffaa9fd"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6460,12 +6504,12 @@ dependencies = [
  "reqwest 0.13.2",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "smallvec",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
- "tokio-tungstenite 0.28.0",
+ "tokio-tungstenite 0.29.0",
  "tokio-util",
  "toml 1.1.2+spec-1.1.0",
  "tracing",
@@ -7473,8 +7517,8 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "const-oid",
- "digest",
+ "const-oid 0.9.6",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
@@ -7525,7 +7569,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "sha2",
+ "sha2 0.10.9",
  "signal-hook",
  "smallvec",
  "syn 2.0.117",
@@ -8071,7 +8115,7 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -8082,7 +8126,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -8143,7 +8198,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -8233,7 +8288,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -8945,14 +9000,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
 dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite 0.28.0",
+ "tungstenite 0.29.0",
 ]
 
 [[package]]
@@ -9619,9 +9674,9 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
 dependencies = [
  "bytes",
  "data-encoding",
@@ -9631,7 +9686,6 @@ dependencies = [
  "rand 0.9.4",
  "sha1",
  "thiserror 2.0.18",
- "utf-8",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,7 @@ minijinja = { version = "2.16", default-features = false, optional = true }
 
 # MCP SDK - now core dependency for MCP server functionality
 # Sprint 46 Phase 4: Switched from "full" to explicit features (saves 150-250 KB)
-pmcp = { version = "1.10", features = ["websocket", "http", "sse", "validation"] }
+pmcp = { version = "2.3", features = ["websocket", "http", "sse", "validation"] }
 
 # Caching
 lru = { version = "0.16", features = ["hashbrown"], optional = true }

--- a/src/mcp_pmcp/server.rs
+++ b/src/mcp_pmcp/server.rs
@@ -14,7 +14,7 @@ use crate::mcp_pmcp::tdg_handlers::{
     TdgPerformanceMetricsTool, TdgStorageManagementTool, TdgSystemDiagnosticsTool,
 };
 use crate::mcp_server::state_manager::StateManager;
-use pmcp::{Server, ServerCapabilities, ToolCapabilities};
+use pmcp::{Server, ServerCapabilities};
 use std::sync::Arc;
 use tokio::sync::Mutex;
 use tracing::info;
@@ -104,10 +104,7 @@ impl PmcpServer {
         let server = Server::builder()
             .name("paiml-mcp-agent-toolkit")
             .version(env!("CARGO_PKG_VERSION"))
-            .capabilities(ServerCapabilities {
-                tools: Some(ToolCapabilities { list_changed: None }),
-                ..Default::default()
-            })
+            .capabilities(ServerCapabilities::tools_only())
             // Analysis tools
             .tool("analyze_complexity", AnalyzeComplexityTool)
             .tool("analyze_satd", AnalyzeSatdTool)

--- a/src/mcp_pmcp/simple_unified_server.rs
+++ b/src/mcp_pmcp/simple_unified_server.rs
@@ -14,7 +14,7 @@ use crate::mcp_pmcp::pdmt_handler::PdmtTool;
 use crate::mcp_pmcp::quality_handlers::QualityGateTool;
 use crate::mcp_pmcp::quality_proxy_handler::QualityProxyTool;
 use crate::mcp_server::state_manager::StateManager;
-use pmcp::{Server, ServerCapabilities, ToolCapabilities};
+use pmcp::{Server, ServerCapabilities};
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::Mutex;
@@ -51,10 +51,7 @@ impl SimpleUnifiedServer {
         let server = Server::builder()
             .name("paiml-mcp-agent-toolkit")
             .version(env!("CARGO_PKG_VERSION"))
-            .capabilities(ServerCapabilities {
-                tools: Some(ToolCapabilities { list_changed: None }),
-                ..Default::default()
-            })
+            .capabilities(ServerCapabilities::tools_only())
             // === Core Analysis Tools (6) ===
             .tool("analyze_complexity", AnalyzeComplexityTool)
             .tool("analyze_satd", AnalyzeSatdTool)
@@ -307,10 +304,7 @@ mod coverage_tests {
         let builder = Server::builder()
             .name("test-server")
             .version("0.1.0")
-            .capabilities(ServerCapabilities {
-                tools: Some(ToolCapabilities { list_changed: None }),
-                ..Default::default()
-            });
+            .capabilities(ServerCapabilities::tools_only());
 
         // Builder should be valid
         let _ = builder;
@@ -385,15 +379,9 @@ mod coverage_tests {
 
     #[test]
     fn test_server_capabilities_structure() {
-        let capabilities = ServerCapabilities {
-            tools: Some(ToolCapabilities { list_changed: None }),
-            ..Default::default()
-        };
+        let capabilities = ServerCapabilities::tools_only();
 
-        // Verify tools capability is set
         assert!(capabilities.tools.is_some());
-
-        // Verify list_changed is None (we don't use it)
         assert!(capabilities.tools.as_ref().unwrap().list_changed.is_none());
     }
 


### PR DESCRIPTION
## Summary

Upgrade `pmcp` from 1.10 → 2.3.0 (latest crates.io) to pick up MCP 2024-11-05 conformance work and stay on the sovereign stack head.

## Breaking change migration

pmcp 2.x marks `ServerCapabilities` and `ToolCapabilities` as `#[non_exhaustive]`, which prohibits struct-expression construction from outside the defining crate (E0639). Replaced all 4 sites with `ServerCapabilities::tools_only()` — the idiomatic pmcp 2.x constructor that is both shorter and clearer than the previous `ServerCapabilities { tools: Some(ToolCapabilities { list_changed: None }), ..Default::default() }` incantation.

Files changed:
- `server/Cargo.toml` — bump `pmcp = "1.10"` → `"2.3"`
- `server/src/mcp_pmcp/server.rs` — use `tools_only()`
- `server/src/mcp_pmcp/simple_unified_server.rs` — 3 sites use `tools_only()` (impl + 2 tests)

## Test plan

- [x] `cargo check --package pmat --lib` passes
- [ ] `cargo test --package pmat --lib mcp_pmcp` passes
- [ ] MCP stdio smoke: `echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{…}}' | pmat` returns protocol version 2024-11-05
- [ ] Full `make test-lib` green

## Related

- Defects (unchanged by this PR — filed separately in #339): analyze_complexity / analyze_satd return zero, analyze_big_o mislabeled, empty inputSchemas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
