### PR TITLE
fix(comply): emit metadata field in work-contract YAMLs (KAIZEN-0175)

### DIFF
--- a/contracts/work/CB-125_126_127__Coverage_gaming_and_slow_test_detection.yaml
+++ b/contracts/work/CB-125_126_127__Coverage_gaming_and_slow_test_detection.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/CB-125_126_127__Coverage_gaming_and_slow_test_detection/contract.json
 name: "CB-125,126,127: Coverage gaming and slow test detection"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for CB-125,126,127: Coverage gaming and slow test detection"
+  references:
+    - ".pmat-work/CB-125_126_127__Coverage_gaming_and_slow_test_detection/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L1
   current_level: L1
+  total_obligations: 13

--- a/contracts/work/DBC-TEST.yaml
+++ b/contracts/work/DBC-TEST.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/DBC-TEST/contract.json
 name: "DBC-TEST"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for DBC-TEST"
+  references:
+    - ".pmat-work/DBC-TEST/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L1
   current_level: L1
+  total_obligations: 36

--- a/contracts/work/DOGFOOD-001.yaml
+++ b/contracts/work/DOGFOOD-001.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/DOGFOOD-001/contract.json
 name: "DOGFOOD-001"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for DOGFOOD-001"
+  references:
+    - ".pmat-work/DOGFOOD-001/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L3
   current_level: L3
+  total_obligations: 21

--- a/contracts/work/GH-168.yaml
+++ b/contracts/work/GH-168.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/GH-168/contract.json
 name: "GH-168"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for GH-168"
+  references:
+    - ".pmat-work/GH-168/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L1
   current_level: L1
+  total_obligations: 17

--- a/contracts/work/GH-226.yaml
+++ b/contracts/work/GH-226.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/GH-226/contract.json
 name: "GH-226"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for GH-226"
+  references:
+    - ".pmat-work/GH-226/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L1
   current_level: L1
+  total_obligations: 22

--- a/contracts/work/GH-228.yaml
+++ b/contracts/work/GH-228.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/GH-228/contract.json
 name: "GH-228"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for GH-228"
+  references:
+    - ".pmat-work/GH-228/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L1
   current_level: L1
+  total_obligations: 22

--- a/contracts/work/GH-230.yaml
+++ b/contracts/work/GH-230.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/GH-230/contract.json
 name: "GH-230"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for GH-230"
+  references:
+    - ".pmat-work/GH-230/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L3
   current_level: L3
+  total_obligations: 22

--- a/contracts/work/GH-232.yaml
+++ b/contracts/work/GH-232.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/GH-232/contract.json
 name: "GH-232"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for GH-232"
+  references:
+    - ".pmat-work/GH-232/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L1
   current_level: L1
+  total_obligations: 22

--- a/contracts/work/GH-235.yaml
+++ b/contracts/work/GH-235.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/GH-235/contract.json
 name: "GH-235"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for GH-235"
+  references:
+    - ".pmat-work/GH-235/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L3
   current_level: L3
+  total_obligations: 22

--- a/contracts/work/PMAT-033.yaml
+++ b/contracts/work/PMAT-033.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-033/contract.json
 name: "PMAT-033"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-033"
+  references:
+    - ".pmat-work/PMAT-033/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L3
   current_level: L3
+  total_obligations: 47

--- a/contracts/work/PMAT-280.yaml
+++ b/contracts/work/PMAT-280.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-280/contract.json
 name: "PMAT-280"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-280"
+  references:
+    - ".pmat-work/PMAT-280/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L3
   current_level: L3
+  total_obligations: 47

--- a/contracts/work/PMAT-445.yaml
+++ b/contracts/work/PMAT-445.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-445/contract.json
 name: "PMAT-445"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-445"
+  references:
+    - ".pmat-work/PMAT-445/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L1
   current_level: L1
+  total_obligations: 17

--- a/contracts/work/PMAT-459.yaml
+++ b/contracts/work/PMAT-459.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-459/contract.json
 name: "PMAT-459"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-459"
+  references:
+    - ".pmat-work/PMAT-459/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L1
   current_level: L1
+  total_obligations: 13

--- a/contracts/work/PMAT-460.yaml
+++ b/contracts/work/PMAT-460.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-460/contract.json
 name: "PMAT-460"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-460"
+  references:
+    - ".pmat-work/PMAT-460/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L1
   current_level: L1
+  total_obligations: 13

--- a/contracts/work/PMAT-461.yaml
+++ b/contracts/work/PMAT-461.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-461/contract.json
 name: "PMAT-461"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-461"
+  references:
+    - ".pmat-work/PMAT-461/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L1
   current_level: L1
+  total_obligations: 13

--- a/contracts/work/PMAT-462.yaml
+++ b/contracts/work/PMAT-462.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-462/contract.json
 name: "PMAT-462"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-462"
+  references:
+    - ".pmat-work/PMAT-462/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L3
   current_level: L3
+  total_obligations: 17

