### PR TITLE
fix(mcp): forward inputSchema for 16 core MCP tools (KAIZEN-0189)

### DIFF
--- a/src/mcp_pmcp/analyze_complexity_handler.rs
+++ b/src/mcp_pmcp/analyze_complexity_handler.rs
@@ -80,4 +80,16 @@ impl ToolHandler for ComplexityTool {
 
         Ok(results)
     }
+
+    fn metadata(&self) -> Option<ToolInfo> {
+        let extra = json!({
+            "top_files": { "type": "integer", "description": "Return only the top N most-complex files" },
+            "threshold": { "type": "integer", "description": "Minimum cyclomatic complexity to report" }
+        });
+        Some(build_tool_info(
+            "analyze_complexity",
+            "Analyze cyclomatic and cognitive complexity for source files.",
+            paths_object_schema(extra, vec!["paths"]),
+        ))
+    }
 }

--- a/src/mcp_pmcp/analyze_debt_handlers.rs
+++ b/src/mcp_pmcp/analyze_debt_handlers.rs
@@ -70,6 +70,17 @@ impl ToolHandler for SatdTool {
 
         Ok(results)
     }
+
+    fn metadata(&self) -> Option<ToolInfo> {
+        let extra = json!({
+            "include_resolved": { "type": "boolean", "description": "Include items already marked resolved" }
+        });
+        Some(build_tool_info(
+            "analyze_satd",
+            "Detect self-admitted technical debt (TODO, FIXME, HACK markers) in source code.",
+            paths_object_schema(extra, vec!["paths"]),
+        ))
+    }
 }
 
 // Dead Code Analysis Tool
@@ -115,5 +126,16 @@ impl ToolHandler for DeadCodeTool {
             .map_err(|e| Error::internal(format!("Dead code analysis failed: {e}")))?;
 
         Ok(results)
+    }
+
+    fn metadata(&self) -> Option<ToolInfo> {
+        let extra = json!({
+            "include_tests": { "type": "boolean", "description": "Include test files when searching for dead code" }
+        });
+        Some(build_tool_info(
+            "analyze_dead_code",
+            "Find unreachable or unused code (functions, types, or modules).",
+            paths_object_schema(extra, vec!["paths"]),
+        ))
     }
 }

--- a/src/mcp_pmcp/analyze_handlers.rs
+++ b/src/mcp_pmcp/analyze_handlers.rs
@@ -14,10 +14,12 @@
 //! - `analyze_handlers_tests_tdg.rs` — Unit tests (TDG, deserialization, integration)
 
 use crate::mcp_pmcp::tool_functions;
+use crate::mcp_pmcp::tool_schemas::{build_tool_info, paths_object_schema};
 use async_trait::async_trait;
+use pmcp::types::ToolInfo;
 use pmcp::{Error, RequestHandlerExtra, Result, ToolHandler};
 use serde::Deserialize;
-use serde_json::Value;
+use serde_json::{json, Value};
 use std::path::PathBuf;
 use tracing::debug;
 

--- a/src/mcp_pmcp/analyze_metrics_handlers.rs
+++ b/src/mcp_pmcp/analyze_metrics_handlers.rs
@@ -42,6 +42,18 @@ impl ToolHandler for LintHotspotTool {
 
         Ok(results)
     }
+
+    fn metadata(&self) -> Option<ToolInfo> {
+        let extra = json!({
+            "top_files": { "type": "integer", "description": "Return only the top N files with the most lint violations" }
+        });
+        // Registered as `analyze_dag` in server.rs; keep the registered name for consistency.
+        Some(build_tool_info(
+            "analyze_dag",
+            "Generate a dependency graph (DAG) / lint hotspot report highlighting files with the most violations.",
+            paths_object_schema(extra, vec!["paths"]),
+        ))
+    }
 }
 
 // Churn Analysis Tool
@@ -90,6 +102,19 @@ impl ToolHandler for ChurnTool {
 
         Ok(results)
     }
