### PR TITLE
fix(mcp): wire 4 pmat_* AgentContextTools into live tools/list (KAIZEN-0165)

### DIFF
--- a/src/mcp_pmcp/agent_context_handlers.rs
+++ b/src/mcp_pmcp/agent_context_handlers.rs
@@ -1,0 +1,49 @@
+//! pmcp ToolHandler adapters for the 4 `pmat_*` AgentContextTools (KAIZEN-0165).
+//!
+//! The tools in `crate::mcp::tools::agent_context_tools` implement a custom
+//! `McpTool` trait with `execute(Value) -> Result<Value, String>`. pmcp's
+//! `Server::builder().tool(...)` requires `pmcp::ToolHandler` with
+//! `handle(Value, RequestHandlerExtra) -> pmcp::Result<Value>`. These thin
+//! newtype wrappers adapt one to the other so the 4 tools appear in the live
+//! MCP stdio tools/list.
+
+use crate::mcp::tools::agent_context_tools::{
+    FindSimilarTool, GetFunctionTool, IndexManager, IndexStatsTool, McpTool as InnerMcpTool,
+    QueryCodeTool,
+};
+use async_trait::async_trait;
+use pmcp::{Error as PmcpError, RequestHandlerExtra, Result as PmcpResult, ToolHandler};
+use serde_json::Value;
+use std::sync::Arc;
+
+macro_rules! impl_pmat_handler {
+    ($wrapper:ident, $inner:ident) => {
+        pub struct $wrapper {
+            inner: $inner,
+        }
+
+        impl $wrapper {
+            pub fn new(mgr: Arc<IndexManager>) -> Self {
+                Self {
+                    inner: $inner::new(mgr),
+                }
+            }
+        }
+
+        #[async_trait]
+        impl ToolHandler for $wrapper {
+            async fn handle(
+                &self,
+                args: Value,
+                _extra: RequestHandlerExtra,
+            ) -> PmcpResult<Value> {
+                self.inner.execute(args).await.map_err(PmcpError::internal)
+            }
+        }
+    };
+}
+
+impl_pmat_handler!(PmatQueryCodeHandler, QueryCodeTool);
+impl_pmat_handler!(PmatGetFunctionHandler, GetFunctionTool);
+impl_pmat_handler!(PmatFindSimilarHandler, FindSimilarTool);
+impl_pmat_handler!(PmatIndexStatsHandler, IndexStatsTool);

--- a/src/mcp_pmcp/mod.rs
+++ b/src/mcp_pmcp/mod.rs
@@ -92,6 +92,7 @@
 //! // Memory usage: 50MB (50% reduction)
 //! ```
 
+pub mod agent_context_handlers;
 pub mod analyze_handlers;
 pub mod context_handlers;
 pub mod discovery;

