### PR TITLE
fix(mcp): resolve authoritative zeros on 4 analyze_* handlers (R17-2 D82)

### DIFF
--- a/src/mcp_pmcp/tool_functions/analysis_tools.rs
+++ b/src/mcp_pmcp/tool_functions/analysis_tools.rs
@@ -1,3 +1,55 @@
+/// Expand a list of paths into a flat list of source files.
+///
+/// When a path is a file, it is included verbatim. When a path is a directory,
+/// walkdir is used to enumerate all source files beneath it (`rs`, `py`, `js`,
+/// `ts`, `tsx`, `jsx`, `java`, `cpp`, `cc`, `cxx`, `c`, `h`, `hpp`, `go`, `rb`,
+/// `php`, `swift`, `kt`, `lua`, `sh`). Hidden dirs, `target/`, and `node_modules/`
+/// are skipped.
+///
+/// R17-2: MCP handlers previously only accepted files, returning zeros for
+/// directory inputs (D82 "authoritative zeros" regression).
+fn expand_paths_to_source_files(paths: &[PathBuf]) -> Vec<PathBuf> {
+    use walkdir::WalkDir;
+    const EXTENSIONS: &[&str] = &[
+        "rs", "py", "js", "ts", "tsx", "jsx", "java", "cpp", "cc", "cxx", "c", "h", "hpp", "go",
+        "rb", "php", "swift", "kt", "lua", "sh",
+    ];
+
+    let mut out = Vec::new();
+    for path in paths {
+        if !path.exists() {
+            continue;
+        }
+        if path.is_file() {
+            out.push(path.clone());
+            continue;
+        }
+        if path.is_dir() {
+            for entry in WalkDir::new(path)
+                .follow_links(false)
+                .into_iter()
+                .filter_entry(|e| {
+                    // Always accept the root, filter only descendant dirs/files.
+                    if e.depth() == 0 {
+                        return true;
+                    }
+                    let n = e.file_name().to_string_lossy();
+                    !(n.starts_with('.') || n == "target" || n == "node_modules")
+                })
+                .filter_map(std::result::Result::ok)
+                .filter(|e| e.file_type().is_file())
+            {
+                if let Some(ext) = entry.path().extension().and_then(|e| e.to_str()) {
+                    if EXTENSIONS.contains(&ext) {
+                        out.push(entry.path().to_path_buf());
+                    }
+                }
+            }
+        }
+    }
+    out
+}
+
 #[provable_contracts_macros::contract("pmat-core.yaml", equation = "path_exists")]
 pub async fn analyze_complexity(
     paths: &[PathBuf],
@@ -12,52 +64,45 @@ pub async fn analyze_complexity(
     }
 
     let threshold_value = threshold.unwrap_or(10);
+    let files = expand_paths_to_source_files(paths);
 
-    // Analyze all provided paths
+    // Analyze all expanded files
     let mut all_functions = Vec::new();
     let mut total_files = 0;
     let mut total_complexity = 0u64;
     let mut violations = Vec::new();
 
-    for path in paths {
-        // Skip non-existent paths
-        if !path.exists() {
-            continue;
-        }
+    for path in &files {
+        match analyze_file_complexity_uncached(path, None).await {
+            Ok(metrics) => {
+                total_files += 1;
 
-        // Analyze single file
-        if path.is_file() {
-            match analyze_file_complexity_uncached(path, None).await {
-                Ok(metrics) => {
-                    total_files += 1;
+                for func in &metrics.functions {
+                    let cc = func.metrics.cyclomatic as u64;
+                    total_complexity += cc;
 
-                    for func in &metrics.functions {
-                        let cc = func.metrics.cyclomatic as u64;
-                        total_complexity += cc;
-
-                        if cc >= threshold_value {
-                            violations.push(json!({
-                                "file": metrics.path.clone(),
-                                "function": func.name.clone(),
-                                "complexity": cc,
-                                "threshold": threshold_value,
-                                "line_start": func.line_start,
-                                "line_end": func.line_end,
-                            }));
-                        }
-
-                        all_functions.push(json!({
+                    if cc >= threshold_value {
+                        violations.push(json!({
                             "file": metrics.path.clone(),
                             "function": func.name.clone(),
-                            "cyclomatic_complexity": func.metrics.cyclomatic,
-                            "cognitive_complexity": func.metrics.cognitive,
+                            "complexity": cc,
+                            "threshold": threshold_value,
                             "line_start": func.line_start,
                             "line_end": func.line_end,
                         }));
                     }
+
+                    all_functions.push(json!({
+                        "file": metrics.path.clone(),
+                        "function": func.name.clone(),
+                        "cyclomatic_complexity": func.metrics.cyclomatic,
+                        "cognitive_complexity": func.metrics.cognitive,
+                        "line_start": func.line_start,
+                        "line_end": func.line_end,
+                    }));
                 }
-                Err(_) => continue, // Skip files that fail to analyze
             }
+            Err(_) => continue, // Skip files that fail to analyze
         }
     }
 
@@ -101,15 +146,12 @@ pub async fn analyze_satd(paths: &[PathBuf], _include_resolved: bool) -> Result<
     }
 
     let detector = SATDDetector::new();
+    let files = expand_paths_to_source_files(paths);
 
     let mut total_satd = 0;
     let mut file_results = Vec::new();
 
-    for path in paths {
-        if !path.exists() || !path.is_file() {
-            continue;
-        }
-
+    for path in &files {
         match tokio::fs::read_to_string(path).await {
             Ok(content) => match detector.extract_from_content(&content, path) {
                 Ok(debts) => {
@@ -159,6 +201,7 @@ pub async fn analyze_satd(paths: &[PathBuf], _include_resolved: bool) -> Result<
 #[provable_contracts_macros::contract("pmat-core.yaml", equation = "path_exists")]
 pub async fn analyze_dead_code(paths: &[PathBuf], _include_tests: bool) -> Result<Value> {
     use crate::services::dead_code_multi_language::analyze_dead_code_multi_language;
+    use std::collections::HashMap;
 
     // Validate input
     if paths.is_empty() {
@@ -166,38 +209,56 @@ pub async fn analyze_dead_code(paths: &[PathBuf], _include_tests: bool) -> Resul
     }
 
     let mut total_dead_code = 0;
-    let mut file_results = Vec::new();
+    let mut total_functions = 0;
+    // R17-2: analyze_dead_code_multi_language() accepts dirs OR files; call it
+    // once per provided path (dir aggregation handled by per-language strategies).
+    // Group results by file rather than by path to keep JSON structure stable.
+    let mut dead_by_file: HashMap<String, Vec<(String, usize)>> = HashMap::new();
+    let mut languages: Vec<String> = Vec::new();
 
     for path in paths {
-        if !path.exists() || !path.is_file() {
+        if !path.exists() {
             continue;
         }
-
         match analyze_dead_code_multi_language(path) {
             Ok(result) => {
-                let dead_count = result.dead_functions.len();
-                total_dead_code += dead_count;
-
-                if dead_count > 0 {
-                    file_results.push(json!({
-                        "file": path.display().to_string(),
-                        "dead_code_count": dead_count,
-                        "dead_functions": result.dead_functions.iter().map(|func| json!({
-                            "name": func.name,
-                            "line": func.line,
-                        })).collect::<Vec<_>>(),
-                    }));
+                total_dead_code += result.dead_functions.len();
+                total_functions += result.total_functions;
+                if !languages.contains(&result.language) {
+                    languages.push(result.language.clone());
+                }
+                for func in &result.dead_functions {
+                    dead_by_file
+                        .entry(func.file.clone())
+                        .or_default()
+                        .push((func.name.clone(), func.line));
                 }
             }
             Err(_) => continue,
         }
     }
 
+    let file_results: Vec<Value> = dead_by_file
+        .into_iter()
+        .map(|(file, funcs)| {
+            json!({
+                "file": file,
+                "dead_code_count": funcs.len(),
+                "dead_functions": funcs.iter().map(|(name, line)| json!({
+                    "name": name,
+                    "line": line,
+                })).collect::<Vec<_>>(),
+            })
+        })
+        .collect();
+
     Ok(json!({
         "status": "completed",
         "message": "Dead code analysis completed",
         "results": {
             "total_dead_code": total_dead_code,
+            "total_functions": total_functions,
+            "languages": languages,
             "files": file_results,
         }
     }))

--- a/src/mcp_pmcp/tool_functions/context_tools.rs
+++ b/src/mcp_pmcp/tool_functions/context_tools.rs
@@ -10,14 +10,13 @@ pub async fn generate_context(
         return Err(anyhow::anyhow!("At least one path must be provided"));
     }
 
+    // R17-2: Walk directories. Previously only `path.is_file()` was analyzed,
+    // yielding instant empty responses for directory inputs (D82).
+    let files = expand_paths_to_source_files(paths);
     let mut all_files = Vec::new();
     let all_dependencies: Vec<String> = Vec::new();
 
-    for path in paths {
-        if !path.exists() {
-            continue;
-        }
-
+    for path in &files {
         // Analyze each file
         match analyze_single_file(path).await {
             Ok(file_context) => {

--- a/src/mcp_pmcp/tool_functions_tests.rs
+++ b/src/mcp_pmcp/tool_functions_tests.rs
@@ -791,4 +791,89 @@ mod coverage_tests {
 
         Ok(())
     }
+
+    // ==================== R17-2 D82 REGRESSION TESTS ====================
+    // Directory inputs must produce non-zero counts. Previously handlers
+    // required path.is_file() and returned authoritative zeros for dirs.
+
+    #[tokio::test]
+    async fn test_analyze_complexity_walks_directory() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        fs::write(
+            temp_dir.path().join("sample.rs"),
+            "fn a() { if true { 1 } else { 2 }; } fn b() {}",
+        )?;
+        fs::write(
+            temp_dir.path().join("nested.rs"),
+            "fn c() { for i in 0..10 { let _ = i; } }",
+        )?;
+
+        let paths = vec![temp_dir.path().to_path_buf()];
+        let json = analyze_complexity(&paths, None, None).await.unwrap();
+
+        let total_files = json["results"]["total_files"].as_u64().unwrap_or(0);
+        assert!(
+            total_files >= 2,
+            "expected >=2 files analyzed, got {total_files}; json={json}"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_analyze_satd_walks_directory() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        fs::write(
+            temp_dir.path().join("debt.rs"),
+            "// TODO: refactor this later\nfn x() {}\n// FIXME: edge case\n",
+        )?;
+
+        let paths = vec![temp_dir.path().to_path_buf()];
+        let json = analyze_satd(&paths, false).await.unwrap();
+
+        let total = json["results"]["total_satd"].as_u64().unwrap_or(0);
+        assert!(
+            total >= 1,
+            "expected >=1 SATD item found, got {total}; json={json}"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_analyze_dead_code_walks_directory() -> Result<()> {
+        // Create a minimal Rust project so language detection finds "rust"
+        let temp_dir = TempDir::new()?;
+        fs::write(temp_dir.path().join("Cargo.toml"), "[package]\nname=\"t\"\nversion=\"0.1.0\"\n")?;
+        let src = temp_dir.path().join("src");
+        fs::create_dir(&src)?;
+        fs::write(src.join("lib.rs"), "pub fn used() {}\nfn unused_helper() { let _=1; }\n")?;
+
+        let paths = vec![temp_dir.path().to_path_buf()];
+        let json = analyze_dead_code(&paths, false).await.unwrap();
+
+        // Must run the analysis (status completed, languages non-empty).
+        assert_eq!(json["status"], "completed");
+        let total_functions = json["results"]["total_functions"].as_u64().unwrap_or(0);
+        assert!(
+            total_functions >= 1,
+            "expected analyzer to see >=1 function, got {total_functions}; json={json}"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_generate_context_walks_directory() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        fs::write(temp_dir.path().join("a.rs"), "pub fn alpha() {}\n")?;
+        fs::write(temp_dir.path().join("b.rs"), "pub struct Beta;\n")?;
+
+        let paths = vec![temp_dir.path().to_path_buf()];
+        let json = generate_context(&paths, None, false).await.unwrap();
+
+        let total = json["context"]["total_files"].as_u64().unwrap_or(0);
+        assert!(
+            total >= 2,
+            "expected >=2 files in context, got {total}; json={json}"
+        );
+        Ok(())
+    }
 }


### PR DESCRIPTION
## Summary
- MCP handlers for `analyze_complexity`, `analyze_satd`, `analyze_dead_code`, and `generate_context` were returning empty payloads on directory inputs (classic D82 "authoritative zeros" pattern).
- Root cause: the `tool_functions::*` implementations required `path.is_file()` for every input and silently skipped directories.
- Fix: a small `expand_paths_to_source_files()` helper that walks directories via `walkdir` with standard exclusions (hidden dirs, `target/`, `node_modules/`). All four tools now analyze directory inputs correctly.
- Also added `total_functions` / `languages` fields to `analyze_dead_code` output so clients can distinguish "ran and found nothing" from "didn't run."

## Verification
Fixture path: `src/services/satd_detector/` (9 Rust source files)

| tool | before | after |
|---|---|---|
| `analyze_complexity` | `total_files: 0` | `total_files: 9, total_complexity: 216` |
| `analyze_satd` | `total_satd: 0` | correct (0 here; 22 on `src/cli/`) |
| `analyze_dead_code` | `total_dead_code: 0, total_functions: —` | `total_dead_code: 4, total_functions: 80, languages: [rust]` |
| `generate_context` | 1 entry (the dir path itself) | 9 real file entries with AST items |

## Test plan
- [x] `cargo check -p pmat --lib` clean
- [x] 4 new regression tests in `tool_functions_tests.rs` pass (one per fixed handler, each asserting non-empty results on a tempdir fixture with known content)
- [x] Existing 75 `tool_functions` unit tests still pass
- [x] Live MCP smoke test via `PMAT_PMCP_MCP=1 pmat` with `tools/call` confirms non-zero output for all 4 tools on `src/services/satd_detector/`

## Scope
- Touches only `src/mcp_pmcp/tool_functions/{analysis_tools,context_tools}.rs` and the shared test file.
- Does NOT touch `simple_unified_server.rs` (R17 #3 owns schema registration).
- Does NOT touch `analyze_dag` / `analyze_big_o` / `analyze_deep_context` (R17 #1 owns wrong-dispatch fix).
- Diff: 201 insertions / 56 deletions across 3 files.

Discovered by R15 #3 bench matrix (`/tmp/pmat-dogfood/round15/r15-3-bench-matrix.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)