+
+    fn metadata(&self) -> Option<ToolInfo> {
+        let extra = json!({
+            "days":      { "type": "integer", "description": "Git history window in days (default: 90)" },
+            "top_files": { "type": "integer", "description": "Return only the top N files by churn" }
+        });
+        // Registered as `analyze_deep_context` in server.rs.
+        Some(build_tool_info(
+            "analyze_deep_context",
+            "Comprehensive code analysis combining git churn history with code metrics.",
+            paths_object_schema(extra, vec!["paths"]),
+        ))
+    }
 }
 
 // Coupling Analysis Tool
@@ -135,5 +160,17 @@ impl ToolHandler for CouplingTool {
             .map_err(|e| Error::internal(format!("Coupling analysis failed: {e}")))?;
 
         Ok(results)
+    }
+
+    fn metadata(&self) -> Option<ToolInfo> {
+        let extra = json!({
+            "threshold": { "type": "number", "description": "Minimum similarity threshold for reporting coupled modules (0.0-1.0)" }
+        });
+        // Registered as `analyze_big_o` in server.rs.
+        Some(build_tool_info(
+            "analyze_big_o",
+            "Big-O complexity / module coupling analysis.",
+            paths_object_schema(extra, vec!["paths"]),
+        ))
     }
 }

--- a/src/mcp_pmcp/analyze_tdg_tool_handlers.rs
+++ b/src/mcp_pmcp/analyze_tdg_tool_handlers.rs
@@ -92,6 +92,20 @@ impl ToolHandler for TdgTool {
 
         Ok(results)
     }
+
+    fn metadata(&self) -> Option<ToolInfo> {
+        let extra = json!({
+            "threshold":          { "type": "number",  "description": "Minimum TDG score threshold" },
+            "top_files":          { "type": "integer", "description": "Return only the top N files" },
+            "include_components": { "type": "boolean", "description": "Include per-metric component breakdown" },
+            "with_git_context":   { "type": "boolean", "description": "Correlate scores with git commit history (Sprint 65)" }
+        });
+        Some(build_tool_info(
+            "analyze_tdg",
+            "Compute Technical Debt Grading (TDG) scores across orthogonal quality metrics.",
+            paths_object_schema(extra, vec!["paths"]),
+        ))
+    }
 }
 
 // TDG Comparison Tool
@@ -152,5 +166,22 @@ impl ToolHandler for TdgCompareTool {
             .map_err(|e| Error::internal(format!("TDG comparison failed: {e}")))?;
 
         Ok(results)
+    }
+
+    fn metadata(&self) -> Option<ToolInfo> {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "path1":            { "type": "string",  "description": "Baseline path to compare" },
+                "path2":            { "type": "string",  "description": "Candidate path to compare" },
+                "with_git_context": { "type": "boolean", "description": "Include git commit correlation (Sprint 65)" }
+            },
+            "required": ["path1", "path2"]
+        });
+        Some(build_tool_info(
+            "analyze_tdg_compare",
+            "Diff TDG scores between two paths (files or directories).",
+            schema,
+        ))
     }
 }

--- a/src/mcp_pmcp/context_handlers.rs
+++ b/src/mcp_pmcp/context_handlers.rs
@@ -1,7 +1,9 @@
 //! Context and git tool handlers for the pmcp-based MCP server.
 
 use crate::mcp_pmcp::tool_functions;
+use crate::mcp_pmcp::tool_schemas::{build_tool_info, paths_object_schema};
 use async_trait::async_trait;
+use pmcp::types::ToolInfo;
 use pmcp::{Error, RequestHandlerExtra, Result, ToolHandler};
 use serde::Deserialize;
 use serde_json::{json, Value};

--- a/src/mcp_pmcp/context_handlers_context.rs
+++ b/src/mcp_pmcp/context_handlers_context.rs
@@ -59,6 +59,20 @@ impl ToolHandler for ContextGenerateTool {
             Some(format) => Err(Error::validation(format!("Unsupported format: {format}"))),
         }
     }
