### PR TITLE
fix(mcp): forward inputSchema/description in pmat_* ToolHandler adapters (KAIZEN-0174)

### DIFF
--- a/src/mcp_pmcp/agent_context_handlers.rs
+++ b/src/mcp_pmcp/agent_context_handlers.rs
@@ -1,0 +1,49 @@
+//! pmcp ToolHandler adapters for the 4 `pmat_*` AgentContextTools (KAIZEN-0165).
+//!
+//! The tools in `crate::mcp::tools::agent_context_tools` implement a custom
+//! `McpTool` trait with `execute(Value) -> Result<Value, String>`. pmcp's
+//! `Server::builder().tool(...)` requires `pmcp::ToolHandler` with
+//! `handle(Value, RequestHandlerExtra) -> pmcp::Result<Value>`. These thin
+//! newtype wrappers adapt one to the other so the 4 tools appear in the live
+//! MCP stdio tools/list.
+
+use crate::mcp::tools::agent_context_tools::{
+    FindSimilarTool, GetFunctionTool, IndexManager, IndexStatsTool, McpTool as InnerMcpTool,
+    QueryCodeTool,
+};
+use async_trait::async_trait;
+use pmcp::{Error as PmcpError, RequestHandlerExtra, Result as PmcpResult, ToolHandler};
+use serde_json::Value;
+use std::sync::Arc;
+
+macro_rules! impl_pmat_handler {
+    ($wrapper:ident, $inner:ident) => {
+        pub struct $wrapper {
+            inner: $inner,
+        }
+
+        impl $wrapper {
+            pub fn new(mgr: Arc<IndexManager>) -> Self {
+                Self {
+                    inner: $inner::new(mgr),
+                }
+            }
+        }
+
+        #[async_trait]
+        impl ToolHandler for $wrapper {
+            async fn handle(
+                &self,
+                args: Value,
+                _extra: RequestHandlerExtra,
+            ) -> PmcpResult<Value> {
+                self.inner.execute(args).await.map_err(PmcpError::internal)
+            }
+        }
+    };
+}
+
+impl_pmat_handler!(PmatQueryCodeHandler, QueryCodeTool);
+impl_pmat_handler!(PmatGetFunctionHandler, GetFunctionTool);
+impl_pmat_handler!(PmatFindSimilarHandler, FindSimilarTool);
+impl_pmat_handler!(PmatIndexStatsHandler, IndexStatsTool);

--- a/src/mcp_pmcp/agent_context_handlers.rs
+++ b/src/mcp_pmcp/agent_context_handlers.rs
@@ -6,15 +6,46 @@
 //! `handle(Value, RequestHandlerExtra) -> pmcp::Result<Value>`. These thin
 //! newtype wrappers adapt one to the other so the 4 tools appear in the live
 //! MCP stdio tools/list.
+//!
+//! KAIZEN-0174: Forward `description` + `input_schema` from the inner tool via
+//! the `ToolHandler::metadata()` override so MCP clients can render forms for
+//! these tools. The inner `McpTool::schema()` returns a JSON shaped as
+//! `{"name": "...", "description": "...", "parameters": {...}}` — we extract
+//! the fields into `pmcp::types::ToolInfo` which pmcp's builder caches at
+//! registration time and serves from `tools/list`.
 
 use crate::mcp::tools::agent_context_tools::{
     FindSimilarTool, GetFunctionTool, IndexManager, IndexStatsTool, McpTool as InnerMcpTool,
     QueryCodeTool,
 };
 use async_trait::async_trait;
+use pmcp::types::ToolInfo;
 use pmcp::{Error as PmcpError, RequestHandlerExtra, Result as PmcpResult, ToolHandler};
-use serde_json::Value;
+use serde_json::{json, Value};
 use std::sync::Arc;
+
+/// Extract `{name, description, input_schema}` from the inner McpTool schema JSON.
+///
+/// The inner `McpTool::schema()` returns a `{"name", "description", "parameters"}`
+/// envelope. pmcp's `ToolInfo` expects a flat `{name, description, input_schema}`.
+/// This helper does the translation so every `pmat_*` handler's `metadata()` can
+/// feed pmcp's builder the real schema instead of `json!({})`.
+fn inner_schema_to_tool_info(inner_schema: &Value) -> ToolInfo {
+    let name = inner_schema
+        .get("name")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let description = inner_schema
+        .get("description")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+    let input_schema = inner_schema
+        .get("parameters")
+        .cloned()
+        .unwrap_or_else(|| json!({"type": "object"}));
+    ToolInfo::new(name, description, input_schema)
+}
 
 macro_rules! impl_pmat_handler {
     ($wrapper:ident, $inner:ident) => {
@@ -39,6 +70,10 @@ macro_rules! impl_pmat_handler {
             ) -> PmcpResult<Value> {
                 self.inner.execute(args).await.map_err(PmcpError::internal)
             }
+
+            fn metadata(&self) -> Option<ToolInfo> {
+                Some(inner_schema_to_tool_info(&self.inner.schema()))
+            }
         }
     };
 }