--- a/contracts/work/PMAT-463.yaml
+++ b/contracts/work/PMAT-463.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-463/contract.json
 name: "PMAT-463"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-463"
+  references:
+    - ".pmat-work/PMAT-463/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L1
   current_level: L1
+  total_obligations: 17

--- a/contracts/work/PMAT-464.yaml
+++ b/contracts/work/PMAT-464.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-464/contract.json
 name: "PMAT-464"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-464"
+  references:
+    - ".pmat-work/PMAT-464/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L1
   current_level: L1
+  total_obligations: 17

--- a/contracts/work/PMAT-465.yaml
+++ b/contracts/work/PMAT-465.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-465/contract.json
 name: "PMAT-465"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-465"
+  references:
+    - ".pmat-work/PMAT-465/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L1
   current_level: L1
+  total_obligations: 17

--- a/contracts/work/PMAT-468.yaml
+++ b/contracts/work/PMAT-468.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-468/contract.json
 name: "PMAT-468"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-468"
+  references:
+    - ".pmat-work/PMAT-468/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L1
   current_level: L1
+  total_obligations: 17

--- a/contracts/work/PMAT-469.yaml
+++ b/contracts/work/PMAT-469.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-469/contract.json
 name: "PMAT-469"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-469"
+  references:
+    - ".pmat-work/PMAT-469/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L3
   current_level: L3
+  total_obligations: 17

--- a/contracts/work/PMAT-470.yaml
+++ b/contracts/work/PMAT-470.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-470/contract.json
 name: "PMAT-470"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-470"
+  references:
+    - ".pmat-work/PMAT-470/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L3
   current_level: L3
+  total_obligations: 17

--- a/contracts/work/PMAT-471.yaml
+++ b/contracts/work/PMAT-471.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-471/contract.json
 name: "PMAT-471"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-471"
+  references:
+    - ".pmat-work/PMAT-471/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L1
   current_level: L1
+  total_obligations: 17

--- a/contracts/work/PMAT-472.yaml
+++ b/contracts/work/PMAT-472.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-472/contract.json
 name: "PMAT-472"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-472"
+  references:
+    - ".pmat-work/PMAT-472/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L3
   current_level: L3
+  total_obligations: 17

--- a/contracts/work/PMAT-475.yaml
+++ b/contracts/work/PMAT-475.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-475/contract.json
 name: "PMAT-475"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-475"
+  references:
+    - ".pmat-work/PMAT-475/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L3
   current_level: L3
+  total_obligations: 17

--- a/contracts/work/PMAT-476.yaml
+++ b/contracts/work/PMAT-476.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-476/contract.json
 name: "PMAT-476"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-476"
+  references:
+    - ".pmat-work/PMAT-476/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L1
   current_level: L1
+  total_obligations: 17

--- a/contracts/work/PMAT-477.yaml
+++ b/contracts/work/PMAT-477.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-477/contract.json
 name: "PMAT-477"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-477"
+  references:
+    - ".pmat-work/PMAT-477/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L3
   current_level: L3
+  total_obligations: 17

--- a/contracts/work/PMAT-478.yaml
+++ b/contracts/work/PMAT-478.yaml
@@ -1,9 +1,15 @@
 # Auto-generated from .pmat-work/PMAT-478/contract.json
 name: "PMAT-478"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-478"
+  references:
+    - ".pmat-work/PMAT-478/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L1
   current_level: L1
+  total_obligations: 0
 preconditions:
   - "pmat query --regex supports Rust regex syntax"
   - "pmat query --literal performs exact string match"

--- a/contracts/work/PMAT-480.yaml
+++ b/contracts/work/PMAT-480.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-480/contract.json
 name: "PMAT-480"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-480"
+  references:
+    - ".pmat-work/PMAT-480/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L1
   current_level: L1
+  total_obligations: 17

--- a/contracts/work/PMAT-481.yaml
+++ b/contracts/work/PMAT-481.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-481/contract.json
 name: "PMAT-481"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-481"
+  references:
+    - ".pmat-work/PMAT-481/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L1
   current_level: L1
+  total_obligations: 17

--- a/contracts/work/PMAT-482.yaml
+++ b/contracts/work/PMAT-482.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-482/contract.json
 name: "PMAT-482"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-482"
+  references:
+    - ".pmat-work/PMAT-482/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L3
   current_level: L3
+  total_obligations: 17

--- a/contracts/work/PMAT-483.yaml
+++ b/contracts/work/PMAT-483.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-483/contract.json
 name: "PMAT-483"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-483"
+  references:
+    - ".pmat-work/PMAT-483/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L1
   current_level: L1
+  total_obligations: 17

--- a/contracts/work/PMAT-485.yaml
+++ b/contracts/work/PMAT-485.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-485/contract.json
 name: "PMAT-485"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-485"
+  references:
+    - ".pmat-work/PMAT-485/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L1
   current_level: L1
+  total_obligations: 17