+
+    fn metadata(&self) -> Option<ToolInfo> {
+        let extra = json!({
+            "format":               { "type": "string", "enum": ["json", "markdown", "xml"], "description": "Output format" },
+            "max_depth":            { "type": "integer", "description": "Max directory-tree depth to include" },
+            "include_dependencies": { "type": "boolean", "description": "Include dependency graph" }
+        });
+        // Registered as `generate_context` in server.rs.
+        Some(build_tool_info(
+            "generate_context",
+            "Generate project context (file tree + optional dependency graph) for LLM/agent consumption.",
+            paths_object_schema(extra, vec!["paths"]),
+        ))
+    }
 }
 
 // Context Analyze Tool
@@ -144,5 +158,17 @@ impl ToolHandler for ContextSummaryTool {
             .map_err(|e| Error::internal(format!("Context summary failed: {e}")))?;
 
         Ok(summary)
+    }
+
+    fn metadata(&self) -> Option<ToolInfo> {
+        let extra = json!({
+            "level": { "type": "string", "enum": ["brief", "normal", "detailed"], "description": "Summary detail level" }
+        });
+        // Registered as `scaffold_project` in server.rs (historical alias).
+        Some(build_tool_info(
+            "scaffold_project",
+            "Produce a high-level project summary scaffold for the given paths.",
+            paths_object_schema(extra, vec!["paths"]),
+        ))
     }
 }

--- a/src/mcp_pmcp/context_handlers_git.rs
+++ b/src/mcp_pmcp/context_handlers_git.rs
@@ -96,4 +96,20 @@ impl ToolHandler for GitStatusTool {
 
         Ok(status)
     }
+
+    fn metadata(&self) -> Option<ToolInfo> {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "path": { "type": "string", "description": "Path to the git repository to query" }
+            },
+            "required": ["path"]
+        });
+        // Registered as `git_operation` in server.rs.
+        Some(build_tool_info(
+            "git_operation",
+            "Query git working-tree status for the given repository path.",
+            schema,
+        ))
+    }
 }

--- a/src/mcp_pmcp/handlers.rs
+++ b/src/mcp_pmcp/handlers.rs
@@ -1,6 +1,8 @@
+use crate::mcp_pmcp::tool_schemas::build_tool_info;
 use crate::mcp_server::state_manager::StateManager;
 use crate::models::refactor::RefactorConfig;
 use async_trait::async_trait;
+use pmcp::types::ToolInfo;
 use pmcp::{Error as PmcpError, RequestHandlerExtra, Result as PmcpResult, ToolHandler};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};

--- a/src/mcp_pmcp/handlers_tool_impls.rs
+++ b/src/mcp_pmcp/handlers_tool_impls.rs
@@ -31,6 +31,29 @@ impl ToolHandler for RefactorStartTool {
             state: state_value,
         })?)
     }
+
+    fn metadata(&self) -> Option<ToolInfo> {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "targets": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Paths to the files or directories to refactor"
+                },
+                "config": {
+                    "type": "object",
+                    "description": "Optional RefactorConfig (profile, thresholds, strategies)"
+                }
+            },
+            "required": ["targets"]
+        });
+        Some(build_tool_info(
+            "refactor.start",
+            "Start a new refactoring session against the given target paths.",
+            schema,
+        ))
+    }
 }
 
 #[async_trait]
@@ -50,6 +73,14 @@ impl ToolHandler for RefactorNextIterationTool {
         serialize_state(state)
             .map_err(|e| PmcpError::internal(format!("Failed to serialize state: {e}")))
     }
+
+    fn metadata(&self) -> Option<ToolInfo> {
+        Some(build_tool_info(
+            "refactor.nextIteration",
+            "Advance the active refactoring session by one iteration.",
+            json!({ "type": "object", "properties": {}, "additionalProperties": false }),
+        ))
+    }
 }
 
 #[async_trait]