@@ -47,3 +82,68 @@ impl_pmat_handler!(PmatQueryCodeHandler, QueryCodeTool);
 impl_pmat_handler!(PmatGetFunctionHandler, GetFunctionTool);
 impl_pmat_handler!(PmatFindSimilarHandler, FindSimilarTool);
 impl_pmat_handler!(PmatIndexStatsHandler, IndexStatsTool);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mcp::tools::agent_context_tools::IndexManager;
+    use std::path::PathBuf;
+
+    fn make_index_manager() -> Arc<IndexManager> {
+        Arc::new(IndexManager::new(PathBuf::from(".")))
+    }
+
+    #[test]
+    fn test_pmat_query_code_has_input_schema() {
+        let handler = PmatQueryCodeHandler::new(make_index_manager());
+        let info = handler.metadata().expect("metadata should be Some");
+
+        assert_eq!(info.name, "pmat_query_code");
+        assert!(
+            info.description.is_some(),
+            "description should be forwarded"
+        );
+        assert!(
+            info.description.as_deref().unwrap().contains("quality"),
+            "description should mention quality filtering"
+        );
+
+        let schema = &info.input_schema;
+        assert_eq!(schema["type"], "object", "input_schema must be object type");
+        assert!(
+            schema["properties"]["query"].is_object(),
+            "input_schema must include `query` property"
+        );
+        assert_eq!(
+            schema["required"].as_array().expect("required array"),
+            &vec![Value::String("query".to_string())]
+        );
+    }
+
+    #[test]
+    fn test_pmat_get_function_has_input_schema() {
+        let handler = PmatGetFunctionHandler::new(make_index_manager());
+        let info = handler.metadata().expect("metadata should be Some");
+        assert_eq!(info.name, "pmat_get_function");
+        assert!(info.description.is_some());
+        assert_eq!(info.input_schema["type"], "object");
+    }
+
+    #[test]
+    fn test_pmat_find_similar_has_input_schema() {
+        let handler = PmatFindSimilarHandler::new(make_index_manager());
+        let info = handler.metadata().expect("metadata should be Some");
+        assert_eq!(info.name, "pmat_find_similar");
+        assert!(info.description.is_some());
+        assert_eq!(info.input_schema["type"], "object");
+    }
+
+    #[test]
+    fn test_pmat_index_stats_has_input_schema() {
+        let handler = PmatIndexStatsHandler::new(make_index_manager());
+        let info = handler.metadata().expect("metadata should be Some");
+        assert_eq!(info.name, "pmat_index_stats");
+        assert!(info.description.is_some());
+        assert_eq!(info.input_schema["type"], "object");
+    }
+}

--- a/src/mcp_pmcp/mod.rs
+++ b/src/mcp_pmcp/mod.rs
@@ -92,6 +92,7 @@
 //! // Memory usage: 50MB (50% reduction)
 //! ```
 
+pub mod agent_context_handlers;
 pub mod analyze_handlers;
 pub mod context_handlers;
 pub mod discovery;

