### PR TITLE
fix(mcp): correct dispatch for analyze_dag/big_o/deep_context (R17-1)

### DIFF
--- a/src/mcp_pmcp/analyze_handlers.rs
+++ b/src/mcp_pmcp/analyze_handlers.rs
@@ -21,12 +21,16 @@ use serde_json::Value;
 use std::path::PathBuf;
 use tracing::debug;
 
-// Re-export for convenience
+// Re-export for convenience.
+//
+// NOTE (R17-1): AnalyzeDagTool / AnalyzeDeepContextTool / AnalyzeBigOTool are
+// *not* aliases for LintHotspotTool / ChurnTool / CouplingTool. They are
+// distinct structs defined below that dispatch to the correct
+// `tool_functions::*` implementation. The earlier aliases mis-routed three
+// MCP tools (see R15 #3 bench matrix).
 pub use self::{
-    ChurnTool as AnalyzeDeepContextTool, ComplexityTool as AnalyzeComplexityTool,
-    CouplingTool as AnalyzeBigOTool, DeadCodeTool as AnalyzeDeadCodeTool,
-    LintHotspotTool as AnalyzeDagTool, SatdTool as AnalyzeSatdTool,
-    TdgCompareTool as AnalyzeTdgCompareTool, TdgTool as AnalyzeTdgTool,
+    ComplexityTool as AnalyzeComplexityTool, DeadCodeTool as AnalyzeDeadCodeTool,
+    SatdTool as AnalyzeSatdTool, TdgCompareTool as AnalyzeTdgCompareTool, TdgTool as AnalyzeTdgTool,
 };
 
 // Complexity analysis tool handler

--- a/src/mcp_pmcp/analyze_handlers_tests_tdg.rs
+++ b/src/mcp_pmcp/analyze_handlers_tests_tdg.rs
@@ -105,11 +105,13 @@ mod tdg_coverage_tests {
         let _: AnalyzeComplexityTool = ComplexityTool::new();
         let _: AnalyzeSatdTool = SatdTool::new();
         let _: AnalyzeDeadCodeTool = DeadCodeTool::new();
-        let _: AnalyzeDagTool = LintHotspotTool::new();
-        let _: AnalyzeDeepContextTool = ChurnTool::new();
-        let _: AnalyzeBigOTool = CouplingTool::new();
         let _: AnalyzeTdgTool = TdgTool::new();
         let _: AnalyzeTdgCompareTool = TdgCompareTool::new();
+        // R17-1: AnalyzeDagTool / AnalyzeBigOTool / AnalyzeDeepContextTool are
+        // now distinct structs, not aliases — they have their own new() ctors.
+        let _ = AnalyzeDagTool::new();
+        let _ = AnalyzeDeepContextTool::new();
+        let _ = AnalyzeBigOTool::new();
     }
 
     // === Args Deserialization Tests ===