@@ -64,6 +95,14 @@ impl ToolHandler for RefactorGetStateTool {
 
         serialize_state(state)
             .map_err(|e| PmcpError::internal(format!("Failed to serialize state: {e}")))
+    }
+
+    fn metadata(&self) -> Option<ToolInfo> {
+        Some(build_tool_info(
+            "refactor.getState",
+            "Return the current state of the active refactoring session.",
+            json!({ "type": "object", "properties": {}, "additionalProperties": false }),
+        ))
     }
 }
 
@@ -81,5 +120,13 @@ impl ToolHandler for RefactorStopTool {
             "status": "stopped",
             "message": "Refactoring session stopped successfully"
         }))
+    }
+
+    fn metadata(&self) -> Option<ToolInfo> {
+        Some(build_tool_info(
+            "refactor.stop",
+            "Stop the active refactoring session and release resources.",
+            json!({ "type": "object", "properties": {}, "additionalProperties": false }),
+        ))
     }
 }

--- a/src/mcp_pmcp/mod.rs
+++ b/src/mcp_pmcp/mod.rs
@@ -102,6 +102,7 @@ pub mod quality_handlers;
 pub mod quality_proxy_handler;
 pub mod server;
 pub mod simple_unified_server;
+pub mod tool_schemas;
 #[cfg_attr(coverage_nightly, coverage(off))]
 #[cfg(test)]
 pub mod tdg_git_context_tests;

--- a/src/mcp_pmcp/pdmt_handler.rs
+++ b/src/mcp_pmcp/pdmt_handler.rs
@@ -1,10 +1,12 @@
+use crate::mcp_pmcp::tool_schemas::build_tool_info;
 use crate::models::pdmt::{EnforcementMode, PdmtQualityConfig};
 use crate::services::pdmt_quality_integration::PdmtQualityEnforcer;
 use crate::services::pdmt_service::PdmtService;
 use async_trait::async_trait;
+use pmcp::types::ToolInfo;
 use pmcp::{Error, RequestHandlerExtra, Result, ToolHandler};
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
+use serde_json::{json, Value};
 use tracing::{debug, error, info};
 
 /// Input parameters for the PDMT deterministic todos tool

--- a/src/mcp_pmcp/pdmt_handler_core.rs
+++ b/src/mcp_pmcp/pdmt_handler_core.rs
@@ -3,6 +3,40 @@
 
 #[async_trait]
 impl ToolHandler for PdmtTool {
+    fn metadata(&self) -> Option<ToolInfo> {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "requirements": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Requirements to convert into deterministic actionable todos"
+                },
+                "project_name": { "type": "string", "description": "Project or component name" },
+                "granularity":  { "type": "string", "enum": ["low", "medium", "high"], "description": "Task detail level (default: high)" },
+                "quality_config": {
+                    "type": "object",
+                    "description": "Quality enforcement config",
+                    "properties": {
+                        "enforcement_mode":       { "type": "string", "enum": ["strict", "advisory", "auto_fix"] },
+                        "coverage_threshold":     { "type": "number"  },
+                        "max_complexity":         { "type": "integer" },
+                        "require_doctests":       { "type": "boolean" },
+                        "require_property_tests": { "type": "boolean" },
+                        "require_examples":       { "type": "boolean" },
+                        "zero_satd_tolerance":    { "type": "boolean" }
+                    }
+                }
+            },
+            "required": ["requirements"]
+        });
+        Some(build_tool_info(
+            "pdmt_deterministic_todos",
+            "Generate deterministic, quality-enforced todo lists from a list of requirements.",
+            schema,
+        ))
+    }
+
     async fn handle(&self, args: Value, _extra: RequestHandlerExtra) -> Result<Value> {
         debug!("Handling pdmt_deterministic_todos with args: {}", args);
 

--- a/src/mcp_pmcp/prompt_handlers.rs
+++ b/src/mcp_pmcp/prompt_handlers.rs
@@ -4,10 +4,12 @@
 //! organizational intelligence and defect patterns from OIP analysis.
 
 use crate::mcp_pmcp::tool_functions;
+use crate::mcp_pmcp::tool_schemas::build_tool_info;
 use async_trait::async_trait;
+use pmcp::types::ToolInfo;
 use pmcp::{Error, RequestHandlerExtra, Result, ToolHandler};
 use serde::Deserialize;
-use serde_json::Value;
+use serde_json::{json, Value};
 use std::path::PathBuf;
 use tracing::debug;
 
@@ -102,6 +104,23 @@ impl ToolHandler for DefectAwarePromptTool {
                 .map_err(|e| Error::internal(format!("Prompt generation failed: {e}")))?;
 
         Ok(results)
+    }
+
+    fn metadata(&self) -> Option<ToolInfo> {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "task":         { "type": "string", "description": "Task description the prompt should address" },
+                "context":      { "type": "string", "description": "Free-form context for the prompt" },
+                "summary_path": { "type": "string", "description": "Path to the organizational intelligence summary YAML" }
+            },
+            "required": ["task", "context", "summary_path"]
+        });
+        Some(build_tool_info(
+            "generate_defect_aware_prompt",
+            "Generate a defect-aware AI prompt enriched with organizational intelligence and historical defect patterns.",
+            schema,
+        ))
     }
 }
 

