### PR TITLE
feat(examples): R6 contract/FALSIFY test harnesses (3 new)

### DIFF
--- a/examples/exit_code_contract.rs
+++ b/examples/exit_code_contract.rs
@@ -1,0 +1,150 @@
+//! Exit-Code Contract Harness (R6)
+//!
+//! Programmatic test that asserts `pmat <subcmd>` exits with the CORRECT
+//! exit code on invalid input. Covers three known bugs from the R-round
+//! issue triage:
+//!
+//!   - D25 (issue #333): `pmat split` with no arg must exit non-zero
+//!   - D26 (issue #336): `pmat predict-quality` with no arg must exit non-zero
+//!   - D35 (issue #339): `pmat roadmap list` unrecognized subcommand must
+//!     exit non-zero
+//!
+//! The CLI contract for clap-based binaries is: missing required args or
+//! unrecognized subcommands must exit with code 2 (standard clap behavior).
+//! Any exit code == 0 on these invalid inputs is a FALSIFY target.
+//!
+//! Run with: `cargo run --example exit_code_contract`
+//!
+//! # Exit-Code Convention
+//!
+//! - `0` : success — NEVER acceptable here; every case is invalid input
+//! - `1` : generic runtime error
+//! - `2` : clap usage error (missing arg, unknown subcommand) — EXPECTED
+//!
+//! Cases printed `FAIL` when the observed exit code is 0 on invalid input.
+//! Otherwise `PASS` — any non-zero exit is treated as contract-respecting.
+//!
+//! # Reproduction
+//!
+//! This harness uses `option_env!("CARGO_BIN_EXE_pmat")` so the example
+//! runs against the freshly built workspace binary when executed via
+//! `cargo run --example`. It falls back to the `pmat` on `PATH` when the
+//! env var is unset (e.g. when the example is compiled outside of cargo).
+//!
+//! # Isolation
+//!
+//! Each invocation runs inside a throwaway directory from `tempfile::tempdir()`
+//! so local `.pmat/` state or project context does not perturb the result.
+
+use std::process::Command;
+
+/// Resolve the pmat binary. Cargo sets `CARGO_BIN_EXE_pmat` for the main
+/// binary at example compile time. If unset we fall back to the PATH.
+fn pmat_bin() -> &'static str {
+    option_env!("CARGO_BIN_EXE_pmat").unwrap_or("pmat")
+}
+
+/// A single exit-code contract case.
+struct Case {
+    id: &'static str,
+    issue: &'static str,
+    args: &'static [&'static str],
+    /// Acceptable exit codes (non-empty). Typically `&[2]` for clap usage errors.
+    /// We also accept anything non-zero to stay robust across clap versions.
+    expected_nonzero: bool,
+}
+
+impl Case {
+    fn run(&self, bin: &str, cwd: &std::path::Path) -> (i32, bool) {
+        let out = Command::new(bin)
+            .args(self.args)
+            .current_dir(cwd)
+            .output()
+            .expect("failed to spawn pmat");
+        let code = out.status.code().unwrap_or(-1);
+        let pass = if self.expected_nonzero {
+            code != 0
+        } else {
+            code == 0
+        };
+        (code, pass)
+    }
+}
+
+fn main() {
+    println!("R6 — Exit-Code Contract Harness");
+    println!("{}", "=".repeat(60));
+
+    let bin = pmat_bin();
+    println!("Using pmat binary: {}", bin);
+
+    // Isolate each case in a throwaway directory so local state
+    // (.pmat/, .git/, .pmat-work/, etc.) does not contaminate results.
+    let td = tempfile::tempdir().expect("failed to create tempdir");
+    let cwd = td.path();
+    println!("Temp cwd: {}", cwd.display());
+    println!();
+
+    let cases: &[Case] = &[
+        Case {
+            id: "D25",
+            issue: "#333",
+            args: &["split"],
+            expected_nonzero: true,
+        },
+        Case {
+            id: "D26",
+            issue: "#336",
+            args: &["predict-quality"],
+            expected_nonzero: true,
+        },
+        Case {
+            id: "D35",
+            issue: "#339",
+            args: &["roadmap", "list"],
+            expected_nonzero: true,
+        },
+    ];
+
+    let mut fails = 0;
+    for (idx, case) in cases.iter().enumerate() {
+        let (code, pass) = case.run(bin, cwd);
+        let verdict = if pass { "PASS" } else { "FAIL" };
+        println!(
+            "CASE {} [{} / {}]: pmat {}  expected exit=nonzero, got exit={}  {}",
+            idx + 1,
+            case.id,
+            case.issue,
+            case.args.join(" "),
+            code,
+            verdict,
+        );
+        if !pass {
+            fails += 1;
+        }
+    }
+
+    println!();
+    println!("{}", "-".repeat(60));
+    println!(
+        "Summary: {} passed, {} failed (total: {})",
+        cases.len() - fails,
+        fails,
+        cases.len()
+    );
+
+    if fails > 0 {
+        println!();
+        println!("NOTE: A FAIL here means the contract was FALSIFIED — pmat");
+        println!("exited 0 on invalid input. This is the bug the issue tracks.");
+        println!("Once the fix lands, this example should print all PASS.");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_example_compiles() {
+        // Smoke test: building the example is the contract.
+    }
+}

--- a/examples/falsify_token_demo.rs
+++ b/examples/falsify_token_demo.rs
@@ -1,0 +1,141 @@
+//! FALSIFY Token Demo (R6)
+//!
+//! Demonstrates the `FALSIFY-XXX-001` pattern on a minimal contract. A
+//! FALSIFY token is a documented, human-readable proof that a specific
+//! contract was exercised with a KNOWN-VIOLATING input and observed to
+//! fail — i.e. the contract was falsifiable, not vacuous.
+//!
+//! Run with: `cargo run --example falsify_token_demo`
+//!
+//! # The Pattern
+//!
+//! Given a function with a pre-condition:
+//!
+//! ```rust,ignore
+//! fn reciprocal(x: f64) -> f64 {
+//!     assert!(x != 0.0, "pre: x must be nonzero");
+//!     1.0 / x
+//! }
+//! ```
+//!
+//! A FALSIFY token records:
+//!
+//!   - `id`          — stable ID, e.g. `FALSIFY-RECIPROCAL-001`
+//!   - `contract`    — the source-level contract text
+//!   - `violation`   — the specific input that violates it
+//!   - `observed`    — what happened (panic, error, etc.)
+//!   - `artifact`    — optional path to the captured panic/log
+//!   - `commit`      — git SHA at which the falsification was observed
+//!
+//! The token lives as a JSON object so CI can parse it, and as a source
+//! comment so reviewers can read it. CB-1400 work-contracts embed a list
+//! of these tokens per ticket.
+//!
+//! # Why Bother?
+//!
+//! Mutation testing asks "would a random perturbation be caught?" but
+//! FALSIFY tokens are the INVERSE: we KNOW the perturbation and assert
+//! the contract catches it. Every claim in a contract.json MUST have a
+//! corresponding falsification receipt — otherwise the claim is vacuous.
+
+use std::panic;
+
+/// Trivial contract: `x` must be nonzero. Panics on violation.
+fn reciprocal(x: f64) -> f64 {
+    assert!(x != 0.0, "pre: x must be nonzero");
+    1.0 / x
+}
+
+/// Attempt to falsify the contract by calling it with a known-violating
+/// input (`0.0`). Capture the panic via `catch_unwind` and build a token.
+fn falsify_reciprocal() -> serde_json::Value {
+    // Suppress the panic hook stderr output for a clean demo.
+    let prev = panic::take_hook();
+    panic::set_hook(Box::new(|_| {}));
+    let result = panic::catch_unwind(|| reciprocal(0.0));
+    panic::set_hook(prev);
+
+    let (observed, caught) = match result {
+        Ok(v) => (format!("UNEXPECTED_OK value={}", v), false),
+        Err(payload) => {
+            // Panic payloads are typed-erased; try the two common shapes.
+            let msg = payload
+                .downcast_ref::<&'static str>()
+                .map(|s| s.to_string())
+                .or_else(|| payload.downcast_ref::<String>().cloned())
+                .unwrap_or_else(|| "<non-string panic>".to_string());
+            (format!("PANIC: {}", msg), true)
+        }
+    };
+
+    serde_json::json!({
+        "id": "FALSIFY-RECIPROCAL-001",
+        "contract": "fn reciprocal(x: f64) -> f64  [pre: x != 0.0]",
+        "violation": {
+            "call": "reciprocal(0.0)",
+            "reason": "pre-condition `x != 0.0` violated"
+        },
+        "observed": observed,
+        "caught": caught,
+        "artifact": null,
+        "commit": option_env!("PMAT_COMMIT_SHA").unwrap_or("<unknown>"),
+        "schema": "FALSIFY-v1"
+    })
+}
+
+fn main() {
+    println!("R6 — FALSIFY Token Demo");
+    println!("{}", "=".repeat(60));
+
+    println!("\nStep 1: define a contract");
+    println!("{}", "-".repeat(40));
+    println!("fn reciprocal(x: f64) -> f64 {{");
+    println!("    assert!(x != 0.0, \"pre: x must be nonzero\");");
+    println!("    1.0 / x");
+    println!("}}");
+
+    println!("\nStep 2: exercise with a violating input");
+    println!("{}", "-".repeat(40));
+    println!("  calling reciprocal(0.0) ...");
+    let token = falsify_reciprocal();
+    let caught = token["caught"].as_bool().unwrap_or(false);
+    println!("  contract caught violation: {}", caught);
+
+    println!("\nStep 3: emit the FALSIFY token");
+    println!("{}", "-".repeat(40));
+    // Pretty-print so the shape is readable in the example output.
+    let pretty = serde_json::to_string_pretty(&token).unwrap_or_default();
+    println!("{}", pretty);
+
+    println!("\nStep 4: token shape (type summary)");
+    println!("{}", "-".repeat(40));
+    println!(
+        "\
+  id         : string   (FALSIFY-<NAME>-<NNN>)
+  contract   : string   (source-level signature + pre/post)
+  violation  : object   (input + natural-language reason)
+  observed   : string   (PANIC: .. | ERROR: .. | UNEXPECTED_OK ..)
+  caught     : bool     (true iff contract rejected the input)
+  artifact   : string?  (path to captured stderr/log, optional)
+  commit     : string   (git SHA; proof the test ran at this commit)
+  schema     : string   (FALSIFY-v1)
+"
+    );
+
+    println!("{}", "=".repeat(60));
+    println!("A token with caught=true is the receipt a reviewer wants to see.");
+    println!("A token with caught=false means the contract is vacuous — fix the contract.");
+
+    // Assert we actually falsified. This double-checks the demo is not silently broken.
+    assert!(caught, "demo broken: reciprocal(0.0) did not panic");
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_falsification_catches_zero() {
+        let token = super::falsify_reciprocal();
+        assert_eq!(token["caught"], serde_json::Value::Bool(true));
+        assert_eq!(token["schema"], "FALSIFY-v1");
+    }
+}

--- a/examples/work_contract_binding.rs
+++ b/examples/work_contract_binding.rs
@@ -1,0 +1,179 @@
+//! Work Contract Binding Walkthrough (R6)
+//!
+//! Small programmatic walkthrough of the CB-1400 work-contract pattern:
+//!
+//!   1. Call `pmat work list` to surface the current work items (if any).
+//!   2. Pick the first ticket ID from stdout (or use a placeholder).
+//!   3. Print a skeleton of `.pmat-work/<TICKET>/contract.json` showing
+//!      where FALSIFY tokens, falsification receipts, and quality claims
+//!      are wired in per the CB-1400 specification.
+//!
+//! Run with: `cargo run --example work_contract_binding`
+//!
+//! # CB-1400 Contract Schema (abbreviated)
+//!
+//! Each ticket gets a `contract.json` under `.pmat-work/<TICKET>/`. The
+//! contract is the ticket's falsifiable promise: every listed claim must
+//! have a corresponding FALSIFY receipt, otherwise the claim is vacuous
+//! and `pmat comply check` rejects it.
+//!
+//! This example does NOT write the file — it only prints the skeleton so
+//! developers understand what `pmat work ship` would generate.
+
+use std::process::Command;
+
+fn pmat_bin() -> &'static str {
+    option_env!("CARGO_BIN_EXE_pmat").unwrap_or("pmat")
+}
+
+/// Shell out to `pmat work list` and capture stdout. Returns `None` if
+/// the command is not available or exits non-zero — this example is
+/// purely illustrative and must not hard-fail on missing state.
+fn run_work_list(bin: &str) -> Option<String> {
+    let out = Command::new(bin).args(["work", "list"]).output().ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    String::from_utf8(out.stdout).ok()
+}
+
+/// Extract the first plausible ticket id (e.g. `PMAT-1234`, `CB-1401`,
+/// `R6-001`) from `pmat work list` output. This is heuristic — the real
+/// pmat APIs expose structured JSON, but the point here is to show the
+/// shape, not to parse every output format.
+fn extract_first_ticket(stdout: &str) -> Option<String> {
+    for line in stdout.lines() {
+        for token in line.split_whitespace() {
+            let trimmed = token.trim_matches(|c: char| !c.is_alphanumeric() && c != '-');
+            if is_ticket_id(trimmed) {
+                return Some(trimmed.to_string());
+            }
+        }
+    }
+    None
+}
+
+/// Matches `<UPPERCASE_PREFIX>-<digits>`, e.g. `PMAT-1204`, `CB-1400`, `R6-001`.
+fn is_ticket_id(s: &str) -> bool {
+    let (prefix, number) = match s.split_once('-') {
+        Some(parts) => parts,
+        None => return false,
+    };
+    if prefix.is_empty() || number.is_empty() {
+        return false;
+    }
+    prefix
+        .chars()
+        .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit())
+        && number.chars().all(|c| c.is_ascii_digit())
+}
+
+fn main() {
+    println!("R6 — Work Contract Binding Walkthrough");
+    println!("{}", "=".repeat(60));
+
+    let bin = pmat_bin();
+    println!("Using pmat binary: {}", bin);
+
+    println!("\nStep 1: invoke `pmat work list`");
+    println!("{}", "-".repeat(40));
+    let list = run_work_list(bin);
+    let ticket = match list.as_deref() {
+        Some(stdout) => {
+            let preview: String = stdout.lines().take(5).collect::<Vec<_>>().join("\n");
+            if preview.is_empty() {
+                println!("  (empty work list)");
+            } else {
+                println!("  first 5 lines of output:");
+                for line in preview.lines() {
+                    println!("    | {}", line);
+                }
+            }
+            extract_first_ticket(stdout).unwrap_or_else(|| "PMAT-0000".to_string())
+        }
+        None => {
+            println!("  `pmat work list` unavailable or failed — using placeholder ticket");
+            "PMAT-0000".to_string()
+        }
+    };
+    println!("  selected ticket: {}", ticket);
+
+    println!("\nStep 2: contract path");
+    println!("{}", "-".repeat(40));
+    let contract_path = format!(".pmat-work/{}/contract.json", ticket);
+    println!("  path: {}", contract_path);
+
+    println!("\nStep 3: CB-1400 contract.json skeleton");
+    println!("{}", "-".repeat(40));
+    let skeleton = serde_json::json!({
+        "schema": "pmat-work-contract/v1",
+        "ticket": ticket,
+        "status": "in_progress",
+        "claims": [
+            {
+                "id": "CLAIM-001",
+                "statement": "Function `foo::bar` exits non-zero on invalid input",
+                "falsify_token": "FALSIFY-FOO-BAR-001",
+                "evidence": {
+                    "kind": "exit_code",
+                    "command": "pmat foo bar",
+                    "expected_nonzero": true
+                }
+            },
+            {
+                "id": "CLAIM-002",
+                "statement": "Cyclomatic complexity of `foo::bar` ≤ 15",
+                "falsify_token": "FALSIFY-FOO-BAR-002",
+                "evidence": {
+                    "kind": "metric",
+                    "metric": "cyclomatic_complexity",
+                    "op": "<=",
+                    "threshold": 15
+                }
+            }
+        ],
+        "falsify_receipts": [
+            {
+                "id": "FALSIFY-FOO-BAR-001",
+                "observed": "PANIC: pre: x != 0.0",
+                "caught": true,
+                "commit": "<git-sha>",
+                "schema": "FALSIFY-v1"
+            }
+        ],
+        "quality_gates": {
+            "tdg_grade": "A",
+            "mutation_coverage": 0.80,
+            "line_coverage": 0.95
+        },
+        "cb_checks": ["CB-1400", "CB-1401", "CB-1402"],
+        "notes": "Every claim MUST have a matching FALSIFY receipt. `pmat comply check` rejects vacuous contracts."
+    });
+    let pretty = serde_json::to_string_pretty(&skeleton).unwrap_or_default();
+    println!("{}", pretty);
+
+    println!("\n{}", "=".repeat(60));
+    println!("The real `pmat work ship` writes this file and `pmat comply check`");
+    println!("verifies every `claims[].falsify_token` resolves to a receipt.");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_ticket_id;
+
+    #[test]
+    fn ticket_id_matches() {
+        assert!(is_ticket_id("PMAT-1204"));
+        assert!(is_ticket_id("CB-1400"));
+        assert!(is_ticket_id("R6-001"));
+    }
+
+    #[test]
+    fn ticket_id_rejects() {
+        assert!(!is_ticket_id(""));
+        assert!(!is_ticket_id("foo"));
+        assert!(!is_ticket_id("PMAT-"));
+        assert!(!is_ticket_id("-1234"));
+        assert!(!is_ticket_id("pmat-1204"));
+    }
+}


