### PR TITLE
feat(examples): Claude Code 3.7 integration (R5)

### DIFF
--- a/examples/claude_code_hooks.rs
+++ b/examples/claude_code_hooks.rs
@@ -1,0 +1,182 @@
+//! Claude Code 3.7 Hooks Integration — `.claude/settings.json` skeleton
+//!
+//! This example demonstrates the R5 agent-ecosystem integration pattern:
+//! generating a Claude Code project `settings.json` that wires a `PreToolUse`
+//! hook to invoke `pmat comply check` before any `git push` escapes the
+//! session. Hooks execute in the Claude Code harness (not the model), so they
+//! enforce quality gates deterministically even if the model would otherwise
+//! skip them.
+//!
+//! Reference: `.bench-results/claude-code-integration.md` recommendation #5.
+//!
+//! Run with: `cargo run --example claude_code_hooks`
+//!
+//! # What this example does
+//!
+//! 1. Builds a JSON object that wires `PreToolUse` with matcher
+//!    `Bash(git push *)` to `pmat comply check`.
+//! 2. Pretty-prints the JSON so it can be written directly to
+//!    `.claude/settings.json`.
+//! 3. Adds permissions + env defaults that complement the hook.
+//!
+//! Dependencies: only `serde_json` (already in `[dependencies]`).
+//!
+//! # Related CLI
+//!
+//! ```bash
+//! pmat comply check              # Run the same gate locally
+//! pmat comply check --format json
+//! ```
+
+use serde_json::{json, Value};
+
+fn main() {
+    println!("=== Claude Code 3.7 settings.json Skeleton ===\n");
+
+    let settings = build_settings();
+    let pretty =
+        serde_json::to_string_pretty(&settings).expect("settings construction is infallible");
+
+    println!("# Emitted .claude/settings.json\n");
+    println!("{}", "-".repeat(60));
+    println!("{pretty}");
+    println!("{}", "-".repeat(60));
+
+    println!("\nHook behaviour:");
+    println!("  - Fires before the harness runs any `git push *` bash command.");
+    println!("  - Executes `pmat comply check` with a 30s timeout.");
+    println!("  - Exit code != 0 blocks the push; stdout is surfaced to the model.");
+    println!("  - Bypass for one-off emergencies: `git push --no-verify` is NOT a bypass");
+    println!("    for harness hooks — use the Claude Code `--skip-hooks` runtime flag.");
+
+    println!("\nTo install:");
+    println!("  mkdir -p .claude");
+    println!("  cargo run --example claude_code_hooks > .claude/settings.json");
+    println!("  # (strip the explanatory output above before saving)");
+}
+
+/// Build a `.claude/settings.json` with a `PreToolUse` compliance gate.
+fn build_settings() -> Value {
+    json!({
+        "version": 1,
+        "permissions": {
+            "allow": [
+                "Bash(pmat *)",
+                "Bash(cargo test *)",
+                "Bash(cargo check *)",
+                "pmat_query_code",
+                "pmat_get_function",
+                "pmat_find_similar"
+            ],
+            "deny": [
+                "Bash(rm -rf *)",
+                "Bash(git push --force *)"
+            ]
+        },
+        "env": {
+            "PMAT_MIN_GRADE": "B",
+            "PMAT_COVERAGE_MIN": "90",
+            "PMAT_FAIL_ON_CONTRADICTION": "1"
+        },
+        "hooks": {
+            "PreToolUse": [
+                {
+                    "matcher": "Bash(git push *)",
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": "pmat comply check",
+                            "timeout": 30,
+                            "blockOnFailure": true,
+                            "description": "Block pushes when the repo is non-compliant (CB-16xx)."
+                        }
+                    ]
+                },
+                {
+                    "matcher": "Bash(git commit *)",
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": "pmat query --faults --exclude-tests --limit 5",
+                            "timeout": 10,
+                            "blockOnFailure": false,
+                            "description": "Advisory: surface fault patterns before each commit."
+                        }
+                    ]
+                }
+            ],
+            "PostToolUse": [
+                {
+                    "matcher": "Bash(pmat work start *)",
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": "pmat comply check --format json",
+                            "timeout": 15,
+                            "blockOnFailure": false,
+                            "description": "Record baseline compliance at the start of a pmat work ticket."
+                        }
+                    ]
+                }
+            ]
+        },
+        "allowManagedHooksOnly": true,
+        "channelsEnabled": false,
+        "disableSkillShellExecution": false
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn settings_has_prepush_hook() {
+        let settings = build_settings();
+        let hooks = settings
+            .pointer("/hooks/PreToolUse")
+            .and_then(Value::as_array)
+            .expect("PreToolUse must be an array");
+        let pushes_blocked = hooks
+            .iter()
+            .any(|h| h.get("matcher").and_then(Value::as_str) == Some("Bash(git push *)"));
+        assert!(pushes_blocked, "git push must be gated");
+    }
+
+    #[test]
+    fn settings_invokes_pmat_comply() {
+        let settings = build_settings();
+        let text = serde_json::to_string(&settings).unwrap();
+        assert!(text.contains("pmat comply check"));
+    }
+
+    #[test]
+    fn settings_is_serialisable_pretty() {
+        let settings = build_settings();
+        let pretty = serde_json::to_string_pretty(&settings).unwrap();
+        assert!(pretty.contains("\"version\": 1"));
+        assert!(pretty.contains("PreToolUse"));
+    }
+
+    #[test]
+    fn settings_allowlist_includes_pmat() {
+        let settings = build_settings();
+        let allow = settings
+            .pointer("/permissions/allow")
+            .and_then(Value::as_array)
+            .expect("permissions.allow must be an array");
+        assert!(allow.iter().any(|v| v.as_str() == Some("Bash(pmat *)")));
+    }
+
+    #[test]
+    fn settings_denies_force_push() {
+        let settings = build_settings();
+        let deny = settings
+            .pointer("/permissions/deny")
+            .and_then(Value::as_array)
+            .expect("permissions.deny must be an array");
+        assert!(deny
+            .iter()
+            .any(|v| v.as_str() == Some("Bash(git push --force *)")));
+    }
+}