--- a/src/mcp_pmcp/quality_handlers.rs
+++ b/src/mcp_pmcp/quality_handlers.rs
@@ -1,5 +1,7 @@
 use crate::mcp_pmcp::tool_functions;
+use crate::mcp_pmcp::tool_schemas::{build_tool_info, paths_object_schema};
 use async_trait::async_trait;
+use pmcp::types::ToolInfo;
 use pmcp::{Error, RequestHandlerExtra, Result, ToolHandler};
 use serde::Deserialize;
 use serde_json::{json, Value};

--- a/src/mcp_pmcp/quality_handlers_impl.rs
+++ b/src/mcp_pmcp/quality_handlers_impl.rs
@@ -29,6 +29,18 @@ impl ToolHandler for QualityGateTool {
 
         Ok(results)
     }
+
+    fn metadata(&self) -> Option<ToolInfo> {
+        let extra = json!({
+            "strict": { "type": "boolean", "description": "Fail the gate on any violation (no tolerance)" },
+            "file":   { "type": "string",  "description": "Check only this single file instead of the paths list" }
+        });
+        Some(build_tool_info(
+            "quality_gate",
+            "Run comprehensive quality-gate checks (complexity, SATD, dead code, lint, docs, etc.) against the given paths.",
+            paths_object_schema(extra, vec!["paths"]),
+        ))
+    }
 }
 
 #[async_trait]

--- a/src/mcp_pmcp/quality_proxy_handler.rs
+++ b/src/mcp_pmcp/quality_proxy_handler.rs
@@ -1,9 +1,11 @@
+use crate::mcp_pmcp::tool_schemas::build_tool_info;
 use crate::models::proxy::{ProxyMode, ProxyOperation, ProxyRequest, QualityConfig};
 use crate::services::quality_proxy::QualityProxyService;
 use async_trait::async_trait;
+use pmcp::types::ToolInfo;
 use pmcp::{Error, RequestHandlerExtra, Result, ToolHandler};
 use serde::Deserialize;
-use serde_json::Value;
+use serde_json::{json, Value};
 use tracing::{debug, info};
 
 /// Input parameters for the quality proxy tool.