--- a/contracts/work/PMAT-486.yaml
+++ b/contracts/work/PMAT-486.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-486/contract.json
 name: "PMAT-486"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-486"
+  references:
+    - ".pmat-work/PMAT-486/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L1
   current_level: L1
+  total_obligations: 17

--- a/contracts/work/PMAT-487.yaml
+++ b/contracts/work/PMAT-487.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-487/contract.json
 name: "PMAT-487"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-487"
+  references:
+    - ".pmat-work/PMAT-487/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L1
   current_level: L1
+  total_obligations: 17

--- a/contracts/work/PMAT-488.yaml
+++ b/contracts/work/PMAT-488.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-488/contract.json
 name: "PMAT-488"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-488"
+  references:
+    - ".pmat-work/PMAT-488/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L1
   current_level: L1
+  total_obligations: 17

--- a/contracts/work/PMAT-489.yaml
+++ b/contracts/work/PMAT-489.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-489/contract.json
 name: "PMAT-489"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-489"
+  references:
+    - ".pmat-work/PMAT-489/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L1
   current_level: L1
+  total_obligations: 17

--- a/contracts/work/PMAT-490.yaml
+++ b/contracts/work/PMAT-490.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-490/contract.json
 name: "PMAT-490"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-490"
+  references:
+    - ".pmat-work/PMAT-490/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L1
   current_level: L1
+  total_obligations: 17

--- a/contracts/work/PMAT-491.yaml
+++ b/contracts/work/PMAT-491.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-491/contract.json
 name: "PMAT-491"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-491"
+  references:
+    - ".pmat-work/PMAT-491/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L3
   current_level: L3
+  total_obligations: 17

--- a/contracts/work/PMAT-492.yaml
+++ b/contracts/work/PMAT-492.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-492/contract.json
 name: "PMAT-492"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-492"
+  references:
+    - ".pmat-work/PMAT-492/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L1
   current_level: L1
+  total_obligations: 17

--- a/contracts/work/PMAT-493.yaml
+++ b/contracts/work/PMAT-493.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-493/contract.json
 name: "PMAT-493"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-493"
+  references:
+    - ".pmat-work/PMAT-493/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L1
   current_level: L1
+  total_obligations: 17

--- a/contracts/work/PMAT-494.yaml
+++ b/contracts/work/PMAT-494.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-494/contract.json
 name: "PMAT-494"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-494"
+  references:
+    - ".pmat-work/PMAT-494/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L1
   current_level: L1
+  total_obligations: 17

--- a/contracts/work/PMAT-495.yaml
+++ b/contracts/work/PMAT-495.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-495/contract.json
 name: "PMAT-495"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-495"
+  references:
+    - ".pmat-work/PMAT-495/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L1
   current_level: L1
+  total_obligations: 17

--- a/contracts/work/PMAT-496.yaml
+++ b/contracts/work/PMAT-496.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-496/contract.json
 name: "PMAT-496"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-496"
+  references:
+    - ".pmat-work/PMAT-496/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L1
   current_level: L1
+  total_obligations: 17

--- a/contracts/work/PMAT-497.yaml
+++ b/contracts/work/PMAT-497.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-497/contract.json
 name: "PMAT-497"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-497"
+  references:
+    - ".pmat-work/PMAT-497/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L3
   current_level: L3
+  total_obligations: 21

--- a/contracts/work/PMAT-498.yaml
+++ b/contracts/work/PMAT-498.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-498/contract.json
 name: "PMAT-498"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-498"
+  references:
+    - ".pmat-work/PMAT-498/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L1
   current_level: L1
+  total_obligations: 22

--- a/contracts/work/PMAT-499.yaml
+++ b/contracts/work/PMAT-499.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-499/contract.json
 name: "PMAT-499"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-499"
+  references:
+    - ".pmat-work/PMAT-499/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L1
   current_level: L1
+  total_obligations: 22

--- a/contracts/work/PMAT-500.yaml
+++ b/contracts/work/PMAT-500.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-500/contract.json
 name: "PMAT-500"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-500"
+  references:
+    - ".pmat-work/PMAT-500/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L1
   current_level: L1
+  total_obligations: 22

--- a/contracts/work/PMAT-500__Variant-coverage_and_fix-chain_falsification_claims_for_cross-project_defect_prevention.yaml
+++ b/contracts/work/PMAT-500__Variant-coverage_and_fix-chain_falsification_claims_for_cross-project_defect_prevention.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-500__Variant-coverage_and_fix-chain_falsification_claims_for_cross-project_defect_prevention/contract.json
 name: "PMAT-500: Variant-coverage and fix-chain falsification claims for cross-project defect prevention"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-500: Variant-coverage and fix-chain falsification claims for cross-project defect prevention"
+  references:
+    - ".pmat-work/PMAT-500__Variant-coverage_and_fix-chain_falsification_claims_for_cross-project_defect_prevention/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L1
   current_level: L1
+  total_obligations: 21