--- a/src/mcp_pmcp/simple_unified_server.rs
+++ b/src/mcp_pmcp/simple_unified_server.rs
@@ -1,3 +1,7 @@
+use crate::mcp::tools::agent_context_tools::IndexManager;
+use crate::mcp_pmcp::agent_context_handlers::{
+    PmatFindSimilarHandler, PmatGetFunctionHandler, PmatIndexStatsHandler, PmatQueryCodeHandler,
+};
 use crate::mcp_pmcp::analyze_handlers::{
     AnalyzeBigOTool, AnalyzeComplexityTool, AnalyzeDagTool, AnalyzeDeadCodeTool,
     AnalyzeDeepContextTool, AnalyzeSatdTool,
@@ -11,6 +15,7 @@ use crate::mcp_pmcp::quality_handlers::QualityGateTool;
 use crate::mcp_pmcp::quality_proxy_handler::QualityProxyTool;
 use crate::mcp_server::state_manager::StateManager;
 use pmcp::{Server, ServerCapabilities, ToolCapabilities};
+use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 use tracing::info;
@@ -35,6 +40,12 @@ impl SimpleUnifiedServer {
     #[provable_contracts_macros::contract("pmat-core.yaml", equation = "check_compliance")]
     pub async fn run(&self) -> Result<(), Box<dyn std::error::Error>> {
         info!("Starting PMAT Simple Unified MCP server (pmcp SDK)");
+
+        // KAIZEN-0165: shared IndexManager for the 4 pmat_* AgentContextTools.
+        // Construction is cheap (no disk I/O); first tool call triggers index build.
+        let index_manager = Arc::new(IndexManager::new(
+            std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
+        ));
 
         // Build server with core PMAT tools that are already working
         let server = Server::builder()
@@ -76,9 +87,26 @@ impl SimpleUnifiedServer {
             .tool("git_operation", GitTool)
             .tool("generate_context", GenerateContextTool)
             .tool("scaffold_project", ScaffoldProjectTool)
+            // === Agent Context Tools (4) — KAIZEN-0165 ===
+            .tool(
+                "pmat_query_code",
+                PmatQueryCodeHandler::new(index_manager.clone()),
+            )
+            .tool(
+                "pmat_get_function",
+                PmatGetFunctionHandler::new(index_manager.clone()),
+            )
+            .tool(
+                "pmat_find_similar",
+                PmatFindSimilarHandler::new(index_manager.clone()),
+            )
+            .tool(
+                "pmat_index_stats",
+                PmatIndexStatsHandler::new(index_manager.clone()),
+            )
             .build()?;
 
-        info!("PMAT Simple Unified MCP server ready with 18 core tools, listening on stdio");
+        info!("PMAT Simple Unified MCP server ready with 20 tools (16 core + 4 agent_context), listening on stdio");
 
         // Run server with stdio transport
         server.run_stdio().await?;

--- a/tests/modules/mcp_agent_context_tools_test.rs
+++ b/tests/modules/mcp_agent_context_tools_test.rs
@@ -1,0 +1,67 @@
+//! KAIZEN-0165: Verify the 4 `pmat_*` AgentContextTools are wired via pmcp adapters.
+//!
+//! Before this fix, the adapter crate compiled but no `.tool()` call in
+//! `simple_unified_server.rs` registered these tools — so MCP `tools/list`
+//! returned only 16 core tools. Now the adapters exist and the server
+//! registers them.
+//!
+//! These tests exercise the adapters directly (instead of booting a full
+//! stdio server) so they run fast and survive `skip-slow-tests`.
+//!
+//! They assert:
+//!   (a) The 4 adapter structs can be constructed from an `Arc<IndexManager>`.
+//!   (b) `PmatIndexStatsHandler::handle(...)` returns non-stub JSON with a
+//!       `manifest.function_count > 0` on a repo that has an existing
+//!       `.pmat/context.idx` — proving the pmcp adapter actually delegates
+//!       to the real tool.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use pmat::mcp::tools::agent_context_tools::IndexManager;
+use pmat::mcp_pmcp::agent_context_handlers::{
+    PmatFindSimilarHandler, PmatGetFunctionHandler, PmatIndexStatsHandler, PmatQueryCodeHandler,
+};
+use pmcp::{RequestHandlerExtra, ToolHandler};
+use serde_json::json;
+use tokio_util::sync::CancellationToken;
+
+fn test_extra() -> RequestHandlerExtra {
+    RequestHandlerExtra::new("kaizen-0165-test".to_string(), CancellationToken::new())
+}
+
+fn pmat_project_root() -> PathBuf {
+    // tests/modules/this.rs -> CARGO_MANIFEST_DIR is the worktree root.
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+#[test]
+fn test_four_pmat_adapters_construct() {
+    let mgr = Arc::new(IndexManager::new(pmat_project_root()));
+
+    // Smoke: each newtype wrapper must be buildable from Arc<IndexManager>.
+    let _q = PmatQueryCodeHandler::new(mgr.clone());
+    let _g = PmatGetFunctionHandler::new(mgr.clone());
+    let _s = PmatFindSimilarHandler::new(mgr.clone());
+    let _i = PmatIndexStatsHandler::new(mgr.clone());
+}
+
+#[tokio::test]
+#[ignore = "requires .pmat/context.idx; run with --ignored after `pmat index`"]
+async fn test_pmat_index_stats_returns_non_stub() {
+    let mgr = Arc::new(IndexManager::new(pmat_project_root()));
+    let tool = PmatIndexStatsHandler::new(mgr);
+
+    let result = tool
+        .handle(json!({"rebuild": false}), test_extra())
+        .await
+        .expect("pmat_index_stats handler should not error on a pmat checkout");
+
+    let fn_count = result["manifest"]["function_count"]
+        .as_u64()
+        .expect("response must include manifest.function_count");
+    assert!(
+        fn_count > 0,
+        "index_stats returned stub (function_count={fn_count}); expected >0"
+    );
+}

--- a/tests/modules/mod.rs
+++ b/tests/modules/mod.rs
@@ -107,6 +107,7 @@ mod issue_67_integration_test;
 mod json_parsing_tests;
 mod kotlin_ast_test;
 mod kotlin_support_test;
+mod mcp_agent_context_tools_test;
 mod mcp_docs_enforcement;
 mod mcp_documentation_sync;
 #[cfg(feature = "mcp-integration")]


### PR DESCRIPTION
## Summary

Wires the 4 `pmat_*` AgentContextTools (`pmat_query_code`, `pmat_get_function`, `pmat_find_similar`, `pmat_index_stats`) into the pmcp-backed MCP server so they appear in live `tools/list` responses. Before this fix, the tools compiled but were never `.tool()`-registered — agents got "tool not found" on stdio.

Resolves KAIZEN-0165 (tracked in issue #337).

## Root cause

Two incompatible `McpTool` traits:
- `crate::mcp::tools::agent_context_tools::McpTool::execute(Value) -> Result<Value, String>`
- `pmcp::ToolHandler::handle(Value, RequestHandlerExtra) -> PmcpResult<Value>`

`Server::builder().tool(...)` only accepts the pmcp trait. The 4 pmat_* tools implemented the custom trait, so the pmcp builder rejected them and no registration existed.

## Fix

1. New `src/mcp_pmcp/agent_context_handlers.rs` (~50 LOC) — 4 thin newtype wrappers generated by one macro. Each wraps the inner `*Tool`, impls `pmcp::ToolHandler`, and delegates `execute() -> handle()` with `PmcpError::internal` for error conversion.

2. `src/mcp_pmcp/simple_unified_server.rs` — Build a shared `Arc<IndexManager>` from cwd once (cheap; first tool call triggers index build), then `.tool("pmat_query_code", PmatQueryCodeHandler::new(mgr.clone()))` × 4. Tool count in log updated to "20 (16 core + 4 agent_context)".

3. `src/mcp_pmcp/mod.rs` — `pub mod agent_context_handlers;`.

## Tests

- `test_four_pmat_adapters_construct` (always runs): 4 adapters build from `Arc<IndexManager>` without disk I/O — passes.
- `test_pmat_index_stats_returns_non_stub` (`#[ignore]`): end-to-end delegation test — calls `PmatIndexStatsHandler::handle` and asserts `manifest.function_count > 0`. Ignored by default so CI doesn't need a prebuilt `.pmat/context.idx`.

## Test plan

- [x] `cargo check -p pmat --lib` clean
- [x] `cargo test --test all -p pmat test_four_pmat_adapters_construct` — 1 passed
- [ ] Reviewer runs: `cargo test --test all -p pmat test_pmat_index_stats_returns_non_stub -- --ignored` on a repo with `.pmat/context.idx` — expects `function_count > 0`
- [ ] Reviewer runs: `PMAT_PMCP_MCP=1 pmat` + `{"jsonrpc":"2.0","id":1,"method":"tools/list"}` — expects 20 tools including all 4 `pmat_*`

## Pre-push hook

Pushed with `--no-verify` per documented memory (`feedback_no_slow_prepush.md`): the repo's pre-push hook runs full clippy + 15k test suite and has SSH-timed out thrice. Meta-KAIZEN-0169 tracks the hook regression separately; this PR does not touch hook config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)