### PR DESCRIPTION
## Summary

Three standalone `cargo run --example` programs that exercise pmat's contract/FALSIFY surface as programmatic test harnesses:

- **`exit_code_contract.rs`** — asserts `pmat split`, `pmat predict-quality`, `pmat roadmap list` return the CORRECT exit code on invalid input. Pinned as D25/D26/D35 regressions from issues #333/#336/#339.
- **`falsify_token_demo.rs`** — demonstrates the FALSIFY-XXX-001 token pattern on a trivial pre-condition contract; prints the token shape for downstream verifier tooling.
- **`work_contract_binding.rs`** — walks `pmat work list` output and prints the `.pmat-work/<TICKET>/contract.json` skeleton per CB-1400.

All three:
- Pass `cargo check --example <name>`.
- Use the `option_env!(\"CARGO_BIN_EXE_pmat\").unwrap_or(\"pmat\")` pattern already established by `examples/comply_demo.rs`.
- Zero new deps (serde_json + tempfile already in dev-deps).
- ~150-200 lines each, 470 insertions total.

Part of the ongoing dogfood-round iteration (R6). Complements the R5 KAIZEN-0017..0044 work (#337) and the D37-D52 defect catalogue (#339, #342).

## Test plan

- [ ] CI green on master base
- [ ] `cargo run --example exit_code_contract` locally reports current exit-code state for the 3 tracked defects
- [ ] `cargo run --example falsify_token_demo` prints a FALSIFY token sample
- [ ] `cargo run --example work_contract_binding` prints a contract.json skeleton for a ticket from `pmat work list`

🤖 Generated with [Claude Code](https://claude.com/claude-code)