--- a/src/mcp_pmcp/quality_proxy_handler_impl.rs
+++ b/src/mcp_pmcp/quality_proxy_handler_impl.rs
@@ -1,5 +1,34 @@
 #[async_trait]
 impl ToolHandler for QualityProxyTool {
+    fn metadata(&self) -> Option<ToolInfo> {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "operation":  { "type": "string", "enum": ["write", "edit", "append"], "description": "File operation to proxy" },
+                "file_path":  { "type": "string", "description": "Target file path" },
+                "content":     { "type": "string", "description": "New content for `write`/`append`" },
+                "old_content": { "type": "string", "description": "Old string for `edit` operations" },
+                "new_content": { "type": "string", "description": "New string for `edit` operations" },
+                "mode":        { "type": "string", "enum": ["strict", "advisory", "auto_fix", "auto-fix"], "description": "Proxy enforcement mode" },
+                "quality_config": {
+                    "type": "object",
+                    "properties": {
+                        "max_complexity": { "type": "integer" },
+                        "allow_satd":     { "type": "boolean" },
+                        "require_docs":   { "type": "boolean" },
+                        "auto_format":    { "type": "boolean" }
+                    }
+                }
+            },
+            "required": ["operation", "file_path"]
+        });
+        Some(build_tool_info(
+            "quality_proxy",
+            "Proxy a file operation (write/edit/append) through the quality gate, optionally auto-fixing violations.",
+            schema,
+        ))
+    }
+
     async fn handle(&self, args: Value, _extra: RequestHandlerExtra) -> Result<Value> {
         debug!("Handling quality_proxy with args: {}", args);
 

--- a/src/mcp_pmcp/tdg_handlers.rs
+++ b/src/mcp_pmcp/tdg_handlers.rs
@@ -17,10 +17,12 @@ use crate::mcp_pmcp::tool_functions::{
     tdg_analyze_with_storage, tdg_configure_storage, tdg_health_check, tdg_performance_metrics,
     tdg_storage_management, tdg_system_diagnostics,
 };
+use crate::mcp_pmcp::tool_schemas::{build_tool_info, paths_object_schema};
 use async_trait::async_trait;
+use pmcp::types::ToolInfo;
 use pmcp::{Error, RequestHandlerExtra, Result, ToolHandler};
 use serde::Deserialize;
-use serde_json::Value;
+use serde_json::{json, Value};
 use std::path::PathBuf;
 use tracing::debug;
 

--- a/src/mcp_pmcp/tdg_handlers_impl.rs
+++ b/src/mcp_pmcp/tdg_handlers_impl.rs
@@ -32,6 +32,24 @@ impl ToolHandler for TdgSystemDiagnosticsTool {
 
         Ok(result)
     }
+
+    fn metadata(&self) -> Option<ToolInfo> {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "detailed":   { "type": "boolean", "description": "Include detailed per-component diagnostics" },
+                "components": {
+                    "type": "array", "items": { "type": "string" },
+                    "description": "Subset of components to inspect (empty = all)"
+                }
+            }
+        });
+        Some(build_tool_info(
+            "tdg_system_diagnostics",
+            "Run comprehensive diagnostics on the TDG (Technical Debt Grading) system.",
+            schema,
+        ))
+    }
 }
 
 // === TdgStorageManagementTool ===
@@ -64,6 +82,22 @@ impl ToolHandler for TdgStorageManagementTool {
             .map_err(|e| Error::internal(format!("TDG storage management failed: {e}")))?;
 
         Ok(result)
+    }
+
+    fn metadata(&self) -> Option<ToolInfo> {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "action":  { "type": "string",  "description": "Storage action (compact, purge, stats, vacuum, etc.)" },
+                "options": { "type": "object",  "description": "Freeform options object for the given action" }
+            },
+            "required": ["action"]
+        });
+        Some(build_tool_info(
+            "tdg_storage_management",
+            "Perform a storage management action (compact, purge, vacuum, etc.) on the TDG backend.",
+            schema,
+        ))
     }
 }
 
@@ -106,6 +140,18 @@ impl ToolHandler for TdgAnalyzeWithStorageTool {
 
         Ok(result)
     }
