### PR TITLE
fix(mcp): rename 3 mis-labeled tools (D39/D47/D48)

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -793,19 +793,19 @@ fn generate_tool_registry(out_dir: &str) {
             vec!["dead", "unused", "code"],
         ),
         (
-            "analyze_dag",
-            "Generate dependency graphs and visualizations",
-            vec!["dependency", "graph", "dag", "architecture"],
+            "analyze_lint_hotspots",
+            "Surface files with the most lint violations",
+            vec!["lint", "hotspot", "lint-hotspot", "violations"],
         ),
         (
-            "analyze_deep_context",
-            "Generate comprehensive codebase context",
-            vec!["context", "summary", "analysis"],
+            "analyze_churn",
+            "Git change frequency / volatility per file",
+            vec!["churn", "git", "volatility", "change", "frequency"],
         ),
         (
-            "analyze_big_o",
-            "Analyze algorithmic complexity",
-            vec!["big-o", "algorithm", "performance"],
+            "analyze_coupling",
+            "Analyze module coupling via shared identifiers",
+            vec!["coupling", "module", "dependency"],
         ),
         (
             "refactor.start",
@@ -955,17 +955,36 @@ fn generate_alias_table(out_dir: &str) {
             ],
         ),
         (
-            "analyze_dag",
+            "analyze_lint_hotspots",
             vec![
+                "lint",
+                "hotspot",
+                "hotspots",
+                "lint hotspot",
+                "lint hotspots",
+                "lint violations",
+                "violations",
+            ],
+        ),
+        (
+            "analyze_churn",
+            vec![
+                "churn",
+                "git churn",
+                "volatility",
+                "change frequency",
+                "hot files",
+                "volatile code",
+            ],
+        ),
+        (
+            "analyze_coupling",
+            vec![
+                "coupling",
+                "module coupling",
+                "coupled modules",
+                "module dependency",
                 "dependency",
-                "dependencies",
-                "graph",
-                "visualize",
-                "diagram",
-                "show dependencies",
-                "dependency graph",
-                "architecture",
-                "dag",
             ],
         ),
         (
@@ -1283,10 +1302,10 @@ pub static TOOL_REGISTRY: LazyLock<HashMap<&'static str, ToolMeta>> =
             description: "Find self-admitted technical debt in comments",
             keywords: &["satd", "debt", "todo", "fixme"],
         });