--- a/contracts/work/PMAT-501.yaml
+++ b/contracts/work/PMAT-501.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-501/contract.json
 name: "PMAT-501"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-501"
+  references:
+    - ".pmat-work/PMAT-501/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L3
   current_level: L3
+  total_obligations: 22

--- a/contracts/work/PMAT-504.yaml
+++ b/contracts/work/PMAT-504.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-504/contract.json
 name: "PMAT-504"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-504"
+  references:
+    - ".pmat-work/PMAT-504/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L1
   current_level: L1
+  total_obligations: 36

--- a/contracts/work/PMAT-505.yaml
+++ b/contracts/work/PMAT-505.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-505/contract.json
 name: "PMAT-505"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-505"
+  references:
+    - ".pmat-work/PMAT-505/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L3
   current_level: L3
+  total_obligations: 36

--- a/contracts/work/PMAT-506.yaml
+++ b/contracts/work/PMAT-506.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-506/contract.json
 name: "PMAT-506"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-506"
+  references:
+    - ".pmat-work/PMAT-506/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L1
   current_level: L1
+  total_obligations: 36

--- a/contracts/work/PMAT-507.yaml
+++ b/contracts/work/PMAT-507.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-507/contract.json
 name: "PMAT-507"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-507"
+  references:
+    - ".pmat-work/PMAT-507/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L1
   current_level: L1
+  total_obligations: 36

--- a/contracts/work/PMAT-508.yaml
+++ b/contracts/work/PMAT-508.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-508/contract.json
 name: "PMAT-508"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-508"
+  references:
+    - ".pmat-work/PMAT-508/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L1
   current_level: L1
+  total_obligations: 36

--- a/contracts/work/PMAT-509.yaml
+++ b/contracts/work/PMAT-509.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-509/contract.json
 name: "PMAT-509"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-509"
+  references:
+    - ".pmat-work/PMAT-509/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L3
   current_level: L3
+  total_obligations: 47

--- a/contracts/work/PMAT-511.yaml
+++ b/contracts/work/PMAT-511.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-511/contract.json
 name: "PMAT-511"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-511"
+  references:
+    - ".pmat-work/PMAT-511/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L1
   current_level: L1
+  total_obligations: 36

--- a/contracts/work/PMAT-512.yaml
+++ b/contracts/work/PMAT-512.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-512/contract.json
 name: "PMAT-512"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-512"
+  references:
+    - ".pmat-work/PMAT-512/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L1
   current_level: L1
+  total_obligations: 36

--- a/contracts/work/PMAT-513.yaml
+++ b/contracts/work/PMAT-513.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-513/contract.json
 name: "PMAT-513"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-513"
+  references:
+    - ".pmat-work/PMAT-513/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L1
   current_level: L1
+  total_obligations: 36

--- a/contracts/work/PMAT-514.yaml
+++ b/contracts/work/PMAT-514.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-514/contract.json
 name: "PMAT-514"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-514"
+  references:
+    - ".pmat-work/PMAT-514/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L1
   current_level: L1
+  total_obligations: 36

--- a/contracts/work/PMAT-515.yaml
+++ b/contracts/work/PMAT-515.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-515/contract.json
 name: "PMAT-515"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-515"
+  references:
+    - ".pmat-work/PMAT-515/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L1
   current_level: L1
+  total_obligations: 36

--- a/contracts/work/PMAT-516.yaml
+++ b/contracts/work/PMAT-516.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-516/contract.json
 name: "PMAT-516"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-516"
+  references:
+    - ".pmat-work/PMAT-516/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L1
   current_level: L1
+  total_obligations: 36

--- a/contracts/work/PMAT-517.yaml
+++ b/contracts/work/PMAT-517.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-517/contract.json
 name: "PMAT-517"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-517"
+  references:
+    - ".pmat-work/PMAT-517/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L1
   current_level: L1
+  total_obligations: 36

--- a/contracts/work/PMAT-518.yaml
+++ b/contracts/work/PMAT-518.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-518/contract.json
 name: "PMAT-518"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-518"
+  references:
+    - ".pmat-work/PMAT-518/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L3
   current_level: L3
+  total_obligations: 36

--- a/contracts/work/PMAT-519.yaml
+++ b/contracts/work/PMAT-519.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-519/contract.json
 name: "PMAT-519"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-519"
+  references:
+    - ".pmat-work/PMAT-519/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L1
   current_level: L1
+  total_obligations: 36

--- a/contracts/work/PMAT-520.yaml
+++ b/contracts/work/PMAT-520.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-520/contract.json
 name: "PMAT-520"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-520"
+  references:
+    - ".pmat-work/PMAT-520/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L1
   current_level: L1
+  total_obligations: 36

--- a/contracts/work/PMAT-521.yaml
+++ b/contracts/work/PMAT-521.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-521/contract.json
 name: "PMAT-521"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-521"
+  references:
+    - ".pmat-work/PMAT-521/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L3
   current_level: L3