+
+    fn metadata(&self) -> Option<ToolInfo> {
+        let extra = json!({
+            "storage_backend": { "type": "string", "description": "Storage backend name (e.g. sqlite, in-memory)" },
+            "priority":        { "type": "string", "description": "Analysis priority (low, normal, high)" }
+        });
+        Some(build_tool_info(
+            "tdg_analyze_with_storage",
+            "Analyze the given paths through the transactional TDG storage backend.",
+            paths_object_schema(extra, vec!["paths"]),
+        ))
+    }
 }
 
 // === TdgPerformanceMetricsTool ===
@@ -138,6 +184,24 @@ impl ToolHandler for TdgPerformanceMetricsTool {
             .map_err(|e| Error::internal(format!("TDG performance metrics failed: {e}")))?;
 
         Ok(result)
+    }
+
+    fn metadata(&self) -> Option<ToolInfo> {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "include_history": { "type": "boolean", "description": "Include historical trend data" },
+                "metrics": {
+                    "type": "array", "items": { "type": "string" },
+                    "description": "Subset of metric names to return (empty = all)"
+                }
+            }
+        });
+        Some(build_tool_info(
+            "tdg_performance_metrics",
+            "Return real-time TDG system performance metrics.",
+            schema,
+        ))
     }
 }
 
@@ -177,6 +241,24 @@ impl ToolHandler for TdgConfigureStorageTool {
 
         Ok(result)
     }
+
+    fn metadata(&self) -> Option<ToolInfo> {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "backend_type":  { "type": "string",  "description": "Backend type identifier (sqlite, rocks, memory, etc.)" },
+                "path":          { "type": "string",  "description": "Storage path" },
+                "cache_size_mb": { "type": "integer", "description": "In-memory cache size in MB" },
+                "compression":   { "type": "boolean", "description": "Enable on-disk compression" }
+            },
+            "required": ["backend_type"]
+        });
+        Some(build_tool_info(
+            "tdg_configure_storage",
+            "Configure and validate the TDG storage backend.",
+            schema,
+        ))
+    }
 }
 
 // === TdgHealthCheckTool ===
@@ -209,5 +291,21 @@ impl ToolHandler for TdgHealthCheckTool {
             .map_err(|e| Error::internal(format!("TDG health check failed: {e}")))?;
 
         Ok(result)
+    }
+
+    fn metadata(&self) -> Option<ToolInfo> {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "include_recommendations": { "type": "boolean", "description": "Include remediation recommendations" },
+                "check_storage":           { "type": "boolean", "description": "Run storage-backend health probe" },
+                "check_performance":       { "type": "boolean", "description": "Run performance-budget health probe" }
+            }
+        });
+        Some(build_tool_info(
+            "tdg_health_check",
+            "Run a comprehensive TDG-system health check (storage, performance, recommendations).",
+            schema,
+        ))
     }
 }

--- a/src/mcp_pmcp/tool_schemas.rs
+++ b/src/mcp_pmcp/tool_schemas.rs
@@ -1,0 +1,54 @@
+//! Shared schema helpers for the pmcp-backed MCP tool handlers.
+//!
+//! KAIZEN-0189 / R17 #3: pmcp 1.10's `ToolHandler::metadata()` defaults to
+//! `None`, which causes `ServerCoreBuilder::tool()` to fall back to an empty
+//! `ToolInfo { description: None, input_schema: json!({}) }`. MCP clients
+//! then see every tool as "no description, no schema" in `tools/list`.
+//!
+//! The fix is for each `ToolHandler` impl to override `metadata()` and return
+//! a `ToolInfo` whose `input_schema` reflects the actual `#[derive(Deserialize)]`
+//! args struct. Since the 24 core tools here do **not** share a `schema()`
+//! method on their inner types, we declare each tool's schema inline via the
+//! `build_tool_info` helper below and keep every schema adjacent to the handler
+//! file that uses it.
+//!
+//! Companion PR #351 applied the same pattern to the 4 `pmat_*` handlers in
+//! `agent_context_handlers.rs`, where the inner `McpTool::schema()` already
+//! existed. Together these three PRs (KAIZEN-0174 / KAIZEN-0189) ensure every
+//! MCP tool advertises a non-empty `inputSchema`.
+
+use pmcp::types::ToolInfo;
+use serde_json::{json, Value};
+
+/// Build a `ToolInfo` with a non-empty description and JSON-Schema.
+///
+/// Every `ToolHandler::metadata()` override in this crate should funnel
+/// through this helper so the behavior stays consistent and auditable.
+#[inline]
+pub fn build_tool_info(name: &str, description: &str, input_schema: Value) -> ToolInfo {
+    ToolInfo::new(name, Some(description.to_string()), input_schema)
+}
+
+/// Convenience for "paths: string[]"-shaped tools that take only a paths
+/// array plus optional fields. Extra properties can be added before calling.
+#[inline]
+pub fn paths_object_schema(extra_properties: Value, required: Vec<&str>) -> Value {
+    let mut base_props = json!({
+        "paths": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Filesystem paths (files or directories) to analyze"
+        }
+    });
+    if let (Some(base), Some(extra)) = (base_props.as_object_mut(), extra_properties.as_object()) {
+        for (k, v) in extra {
+            base.insert(k.clone(), v.clone());
+        }
+    }
+    let req: Vec<Value> = required.into_iter().map(|s| Value::String(s.into())).collect();
+    json!({
+        "type": "object",
+        "properties": base_props,
+        "required": req
+    })
+}