--- a/src/mcp_pmcp/simple_unified_server.rs
+++ b/src/mcp_pmcp/simple_unified_server.rs
@@ -1,3 +1,7 @@
+use crate::mcp::tools::agent_context_tools::IndexManager;
+use crate::mcp_pmcp::agent_context_handlers::{
+    PmatFindSimilarHandler, PmatGetFunctionHandler, PmatIndexStatsHandler, PmatQueryCodeHandler,
+};
 use crate::mcp_pmcp::analyze_handlers::{
     AnalyzeBigOTool, AnalyzeComplexityTool, AnalyzeDagTool, AnalyzeDeadCodeTool,
     AnalyzeDeepContextTool, AnalyzeSatdTool,
@@ -11,6 +15,7 @@ use crate::mcp_pmcp::quality_handlers::QualityGateTool;
 use crate::mcp_pmcp::quality_proxy_handler::QualityProxyTool;
 use crate::mcp_server::state_manager::StateManager;
 use pmcp::{Server, ServerCapabilities, ToolCapabilities};
+use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 use tracing::info;
@@ -35,6 +40,12 @@ impl SimpleUnifiedServer {
     #[provable_contracts_macros::contract("pmat-core.yaml", equation = "check_compliance")]
     pub async fn run(&self) -> Result<(), Box<dyn std::error::Error>> {
         info!("Starting PMAT Simple Unified MCP server (pmcp SDK)");
+
+        // KAIZEN-0165: shared IndexManager for the 4 pmat_* AgentContextTools.
+        // Construction is cheap (no disk I/O); first tool call triggers index build.
+        let index_manager = Arc::new(IndexManager::new(
+            std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
+        ));
 
         // Build server with core PMAT tools that are already working
         let server = Server::builder()
@@ -76,9 +87,26 @@ impl SimpleUnifiedServer {
             .tool("git_operation", GitTool)
             .tool("generate_context", GenerateContextTool)
             .tool("scaffold_project", ScaffoldProjectTool)
+            // === Agent Context Tools (4) — KAIZEN-0165 ===
+            .tool(
+                "pmat_query_code",
+                PmatQueryCodeHandler::new(index_manager.clone()),
+            )
+            .tool(
+                "pmat_get_function",
+                PmatGetFunctionHandler::new(index_manager.clone()),
+            )
+            .tool(
+                "pmat_find_similar",
+                PmatFindSimilarHandler::new(index_manager.clone()),
+            )
+            .tool(
+                "pmat_index_stats",
+                PmatIndexStatsHandler::new(index_manager.clone()),
+            )
             .build()?;
 
-        info!("PMAT Simple Unified MCP server ready with 18 core tools, listening on stdio");
+        info!("PMAT Simple Unified MCP server ready with 20 tools (16 core + 4 agent_context), listening on stdio");
 
         // Run server with stdio transport
         server.run_stdio().await?;

--- a/tests/modules/mcp_agent_context_tools_test.rs
+++ b/tests/modules/mcp_agent_context_tools_test.rs
@@ -1,0 +1,67 @@
+//! KAIZEN-0165: Verify the 4 `pmat_*` AgentContextTools are wired via pmcp adapters.
+//!
+//! Before this fix, the adapter crate compiled but no `.tool()` call in
+//! `simple_unified_server.rs` registered these tools — so MCP `tools/list`
+//! returned only 16 core tools. Now the adapters exist and the server
+//! registers them.
+//!
+//! These tests exercise the adapters directly (instead of booting a full
+//! stdio server) so they run fast and survive `skip-slow-tests`.
+//!
+//! They assert:
+//!   (a) The 4 adapter structs can be constructed from an `Arc<IndexManager>`.
+//!   (b) `PmatIndexStatsHandler::handle(...)` returns non-stub JSON with a
+//!       `manifest.function_count > 0` on a repo that has an existing
+//!       `.pmat/context.idx` — proving the pmcp adapter actually delegates
+//!       to the real tool.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use pmat::mcp::tools::agent_context_tools::IndexManager;
+use pmat::mcp_pmcp::agent_context_handlers::{
+    PmatFindSimilarHandler, PmatGetFunctionHandler, PmatIndexStatsHandler, PmatQueryCodeHandler,
+};
+use pmcp::{RequestHandlerExtra, ToolHandler};
+use serde_json::json;
+use tokio_util::sync::CancellationToken;
+
+fn test_extra() -> RequestHandlerExtra {
+    RequestHandlerExtra::new("kaizen-0165-test".to_string(), CancellationToken::new())
+}
+
+fn pmat_project_root() -> PathBuf {
+    // tests/modules/this.rs -> CARGO_MANIFEST_DIR is the worktree root.
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+#[test]
+fn test_four_pmat_adapters_construct() {
+    let mgr = Arc::new(IndexManager::new(pmat_project_root()));
+
+    // Smoke: each newtype wrapper must be buildable from Arc<IndexManager>.
+    let _q = PmatQueryCodeHandler::new(mgr.clone());
+    let _g = PmatGetFunctionHandler::new(mgr.clone());
+    let _s = PmatFindSimilarHandler::new(mgr.clone());
+    let _i = PmatIndexStatsHandler::new(mgr.clone());
+}
+
+#[tokio::test]
+#[ignore = "requires .pmat/context.idx; run with --ignored after `pmat index`"]
+async fn test_pmat_index_stats_returns_non_stub() {
+    let mgr = Arc::new(IndexManager::new(pmat_project_root()));
+    let tool = PmatIndexStatsHandler::new(mgr);
+
+    let result = tool
+        .handle(json!({"rebuild": false}), test_extra())
+        .await
+        .expect("pmat_index_stats handler should not error on a pmat checkout");
+
+    let fn_count = result["manifest"]["function_count"]
+        .as_u64()
+        .expect("response must include manifest.function_count");
+    assert!(
+        fn_count > 0,
+        "index_stats returned stub (function_count={fn_count}); expected >0"
+    );
+}

--- a/tests/modules/mod.rs
+++ b/tests/modules/mod.rs
@@ -107,6 +107,7 @@ mod issue_67_integration_test;
 mod json_parsing_tests;
 mod kotlin_ast_test;
 mod kotlin_support_test;
+mod mcp_agent_context_tools_test;
 mod mcp_docs_enforcement;
 mod mcp_documentation_sync;
 #[cfg(feature = "mcp-integration")]


### PR DESCRIPTION
## Summary

Fixes R14 #1 validator finding that MCP tools advertise **empty `description`** and **empty `inputSchema`** in `tools/list`, making them unrenderable by MCP clients like ChatGPT Apps, Claude Desktop, and Smithery.

Stacks on PR #349 (`fix/k0165-mcp-wiring`).

## Root Cause

pmcp 1.20's `ToolHandler` trait has a default `metadata() -> Option<ToolInfo>` that returns `None`. When `None`, `Server::builder().tool(name, handler)` falls back to:

```rust
ToolInfo::new(name.clone(), None, serde_json::json!({}))
```

So tools appear in `tools/list` with an empty object schema and no description. The `impl_pmat_handler!` macro in `src/mcp_pmcp/agent_context_handlers.rs` only implemented `handle()`, accepting this default.

## Fix

Override `metadata()` in the macro to forward the inner `McpTool::schema()` through a helper that extracts `{name, description, parameters}` into a `pmcp::types::ToolInfo`:

```rust
fn inner_schema_to_tool_info(inner_schema: &Value) -> ToolInfo {
    let name = inner_schema.get("name").and_then(|v| v.as_str()).unwrap_or("").to_string();
    let description = inner_schema.get("description").and_then(|v| v.as_str()).map(String::from);
    let input_schema = inner_schema.get("parameters").cloned().unwrap_or_else(|| json!({"type": "object"}));
    ToolInfo::new(name, description, input_schema)
}

// In macro:
fn metadata(&self) -> Option<ToolInfo> {
    Some(inner_schema_to_tool_info(&self.inner.schema()))
}
```

The pmcp builder caches the `ToolInfo` at registration time (single call to `handler.metadata()`) and serves it from `tools/list`, so there's no per-request overhead.

## Verification

**Unit tests** (4 added, all passing):
- `test_pmat_query_code_has_input_schema` — asserts `type: object`, `properties.query` present, `required: ["query"]`
- `test_pmat_get_function_has_input_schema`
- `test_pmat_find_similar_has_input_schema`
- `test_pmat_index_stats_has_input_schema`

**Manual stdio verification** (`PMAT_PMCP_MCP=1 pmat` → `tools/list`):

```json
{
  "name": "pmat_query_code",
  "description": "Search code functions by natural language query with TDG quality filtering...",
  "inputSchema": {
    "type": "object",
    "properties": {
      "query": { "type": "string", "description": "Natural language search query..." },
      "limit": { "type": "integer", "minimum": 1, "maximum": 100, "default": 10 },
      "min_grade": { "type": "string", "enum": ["A","B","C","D","F"] },
      "max_complexity": { "type": "integer" },
      "language": { "type": "string", "enum": ["rust","typescript","python","go","java","c","cpp"] },
      "path_pattern": { "type": "string" },
      "include_source": { "type": "boolean", "default": false },
      "rebuild_index": { "type": "boolean", "default": false }
    },
    "required": ["query"]
  }
}
```

All 4 `pmat_*` tools now present full descriptions, `type: object`, rich `properties`, and correct `required` fields.

## Scope

**In scope**: 4 `pmat_*` adapters (`PmatQueryCodeHandler`, `PmatGetFunctionHandler`, `PmatFindSimilarHandler`, `PmatIndexStatsHandler`).

**Out of scope** (same bug, same fix, but deferred to avoid PR sprawl): the 16 core tools in `simple_unified_server.rs` (`analyze_*`, `refactor.*`, `quality_*`, `git_operation`, `generate_context`, `scaffold_project`, `pdmt_deterministic_todos`). Their `ToolHandler` impls also don't override `metadata()`. Tracked separately.

## Test plan

- [x] `cargo check -p pmat --lib` — clean
- [x] `cargo test -p pmat --lib mcp_pmcp::agent_context_handlers::tests` — 4/4 pass
- [x] `cargo test -p pmat --lib mcp_pmcp::` — 452/452 pass, 0 regressions
- [x] Manual stdio: `pmat_query_code`, `pmat_get_function`, `pmat_find_similar`, `pmat_index_stats` all show non-empty description + structured inputSchema

---

Generated with [Claude Code](https://claude.com/claude-code)