+  total_obligations: 47

--- a/contracts/work/PMAT-522.yaml
+++ b/contracts/work/PMAT-522.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-522/contract.json
 name: "PMAT-522"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-522"
+  references:
+    - ".pmat-work/PMAT-522/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L1
   current_level: L1
+  total_obligations: 36

--- a/contracts/work/PMAT-523.yaml
+++ b/contracts/work/PMAT-523.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-523/contract.json
 name: "PMAT-523"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-523"
+  references:
+    - ".pmat-work/PMAT-523/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L1
   current_level: L1
+  total_obligations: 36

--- a/contracts/work/PMAT-524.yaml
+++ b/contracts/work/PMAT-524.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-524/contract.json
 name: "PMAT-524"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-524"
+  references:
+    - ".pmat-work/PMAT-524/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L1
   current_level: L1
+  total_obligations: 36

--- a/contracts/work/PMAT-525.yaml
+++ b/contracts/work/PMAT-525.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-525/contract.json
 name: "PMAT-525"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-525"
+  references:
+    - ".pmat-work/PMAT-525/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L1
   current_level: L1
+  total_obligations: 36

--- a/contracts/work/PMAT-526.yaml
+++ b/contracts/work/PMAT-526.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-526/contract.json
 name: "PMAT-526"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-526"
+  references:
+    - ".pmat-work/PMAT-526/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L1
   current_level: L1
+  total_obligations: 36

--- a/contracts/work/PMAT-527.yaml
+++ b/contracts/work/PMAT-527.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-527/contract.json
 name: "PMAT-527"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-527"
+  references:
+    - ".pmat-work/PMAT-527/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L1
   current_level: L1
+  total_obligations: 36

--- a/contracts/work/PMAT-539.yaml
+++ b/contracts/work/PMAT-539.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-539/contract.json
 name: "PMAT-539"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-539"
+  references:
+    - ".pmat-work/PMAT-539/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L3
   current_level: L3
+  total_obligations: 47

--- a/contracts/work/PMAT-540.yaml
+++ b/contracts/work/PMAT-540.yaml
@@ -1,9 +1,15 @@
 # Auto-generated from .pmat-work/PMAT-540/contract.json
 name: "PMAT-540"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-540"
+  references:
+    - ".pmat-work/PMAT-540/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L2
   current_level: L2
+  total_obligations: 0
 preconditions:
   - "All 8 phases of commit-level enforcement implemented with 29 CB checks"
   - "9/10 remediation items done (R-1..R-10, R-3 deferred)"

--- a/contracts/work/PMAT-541.yaml
+++ b/contracts/work/PMAT-541.yaml
@@ -1,9 +1,15 @@
 # Auto-generated from .pmat-work/PMAT-541/contract.json
 name: "PMAT-541"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-541"
+  references:
+    - ".pmat-work/PMAT-541/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L2
   current_level: L2
+  total_obligations: 0
 preconditions:
   - "#[contract] proc_macro generates debug_assert! from YAML preconditions"
   - "CB-1340 penetration increases from 1.6% to 10%+ after bulk annotation"

--- a/contracts/work/PMAT-600.yaml
+++ b/contracts/work/PMAT-600.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-600/contract.json
 name: "PMAT-600"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-600"
+  references:
+    - ".pmat-work/PMAT-600/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L3
   current_level: L3
+  total_obligations: 47

--- a/contracts/work/PMAT-601.yaml
+++ b/contracts/work/PMAT-601.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-601/contract.json
 name: "PMAT-601"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-601"
+  references:
+    - ".pmat-work/PMAT-601/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L3
   current_level: L3
+  total_obligations: 47

--- a/contracts/work/PMAT-602.yaml
+++ b/contracts/work/PMAT-602.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-602/contract.json
 name: "PMAT-602"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-602"
+  references:
+    - ".pmat-work/PMAT-602/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L3
   current_level: L3
+  total_obligations: 47

--- a/contracts/work/PMAT-603.yaml
+++ b/contracts/work/PMAT-603.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-603/contract.json
 name: "PMAT-603"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-603"
+  references:
+    - ".pmat-work/PMAT-603/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L3
   current_level: L3
+  total_obligations: 47

--- a/contracts/work/PMAT-604.yaml
+++ b/contracts/work/PMAT-604.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-604/contract.json
 name: "PMAT-604"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-604"
+  references:
+    - ".pmat-work/PMAT-604/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L3
   current_level: L3
+  total_obligations: 47

--- a/contracts/work/PMAT-605.yaml
+++ b/contracts/work/PMAT-605.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-605/contract.json
 name: "PMAT-605"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-605"
+  references:
+    - ".pmat-work/PMAT-605/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L3
   current_level: L3
+  total_obligations: 47

--- a/contracts/work/PMAT-606.yaml
+++ b/contracts/work/PMAT-606.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-606/contract.json
 name: "PMAT-606"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-606"