--- a/examples/claude_code_skill.rs
+++ b/examples/claude_code_skill.rs
@@ -1,0 +1,191 @@
+//! Claude Code 3.7 Skill Integration — `.claude/skills/pmat-coverage/SKILL.md`
+//!
+//! This example demonstrates the R5 agent-ecosystem integration pattern:
+//! generating a Claude Code *skill* file that wraps `pmat query --coverage-gaps`
+//! as a single-keystroke workflow. Claude Code skills live under
+//! `.claude/skills/<name>/SKILL.md` and combine YAML frontmatter with a markdown
+//! body the model consults when the skill name is invoked (`/pmat-coverage`).
+//!
+//! Reference: `.bench-results/claude-code-integration.md` recommendation #3.
+//!
+//! Run with: `cargo run --example claude_code_skill`
+//!
+//! # What this example does
+//!
+//! 1. Programmatically builds a complete SKILL.md payload (frontmatter + body)
+//!    and prints it to stdout — copy-paste into `.claude/skills/pmat-coverage/SKILL.md`.
+//! 2. Parses a sample in-memory SKILL.md and extracts the YAML frontmatter,
+//!    demonstrating the round-trip shape Claude Code expects.
+//!
+//! No new dependencies: uses `std` + a hand-rolled minimal YAML emitter (the
+//! frontmatter surface is small and fixed).
+//!
+//! # Related CLI
+//!
+//! ```bash
+//! pmat query --coverage-gaps --rank-by impact --limit 20
+//! pmat query --coverage-gaps --limit 30 --exclude-tests
+//! ```
+
+use std::collections::BTreeMap;
+
+fn main() {
+    println!("=== Claude Code 3.7 Skill Generator: pmat-coverage ===\n");
+
+    // Example 1: Generate SKILL.md from scratch
+    println!("# Example 1: Emitted .claude/skills/pmat-coverage/SKILL.md\n");
+    println!("{}", "-".repeat(60));
+    let skill_md = build_coverage_skill();
+    println!("{skill_md}");
+    println!("{}", "-".repeat(60));
+
+    // Example 2: Parse a sample SKILL.md and dump its frontmatter keys
+    println!("\n# Example 2: Parse existing SKILL.md frontmatter\n");
+    println!("{}", "-".repeat(60));
+    let sample = sample_existing_skill();
+    let frontmatter = parse_frontmatter(&sample);
+    for (k, v) in &frontmatter {
+        println!("  {k}: {v}");
+    }
+    println!("{}", "-".repeat(60));
+
+    println!("\nTo install:");
+    println!("  mkdir -p .claude/skills/pmat-coverage");
+    println!("  cargo run --example claude_code_skill > .claude/skills/pmat-coverage/SKILL.md");
+    println!("  # (strip the Example 2 section before saving)");
+}
+
+/// Build a complete SKILL.md for the pmat-coverage skill.
+fn build_coverage_skill() -> String {
+    let mut fm: BTreeMap<&str, String> = BTreeMap::new();
+    fm.insert("name", "pmat-coverage".to_string());
+    fm.insert(
+        "description",
+        "Rank uncovered functions by ROI impact using pmat query --coverage-gaps".to_string(),
+    );
+    fm.insert("disable-model-invocation", "true".to_string());
+    fm.insert("effort", "low".to_string());
+    fm.insert("context", "fork".to_string());
+    fm.insert(
+        "allowed-tools",
+        "[Bash(pmat query *), pmat_query_code]".to_string(),
+    );
+    fm.insert("paths", "[server/src/**]".to_string());
+
+    let body = r#"
+# pmat-coverage
+
+Find uncovered functions in the current workspace ranked by impact score
+(missed_lines * pagerank / complexity). Returns the top 20 highest-ROI
+targets so the next test-writing loop spends effort where it matters most.
+
+## Workflow
+
+1. Invoke `pmat query --coverage-gaps --rank-by impact --limit 20` to
+   materialise the gap list.
+2. For each candidate, re-run `pmat query "<function>" --include-source --limit 1`
+   to pull the full body (never use `cat`/`grep` — quality context is lost).
+3. Write tests targeting uncovered lines, re-run the skill to verify deltas.
+
+## Live Command
+
+!`pmat query --coverage-gaps --rank-by impact --limit 20`
+
+## Notes
+
+- `disable-model-invocation: true` keeps this deterministic — the shell
+  command is executed by the Claude Code harness, not paraphrased.
+- Requires an up-to-date coverage profile (`make coverage`) and
+  `.pmat/context.db` (auto-built on first `pmat query`).
+- To narrow scope, restrict via `--exclude-tests` or `pmat query
+  "<concept>" --coverage --uncovered-only`.
+"#;
+
+    render_skill(&fm, body.trim_start())
+}
+
+/// Render a SKILL.md as `---\n<yaml>\n---\n\n<body>`.
+fn render_skill(frontmatter: &BTreeMap<&str, String>, body: &str) -> String {
+    let mut out = String::from("---\n");
+    for (k, v) in frontmatter {
+        // Keep the emitter intentionally tiny — all values are short
+        // scalars or inline flow sequences. No multi-line scalars used.
+        out.push_str(k);
+        out.push_str(": ");
+        out.push_str(v);
+        out.push('\n');
+    }
+    out.push_str("---\n\n");
+    out.push_str(body);
+    out
+}
+
+/// A representative SKILL.md as the harness would emit it, for Example 2.
+fn sample_existing_skill() -> String {
+    String::from(
+        "---\n\
+         name: pmat-faults\n\
+         description: Surface unwrap/panic/unsafe fault patterns via pmat query --faults\n\
+         disable-model-invocation: true\n\
+         allowed-tools: [Bash(pmat query *)]\n\
+         ---\n\
+         \n\
+         # pmat-faults\n\
+         \n\
+         Runs `pmat query --faults --exclude-tests --limit 30` to surface\n\
+         mutation-testing targets and boundary conditions.\n",
+    )
+}
+
+/// Extract YAML frontmatter from a SKILL.md. Returns `key -> value` pairs
+/// preserving insertion order (BTreeMap = alphabetical for display clarity).
+fn parse_frontmatter(md: &str) -> BTreeMap<String, String> {
+    let mut out = BTreeMap::new();
+    let trimmed = md.trim_start();
+    if !trimmed.starts_with("---") {
+        return out;
+    }
+    let after_first = &trimmed[3..].trim_start_matches('\n');
+    let Some(end) = after_first.find("\n---") else {
+        return out;
+    };
+    let yaml = &after_first[..end];
+    for line in yaml.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        if let Some((k, v)) = line.split_once(':') {
+            out.insert(k.trim().to_string(), v.trim().to_string());
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn skill_has_frontmatter_markers() {
+        let md = build_coverage_skill();
+        assert!(md.starts_with("---\n"));
+        assert!(md.contains("\n---\n\n"));
+        assert!(md.contains("pmat query --coverage-gaps"));
+        assert!(md.contains("disable-model-invocation: true"));
+    }
+
+    #[test]
+    fn round_trip_parse() {
+        let md = build_coverage_skill();
+        let fm = parse_frontmatter(&md);
+        assert_eq!(fm.get("name").map(String::as_str), Some("pmat-coverage"));
+        assert!(fm.contains_key("allowed-tools"));
+    }
+
+    #[test]
+    fn sample_parse_recovers_keys() {
+        let fm = parse_frontmatter(&sample_existing_skill());
+        assert_eq!(fm.get("name").map(String::as_str), Some("pmat-faults"));
+    }
+}

--- a/examples/claude_code_subagent.rs
+++ b/examples/claude_code_subagent.rs
@@ -1,0 +1,189 @@
+//! Claude Code 3.7 Subagent Integration — `.claude/agents/code-quality.md`
+//!
+//! This example demonstrates the R5 agent-ecosystem integration pattern:
+//! generating a Claude Code *subagent* manifest scoped to pmat-driven code
+//! quality reviews. Subagents isolate context (sparse worktrees + tool
+//! whitelists) so the parent session can delegate audits without pulling in
+//! the full repo or losing token budget to transcript churn.
+//!
+//! Reference: `.bench-results/claude-code-integration.md` recommendation #1.
+//!
+//! Run with: `cargo run --example claude_code_subagent`
+//!
+//! # What this example does
+//!
+//! 1. Builds a complete `.claude/agents/code-quality.md` (frontmatter + body).
+//! 2. Shows a `worktree.sparsePaths` allowlist limited to `server/src/**` so
+//!    the subagent only sees production code.
+//! 3. Demonstrates the tools whitelist: `Bash(pmat *)`, `pmat_query_code`,
+//!    `pmat_get_function` — all other tools (including network, shell
+//!    escapes) are denied by default.
+//!
+//! No new dependencies — pure `std` string construction.
+//!
+//! # Related reading
+//!
+//! - Claude Code 3.7 subagent spec: sparse worktrees, `@mention` typeahead,
+//!   `initialPrompt`, model pinning.
+//! - pmat MCP tools: `pmat_query_code`, `pmat_get_function`,
+//!   `pmat_find_similar`, `pmat_index_stats`.
+
+fn main() {
+    println!("=== Claude Code 3.7 Subagent Generator: code-quality ===\n");
+
+    println!("# Emitted .claude/agents/code-quality.md\n");
+    println!("{}", "-".repeat(60));
+    println!("{}", build_code_quality_subagent());
+    println!("{}", "-".repeat(60));
+
+    println!("\nWhy this shape?");
+    for note in rationale() {
+        println!("  - {note}");
+    }
+
+    println!("\nTo install:");
+    println!("  mkdir -p .claude/agents");
+    println!("  cargo run --example claude_code_subagent > .claude/agents/code-quality.md");
+    println!("  # (trim the trailing 'Why this shape?' section before saving)");
+}
+
+/// Build a complete subagent manifest scoped to pmat-driven code review.
+fn build_code_quality_subagent() -> String {
+    let frontmatter = r#"---
+name: code-quality
+description: Audit code for defects, coverage gaps, and quality violations using pmat. Delegates reviews without flooding parent context.
+model: claude-haiku-4
+initialPrompt: |
+  You are a code-quality auditor. Use pmat_query_code and `pmat query` to
+  surface fault patterns, coverage gaps, and complexity hotspots. Report
+  findings as a short bulleted list with file:line refs — never dump full
+  function bodies unless explicitly asked.
+worktree:
+  sparsePaths:
+    - server/src/**
+    - Cargo.toml
+    - .pmat/context.db
+  fetch: lazy
+tools:
+  allow:
+    - Bash(pmat *)
+    - Bash(cargo test *)
+    - pmat_query_code
+    - pmat_get_function
+    - pmat_find_similar
+    - pmat_index_stats
+  deny:
+    - Bash(git push *)
+    - Bash(cargo publish *)
+    - Bash(rm *)
+    - WebFetch
+    - WebSearch
+env:
+  PMAT_MIN_GRADE: B
+  PMAT_COVERAGE_MIN: "90"
+---"#;
+
+    let body = r#"
+# code-quality subagent
+
+Context-isolated auditor for pmat-managed Rust repos. Use this subagent to
+delegate review tasks so the parent session keeps a small context window.
+
+## Canonical workflows
+
+### 1. Fault-pattern sweep
+
+```bash
+pmat query --faults --exclude-tests --limit 30
+```
+
+Returns functions with `unwrap()`, `panic!`, `unsafe`, or other fault
+markers. Use as a mutation-testing or hardening backlog.
+
+### 2. Coverage-gap triage
+
+```bash
+pmat query --coverage-gaps --rank-by impact --limit 20
+```
+
+Sorts uncovered functions by ROI (missed_lines * pagerank / complexity).
+Top entries are the highest-leverage test targets.
+
+### 3. Hot-spot detection
+
+```bash
+pmat query "error handling" --churn --duplicates --min-grade C
+```
+
+Finds volatile + duplicated + low-grade code — prime refactor candidates.
+
+## Output contract
+
+- Always cite `file:line` for every finding.
+- Never dump function bodies larger than 40 lines; link to
+  `pmat query "<name>" --include-source --limit 1` instead.
+- If a batch returns 0 results, say so explicitly — silence is ambiguous.
+
+## Escalation
+
+If a finding blocks `make lint`, `cargo test`, or `pmat comply check`, raise
+it to the parent session via `@mention` rather than attempting autonomous
+fixes. Hard write operations (commits, pushes, publishes) are denied by
+policy — the parent session owns state mutations.
+"#;
+
+    format!("{frontmatter}\n{body}", body = body.trim_start())
+}
+
+/// Short rationale bullets explaining the trade-offs of each frontmatter
+/// field — useful for reviewers unfamiliar with Claude Code 3.7 internals.
+fn rationale() -> Vec<&'static str> {
+    vec![
+        "model: claude-haiku-4 — audits rarely need deep reasoning; Haiku is ~5x cheaper.",
+        "worktree.sparsePaths limits what the subagent checks out to server/src/** + Cargo.toml.",
+        "fetch: lazy defers file content reads until a tool actually references them.",
+        "tools.allow restricts the subagent to pmat + cargo-test + read-only MCP tools.",
+        "tools.deny explicitly blocks git push / cargo publish / rm so reviews cannot mutate.",
+        "env injects PMAT_MIN_GRADE and PMAT_COVERAGE_MIN so thresholds are discoverable.",
+        "initialPrompt sets output-contract expectations before the first user message.",
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn manifest_has_frontmatter() {
+        let md = build_code_quality_subagent();
+        assert!(md.starts_with("---\n"));
+        assert!(md.contains("\n---\n"));
+    }
+
+    #[test]
+    fn manifest_whitelists_pmat_tools() {
+        let md = build_code_quality_subagent();
+        assert!(md.contains("Bash(pmat *)"));
+        assert!(md.contains("pmat_query_code"));
+        assert!(md.contains("pmat_get_function"));
+    }
+
+    #[test]
+    fn manifest_restricts_worktree() {
+        let md = build_code_quality_subagent();
+        assert!(md.contains("sparsePaths"));
+        assert!(md.contains("server/src/**"));
+    }
+
+    #[test]
+    fn manifest_denies_destructive_ops() {
+        let md = build_code_quality_subagent();
+        assert!(md.contains("Bash(git push *)"));
+        assert!(md.contains("Bash(cargo publish *)"));
+    }
+
+    #[test]
+    fn rationale_is_non_empty() {
+        assert!(!rationale().is_empty());
+    }
+}


### PR DESCRIPTION
## Summary

Round 5 (R5) agent-ecosystem integration examples — three standalone `cargo run --example` demos wiring pmat into Claude Code 3.7's skill / subagent / hook surfaces. R2 covered CLI basics and R4 covered MCP walkthroughs; this round shows how pmat slots into the agent runtime itself.

Each example emits a ready-to-copy config artefact to stdout:

- `examples/claude_code_skill.rs` → `.claude/skills/pmat-coverage/SKILL.md` with frontmatter + body calling `pmat query --coverage-gaps --rank-by impact --limit 20`. Also demonstrates parsing an existing SKILL.md and extracting its YAML frontmatter.
- `examples/claude_code_subagent.rs` → `.claude/agents/code-quality.md` subagent manifest with `worktree.sparsePaths` scoped to `server/src/**` and a tools whitelist of `Bash(pmat *)` + `pmat_query_code` + `pmat_get_function`. Destructive ops (`git push`, `cargo publish`, `rm`) are explicitly denied.
- `examples/claude_code_hooks.rs` → `.claude/settings.json` skeleton wiring a `PreToolUse` hook with matcher `Bash(git push *)` to `pmat comply check`, so non-compliant pushes are blocked deterministically by the harness (not by the model).

Reference: `.bench-results/claude-code-integration.md` recommendations #1 (subagent), #3 (skill), #5 (hook).

## Implementation notes

- Zero new dependencies — pure `std` + existing `serde_json`.
- Each file carries unit tests covering the emitted shape (frontmatter markers, allowlist/denylist contents, JSON structure invariants).
- All three pass `cargo check --example <name>` in the worktree.

## Test plan

- [x] `cargo check --example claude_code_skill` (passes)
- [x] `cargo check --example claude_code_subagent` (passes)
- [x] `cargo check --example claude_code_hooks` (passes)
- [x] `cargo run --example <each>` produces copy-pasteable config
- [x] `cargo fmt` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)