-        m.insert("analyze_dag", ToolMeta {
-            name: "analyze_dag",
-            description: "Generate dependency graphs and visualizations",
-            keywords: &["dependency", "graph", "dag", "architecture"],
+        m.insert("analyze_lint_hotspots", ToolMeta {
+            name: "analyze_lint_hotspots",
+            description: "Surface files with the most lint violations",
+            keywords: &["lint", "hotspot", "lint-hotspot", "violations"],
         });
         m.insert("generate_context", ToolMeta {
             name: "generate_context",
@@ -1308,15 +1327,15 @@ pub static TOOL_REGISTRY: LazyLock<HashMap<&'static str, ToolMeta>> =
             description: "Detect unused functions and variables",
             keywords: &["dead", "unused", "code"],
         });
-        m.insert("analyze_big_o", ToolMeta {
-            name: "analyze_big_o",
-            description: "Analyze algorithmic complexity",
-            keywords: &["big-o", "algorithm", "performance"],
+        m.insert("analyze_coupling", ToolMeta {
+            name: "analyze_coupling",
+            description: "Analyze module coupling via shared identifiers",
+            keywords: &["coupling", "module", "dependency"],
         });
-        m.insert("analyze_deep_context", ToolMeta {
-            name: "analyze_deep_context",
-            description: "Generate comprehensive codebase context",
-            keywords: &["context", "summary", "analysis"],
+        m.insert("analyze_churn", ToolMeta {
+            name: "analyze_churn",
+            description: "Git change frequency / volatility per file",
+            keywords: &["churn", "git", "volatility", "change", "frequency"],
         });
         m.insert("refactor.nextIteration", ToolMeta {
             name: "refactor.nextIteration",
@@ -1353,7 +1372,9 @@ pub static ALIAS_TABLE: std::sync::LazyLock<std::collections::HashMap<&'static s
         let mut m = std::collections::HashMap::new();
         m.insert("analyze_complexity", vec!["complexity", "analyze", "metrics", "complxity", "complx"]);
         m.insert("analyze_satd", vec!["debt", "technical debt", "todo", "fixme"]);
-        m.insert("analyze_dag", vec!["dependency", "dependencies", "graph", "show dependencies", "dependency graph"]);
+        m.insert("analyze_lint_hotspots", vec!["lint", "hotspot", "hotspots", "lint hotspot", "violations"]);
+        m.insert("analyze_churn", vec!["churn", "git churn", "volatility", "change frequency", "hot files"]);
+        m.insert("analyze_coupling", vec!["coupling", "module coupling", "coupled modules", "module dependency"]);
         m.insert("scaffold_project", vec!["scaffold", "create", "generate", "create project", "scafold"]);
         m.insert("generate_context", vec!["context", "generate context", "ai context"]);
         m.insert("quality_gate", vec!["quality", "check quality", "quality check", "qualit"]);

--- a/src/mcp_pmcp/analyze_handlers.rs
+++ b/src/mcp_pmcp/analyze_handlers.rs
@@ -21,11 +21,17 @@ use serde_json::Value;
 use std::path::PathBuf;
 use tracing::debug;
 
-// Re-export for convenience
+// Re-export for convenience.
+//
+// NOTE (D39/D47/D48 fix): These aliases were previously mis-labeled — the
+// `AnalyzeBigOTool`, `AnalyzeDeepContextTool`, and `AnalyzeDagTool` names
+// aliased `CouplingTool`, `ChurnTool`, and `LintHotspotTool` respectively,
+// which dispatched MCP calls to the wrong handlers. The aliases now match
+// the underlying behavior: coupling, churn, and lint-hotspot analysis.
 pub use self::{
-    ChurnTool as AnalyzeDeepContextTool, ComplexityTool as AnalyzeComplexityTool,
-    CouplingTool as AnalyzeBigOTool, DeadCodeTool as AnalyzeDeadCodeTool,
-    LintHotspotTool as AnalyzeDagTool, SatdTool as AnalyzeSatdTool,
+    ChurnTool as AnalyzeChurnTool, ComplexityTool as AnalyzeComplexityTool,
+    CouplingTool as AnalyzeCouplingTool, DeadCodeTool as AnalyzeDeadCodeTool,
+    LintHotspotTool as AnalyzeLintHotspotsTool, SatdTool as AnalyzeSatdTool,
     TdgCompareTool as AnalyzeTdgCompareTool, TdgTool as AnalyzeTdgTool,
 };
 

--- a/src/mcp_pmcp/analyze_handlers_tests_tdg.rs
+++ b/src/mcp_pmcp/analyze_handlers_tests_tdg.rs
@@ -101,13 +101,14 @@ mod tdg_coverage_tests {
 
     #[test]
     fn test_re_exports_exist() {
-        // Test that re-exports are accessible
+        // Test that re-exports are accessible AND correctly match the
+        // underlying handlers they dispatch to (D39/D47/D48 guard).
         let _: AnalyzeComplexityTool = ComplexityTool::new();
         let _: AnalyzeSatdTool = SatdTool::new();
         let _: AnalyzeDeadCodeTool = DeadCodeTool::new();
-        let _: AnalyzeDagTool = LintHotspotTool::new();
-        let _: AnalyzeDeepContextTool = ChurnTool::new();
-        let _: AnalyzeBigOTool = CouplingTool::new();
+        let _: AnalyzeLintHotspotsTool = LintHotspotTool::new();
+        let _: AnalyzeChurnTool = ChurnTool::new();
+        let _: AnalyzeCouplingTool = CouplingTool::new();
         let _: AnalyzeTdgTool = TdgTool::new();
         let _: AnalyzeTdgCompareTool = TdgCompareTool::new();
     }

--- a/src/mcp_pmcp/discovery.rs
+++ b/src/mcp_pmcp/discovery.rs
@@ -114,7 +114,9 @@ impl DiscoveryService {
         let ext = context.and_then(|ctx| ctx.file_extension.as_deref())?;
         match ext {
             "rs" if candidates.contains(&"analyze_complexity") => Some("analyze_complexity"),
-            "ts" | "js" if candidates.contains(&"analyze_dag") => Some("analyze_dag"),
+            "ts" | "js" if candidates.contains(&"analyze_lint_hotspots") => {
+                Some("analyze_lint_hotspots")
+            }
             _ => None,
         }
     }
@@ -249,7 +251,7 @@ mod tests {
         );
 
         // Test file extension affinity
-        let candidates = vec!["analyze_dag", "analyze_complexity"];
+        let candidates = vec!["analyze_lint_hotspots", "analyze_complexity"];
         let context = Context {
             file_extension: Some("rs".to_string()),
             current_directory: None,

--- a/src/mcp_pmcp/discovery_integration_test.rs
+++ b/src/mcp_pmcp/discovery_integration_test.rs
@@ -18,8 +18,10 @@ mod discovery_integration_tests {
         ("complexity", "analyze_complexity"),
         ("debt", "analyze_satd"),
         ("technical debt", "analyze_satd"),
-        ("dependencies", "analyze_dag"),
-        ("dependency graph", "analyze_dag"),
+        // D39/D47/D48 fix: rewired aliases from mis-named tools to their
+        // real behavior (coupling, churn, lint hotspots).
+        ("coupling", "analyze_coupling"),
+        ("module coupling", "analyze_coupling"),
         ("context", "generate_context"),
         ("quality check", "quality_gate"),
         ("refactor", "refactor.start"),
@@ -33,7 +35,7 @@ mod discovery_integration_tests {
         // Natural language queries
         ("analyze code complexity", "analyze_complexity"),
         ("find technical debt", "analyze_satd"),
-        ("show dependencies", "analyze_dag"),
+        ("hot files", "analyze_churn"),
         ("create project", "scaffold_project"),
         ("check code quality", "quality_gate"),
         ("start refactoring", "refactor.start"),
@@ -168,9 +170,9 @@ mod discovery_integration_tests {
             "analyze_complexity",
             "analyze_satd",
             "analyze_dead_code",
-            "analyze_dag",
-            "analyze_deep_context",
-            "analyze_big_o",
+            "analyze_lint_hotspots",
+            "analyze_churn",
+            "analyze_coupling",
             "refactor.start",
             "refactor.nextIteration",
             "refactor.getState",
@@ -220,7 +222,7 @@ mod discovery_integration_tests {
             recent_tools: vec![],
         };
 
-        let candidates = vec!["analyze_dag", "analyze_complexity"];
+        let candidates = vec!["analyze_lint_hotspots", "analyze_complexity"];
         let result = service.disambiguate(candidates, Some(&context));
         assert_eq!(
             result, "analyze_complexity",

--- a/src/mcp_pmcp/mod.rs
+++ b/src/mcp_pmcp/mod.rs
@@ -48,9 +48,9 @@
 //! - `analyze_complexity` - Analyze code complexity metrics
 //! - `analyze_satd` - Detect self-admitted technical debt
 //! - `analyze_dead_code` - Find unused code
-//! - `analyze_dag` - Generate dependency graphs
-//! - `analyze_deep_context` - Comprehensive code analysis
-//! - `analyze_big_o` - Big-O complexity analysis
+//! - `analyze_lint_hotspots` - Surface files with the most lint violations
+//! - `analyze_churn` - Git change frequency / volatility per file
+//! - `analyze_coupling` - Module coupling analysis
 //!
 //! ## Refactoring Tools
 //! - `refactor.start` - Start a refactoring session

--- a/src/mcp_pmcp/server.rs
+++ b/src/mcp_pmcp/server.rs
@@ -1,6 +1,6 @@
 use crate::mcp_pmcp::analyze_handlers::{
-    AnalyzeBigOTool, AnalyzeComplexityTool, AnalyzeDagTool, AnalyzeDeadCodeTool,
-    AnalyzeDeepContextTool, AnalyzeSatdTool, AnalyzeTdgCompareTool, AnalyzeTdgTool,
+    AnalyzeChurnTool, AnalyzeComplexityTool, AnalyzeCouplingTool, AnalyzeDeadCodeTool,
+    AnalyzeLintHotspotsTool, AnalyzeSatdTool, AnalyzeTdgCompareTool, AnalyzeTdgTool,
 };
 use crate::mcp_pmcp::context_handlers::{GenerateContextTool, GitTool, ScaffoldProjectTool};
 use crate::mcp_pmcp::handlers::{
@@ -112,9 +112,9 @@ impl PmcpServer {
             .tool("analyze_complexity", AnalyzeComplexityTool)
             .tool("analyze_satd", AnalyzeSatdTool)
             .tool("analyze_dead_code", AnalyzeDeadCodeTool)
-            .tool("analyze_dag", AnalyzeDagTool)
-            .tool("analyze_deep_context", AnalyzeDeepContextTool)
-            .tool("analyze_big_o", AnalyzeBigOTool)
+            .tool("analyze_lint_hotspots", AnalyzeLintHotspotsTool)
+            .tool("analyze_churn", AnalyzeChurnTool)
+            .tool("analyze_coupling", AnalyzeCouplingTool)
             .tool("analyze_tdg", AnalyzeTdgTool)
             .tool("analyze_tdg_compare", AnalyzeTdgCompareTool)
             // Refactoring tools

--- a/src/mcp_pmcp/server_tests.rs
+++ b/src/mcp_pmcp/server_tests.rs
@@ -164,14 +164,16 @@ mod coverage_tests {
     fn test_server_has_analysis_tools() {
         // Verify the tool registration pattern is correct
         // We can't run the server, but we can verify the tools exist
-        let expected_tools = ["analyze_complexity",
+        let expected_tools = [
+            "analyze_complexity",
             "analyze_satd",
             "analyze_dead_code",
-            "analyze_dag",
-            "analyze_deep_context",
-            "analyze_big_o",
+            "analyze_lint_hotspots",
+            "analyze_churn",
+            "analyze_coupling",
             "analyze_tdg",
-            "analyze_tdg_compare"];
+            "analyze_tdg_compare",
+        ];
 
         // Just verify the list is non-empty and has expected structure
         assert!(!expected_tools.is_empty());
@@ -180,10 +182,12 @@ mod coverage_tests {
 
     #[test]
     fn test_server_has_refactoring_tools() {
-        let expected_tools = ["refactor.start",
+        let expected_tools = [
+            "refactor.start",
             "refactor.nextIteration",
             "refactor.getState",
-            "refactor.stop"];
+            "refactor.stop",
+        ];
 
         assert_eq!(expected_tools.len(), 4);
         assert!(expected_tools.contains(&"refactor.start"));
@@ -199,12 +203,14 @@ mod coverage_tests {
 
     #[test]
     fn test_server_has_tdg_tools() {
-        let expected_tools = ["tdg_system_diagnostics",
+        let expected_tools = [
+            "tdg_system_diagnostics",
             "tdg_storage_management",
             "tdg_analyze_with_storage",
             "tdg_performance_metrics",
             "tdg_configure_storage",
-            "tdg_health_check"];
+            "tdg_health_check",
+        ];
 
         assert_eq!(expected_tools.len(), 6);
     }
@@ -348,9 +354,9 @@ mod coverage_tests {
         let _ = std::any::TypeId::of::<AnalyzeComplexityTool>();
         let _ = std::any::TypeId::of::<AnalyzeSatdTool>();
         let _ = std::any::TypeId::of::<AnalyzeDeadCodeTool>();
-        let _ = std::any::TypeId::of::<AnalyzeDagTool>();
-        let _ = std::any::TypeId::of::<AnalyzeDeepContextTool>();
-        let _ = std::any::TypeId::of::<AnalyzeBigOTool>();
+        let _ = std::any::TypeId::of::<AnalyzeLintHotspotsTool>();
+        let _ = std::any::TypeId::of::<AnalyzeChurnTool>();
+        let _ = std::any::TypeId::of::<AnalyzeCouplingTool>();
         let _ = std::any::TypeId::of::<AnalyzeTdgTool>();
         let _ = std::any::TypeId::of::<AnalyzeTdgCompareTool>();
     }

--- a/src/mcp_pmcp/simple_unified_server.rs
+++ b/src/mcp_pmcp/simple_unified_server.rs
@@ -1,6 +1,6 @@
 use crate::mcp_pmcp::analyze_handlers::{
-    AnalyzeBigOTool, AnalyzeComplexityTool, AnalyzeDagTool, AnalyzeDeadCodeTool,
-    AnalyzeDeepContextTool, AnalyzeSatdTool,
+    AnalyzeChurnTool, AnalyzeComplexityTool, AnalyzeCouplingTool, AnalyzeDeadCodeTool,
+    AnalyzeLintHotspotsTool, AnalyzeSatdTool,
 };
 use crate::mcp_pmcp::context_handlers::{GenerateContextTool, GitTool, ScaffoldProjectTool};
 use crate::mcp_pmcp::handlers::{
@@ -48,9 +48,9 @@ impl SimpleUnifiedServer {
             .tool("analyze_complexity", AnalyzeComplexityTool)
             .tool("analyze_satd", AnalyzeSatdTool)
             .tool("analyze_dead_code", AnalyzeDeadCodeTool)
-            .tool("analyze_dag", AnalyzeDagTool)
-            .tool("analyze_deep_context", AnalyzeDeepContextTool)
-            .tool("analyze_big_o", AnalyzeBigOTool)
+            .tool("analyze_lint_hotspots", AnalyzeLintHotspotsTool)
+            .tool("analyze_churn", AnalyzeChurnTool)
+            .tool("analyze_coupling", AnalyzeCouplingTool)
             // === Refactoring Tools (4) ===
             .tool(
                 "refactor.start",
@@ -240,9 +240,9 @@ mod coverage_tests {
         let _ = AnalyzeComplexityTool::new();
         let _ = AnalyzeSatdTool::new();
         let _ = AnalyzeDeadCodeTool::new();
-        let _ = AnalyzeDagTool::new();
-        let _ = AnalyzeDeepContextTool::new();
-        let _ = AnalyzeBigOTool::new();
+        let _ = AnalyzeLintHotspotsTool::new();
+        let _ = AnalyzeChurnTool::new();
+        let _ = AnalyzeCouplingTool::new();
     }
 
     #[test]
@@ -333,13 +333,14 @@ mod coverage_tests {
 
     #[test]
     fn test_all_tool_types_accessible() {
-        // Analysis tools
+        // Analysis tools — aliases MUST match the behavior they dispatch to
+        // (D39/D47/D48 regression guard: these asserted misnaming before).
         assert!(std::any::type_name::<AnalyzeComplexityTool>().contains("ComplexityTool"));
         assert!(std::any::type_name::<AnalyzeSatdTool>().contains("SatdTool"));
         assert!(std::any::type_name::<AnalyzeDeadCodeTool>().contains("DeadCodeTool"));
-        assert!(std::any::type_name::<AnalyzeDagTool>().contains("LintHotspotTool"));
-        assert!(std::any::type_name::<AnalyzeDeepContextTool>().contains("ChurnTool"));
-        assert!(std::any::type_name::<AnalyzeBigOTool>().contains("CouplingTool"));
+        assert!(std::any::type_name::<AnalyzeLintHotspotsTool>().contains("LintHotspotTool"));
+        assert!(std::any::type_name::<AnalyzeChurnTool>().contains("ChurnTool"));
+        assert!(std::any::type_name::<AnalyzeCouplingTool>().contains("CouplingTool"));
 
         // Quality tools
         assert!(std::any::type_name::<QualityGateTool>().contains("QualityGateTool"));


### PR DESCRIPTION
## Summary

Three MCP tools in the pmcp server were registered under names that had nothing to do with the handlers they dispatched to. The misnaming was even self-asserted as a "test" in `simple_unified_server.rs:337-342`:

```rust
assert!(std::any::type_name::<AnalyzeDagTool>().contains("LintHotspotTool"));
assert!(std::any::type_name::<AnalyzeDeepContextTool>().contains("ChurnTool"));
assert!(std::any::type_name::<AnalyzeBigOTool>().contains("CouplingTool"));
```

And the aliases in `src/mcp_pmcp/analyze_handlers.rs` literally encoded the lie:

```rust
ChurnTool       as AnalyzeDeepContextTool   (D47)
CouplingTool    as AnalyzeBigOTool          (D39)
LintHotspotTool as AnalyzeDagTool           (D48)
```

Fix: rename the MCP tools to match the handlers they actually dispatch to (safer than rewiring handlers and breaking any internal contract).

| Old MCP tool name | New MCP tool name | Underlying handler |
|---|---|---|
| `analyze_big_o` | `analyze_coupling` | `CouplingTool` |
| `analyze_deep_context` | `analyze_churn` | `ChurnTool` |
| `analyze_dag` | `analyze_lint_hotspots` | `LintHotspotTool` |

The self-asserted-misnaming tests were flipped to assert correctness (regression guard).

## Scope

- `src/mcp_pmcp/analyze_handlers.rs`: rename aliases.
- `src/mcp_pmcp/server.rs` + `simple_unified_server.rs`: update imports and registered tool-name strings.
- `src/mcp_pmcp/analyze_handlers_tests_tdg.rs`, `server_tests.rs`: update type re-export tests and tool-registration expectations.
- `src/mcp_pmcp/discovery.rs`, `discovery_integration_test.rs`, `mod.rs`: update in-memory tool discovery fixtures, docs, and tests.
- `build.rs`: regenerate the compile-time tool registry, alias table, and coverage-build stubs with the new names + accurate keywords.

Out of scope: the legacy `src/handlers/` MCP server (non-pmcp) uses dedicated handler functions (`handle_analyze_dag`, `handle_analyze_deep_context`) and was never mis-dispatched.

## Test plan

- [x] `cargo check --lib` passes
- [x] `cargo test --lib -- mcp_pmcp` passes (448/448)
- [x] `cargo test --lib -- discovery` passes (52/52)
- [ ] CI runs full suite

Refs: issue #339 (D39, D47, D48)

🤖 Generated with [Claude Code](https://claude.com/claude-code)