+  references:
+    - ".pmat-work/PMAT-606/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L3
   current_level: L3
+  total_obligations: 47

--- a/contracts/work/PMAT-607.yaml
+++ b/contracts/work/PMAT-607.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-607/contract.json
 name: "PMAT-607"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-607"
+  references:
+    - ".pmat-work/PMAT-607/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L3
   current_level: L3
+  total_obligations: 47

--- a/contracts/work/PMAT-608.yaml
+++ b/contracts/work/PMAT-608.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-608/contract.json
 name: "PMAT-608"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-608"
+  references:
+    - ".pmat-work/PMAT-608/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L3
   current_level: L3
+  total_obligations: 47

--- a/contracts/work/PMAT-609.yaml
+++ b/contracts/work/PMAT-609.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-609/contract.json
 name: "PMAT-609"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-609"
+  references:
+    - ".pmat-work/PMAT-609/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L3
   current_level: L3
+  total_obligations: 47

--- a/contracts/work/PMAT-610.yaml
+++ b/contracts/work/PMAT-610.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-610/contract.json
 name: "PMAT-610"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-610"
+  references:
+    - ".pmat-work/PMAT-610/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L3
   current_level: L3
+  total_obligations: 47

--- a/contracts/work/PMAT-611.yaml
+++ b/contracts/work/PMAT-611.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-611/contract.json
 name: "PMAT-611"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-611"
+  references:
+    - ".pmat-work/PMAT-611/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L3
   current_level: L3
+  total_obligations: 47

--- a/contracts/work/PMAT-612.yaml
+++ b/contracts/work/PMAT-612.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-612/contract.json
 name: "PMAT-612"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-612"
+  references:
+    - ".pmat-work/PMAT-612/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L3
   current_level: L3
+  total_obligations: 47

--- a/contracts/work/PMAT-613.yaml
+++ b/contracts/work/PMAT-613.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-613/contract.json
 name: "PMAT-613"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-613"
+  references:
+    - ".pmat-work/PMAT-613/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L3
   current_level: L3
+  total_obligations: 47

--- a/contracts/work/PMAT-615.yaml
+++ b/contracts/work/PMAT-615.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-615/contract.json
 name: "PMAT-615"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-615"
+  references:
+    - ".pmat-work/PMAT-615/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L3
   current_level: L3
+  total_obligations: 47

--- a/contracts/work/PMAT-616.yaml
+++ b/contracts/work/PMAT-616.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-616/contract.json
 name: "PMAT-616"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-616"
+  references:
+    - ".pmat-work/PMAT-616/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L3
   current_level: L3
+  total_obligations: 47

--- a/contracts/work/PMAT-617.yaml
+++ b/contracts/work/PMAT-617.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-617/contract.json
 name: "PMAT-617"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-617"
+  references:
+    - ".pmat-work/PMAT-617/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L3
   current_level: L3
+  total_obligations: 47

--- a/contracts/work/PMAT-618.yaml
+++ b/contracts/work/PMAT-618.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-618/contract.json
 name: "PMAT-618"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-618"
+  references:
+    - ".pmat-work/PMAT-618/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L3
   current_level: L3
+  total_obligations: 47

--- a/contracts/work/PMAT-619.yaml
+++ b/contracts/work/PMAT-619.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-619/contract.json
 name: "PMAT-619"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-619"
+  references:
+    - ".pmat-work/PMAT-619/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L3
   current_level: L3
+  total_obligations: 47

--- a/contracts/work/PMAT-620.yaml
+++ b/contracts/work/PMAT-620.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-620/contract.json
 name: "PMAT-620"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-620"
+  references:
+    - ".pmat-work/PMAT-620/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L3
   current_level: L3
+  total_obligations: 47

--- a/contracts/work/PMAT-621.yaml
+++ b/contracts/work/PMAT-621.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-621/contract.json
 name: "PMAT-621"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-621"
+  references:
+    - ".pmat-work/PMAT-621/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L3
   current_level: L3
+  total_obligations: 47

--- a/contracts/work/PMAT-622.yaml
+++ b/contracts/work/PMAT-622.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-622/contract.json
 name: "PMAT-622"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-622"
+  references:
+    - ".pmat-work/PMAT-622/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L3
   current_level: L3
+  total_obligations: 47

--- a/contracts/work/PMAT-623.yaml
+++ b/contracts/work/PMAT-623.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-623/contract.json
 name: "PMAT-623"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-623"
+  references:
+    - ".pmat-work/PMAT-623/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L3
   current_level: L3
+  total_obligations: 47

--- a/contracts/work/PMAT-624.yaml
+++ b/contracts/work/PMAT-624.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-624/contract.json
 name: "PMAT-624"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-624"
+  references:
+    - ".pmat-work/PMAT-624/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L3
   current_level: L3
+  total_obligations: 47

--- a/contracts/work/PMAT-ARCH-001.yaml
+++ b/contracts/work/PMAT-ARCH-001.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-ARCH-001/contract.json
 name: "PMAT-ARCH-001"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-ARCH-001"