@@ -238,5 +240,115 @@ mod tdg_coverage_tests {
         assert!(result.is_ok());
         let value = result.unwrap();
         assert_eq!(value["status"], "completed");
+    }
+
+    // === R17-1 Regression Tests: dispatch correctness ===
+    //
+    // Each test asserts that the tool's response message contains a marker
+    // that is specific to the CORRECT underlying analysis — so that a
+    // future mis-wiring (as in R15 #3) would fail fast. Previously,
+    // analyze_dag aliased to LintHotspotTool → message mentioned "Lint
+    // hotspot"; analyze_big_o → "Coupling analysis"; analyze_deep_context
+    // → "Churn analysis". These tests falsify that regression.
+
+    #[tokio::test]
+    async fn test_analyze_dag_tool_dispatches_to_dag() {
+        let tool = AnalyzeDagTool::new();
+        let args = json!({ "paths": [env!("CARGO_MANIFEST_DIR")] });
+        let result = tool.handle(args, test_extra()).await;
+        // Either succeeds with DAG output, or errors — but must NOT
+        // return lint-hotspot / coupling / churn content.
+        if let Ok(value) = result {
+            let msg = value["message"].as_str().unwrap_or("");
+            assert!(
+                msg.contains("DAG") || msg.contains("dag"),
+                "analyze_dag should produce DAG output, got: {msg}"
+            );
+            assert!(
+                !msg.contains("Lint hotspot"),
+                "analyze_dag must NOT dispatch to lint-hotspot (R17-1 regression): {msg}"
+            );
+            assert!(
+                !msg.contains("Coupling"),
+                "analyze_dag must NOT dispatch to coupling (R17-1 regression): {msg}"
+            );
+            assert!(
+                !msg.contains("Churn"),
+                "analyze_dag must NOT dispatch to churn (R17-1 regression): {msg}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_analyze_big_o_tool_dispatches_to_big_o() {
+        let tool = AnalyzeBigOTool::new();
+        let args = json!({ "paths": [env!("CARGO_MANIFEST_DIR")] });
+        let result = tool.handle(args, test_extra()).await;
+        if let Ok(value) = result {
+            let msg = value["message"].as_str().unwrap_or("");
+            assert!(
+                msg.contains("Big-O") || msg.contains("big_o") || msg.contains("big-o"),
+                "analyze_big_o should produce Big-O output, got: {msg}"
+            );
+            assert!(
+                !msg.contains("Coupling"),
+                "analyze_big_o must NOT dispatch to coupling (R17-1 regression): {msg}"
+            );
+            assert!(
+                !msg.contains("Lint hotspot"),
+                "analyze_big_o must NOT dispatch to lint-hotspot (R17-1 regression): {msg}"
+            );
+            assert!(
+                !msg.contains("Churn"),
+                "analyze_big_o must NOT dispatch to churn (R17-1 regression): {msg}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_analyze_deep_context_tool_dispatches_to_deep_context() {
+        let tool = AnalyzeDeepContextTool::new();
+        let args = json!({ "paths": [env!("CARGO_MANIFEST_DIR")] });
+        let result = tool.handle(args, test_extra()).await;
+        if let Ok(value) = result {
+            let msg = value["message"].as_str().unwrap_or("");
+            assert!(
+                msg.contains("Deep context") || msg.contains("deep_context") || msg.contains("deep context"),
+                "analyze_deep_context should produce deep-context output, got: {msg}"
+            );
+            assert!(
+                !msg.contains("Churn"),
+                "analyze_deep_context must NOT dispatch to churn (R17-1 regression): {msg}"
+            );
+            assert!(
+                !msg.contains("Coupling"),
+                "analyze_deep_context must NOT dispatch to coupling (R17-1 regression): {msg}"
+            );
+            assert!(
+                !msg.contains("Lint hotspot"),
+                "analyze_deep_context must NOT dispatch to lint-hotspot (R17-1 regression): {msg}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_r17_1_dag_tool_is_distinct_from_lint_hotspot() {
+        // Static guarantee: the three renamed tools are NOT the same type as
+        // the tools they were previously aliased to.
+        assert_ne!(
+            std::any::TypeId::of::<AnalyzeDagTool>(),
+            std::any::TypeId::of::<LintHotspotTool>(),
+            "AnalyzeDagTool must not be aliased to LintHotspotTool (R17-1)"
+        );
+        assert_ne!(
+            std::any::TypeId::of::<AnalyzeBigOTool>(),
+            std::any::TypeId::of::<CouplingTool>(),
+            "AnalyzeBigOTool must not be aliased to CouplingTool (R17-1)"
+        );
+        assert_ne!(
+            std::any::TypeId::of::<AnalyzeDeepContextTool>(),
+            std::any::TypeId::of::<ChurnTool>(),
+            "AnalyzeDeepContextTool must not be aliased to ChurnTool (R17-1)"
+        );
     }
 }

--- a/src/mcp_pmcp/analyze_metrics_handlers.rs
+++ b/src/mcp_pmcp/analyze_metrics_handlers.rs
@@ -137,3 +137,149 @@ impl ToolHandler for CouplingTool {
         Ok(results)
     }
 }
+
+// ============================================================================
+// R17-1: Correct handlers for analyze_dag / analyze_big_o / analyze_deep_context
+//
+// These handlers replace the old type aliases that mis-routed these three MCP
+// tools to lint-hotspot / coupling / churn. Each now dispatches to the right
+// `tool_functions::*` implementation.
+// ============================================================================
+
+// --- DAG analysis tool ---
+
+/// MCP args for analyze_dag: project paths and optional DAG type filter.
+#[derive(Debug, Deserialize)]
+struct AnalyzeDagArgs {
+    paths: Vec<String>,
+    #[serde(default)]
+    dag_type: Option<String>,
+}
+
+/// DAG analysis tool. Generates dependency graphs (call / import / inheritance).
+pub struct AnalyzeDagTool;
+
+impl AnalyzeDagTool {
+    #[must_use]
+    #[provable_contracts_macros::contract("pmat-core.yaml", equation = "check_compliance")]
+    /// Create a new instance.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for AnalyzeDagTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl ToolHandler for AnalyzeDagTool {
+    async fn handle(&self, args: Value, _extra: RequestHandlerExtra) -> Result<Value> {
+        debug!("Handling analyze_dag with args: {}", args);
+
+        let params: AnalyzeDagArgs = serde_json::from_value(args)
+            .map_err(|e| Error::validation(format!("Invalid arguments: {e}")))?;
+
+        let paths: Vec<PathBuf> = params.paths.into_iter().map(PathBuf::from).collect();
+
+        let results = tool_functions::analyze_dag(&paths, params.dag_type)
+            .await
+            .map_err(|e| Error::internal(format!("DAG analysis failed: {e}")))?;
+
+        Ok(results)
+    }
+}
+
+// --- Big-O analysis tool ---
+
+/// MCP args for analyze_big_o: project paths and optional top_files limit.
+#[derive(Debug, Deserialize)]
+struct AnalyzeBigOArgs {
+    paths: Vec<String>,
+    #[serde(default)]
+    top_files: Option<usize>,
+}
+
+/// Big-O analysis tool. Classifies function time complexity.
+pub struct AnalyzeBigOTool;
+
+impl AnalyzeBigOTool {
+    #[must_use]
+    #[provable_contracts_macros::contract("pmat-core.yaml", equation = "check_compliance")]
+    /// Create a new instance.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for AnalyzeBigOTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl ToolHandler for AnalyzeBigOTool {
+    async fn handle(&self, args: Value, _extra: RequestHandlerExtra) -> Result<Value> {
+        debug!("Handling analyze_big_o with args: {}", args);
+
+        let params: AnalyzeBigOArgs = serde_json::from_value(args)
+            .map_err(|e| Error::validation(format!("Invalid arguments: {e}")))?;
+
+        let paths: Vec<PathBuf> = params.paths.into_iter().map(PathBuf::from).collect();
+
+        let results = tool_functions::analyze_big_o(&paths, params.top_files)
+            .await
+            .map_err(|e| Error::internal(format!("Big-O analysis failed: {e}")))?;
+
+        Ok(results)
+    }
+}
+
+// --- Deep context analysis tool ---
+
+/// MCP args for analyze_deep_context: project paths and optional include patterns.
+#[derive(Debug, Deserialize)]
+struct AnalyzeDeepContextArgs {
+    paths: Vec<String>,
+    #[serde(default)]
+    include_patterns: Option<Vec<String>>,
+}
+
+/// Deep context analysis tool. Runs the full deep-context pipeline.
+pub struct AnalyzeDeepContextTool;
+
+impl AnalyzeDeepContextTool {
+    #[must_use]
+    #[provable_contracts_macros::contract("pmat-core.yaml", equation = "check_compliance")]
+    /// Create a new instance.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for AnalyzeDeepContextTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl ToolHandler for AnalyzeDeepContextTool {
+    async fn handle(&self, args: Value, _extra: RequestHandlerExtra) -> Result<Value> {
+        debug!("Handling analyze_deep_context with args: {}", args);
+
+        let params: AnalyzeDeepContextArgs = serde_json::from_value(args)
+            .map_err(|e| Error::validation(format!("Invalid arguments: {e}")))?;
+
+        let paths: Vec<PathBuf> = params.paths.into_iter().map(PathBuf::from).collect();
+
+        let results = tool_functions::analyze_deep_context(&paths, params.include_patterns)
+            .await
+            .map_err(|e| Error::internal(format!("Deep context analysis failed: {e}")))?;
+
+        Ok(results)
+    }
+}

--- a/src/mcp_pmcp/simple_unified_server.rs
+++ b/src/mcp_pmcp/simple_unified_server.rs
@@ -337,9 +337,11 @@ mod coverage_tests {
         assert!(std::any::type_name::<AnalyzeComplexityTool>().contains("ComplexityTool"));
         assert!(std::any::type_name::<AnalyzeSatdTool>().contains("SatdTool"));
         assert!(std::any::type_name::<AnalyzeDeadCodeTool>().contains("DeadCodeTool"));
-        assert!(std::any::type_name::<AnalyzeDagTool>().contains("LintHotspotTool"));
-        assert!(std::any::type_name::<AnalyzeDeepContextTool>().contains("ChurnTool"));
-        assert!(std::any::type_name::<AnalyzeBigOTool>().contains("CouplingTool"));
+        // R17-1: Dag/BigO/DeepContext tools are now distinct structs that
+        // dispatch to the correct analysis functions (not lint/coupling/churn).
+        assert!(std::any::type_name::<AnalyzeDagTool>().contains("AnalyzeDagTool"));
+        assert!(std::any::type_name::<AnalyzeDeepContextTool>().contains("AnalyzeDeepContextTool"));
+        assert!(std::any::type_name::<AnalyzeBigOTool>().contains("AnalyzeBigOTool"));
 
         // Quality tools
         assert!(std::any::type_name::<QualityGateTool>().contains("QualityGateTool"));

--- a/src/mcp_pmcp/tool_functions/analysis_tools.rs
+++ b/src/mcp_pmcp/tool_functions/analysis_tools.rs
@@ -319,6 +319,160 @@ pub async fn analyze_churn(
     }
 }
 
+// --- DAG analysis (R17-1) ---
+//
+// Dispatches to `services::deep_context::analysis_functions::analyze_dag`,
+// which builds a ProjectContext + DagBuilder graph. This is the analysis
+// powering `pmat analyze dag`.
+#[provable_contracts_macros::contract("pmat-core.yaml", equation = "path_exists")]
+pub async fn analyze_dag(paths: &[PathBuf], dag_type: Option<String>) -> Result<Value> {
+    use crate::services::deep_context::analysis_functions::analyze_dag as svc_analyze_dag;
+    use crate::services::deep_context::DagType;
+
+    if paths.is_empty() {
+        return Err(anyhow::anyhow!("At least one path must be provided"));
+    }
+
+    let dag_type_parsed = match dag_type.as_deref().unwrap_or("full-dependency") {
+        "call-graph" | "call_graph" => DagType::CallGraph,
+        "import-graph" | "import_graph" => DagType::ImportGraph,
+        "inheritance" => DagType::Inheritance,
+        _ => DagType::FullDependency,
+    };
+    let dag_type_label = format!("{:?}", dag_type_parsed);
+
+    let project_path = &paths[0];
+    let graph = svc_analyze_dag(project_path, dag_type_parsed)
+        .await
+        .map_err(|e| anyhow::anyhow!("DAG analysis failed: {e}"))?;
+
+    let node_count = graph.nodes.len();
+    let edge_count = graph.edges.len();
+
+    // Emit a compact summary plus the raw graph. Callers that want full
+    // mermaid output can use the CLI's `pmat analyze dag` path.
+    let top_nodes: Vec<Value> = graph
+        .nodes
+        .values()
+        .take(25)
+        .map(|n| {
+            json!({
+                "id": n.id,
+                "label": n.label,
+                "node_type": n.node_type,
+                "file_path": n.file_path,
+                "line_number": n.line_number,
+                "complexity": n.complexity,
+            })
+        })
+        .collect();
+
+    Ok(json!({
+        "status": "completed",
+        "message": format!("DAG analysis completed ({node_count} nodes, {edge_count} edges)"),
+        "results": {
+            "dag_type": dag_type_label,
+            "node_count": node_count,
+            "edge_count": edge_count,
+            "top_nodes": top_nodes,
+        }
+    }))
+}
+
+// --- Big-O analysis (R17-1) ---
+//
+// Dispatches to `services::deep_context::analysis_functions::analyze_big_o`,
+// which classifies function time complexity via BigOAnalyzer. This is the
+// analysis powering `pmat analyze big-o`.
+#[provable_contracts_macros::contract("pmat-core.yaml", equation = "path_exists")]
+pub async fn analyze_big_o(paths: &[PathBuf], top_files: Option<usize>) -> Result<Value> {
+    use crate::services::deep_context::analysis_functions::analyze_big_o as svc_analyze_big_o;
+
+    if paths.is_empty() {
+        return Err(anyhow::anyhow!("At least one path must be provided"));
+    }
+
+    let project_path = &paths[0];
+    let report = svc_analyze_big_o(project_path)
+        .await
+        .map_err(|e| anyhow::anyhow!("Big-O analysis failed: {e}"))?;
+
+    let top_limit = top_files.unwrap_or(25);
+    let high_complexity: Vec<Value> = report
+        .high_complexity_functions
+        .iter()
+        .take(top_limit)
+        .map(|f| {
+            json!({
+                "file_path": f.file_path,
+                "function_name": f.function_name,
+                "line_number": f.line_number,
+                "time_complexity": f.time_complexity,
+                "space_complexity": f.space_complexity,
+                "confidence": f.confidence,
+            })
+        })
+        .collect();
+
+    Ok(json!({
+        "status": "completed",
+        "message": format!("Big-O analysis completed ({} functions analyzed)", report.analyzed_functions),
+        "results": {
+            "analyzed_functions": report.analyzed_functions,
+            "complexity_distribution": report.complexity_distribution,
+            "high_complexity_functions": high_complexity,
+            "recommendations": report.recommendations,
+        }
+    }))
+}
+
+// --- Deep context analysis (R17-1) ---
+//
+// Dispatches to `services::deep_context::DeepContextAnalyzer`, which runs the
+// full multi-phase deep context pipeline. This is the analysis powering
+// `pmat context` / `pmat analyze deep-context`.
+#[provable_contracts_macros::contract("pmat-core.yaml", equation = "path_exists")]
+pub async fn analyze_deep_context(
+    paths: &[PathBuf],
+    _include_patterns: Option<Vec<String>>,
+) -> Result<Value> {
+    use crate::services::deep_context::{DeepContextAnalyzer, DeepContextConfig};
+
+    if paths.is_empty() {
+        return Err(anyhow::anyhow!("At least one path must be provided"));
+    }
+
+    let project_path = &paths[0];
+    let config = DeepContextConfig::default();
+    let analyzer = DeepContextAnalyzer::new(config);
+    let context = analyzer
+        .analyze_project(&project_path.to_path_buf())
+        .await
+        .map_err(|e| anyhow::anyhow!("Deep context analysis failed: {e}"))?;
+
+    Ok(json!({
+        "status": "completed",
+        "message": format!("Deep context analysis completed ({} files)", context.file_tree.total_files),
+        "results": {
+            "metadata": {
+                "project_root": context.metadata.project_root,
+                "tool_version": context.metadata.tool_version,
+                "generated_at": context.metadata.generated_at.to_rfc3339(),
+                "analysis_duration_ms": context.metadata.analysis_duration.as_millis(),
+            },
+            "quality_scorecard": {
+                "overall_health": context.quality_scorecard.overall_health,
+                "complexity_score": context.quality_scorecard.complexity_score,
+                "maintainability_index": context.quality_scorecard.maintainability_index,
+                "modularity_score": context.quality_scorecard.modularity_score,
+                "technical_debt_hours": context.quality_scorecard.technical_debt_hours,
+            },
+            "file_count": context.file_tree.total_files,
+            "ast_contexts": context.analyses.ast_contexts.len(),
+        }
+    }))
+}
+
 #[provable_contracts_macros::contract("pmat-core.yaml", equation = "path_exists")]
 pub async fn analyze_coupling(paths: &[PathBuf], threshold: Option<f64>) -> Result<Value> {
     use crate::services::deep_context::{DeepContextAnalyzer, DeepContextConfig};


### PR DESCRIPTION
## Summary

Three MCP tools were mis-routed to wrong analyzers via misleading type aliases in `src/mcp_pmcp/analyze_handlers.rs`:

- `analyze_dag` was aliased to `LintHotspotTool` → returned lint hotspot data
- `analyze_big_o` was aliased to `CouplingTool` → returned coupling metrics
- `analyze_deep_context` was aliased to `ChurnTool` → returned git churn

Each of these tools now has its own distinct handler struct that dispatches to the correct `services::deep_context::analysis_functions::*` implementation, matching its CLI counterpart.

Discovered by **R15 #3 bench matrix** (`/tmp/pmat-dogfood/round15/r15-3-bench-matrix.md`):

> **MAJOR**: analyze_dag/big_o/deep_context execute wrong analyses (schema lies)
> - analyze_dag: "Lint hotspot analysis completed (10 hotspots)" → WRONG TOOL
> - analyze_big_o: "Coupling analysis completed (3545 files)" → WRONG TOOL
> - analyze_deep_context: "Churn analysis completed for last 30 days" → WRONG TOOL

## Fix

### `src/mcp_pmcp/analyze_handlers.rs`
Removed the mis-directing `pub use self::{...}` aliases that pointed three analyzer names at unrelated tool structs.

### `src/mcp_pmcp/analyze_metrics_handlers.rs`
Added three new handler structs with correct `ToolHandler::handle()` dispatch:
- `AnalyzeDagTool` → `tool_functions::analyze_dag`
- `AnalyzeBigOTool` → `tool_functions::analyze_big_o`
- `AnalyzeDeepContextTool` → `tool_functions::analyze_deep_context`

### `src/mcp_pmcp/tool_functions/analysis_tools.rs`
Added three new tool_function implementations that wrap the existing, correct CLI-side analysis services:
- `analyze_dag` → `services::deep_context::analysis_functions::analyze_dag` (DagBuilder → DependencyGraph with node/edge counts)
- `analyze_big_o` → `services::deep_context::analysis_functions::analyze_big_o` (BigOAnalyzer → complexity distribution + high-complexity functions)
- `analyze_deep_context` → `DeepContextAnalyzer::analyze_project` (full multi-phase deep context pipeline)

### Regression tests (`src/mcp_pmcp/analyze_handlers_tests_tdg.rs`)
Three new dispatch regression tests assert that the response message does **NOT** contain the wrong-analyzer markers (`"Lint hotspot"` / `"Coupling"` / `"Churn"`), plus a static TypeId guard that prevents future re-aliasing.

## Before / After verification

MCP output now matches the CLI output byte-for-byte structurally:

| tool | MCP before | MCP after | CLI golden |
|---|---|---|---|
| `analyze_dag` | `Lint hotspot analysis completed (10 hotspots)` | `DAG analysis completed (7178 nodes, 181 edges)` | `7178 nodes, 181 edges` |
| `analyze_big_o` | `Coupling analysis completed (3545 files)` | `Big-O analysis completed (8854 functions analyzed)` | `analyzed_functions: 8854` |
| `analyze_deep_context` | `Churn analysis completed for last 30 days` | `Deep context analysis completed (1362 files)` | — |

## Test plan

- [x] `cargo build --bin pmat` succeeds
- [x] `cargo test --lib mcp_pmcp::` — 452 passed, 0 failed, 1 ignored
- [x] Three R17-1 regression tests pass (`test_analyze_dag_tool_dispatches_to_dag`, `test_analyze_big_o_tool_dispatches_to_big_o`, `test_analyze_deep_context_tool_dispatches_to_deep_context`)
- [x] Static TypeId test `test_r17_1_dag_tool_is_distinct_from_lint_hotspot` passes
- [x] Stdio MCP reproduction against `src/services`:
  - `analyze_dag` → DAG output (was lint hotspots)
  - `analyze_big_o` → Big-O classification (was coupling)
  - `analyze_deep_context` → deep-context metadata + quality scorecard (was churn)
- [x] CLI-side `pmat analyze dag` and `pmat analyze big-o` still produce matching metrics (no CLI regression)

## Notes

The diff is ~430 lines (slightly over the 300-LOC target in the R17-1 brief) because the fix required *adding* three real MCP tool implementations that previously did not exist — the old aliases were the entire implementation. ~130 lines are tests, ~300 lines are new handler + new service dispatch. No refactor, all additive to the `mcp_pmcp/` module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)