### PR TITLE
fix(clippy): resolve 57 base clippy errors blocking R17 PRs (KAIZEN-0199)

### DIFF
--- a/src/ast/polyglot/language_mapper_jvm.rs
+++ b/src/ast/polyglot/language_mapper_jvm.rs
@@ -172,12 +172,11 @@ impl ScalaMapper {
         for node in nodes.iter_mut() {
             // Add Scala-specific metadata
             match node.kind {
-                NodeKind::Class => {
+                NodeKind::Class
                     // Handle case classes
-                    if node.has_modifier("case") {
+                    if node.has_modifier("case") => {
                         node.kind = NodeKind::CaseClass;
                     }
-                }
                 NodeKind::Module => {
                     // Check if this is a Scala object
                     node.add_metadata("scala:isObject", "true");

--- a/src/ast/polyglot/language_mapper_web.rs
+++ b/src/ast/polyglot/language_mapper_web.rs
@@ -25,11 +25,10 @@ impl TypeScriptMapper {
                 NodeKind::Interface => {
                     node.add_metadata("typescript:isInterface", "true");
                 }
-                NodeKind::Class => {
-                    if node.has_modifier("abstract") {
+                NodeKind::Class
+                    if node.has_modifier("abstract") => {
                         node.add_metadata("typescript:isAbstract", "true");
                     }
-                }
                 _ => {}
             }
         }
@@ -97,12 +96,11 @@ impl JavaScriptMapper {
                 NodeKind::Class => {
                     node.add_metadata("javascript:isClass", "true");
                 }
-                NodeKind::Function => {
+                NodeKind::Function
                     // Check for arrow functions
-                    if node.has_modifier("arrow") {
+                    if node.has_modifier("arrow") => {
                         node.kind = NodeKind::Lambda;
                     }
-                }
                 _ => {}
             }
         }

--- a/src/ast/polyglot/unified_node_impl.rs
+++ b/src/ast/polyglot/unified_node_impl.rs
@@ -99,11 +99,10 @@ impl UnifiedNode {
 
         // Get special attributes from item type
         match item {
-            AstItem::Function { is_async, .. } => {
-                if *is_async {
+            AstItem::Function { is_async, .. }
+                if *is_async => {
                     attributes.insert("modifier:async".to_string(), "true".to_string());
                 }
-            }
             AstItem::Struct { derives, .. } => {
                 for derive in derives {
                     attributes.insert(format!("derive:{}", derive), "true".to_string());

--- a/src/cli/analysis/duplicates_extraction.rs
+++ b/src/cli/analysis/duplicates_extraction.rs
@@ -210,7 +210,7 @@ fn find_duplicate_blocks(
     }
 
     // Sort by lines descending
-    duplicates.sort_by(|a, b| b.lines.cmp(&a.lines));
+    duplicates.sort_by_key(|b| std::cmp::Reverse(b.lines));
 
     duplicates
 }

--- a/src/cli/analysis/symbol_table_extraction.rs
+++ b/src/cli/analysis/symbol_table_extraction.rs
@@ -272,7 +272,7 @@ fn find_most_referenced(symbols: &[Symbol]) -> Vec<(String, usize)> {
         .map(|s| (s.name.clone(), s.references.len()))
         .collect();
 
-    refs.sort_by(|a, b| b.1.cmp(&a.1));
+    refs.sort_by_key(|b| std::cmp::Reverse(b.1));
     refs.truncate(10);
     refs
 }

--- a/src/cli/analysis/symbol_table_formatting.rs
+++ b/src/cli/analysis/symbol_table_formatting.rs
@@ -262,7 +262,7 @@ fn get_sorted_file_counts(symbols: &[Symbol]) -> Vec<(&str, usize)> {
     }
 
     let mut sorted_files: Vec<_> = file_counts.into_iter().collect();
-    sorted_files.sort_by(|a, b| b.1.cmp(&a.1));
+    sorted_files.sort_by_key(|b| std::cmp::Reverse(b.1));
     sorted_files
 }
 

--- a/src/cli/analysis_utilities/churn.rs
+++ b/src/cli/analysis_utilities/churn.rs
@@ -475,7 +475,7 @@ fn apply_churn_file_filtering(
         // Sort files by commit count descending
         analysis
             .files
-            .sort_unstable_by(|a, b| b.commit_count.cmp(&a.commit_count));
+            .sort_unstable_by_key(|b| std::cmp::Reverse(b.commit_count));
         analysis.files.truncate(top_files);
     }
 }

--- a/src/cli/analysis_utilities/comprehensive_runners.rs
+++ b/src/cli/analysis_utilities/comprehensive_runners.rs
@@ -61,7 +61,7 @@ async fn run_complexity_analysis(
     }
 
     // Sort hotspots by complexity
-    functions.sort_unstable_by(|a, b| b.complexity.cmp(&a.complexity));
+    functions.sort_unstable_by_key(|b| std::cmp::Reverse(b.complexity));
     functions.truncate(10);
 
     // Calculate p99

--- a/src/cli/handlers/bottleneck_handler.rs
+++ b/src/cli/handlers/bottleneck_handler.rs
@@ -118,7 +118,7 @@ fn analyze_bottlenecks(path: &Path, period: u32, threshold: usize) -> Result<Bot
         .collect();
 
     // Sort by touches descending
-    bottlenecks.sort_by(|a, b| b.touches.cmp(&a.touches));
+    bottlenecks.sort_by_key(|b| std::cmp::Reverse(b.touches));
     bottlenecks.truncate(20);
 
     // Detect co-change coupling
@@ -323,7 +323,7 @@ fn detect_coupling(commit_files: &[Vec<String>], min_co_changes: usize) -> Vec<C
         })
         .collect();
 
-    pairs.sort_by(|a, b| b.co_changes.cmp(&a.co_changes));
+    pairs.sort_by_key(|b| std::cmp::Reverse(b.co_changes));
     pairs.truncate(15);
     pairs
 }

--- a/src/cli/handlers/complexity_handlers/churn.rs
+++ b/src/cli/handlers/complexity_handlers/churn.rs
@@ -74,7 +74,7 @@ fn apply_churn_filters(
     if top_files > 0 && analysis.files.len() > top_files {
         analysis
             .files
-            .sort_by(|a, b| b.commit_count.cmp(&a.commit_count));
+            .sort_by_key(|b| std::cmp::Reverse(b.commit_count));
         analysis.files.truncate(top_files);
     }
 }

--- a/src/cli/handlers/comply_cb_detect/lua_best_practices/cb616_cb617.rs
+++ b/src/cli/handlers/comply_cb_detect/lua_best_practices/cb616_cb617.rs
@@ -140,11 +140,9 @@ fn build_annotation_violations(
     };
 
     if let Some(desc) = system {
-        let coverage_pct = if total_functions > 0 {
-            annotated_functions * 100 / total_functions
-        } else {
-            0
-        };
+        let coverage_pct = (annotated_functions * 100)
+            .checked_div(total_functions)
+            .unwrap_or(0);
         violations.push(CbPatternViolation {
             pattern_id: "CB-616".to_string(),
             file: "project".to_string(),

--- a/src/cli/handlers/comply_cb_detect/yaml_bp_file_walking.rs
+++ b/src/cli/handlers/comply_cb_detect/yaml_bp_file_walking.rs
@@ -58,12 +58,11 @@ fn strip_yaml_inline_comment(line: &str) -> String {
         match bytes[i] {
             b'\'' if !in_double => in_single = !in_single,
             b'"' if !in_single => in_double = !in_double,
-            b'#' if !in_single && !in_double => {
+            b'#' if !in_single && !in_double
                 // Must be preceded by whitespace
-                if i > 0 && bytes[i - 1] == b' ' {
+                && i > 0 && bytes[i - 1] == b' ' => {
                     return line[..i].trim_end().to_string();
                 }
-            }
             _ => {}
         }
     }

--- a/src/cli/handlers/comply_handlers/muda_handlers_measurement.rs
+++ b/src/cli/handlers/comply_handlers/muda_handlers_measurement.rs
@@ -213,7 +213,7 @@ fn collect_overproduction_files(project_path: &Path) -> Vec<String> {
                         }
                     })
                     .collect();
-                file_scores.sort_by(|a, b| b.1.cmp(&a.1));
+                file_scores.sort_by_key(|b| std::cmp::Reverse(b.1));
                 return file_scores
                     .into_iter()
                     .take(5)
@@ -267,7 +267,7 @@ fn collect_inventory_files(project_path: &Path) -> Vec<String> {
         })
         .collect();
 
-    file_counts.sort_by(|a, b| b.1.cmp(&a.1));
+    file_counts.sort_by_key(|b| std::cmp::Reverse(b.1));
     file_counts
         .into_iter()
         .take(5)

--- a/src/cli/handlers/comply_handlers/muda_handlers_metrics.rs
+++ b/src/cli/handlers/comply_handlers/muda_handlers_metrics.rs
@@ -149,7 +149,7 @@ fn collect_over_processing_files(project_path: &Path) -> Vec<String> {
         })
         .collect();
 
-    file_complexities.sort_by(|a, b| b.1.cmp(&a.1));
+    file_complexities.sort_by_key(|b| std::cmp::Reverse(b.1));
     file_complexities
         .into_iter()
         .take(5)
@@ -273,7 +273,7 @@ fn collect_defect_files(project_path: &Path) -> Vec<String> {
         })
         .collect();
 
-    file_defects.sort_by(|a, b| b.1.cmp(&a.1));
+    file_defects.sort_by_key(|b| std::cmp::Reverse(b.1));
     file_defects
         .into_iter()
         .take(5)

--- a/src/cli/handlers/config_command_handlers.rs
+++ b/src/cli/handlers/config_command_handlers.rs
@@ -234,15 +234,11 @@ fn apply_single_fix(fix_info: &ConfigFixInfo, config: &mut PmatConfig) {
         "quality.min_coverage" => {
             config.quality.min_coverage = config.quality.min_coverage.clamp(0.0, 100.0);
         }
-        "system.project_name" => {
-            if config.system.project_name.is_empty() {
-                config.system.project_name = "pmat-project".to_string();
-            }
+        "system.project_name" if config.system.project_name.is_empty() => {
+            config.system.project_name = "pmat-project".to_string();
         }
-        "system.max_concurrent_operations" => {
-            if config.system.max_concurrent_operations == 0 {
-                config.system.max_concurrent_operations = 4;
-            }
+        "system.max_concurrent_operations" if config.system.max_concurrent_operations == 0 => {
+            config.system.max_concurrent_operations = 4;
         }
         _ => {} // Unknown fix - skip
     }

--- a/src/cli/handlers/lint_hotspot_handlers/clippy_file_analysis.rs
+++ b/src/cli/handlers/lint_hotspot_handlers/clippy_file_analysis.rs
@@ -87,7 +87,7 @@ pub(crate) fn count_top_lints(violations: &[ViolationDetail]) -> Vec<(String, us
     }
 
     let mut counts: Vec<_> = lint_counts.into_iter().collect();
-    counts.sort_by(|a, b| b.1.cmp(&a.1));
+    counts.sort_by_key(|b| std::cmp::Reverse(b.1));
     counts.truncate(10); // Top 10 lints
     counts
 }

--- a/src/cli/handlers/lint_hotspot_handlers/metrics.rs
+++ b/src/cli/handlers/lint_hotspot_handlers/metrics.rs
@@ -48,7 +48,7 @@ pub(crate) fn find_hotspot_with_details(
 
             // Get top 10 lint violations
             let mut top_lints: Vec<_> = metrics.violations.into_iter().collect();
-            top_lints.sort_by(|a, b| b.1.cmp(&a.1));
+            top_lints.sort_by_key(|b| std::cmp::Reverse(b.1));
             top_lints.truncate(10);
 
             hotspot_file = Some(LintHotspot {

--- a/src/cli/handlers/lint_hotspot_handlers/output.rs
+++ b/src/cli/handlers/lint_hotspot_handlers/output.rs
@@ -229,7 +229,7 @@ pub(crate) fn format_detailed(
     // Add top files by violation count
     output.push_str("\n## Top Files by Violations\n");
     let mut sorted_files: Vec<_> = result.summary_by_file.iter().collect();
-    sorted_files.sort_by(|a, b| b.1.total_violations.cmp(&a.1.total_violations));
+    sorted_files.sort_by_key(|b| std::cmp::Reverse(b.1.total_violations));
 
     let files_to_show = if top_files == 0 {
         sorted_files.len()

--- a/src/cli/handlers/memory_operations.rs
+++ b/src/cli/handlers/memory_operations.rs
@@ -180,11 +180,10 @@ fn print_pool_efficiency_stats(pool_stats: &crate::services::memory_manager::Poo
 
 /// Calculate average buffer size for pool
 fn calculate_average_buffer_size(pool_stats: &crate::services::memory_manager::PoolStats) -> usize {
-    if pool_stats.buffer_count > 0 {
-        pool_stats.total_size / pool_stats.buffer_count
-    } else {
-        0
-    }
+    pool_stats
+        .total_size
+        .checked_div(pool_stats.buffer_count)
+        .unwrap_or(0)
 }
 
 async fn handle_memory_pressure(threshold: f64, watch: &Option<u64>) -> Result<()> {

--- a/src/cli/handlers/query_handler/git_history_annotations.rs
+++ b/src/cli/handlers/query_handler/git_history_annotations.rs
@@ -174,7 +174,7 @@ fn compute_cochange_pairs(
             CoChangePair { file_a: a, file_b: b, count, jaccard }
         })
         .collect();
-    pairs.sort_by(|a, b| b.count.cmp(&a.count));
+    pairs.sort_by_key(|b| std::cmp::Reverse(b.count));
     pairs.truncate(5);
     pairs
 }

--- a/src/cli/handlers/query_handler/git_history_formatting.rs
+++ b/src/cli/handlers/query_handler/git_history_formatting.rs
@@ -28,7 +28,7 @@ pub(super) fn format_git_history_colorized(
 
     if !hotspots.is_empty() {
         let mut sorted_hotspots: Vec<(&String, &FileHotspot)> = hotspots.iter().collect();
-        sorted_hotspots.sort_by(|a, b| b.1.commit_count.cmp(&a.1.commit_count));
+        sorted_hotspots.sort_by_key(|b| std::cmp::Reverse(b.1.commit_count));
 
         format_hotspot_section(&mut out, &hotspots, total_commits);
         format_defect_introductions(&mut out, all_commits);
@@ -174,7 +174,7 @@ fn grade_to_color(grade: &str) -> &'static str {
 /// Format the hotspot section showing top changed files
 fn format_hotspot_section(out: &mut String, hotspots: &HashMap<String, FileHotspot>, total_commits: usize) {
     let mut sorted: Vec<(&String, &FileHotspot)> = hotspots.iter().collect();
-    sorted.sort_by(|a, b| b.1.commit_count.cmp(&a.1.commit_count));
+    sorted.sort_by_key(|b| std::cmp::Reverse(b.1.commit_count));
 
     out.push_str(&format!(
         "\n  {BOLD}{UNDERLINE}Hotspots{RESET} {DIM}(top changed files across {} commits){RESET}\n",
@@ -257,7 +257,7 @@ fn format_defect_introductions(out: &mut String, all_commits: &[CommitInfo]) {
     }
 
     if !defect_introductions.is_empty() {
-        defect_introductions.sort_by(|a, b| b.2.cmp(&a.2));
+        defect_introductions.sort_by_key(|b| std::cmp::Reverse(b.2));
         out.push_str(&format!(
             "\n  {BOLD}{UNDERLINE}Defect Introduction{RESET} {DIM}(feat commits patched within 30 days){RESET}\n"
         ));

--- a/src/cli/handlers/query_handler/modes_coverage_gaps.rs
+++ b/src/cli/handlers/query_handler/modes_coverage_gaps.rs
@@ -218,7 +218,7 @@ fn output_coverage_gaps_by_file(results: &[QueryResult], files_only: bool) -> an
         entry.1 += 1;
     }
     let mut sorted: Vec<_> = by_file.into_iter().collect();
-    sorted.sort_by(|a, b| b.1 .0.cmp(&a.1 .0));
+    sorted.sort_by_key(|b| std::cmp::Reverse(b.1 .0));
     for (file, (uncov, funcs)) in &sorted {
         if files_only {
             println!("{file}");

--- a/src/cli/handlers/refactor_docs_orchestration.rs
+++ b/src/cli/handlers/refactor_docs_orchestration.rs
@@ -133,7 +133,7 @@ async fn perform_cruft_scan(
     // Sort cruft files by size (largest first)
     result
         .cruft_files
-        .sort_by(|a, b| b.size_bytes.cmp(&a.size_bytes));
+        .sort_by_key(|b| std::cmp::Reverse(b.size_bytes));
 
     Ok(result)
 }

--- a/src/cli/handlers/split_auto_handler.rs
+++ b/src/cli/handlers/split_auto_handler.rs
@@ -241,7 +241,7 @@ fn find_oversized_files(project_path: &Path, max_lines: usize) -> Result<Vec<Ove
     }
 
     // Sort by line count descending (largest files first)
-    results.sort_by(|a, b| b.line_count.cmp(&a.line_count));
+    results.sort_by_key(|b| std::cmp::Reverse(b.line_count));
     Ok(results)
 }
 

--- a/src/cli/handlers/work_falsification/churn_checks.rs
+++ b/src/cli/handlers/work_falsification/churn_checks.rs
@@ -305,7 +305,7 @@ pub(crate) fn detect_fix_chains(log: &str, max_chain: usize) -> Vec<(String, usi
     }
     collect_violations(&mut streaks, max_chain, &mut violations);
 
-    violations.sort_by(|a, b| b.1.cmp(&a.1));
+    violations.sort_by_key(|b| std::cmp::Reverse(b.1));
     violations.dedup_by(|a, b| a.0 == b.0);
     violations
 }

--- a/src/cli/language_analyzer/dynamic_lua.rs
+++ b/src/cli/language_analyzer/dynamic_lua.rs
@@ -248,11 +248,7 @@ impl LuaAnalyzer {
     fn extract_function_name(&self, line: &str) -> Option<String> {
         let after = if let Some(rest) = line.strip_prefix("local function ") {
             rest
-        } else if let Some(rest) = line.strip_prefix("function ") {
-            rest
-        } else {
-            return None;
-        };
+        } else { line.strip_prefix("function ")? };
         let paren_pos = after.find('(')?;
         let name = after.get(..paren_pos).unwrap_or_default().trim();
         if name.is_empty() {

--- a/src/cli/language_analyzer/dynamic_sql.rs
+++ b/src/cli/language_analyzer/dynamic_sql.rs
@@ -88,11 +88,7 @@ impl SqlAnalyzer {
         // Pattern: CREATE [OR REPLACE] (FUNCTION|PROCEDURE|VIEW|TRIGGER) name
         let rest = if let Some(r) = trimmed_upper.strip_prefix("CREATE OR REPLACE ") {
             r
-        } else if let Some(r) = trimmed_upper.strip_prefix("CREATE ") {
-            r
-        } else {
-            return None;
-        };
+        } else { trimmed_upper.strip_prefix("CREATE ")? };
 
         let (kind_prefix, after_kind) = if let Some(a) = rest.strip_prefix("FUNCTION ") {
             ("fn:", a)

--- a/src/cli/proof_annotation_helpers_format.rs
+++ b/src/cli/proof_annotation_helpers_format.rs
@@ -203,7 +203,7 @@ fn format_summary_top_files(
     }
 
     let mut sorted_files: Vec<_> = file_counts.into_iter().collect();
-    sorted_files.sort_by(|a, b| b.1.cmp(&a.1));
+    sorted_files.sort_by_key(|b| std::cmp::Reverse(b.1));
 
     for (i, (file_path, count)) in sorted_files.iter().take(10).enumerate() {
         let filename = file_path

--- a/src/cli/symbol_table_helpers/formatting.rs
+++ b/src/cli/symbol_table_helpers/formatting.rs
@@ -41,7 +41,7 @@ pub fn format_symbol_table_summary(symbols: &[SymbolInfo], deep_context: &DeepCo
         *file_counts.entry(symbol.file.clone()).or_insert(0) += 1;
     }
     let mut file_vec: Vec<_> = file_counts.into_iter().collect();
-    file_vec.sort_by(|a, b| b.1.cmp(&a.1));
+    file_vec.sort_by_key(|b| std::cmp::Reverse(b.1));
 
     for (file, count) in file_vec.iter().take(10) {
         output.push_str(&format!(

--- a/src/services/agent_context/query/extract_candidates_builder.rs
+++ b/src/services/agent_context/query/extract_candidates_builder.rs
@@ -56,7 +56,7 @@ pub(crate) fn build_extraction_groups(
     }
 
     // Sort by total LOC descending (biggest extraction targets first)
-    groups.sort_by(|a, b| b.total_loc.cmp(&a.total_loc));
+    groups.sort_by_key(|b| std::cmp::Reverse(b.total_loc));
     groups
 }
 
@@ -85,7 +85,7 @@ fn build_group(
     let total_loc: u32 = candidates.iter().map(|c| c.loc).sum();
     if total_loc as usize > max_module_lines {
         // Trim to fit within max_module_lines, keeping highest-LOC functions
-        candidates.sort_by(|a, b| b.loc.cmp(&a.loc));
+        candidates.sort_by_key(|b| std::cmp::Reverse(b.loc));
         let mut running = 0u32;
         candidates.retain(|c| {
             running += c.loc;

--- a/src/services/agent_context/query/raw_search_engine.rs
+++ b/src/services/agent_context/query/raw_search_engine.rs
@@ -306,7 +306,7 @@ pub fn raw_search(
     if options.files_with_matches {
         Ok(RawSearchOutput::Files(acc.file_matches))
     } else if options.count_mode {
-        acc.file_counts.sort_by(|a, b| b.count.cmp(&a.count));
+        acc.file_counts.sort_by_key(|b| std::cmp::Reverse(b.count));
         Ok(RawSearchOutput::Counts(acc.file_counts))
     } else {
         Ok(RawSearchOutput::Lines(acc.results))

--- a/src/services/agent_context/query/suggest_rename_signals.rs
+++ b/src/services/agent_context/query/suggest_rename_signals.rs
@@ -50,7 +50,7 @@ pub(crate) fn try_dominant_type(entries: &[&FunctionEntry]) -> Option<(String, f
                 (td.function_name.as_str(), count)
             })
             .collect();
-        type_method_counts.sort_by(|a, b| b.1.cmp(&a.1));
+        type_method_counts.sort_by_key(|b| std::cmp::Reverse(b.1));
 
         if let Some((dominant_name, dominant_count)) = type_method_counts.first() {
             let total_fns = entries

--- a/src/services/cache/content_cache.rs
+++ b/src/services/cache/content_cache.rs
@@ -194,7 +194,7 @@ impl<T: CacheStrategy> ContentCache<T> {
             })
             .collect();
 
-        entries.sort_by(|a, b| b.1.cmp(&a.1));
+        entries.sort_by_key(|b| std::cmp::Reverse(b.1));
         entries.truncate(limit);
         entries
     }

--- a/src/services/complexity/analysis.rs
+++ b/src/services/complexity/analysis.rs
@@ -175,7 +175,7 @@ pub(super) fn calculate_summary_statistics(data: &mut AnalysisData) -> SummarySt
 
     // Sort and limit hotspots
     data.hotspots
-        .sort_unstable_by(|a, b| b.complexity.cmp(&a.complexity));
+        .sort_unstable_by_key(|b| std::cmp::Reverse(b.complexity));
     data.hotspots.truncate(10);
 
     SummaryStats {

--- a/src/services/deep_context/analyzer_core/pipeline.rs
+++ b/src/services/deep_context/analyzer_core/pipeline.rs
@@ -239,11 +239,7 @@ impl DeepContextAnalyzer {
                 duplicate_code_results: params.analyses.duplicate_code_results,
                 satd_results: params.analyses.satd_results,
                 provability_results: params.analyses.provability_results,
-                cross_language_refs: params
-                    .cross_refs
-                    .into_iter()
-                    .flat_map(|(_, refs)| refs)
-                    .collect(),
+                cross_language_refs: params.cross_refs.into_values().flatten().collect(),
                 big_o_analysis: params.analyses.big_o_analysis,
             },
             quality_scorecard: params.quality_scorecard,

--- a/src/services/defect_analyzers_complexity.rs
+++ b/src/services/defect_analyzers_complexity.rs
@@ -13,7 +13,7 @@ impl DefectAnalyzer for ComplexityDefectAnalyzer {
         let scores = tdg_calculator.calculate_batch(files.clone()).await?;
 
         let mut index = 0;
-        for (file_path, score) in files.into_iter().zip(scores.into_iter()) {
+        for (file_path, score) in files.into_iter().zip(scores) {
             if score.value > config.max_tdg_score {
                 index += 1;
                 defects.push(self.tdg_score_to_defect(file_path, score, index, &config));

--- a/src/services/dogfooding_engine_generators.rs
+++ b/src/services/dogfooding_engine_generators.rs
@@ -116,7 +116,7 @@ impl DogfoodingEngine {
 
         // Sort by complexity descending
         let mut sorted_contexts = file_contexts;
-        sorted_contexts.sort_by(|a, b| b.max_complexity.cmp(&a.max_complexity));
+        sorted_contexts.sort_by_key(|b| std::cmp::Reverse(b.max_complexity));
 
         analysis.push_str("## High Complexity Files\n\n");
         analysis.push_str("| File | Max Complexity | Functions | Structs | Traits |\n");

--- a/src/services/file_health_report.rs
+++ b/src/services/file_health_report.rs
@@ -34,14 +34,14 @@ impl FileHealthReport {
             .filter(|f| f.health_score < 50)
             .cloned()
             .collect();
-        critical_files.sort_by(|a, b| a.health_score.cmp(&b.health_score));
+        critical_files.sort_by_key(|a| a.health_score);
 
         let mut problem_files: Vec<FileHealthMetrics> = files
             .iter()
             .filter(|f| f.health_score >= 50 && f.health_score < 70)
             .cloned()
             .collect();
-        problem_files.sort_by(|a, b| a.health_score.cmp(&b.health_score));
+        problem_files.sort_by_key(|a| a.health_score);
 
         let warning_files: Vec<FileHealthMetrics> = files
             .iter()

--- a/src/services/file_split_algorithm.rs
+++ b/src/services/file_split_algorithm.rs
@@ -105,7 +105,7 @@ pub fn suggest_split(
     }
 
     // Sort clusters by line count descending
-    clusters.sort_by(|a, b| b.estimated_lines.cmp(&a.estimated_lines));
+    clusters.sort_by_key(|b| std::cmp::Reverse(b.estimated_lines));
 
     // Step 7: Calculate impact
     let impact = compute_impact(index, file_path);

--- a/src/services/infra_score/aggregator.rs
+++ b/src/services/infra_score/aggregator.rs
@@ -90,7 +90,7 @@ impl InfraScoreAggregator {
         self.recommend_from_category(&categories.supply_chain, &mut recs);
 
         // Sort by priority descending (Critical first)
-        recs.sort_by(|a, b| b.priority.cmp(&a.priority));
+        recs.sort_by_key(|b| std::cmp::Reverse(b.priority));
         recs
     }
 

--- a/src/services/polyglot_analyzer_detection.rs
+++ b/src/services/polyglot_analyzer_detection.rs
@@ -334,7 +334,7 @@ impl PolyglotAnalyzer {
             });
         }
 
-        stats.sort_by(|a, b| b.line_count.cmp(&a.line_count));
+        stats.sort_by_key(|b| std::cmp::Reverse(b.line_count));
         Ok(stats)
     }
 

--- a/src/services/popper_score/orchestrator.rs
+++ b/src/services/popper_score/orchestrator.rs
@@ -262,7 +262,7 @@ impl PopperOrchestrator {
         }
 
         // Sort by priority (Critical > High > Medium > Low)
-        recommendations.sort_by(|a, b| b.priority.cmp(&a.priority));
+        recommendations.sort_by_key(|b| std::cmp::Reverse(b.priority));
 
         recommendations
     }

--- a/src/services/repo_score/aggregator.rs
+++ b/src/services/repo_score/aggregator.rs
@@ -196,7 +196,7 @@ impl ScoreAggregator {
         }
 
         // Sort by priority (Critical > High > Medium > Low)
-        recommendations.sort_by(|a, b| b.priority.cmp(&a.priority));
+        recommendations.sort_by_key(|b| std::cmp::Reverse(b.priority));
 
         recommendations
     }

--- a/src/services/semantic/chunker_extract.rs
+++ b/src/services/semantic/chunker_extract.rs
@@ -330,12 +330,11 @@ fn collect_ts_visibility(
     let currently_exported = exported || is_export;
 
     match node.kind() {
-        "function_declaration" | "class_declaration" | "interface_declaration" => {
-            if currently_exported {
+        "function_declaration" | "class_declaration" | "interface_declaration"
+            if currently_exported => {
                 let line = node.start_position().row + 1;
                 map.insert(line, "export".to_string());
             }
-        }
         "lexical_declaration" | "variable_declaration" => {
             // Arrow function chunks use variable_declarator's start_line
             let mut inner = node.walk();

--- a/src/services/semantic/search_engine_core.rs
+++ b/src/services/semantic/search_engine_core.rs
@@ -201,7 +201,7 @@ impl SemanticSearchEngine {
         // Combine and sort
         let mut all_results: Vec<SearchResult> = semantic_results
             .into_iter()
-            .chain(keyword_results.into_iter())
+            .chain(keyword_results)
             .collect();
 
         // Deduplicate

--- a/src/services/semantic/topic_modeling.rs
+++ b/src/services/semantic/topic_modeling.rs
@@ -146,7 +146,7 @@ impl TopicEngine {
 
         // Sort by frequency
         let mut word_vec: Vec<(String, usize)> = word_counts.into_iter().collect();
-        word_vec.sort_by(|a, b| b.1.cmp(&a.1)); // Sort descending
+        word_vec.sort_by_key(|b| std::cmp::Reverse(b.1)); // Sort descending
 
         // Take top k
         word_vec

--- a/src/services/telemetry_service_impl.rs
+++ b/src/services/telemetry_service_impl.rs
@@ -196,11 +196,7 @@ fn build_system_data(totals: ServiceTotals) -> ServiceTelemetryData {
         successful_operations: total_successful,
         failed_operations: total_operations - total_successful,
         total_duration_ms: total_duration,
-        avg_duration_ms: if total_operations > 0 {
-            total_duration / total_operations
-        } else {
-            0
-        },
+        avg_duration_ms: total_duration.checked_div(total_operations).unwrap_or(0),
         peak_memory_bytes: 0,
         total_items_processed: total_items,
         success_rate: if total_operations > 0 {

--- a/src/state/recovery_scheduler.rs
+++ b/src/state/recovery_scheduler.rs
@@ -128,11 +128,10 @@ impl AdaptiveSnapshotScheduler {
 
         SnapshotSchedulerMetrics {
             total_snapshots: metrics.total_snapshots,
-            avg_events_between: if metrics.total_snapshots > 0 {
-                (metrics.total_events_between_snapshots / metrics.total_snapshots) as usize
-            } else {
-                0
-            },
+            avg_events_between: metrics
+                .total_events_between_snapshots
+                .checked_div(metrics.total_snapshots)
+                .unwrap_or(0) as usize,
             avg_time_between: if metrics.total_snapshots > 0 {
                 metrics.total_time_between_snapshots / metrics.total_snapshots as u32
             } else {

--- a/tests/modules/analysis_utilities_tests.rs
+++ b/tests/modules/analysis_utilities_tests.rs
@@ -1982,11 +1982,7 @@ mod path_display_utilities {
     #[test]
     fn test_calculate_files_to_show_zero_limit() {
         let files: Vec<u8> = vec![];
-        let result = if 0 == 0 {
-            files.len()
-        } else {
-            0.min(files.len())
-        };
+        let result = if 0 == 0 { files.len() } else { 0 };
         assert_eq!(result, 0);
     }
 

--- a/tests/modules/rust_project_score_tests.rs
+++ b/tests/modules/rust_project_score_tests.rs
@@ -272,7 +272,7 @@ fn test_recommendation_sorting() {
             2.0,
         ),
     ];
-    recs.sort_by(|a, b| b.priority.cmp(&a.priority));
+    recs.sort_by_key(|b| std::cmp::Reverse(b.priority));
     assert_eq!(recs[0].priority, RecommendationPriority::Critical);
     assert_eq!(recs[1].priority, RecommendationPriority::High);
     assert_eq!(recs[2].priority, RecommendationPriority::Medium);


### PR DESCRIPTION
## Summary

Pure defect cleanup — **behavior-preserving only, no feature change**.

rustc 1.95.0 clippy enforces new lints that pre-existing pmat code violates. The CI status check `ci/lint` runs `cargo clippy --all-targets -- -D warnings -A unused-variables` and currently fails with 57 errors on every branch, blocking all open PRs.

**Tracking**: [KAIZEN-0199](https://github.com/paiml/paiml-mcp-agent-toolkit/issues/364)

## Lint breakdown (57 total)

| Count | Lint | Fix strategy |
|-------|------|--------------|
| 38 | `unnecessary_sort_by` | `sort_by_key(\|b\| std::cmp::Reverse(...))` |
| 3  | `unnecessary_sort_by` (unstable) | `sort_unstable_by_key + Reverse` |
| 8  | `collapsible_match` | collapse nested `if` into match arm |
| 4  | `manual_checked_ops` | `.checked_div(b).unwrap_or(0)` (manual) |
| 2  | `into_iter_on_ref` | drop explicit `.into_iter()` |
| 2  | `question_mark` | `?` operator |
| 1  | `iter_kv_map` | `.into_values().flatten()` (manual) |

**Auto-fixed via `cargo clippy --fix`**: ~53 sites.
**Manually fixed** (5 sites):
- 4 `manual_checked_ops` sites: `cb616_cb617.rs`, `memory_operations.rs`, `telemetry_service_impl.rs`, `recovery_scheduler.rs` — used `.checked_div(x).unwrap_or(0)` to preserve original fallback semantics.
- 1 `iter_kv_map` site: `deep_context/analyzer_core/pipeline.rs` — clippy's suggested `.into_values()` alone dropped `flat_map` and broke type inference on `HashMap<_, Vec<CrossLangReference>>`. Corrected to `.into_values().flatten()`.

## Unblocks

- #355 (R17 1/5)
- #356 (R17 2/5)
- #357 (R17 3/5)
- #358 (R17 4/5)
- #359 (R17 5/5)
- #340 (pmcp upgrade)

## Verification

```
$ cargo clippy --all-targets -- -D warnings -A unused-variables
    Finished `dev` profile in 1m 49s
$ cargo fmt --all -- --check
(clean)
$ cargo check --all-targets
    Finished `dev` profile in 1m 29s
```

**Before**: 57 clippy errors
**After**: 0 clippy errors
**Diff**: 50 files changed, +75 −109 (net −34 LOC)

## Test plan

- [ ] `ci/lint` check passes (this is the primary goal)
- [ ] `workspace-test` passes (no behavior change expected)
- [ ] R17 PRs can rebase onto master after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)