+  references:
+    - ".pmat-work/PMAT-ARCH-001/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L1
   current_level: L1
+  total_obligations: 17

--- a/contracts/work/PMAT-COV-001.yaml
+++ b/contracts/work/PMAT-COV-001.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-COV-001/contract.json
 name: "PMAT-COV-001"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-COV-001"
+  references:
+    - ".pmat-work/PMAT-COV-001/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L1
   current_level: L1
+  total_obligations: 17

--- a/contracts/work/PMAT-DBC-12.yaml
+++ b/contracts/work/PMAT-DBC-12.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-DBC-12/contract.json
 name: "PMAT-DBC-12"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-DBC-12"
+  references:
+    - ".pmat-work/PMAT-DBC-12/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L1
   current_level: L1
+  total_obligations: 36

--- a/contracts/work/PMAT-DBC-13.yaml
+++ b/contracts/work/PMAT-DBC-13.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-DBC-13/contract.json
 name: "PMAT-DBC-13"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-DBC-13"
+  references:
+    - ".pmat-work/PMAT-DBC-13/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L1
   current_level: L1
+  total_obligations: 36

--- a/contracts/work/PMAT-DBC.yaml
+++ b/contracts/work/PMAT-DBC.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/PMAT-DBC/contract.json
 name: "PMAT-DBC"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for PMAT-DBC"
+  references:
+    - ".pmat-work/PMAT-DBC/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L1
   current_level: L1
+  total_obligations: 22

--- a/contracts/work/baseline-v1.yaml
+++ b/contracts/work/baseline-v1.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/baseline-v1/contract.json
 name: "baseline-v1"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for baseline-v1"
+  references:
+    - ".pmat-work/baseline-v1/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L3
   current_level: L3
+  total_obligations: 22

--- a/contracts/work/falsify-rag.yaml
+++ b/contracts/work/falsify-rag.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/falsify-rag/contract.json
 name: "falsify-rag"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for falsify-rag"
+  references:
+    - ".pmat-work/falsify-rag/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L1
   current_level: L1
+  total_obligations: 21

--- a/contracts/work/make_coverage_at_95__-_fast__no_workarounds.yaml
+++ b/contracts/work/make_coverage_at_95__-_fast__no_workarounds.yaml
@@ -1,6 +1,12 @@
 # Auto-generated from .pmat-work/make_coverage_at_95__-_fast__no_workarounds/contract.json
 name: "make coverage at 95% - fast, no workarounds"
+metadata:
+  version: "1.0.0"
+  description: "Auto-generated work-contract for make coverage at 95% - fast, no workarounds"
+  references:
+    - ".pmat-work/make_coverage_at_95__-_fast__no_workarounds/contract.json"
 surface: work-contract
 verification_summary:
   target_level: L1
   current_level: L1
+  total_obligations: 17

--- a/src/cli/handlers/comply_handlers/check_handlers/check_commit_enforcement_p10.rs
+++ b/src/cli/handlers/comply_handlers/check_handlers/check_commit_enforcement_p10.rs
@@ -409,4 +409,63 @@ mod tests_commit_enforcement_p2 {
         assert_eq!(check.status, CheckStatus::Warn);
         assert!(check.message.contains("placeholder"));
     }
+
+    // KAIZEN-0175: work-contract YAML generator must emit a `metadata:` block
+    // with version/description/references so `pv lint` accepts them.
+    #[test]
+    fn test_kaizen0175_generator_emits_metadata_block() {
+        let dir = tempdir().unwrap();
+        let work = dir.path().join(".pmat-work/TEST-123");
+        fs::create_dir_all(&work).unwrap();
+        fs::write(
+            work.join("contract.json"),
+            r#"{
+                "work_item_id": "TEST-123",
+                "verification_level": "L2",
+                "falsifiable_claims": [{"claim": "foo > 0"}],
+                "ensure": ["bar is valid"],
+                "require": ["baz exists"]
+            }"#,
+        )
+        .unwrap();
+
+        let count = generate_work_contract_yamls(dir.path()).unwrap();
+        assert_eq!(count, 1);
+
+        let yaml = fs::read_to_string(dir.path().join("contracts/work/TEST-123.yaml")).unwrap();
+
+        // Metadata block must be present with the three fields pv 0.31 requires.
+        assert!(
+            yaml.contains("metadata:\n"),
+            "missing `metadata:` block: {yaml}"
+        );
+        assert!(
+            yaml.contains("  version: \"1.0.0\"\n"),
+            "missing metadata.version: {yaml}"
+        );
+        assert!(
+            yaml.contains("  description: \"Auto-generated work-contract for TEST-123\"\n"),
+            "missing metadata.description: {yaml}"
+        );
+        assert!(
+            yaml.contains("  references:\n"),
+            "missing metadata.references: {yaml}"
+        );
+        assert!(
+            yaml.contains("    - \".pmat-work/TEST-123/contract.json\"\n"),
+            "missing references entry: {yaml}"
+        );
+
+        // Metadata must precede surface/verification_summary so it is the first
+        // map-entry (line 2 per pv's "missing field metadata at line 2 column 1").
+        let meta_pos = yaml.find("metadata:").expect("metadata: present");
+        let surface_pos = yaml.find("surface:").expect("surface: present");
+        let vs_pos = yaml
+            .find("verification_summary:")
+            .expect("verification_summary: present");
+        assert!(
+            meta_pos < surface_pos && meta_pos < vs_pos,
+            "metadata must come before surface and verification_summary: {yaml}"
+        );
+    }
 }

