### PR TITLE
fix(build): make --no-default-features build compile (R21-2 / D83)

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -307,31 +307,39 @@ fn compress_templates() {
     let out_dir = env::var("OUT_DIR").expect("OUT_DIR must be set");
     let hash_path = Path::new(&out_dir).join("templates.hash");
 
-    if let Some(current_hash) = calculate_templates_hash(templates_dir) {
-        if hash_path.exists() {
-            if let Some(stored_hash) = read_stored_hash(&hash_path) {
-                if current_hash == stored_hash {
-                    println!("cargo:warning=Skipping unchanged templates (O(1) hash check)");
-                    return;
-                }
+    let current_hash = calculate_templates_hash(templates_dir);
+
+    // O(1) skip when available (standard-deps enabled and hash matches)
+    if let Some(h) = &current_hash {
+        if let Some(stored_hash) = read_stored_hash(&hash_path) {
+            if *h == stored_hash {
+                println!("cargo:warning=Skipping unchanged templates (O(1) hash check)");
+                return;
             }
         }
+    }
 
-        let (templates, total_original) = load_all_templates(templates_dir);
+    let (templates, total_original) = load_all_templates(templates_dir);
 
-        if templates.is_empty() {
-            println!("cargo:warning=No templates found for compression");
-            return;
-        }
+    if templates.is_empty() {
+        println!("cargo:warning=No templates found for compression");
+        return;
+    }
 
-        compress_and_save_templates(&templates, total_original);
+    compress_and_save_templates(&templates, total_original);
 
-        // Save hash for O(1) skip detection on next build
-        let _ = write_hash_file(&hash_path, &current_hash);
+    // Save hash for O(1) skip detection on next build (best-effort)
+    if let Some(h) = current_hash {
+        let _ = write_hash_file(&hash_path, &h);
     }
 }
 
-/// Calculate combined hash of all template files
+/// Calculate combined hash of all template files.
+///
+/// Returns `None` under `--no-default-features` (no `sha2` in build-deps);
+/// callers fall back to unconditional recompression, losing only the O(1)
+/// skip optimization.
+#[cfg(feature = "standard-deps")]
 fn calculate_templates_hash(templates_dir: &Path) -> Option<String> {
     use sha2::{Digest, Sha256};
 
@@ -358,6 +366,11 @@ fn calculate_templates_hash(templates_dir: &Path) -> Option<String> {
     }
 
     Some(format!("{:x}", hasher.finalize()))
+}
+
+#[cfg(not(feature = "standard-deps"))]
+fn calculate_templates_hash(_templates_dir: &Path) -> Option<String> {
+    None
 }
 
 /// Validate templates directory exists (cognitive complexity ≤2)
@@ -704,7 +717,11 @@ fn calculate_asset_hash() -> String {
     format!("{:x}", hasher.finish())
 }
 
-/// Calculate SHA256 hash of a file for change detection
+/// Calculate SHA256 hash of a file for change detection.
+///
+/// Returns `None` under `--no-default-features` (no `sha2` in build-deps);
+/// callers treat this as "changed" and reprocess unconditionally.
+#[cfg(feature = "standard-deps")]
 fn calculate_file_hash(path: &Path) -> Option<String> {
     use sha2::{Digest, Sha256};
 
@@ -712,6 +729,11 @@ fn calculate_file_hash(path: &Path) -> Option<String> {
     let mut hasher = Sha256::new();
     hasher.update(&content);
     Some(format!("{:x}", hasher.finalize()))
+}
+
+#[cfg(not(feature = "standard-deps"))]
+fn calculate_file_hash(_path: &Path) -> Option<String> {
+    None
 }
 
 /// Read stored hash from .hash file
@@ -1447,6 +1469,11 @@ pub static COMPRESSED_TEMPLATES: LazyLock<HashMap<&'static str, Vec<u8>>> = Lazy
 
         println!("cargo:rerun-if-changed={}", binding_path.display());
 
+        // provable-contracts validation requires serde_yaml_ng, which is
+        // gated behind `standard-deps`. Under --no-default-features this
+        // enforcement is skipped (contract YAML is irrelevant for minimal
+        // builds that don't ship those subsystems).
+        #[cfg(feature = "standard-deps")]
         if binding_path.exists() {
             #[derive(serde::Deserialize)]
             struct BF {


### PR DESCRIPTION
## Summary

- Fix D83: `cargo install --path . --force --locked --no-default-features --features core-languages,viz` — the spec-documented minimal install incantation — failed at the build-script phase because `build.rs` unconditionally imported `sha2` and `serde_yaml_ng`, which are `optional = true` in `[build-dependencies]` gated behind the `standard-deps` feature.
- **Option A** (gate the call sites) was chosen over Option B (promote to unconditional build-deps). Both usages are strictly optional — build-time caching and optional contract validation, not required codegen — so keeping them gated preserves the sovereign-AI minimal-dependency posture for `--no-default-features` builds.
- Scope: `build.rs` only. +44 / −17 = **27 net LOC** (budget ≤50).

## Root cause

Three unconditional references inside `build.rs` dereferenced optional `[build-dependencies]`:
* `build.rs:336` — `use sha2::{Digest, Sha256};` in `calculate_templates_hash`
* `build.rs:709` — `use sha2::{Digest, Sha256};` in `calculate_file_hash`
* `build.rs:1465` — `serde_yaml_ng::from_str::<BF>(&yaml)` inside `generate_stub_compressed_templates` (provable-contracts validation)

Under `--no-default-features --features core-languages,viz`, the `standard-deps` feature is off, so Cargo does not link those crates into the build script → `E0432 unresolved import 'sha2'` (×2) and `E0433 failed to resolve 'serde_yaml_ng'`.

## Fix

* `calculate_templates_hash` and `calculate_file_hash` now have `#[cfg(feature = "standard-deps")]` bodies plus stub `None` variants. Callers already handle `None` as "cache miss → reprocess", so the O(1) hash-skip optimization is simply disabled under the minimal feature set (builds still work — just without the template-change cache).
* `compress_templates` was flattened so an `Option::None` hash no longer short-circuits the whole compression step.
* The provable-contracts `binding.yaml` validation block in `generate_stub_compressed_templates` is gated on `standard-deps`. `println!(\"cargo:rerun-if-changed=…\")` stays unconditional so changes still trigger rebuilds when the feature flips on.

## Why Option A, not Option B

Option B (promote `sha2` + `serde_yaml_ng` to unconditional `[build-dependencies]`) would add ~1 MB of build-time deps to every build configuration. Neither dep is required for codegen — only for the O(1) build-cache optimization and optional YAML-schema contract validation. Option A keeps the minimal-feature build posture clean and costs only a `Option::None` fallback path that callers already handle correctly.

## Out of scope (separate tickets)

Once `build.rs` compiles, the library itself still has ~894 `#[cfg]` gating gaps throughout `src/services/*` (globset, toml, and many other sites that need `#[cfg(feature = \"standard-deps\")]` gates). These are pre-existing issues — not regressions introduced by this patch — and explicitly out of scope per the R21-2 constraint: \"build.rs only. Do NOT refactor the rest of build.rs.\" Fixing the library-side gates is a much larger effort that should follow as a separate R21-N ticket.

## Test plan

- [x] `cargo build --no-default-features --features core-languages,viz` now gets past build.rs (3 D83 errors gone). Build-script reports `Compressed 18 templates (20891 -> 4361 bytes, 79.1% reduction)` and `Generating MCP discovery optimization tables` — build.rs runs cleanly.
- [x] Default `cargo build` still compiles end-to-end and emits `Skipping unchanged templates (O(1) hash check)` confirming the cache still works.
- [x] `cargo clippy --all-targets -- -D warnings` green (exit 0, 15m 03s).
- [x] `cargo fmt --all -- --check` clean.
- [ ] CI will verify `cargo build --all-features` on a clean environment.
- [ ] CI will re-verify the full install incantation once library-side `#[cfg]` gating gaps are addressed (tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)