### PR DESCRIPTION
## Summary

Fixes empty `description` / `inputSchema` in `tools/list` for the **16 core MCP tools** registered by `SimpleUnifiedServer` (the active pmcp-backed MCP server). Applies the PR #351 pattern:

- Override `ToolHandler::metadata()` on every handler
- Return a `ToolInfo` with human-readable description + real JSON-Schema
- Schemas declared inline next to each handler (helpers in new `src/mcp_pmcp/tool_schemas.rs`)

Tools fixed (as registered in `simple_unified_server.rs`):

1. `analyze_complexity`
2. `analyze_satd`
3. `analyze_dead_code`
4. `analyze_dag`
5. `analyze_deep_context`
6. `analyze_big_o`
7. `refactor.start`
8. `refactor.nextIteration`
9. `refactor.getState`
10. `refactor.stop`
11. `quality_gate`
12. `quality_proxy`
13. `pdmt_deterministic_todos`
14. `git_operation`
15. `generate_context`
16. `scaffold_project`

Plus the 6 TDG-system tools + `generate_defect_aware_prompt` + `analyze_tdg` / `analyze_tdg_compare` registered by the alternate `PmcpServer`, so both server entry points stay consistent.

## Root cause

pmcp 1.10's `ToolHandler::metadata()` defaults to `None`. When `None`, `ServerCoreBuilder::tool()` falls back to `ToolInfo::new(name, None, json!({}))` — every tool then shows up as "no description, no schema" in `tools/list`. MCP clients can't render forms for them.

## Fix

Additive only: every handler now overrides `metadata()` and returns a `ToolInfo` with (a) description and (b) hand-written JSON-Schema reflecting the `#[derive(Deserialize)]` args struct. **No `handle()` bodies were modified** — this keeps the PR conflict-free with R17 #1 (dispatch) and R17 #2 (authoritative zeros).

## Test plan

- [x] `cargo check -p pmat --lib` — clean
- [x] `cargo test -p pmat --lib mcp_pmcp` — 448 passed / 0 failed
- [x] Live stdio `PMAT_PMCP_MCP=1 pmat` + `tools/list` dump shows:
  - 16 tools total
  - 0 with non-object schemas
  - 0 missing description
  - Only the 3 no-arg refactor tools report zero properties (correct)

## Relationship to adjacent PRs

- PR #351 (KAIZEN-0174) fixes the 4 `pmat_*` tools in `agent_context_handlers.rs`
- This PR (KAIZEN-0189) fixes the remaining 16+ core tools
- Together: every pmcp-served tool now advertises a non-empty `inputSchema` and `description`

🤖 Generated with [Claude Code](https://claude.com/claude-code)