--- a/src/cli/handlers/comply_handlers/check_handlers/check_commit_enforcement_p8.rs
+++ b/src/cli/handlers/comply_handlers/check_handlers/check_commit_enforcement_p8.rs
@@ -97,6 +97,20 @@ fn generate_work_contract_yamls(project_path: &Path) -> anyhow::Result<usize> {
             safe_id
         );
         yaml.push_str(&format!("name: \"{}\"\n", yaml_escape_string(id)));
+        // Emit metadata block (KAIZEN-0175): pv 0.31 schema requires metadata
+        // with version/description/references. Deterministic values only —
+        // no timestamps, to avoid daily churn in contracts/work/*.yaml.
+        yaml.push_str("metadata:\n");
+        yaml.push_str("  version: \"1.0.0\"\n");
+        yaml.push_str(&format!(
+            "  description: \"Auto-generated work-contract for {}\"\n",
+            yaml_escape_string(id)
+        ));
+        yaml.push_str("  references:\n");
+        yaml.push_str(&format!(
+            "    - \".pmat-work/{}/contract.json\"\n",
+            safe_id
+        ));
         yaml.push_str("surface: work-contract\n");
         yaml.push_str(&format!(
             "verification_summary:\n  target_level: {}\n  current_level: {}\n  total_obligations: {}\n",


### PR DESCRIPTION
## Summary

Extends KAIZEN-0136 (#348) to satisfy the next \`pv 0.31\` schema gap:
\`generate_work_contract_yamls()\` now emits a deterministic \`metadata:\` block
so \`pv lint contracts/work\` stops choking on *"missing field metadata at line 2 column 1"*.

## Before / After

\`\`\`
BEFORE (round14 dogfood):   108 × PV-VAL-001 — "missing field \`metadata\` at line 2 column 1"
AFTER (this PR):              0 × metadata-parse errors
\`\`\`

432 new errors are *unmasked* (4 × 108), all in brand-new categories
(SCHEMA-003 equations, PROVABILITY-001 × 3 for \`proof_obligations\`,
\`falsification_tests\`, \`kani_harnesses\`). These are scoped to later
KAIZEN tickets — they couldn't surface before because pv couldn't even
parse the YAML past line 2.

## Generated YAML snippet

\`\`\`yaml
# Auto-generated from .pmat-work/PMAT-619/contract.json
name: "PMAT-619"
metadata:
  version: "1.0.0"
  description: "Auto-generated work-contract for PMAT-619"
  references:
    - ".pmat-work/PMAT-619/contract.json"
surface: work-contract
verification_summary:
  target_level: L3
  current_level: L3
  total_obligations: 47
\`\`\`

## Fields added

- \`metadata.version\` — \`"1.0.0"\` (constant — work-contracts share a schema version)
- \`metadata.description\` — \`"Auto-generated work-contract for <id>"\`
- \`metadata.references\` — one-entry list pointing at the source \`.pmat-work/<id>/contract.json\`

No timestamps → **zero daily churn** in \`contracts/work/\`.

## Changes

- \`src/cli/handlers/comply_handlers/check_handlers/check_commit_enforcement_p8.rs\` — generator change (9 new lines inside \`generate_work_contract_yamls\`)
- \`src/cli/handlers/comply_handlers/check_handlers/check_commit_enforcement_p10.rs\` — unit test \`test_kaizen0175_generator_emits_metadata_block\` asserts the block is present, has the three required fields, and precedes \`surface:\`/\`verification_summary:\`
- \`contracts/work/*.yaml\` × 108 — regenerated via \`pmat comply refresh-bindings\`; each gains the \`metadata:\` block (and picks up the \`total_obligations\` count from the KAIZEN-0136 generator change that wasn't regen'd in #348)

Stacks on \`fix/k0136-total-obligations\` (#348).

## Test plan

- [x] \`cargo test --lib test_kaizen0175\` — new unit test passes
- [x] \`pv validate contracts/work/TEST-123.yaml\` on a synthetic fixture — parse error gone, only deep-schema errors remain
- [x] \`pv lint contracts/work\` against all 108 regenerated YAMLs — \`missing field metadata\` count: \`108 → 0\`
- [x] \`cargo fmt --all -- --check\` clean
- [ ] CI green

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>