### PR TITLE
fix(mcp): handle ** glob prefix in expand_paths_to_source_files (R21-4 / D98)

### DIFF
--- a/src/mcp_pmcp/tool_functions/analysis_tools.rs
+++ b/src/mcp_pmcp/tool_functions/analysis_tools.rs
@@ -1,13 +1,76 @@
+/// Returns `true` when `p` contains glob metacharacters (`*`, `?`, `[`).
+///
+/// Used to decide whether a raw input path should be routed through
+/// [`glob::glob_with`] before the filesystem walk in
+/// [`expand_paths_to_source_files`].
+fn path_has_glob_meta(p: &Path) -> bool {
+    p.to_str()
+        .is_some_and(|s| s.contains('*') || s.contains('?') || s.contains('['))
+}
+
+/// Expand shell-style glob patterns into concrete filesystem entries.
+///
+/// Non-glob paths pass through unchanged. Glob entries are matched with
+/// `require_literal_separator = false`, letting `**` (and a bare `*`) cross
+/// directory boundaries so that `**/*.rs`, `src/**`, and `src/**/*.rs` all
+/// produce the results users expect. Patterns that match nothing yield an
+/// empty set (no literal fallback, mirroring POSIX shell behavior).
+///
+/// R21-4 (D98): MCP analysis tools receive `paths` as raw strings converted
+/// to `PathBuf`. A pattern like `"**/*.rs"` becomes a non-existent literal
+/// path; `path.exists()` is false and the downstream walk yields authoritative
+/// zeros. Expanding globs here makes the pipeline match the documented CLI
+/// semantics (`rust-docs/cli-reference.md` lines 403-404).
+fn resolve_paths_with_globs(paths: &[PathBuf]) -> Vec<PathBuf> {
+    use glob::{glob_with, MatchOptions};
+
+    // `require_literal_separator = false` is the critical flag: it lets `**`
+    // (and a bare `*`) match across `/` boundaries, which is what every user
+    // expects from `**/*.rs`.
+    let opts = MatchOptions {
+        case_sensitive: true,
+        require_literal_separator: false,
+        require_literal_leading_dot: false,
+    };
+
+    let mut out = Vec::with_capacity(paths.len());
+    for path in paths {
+        if !path_has_glob_meta(path) {
+            out.push(path.clone());
+            continue;
+        }
+        let Some(pattern) = path.to_str() else {
+            // Non-UTF8 globs are unsupported; preserve the literal PathBuf so
+            // existence checks yield a clean zero rather than an error.
+            out.push(path.clone());
+            continue;
+        };
+        match glob_with(pattern, opts) {
+            Ok(iter) => out.extend(iter.flatten()),
+            Err(_) => {
+                // Malformed pattern: fall back to literal (will miss later).
+                out.push(path.clone());
+            }
+        }
+    }
+    out
+}
+
 /// Expand a list of paths into a flat list of source files.
 ///
-/// When a path is a file, it is included verbatim. When a path is a directory,
-/// walkdir is used to enumerate all source files beneath it (`rs`, `py`, `js`,
-/// `ts`, `tsx`, `jsx`, `java`, `cpp`, `cc`, `cxx`, `c`, `h`, `hpp`, `go`, `rb`,
-/// `php`, `swift`, `kt`, `lua`, `sh`). Hidden dirs, `target/`, and `node_modules/`
-/// are skipped.
+/// When a path contains glob metacharacters (`*`, `?`, `[`) it is first
+/// expanded via [`resolve_paths_with_globs`], then each resolved entry is
+/// processed: files are included verbatim; directories are walked (via
+/// `walkdir`) to enumerate all source files beneath them (`rs`, `py`, `js`,
+/// `ts`, `tsx`, `jsx`, `java`, `cpp`, `cc`, `cxx`, `c`, `h`, `hpp`, `go`,
+/// `rb`, `php`, `swift`, `kt`, `lua`, `sh`). Hidden dirs, `target/`, and
+/// `node_modules/` are skipped.
 ///
-/// R17-2: MCP handlers previously only accepted files, returning zeros for
-/// directory inputs (D82 "authoritative zeros" regression).
+/// R17-2 (D82): MCP handlers previously only accepted files, returning zeros
+/// for directory inputs ("authoritative zeros" regression).
+/// R21-4 (D98): The same handlers also silently ignored glob-style inputs like
+/// `**/*.rs` because the raw `PathBuf` was a non-existent literal. Globs are
+/// now resolved before the walk.
 fn expand_paths_to_source_files(paths: &[PathBuf]) -> Vec<PathBuf> {
     use walkdir::WalkDir;
     const EXTENSIONS: &[&str] = &[
@@ -15,8 +78,9 @@ fn expand_paths_to_source_files(paths: &[PathBuf]) -> Vec<PathBuf> {
         "rb", "php", "swift", "kt", "lua", "sh",
     ];
 
+    let resolved = resolve_paths_with_globs(paths);
     let mut out = Vec::new();
-    for path in paths {
+    for path in &resolved {
         if !path.exists() {
             continue;
         }
@@ -159,10 +223,13 @@ pub async fn analyze_satd(paths: &[PathBuf], _include_resolved: bool) -> Result<
                     let debts: Vec<_> = if _include_resolved {
                         debts
                     } else {
-                        debts.into_iter()
+                        debts
+                            .into_iter()
                             .filter(|d| {
                                 let upper = d.text.to_uppercase();
-                                !upper.contains("DONE") && !upper.contains("RESOLVED") && !upper.contains("FIXED")
+                                !upper.contains("DONE")
+                                    && !upper.contains("RESOLVED")
+                                    && !upper.contains("FIXED")
                             })
                             .collect()
                     };

--- a/src/mcp_pmcp/tool_functions_tests.rs
+++ b/src/mcp_pmcp/tool_functions_tests.rs
@@ -842,10 +842,16 @@ mod coverage_tests {
     async fn test_analyze_dead_code_walks_directory() -> Result<()> {
         // Create a minimal Rust project so language detection finds "rust"
         let temp_dir = TempDir::new()?;
-        fs::write(temp_dir.path().join("Cargo.toml"), "[package]\nname=\"t\"\nversion=\"0.1.0\"\n")?;
+        fs::write(
+            temp_dir.path().join("Cargo.toml"),
+            "[package]\nname=\"t\"\nversion=\"0.1.0\"\n",
+        )?;
         let src = temp_dir.path().join("src");
         fs::create_dir(&src)?;
-        fs::write(src.join("lib.rs"), "pub fn used() {}\nfn unused_helper() { let _=1; }\n")?;
+        fs::write(
+            src.join("lib.rs"),
+            "pub fn used() {}\nfn unused_helper() { let _=1; }\n",
+        )?;
 
         let paths = vec![temp_dir.path().to_path_buf()];
         let json = analyze_dead_code(&paths, false).await.unwrap();
@@ -873,6 +879,197 @@ mod coverage_tests {
         assert!(
             total >= 2,
             "expected >=2 files in context, got {total}; json={json}"
+        );
+        Ok(())
+    }
+
+    // ==================== R21-4 D98 GLOB EXPANSION TESTS ====================
+    // MCP analyze_* handlers receive PathBufs built from raw client strings.
+    // When the client passes `**/*.rs`, the PathBuf is a literal non-existent
+    // path and `path.exists()` returns false. `resolve_paths_with_globs` must
+    // expand such glob patterns BEFORE the existence check so downstream
+    // file-count metrics are non-zero.
+
+    /// Helper: build a small on-disk Rust project with root + nested files.
+    fn make_rust_project(temp: &TempDir) -> Result<(PathBuf, PathBuf, PathBuf)> {
+        let root = temp.path().join("root.rs");
+        fs::write(&root, "fn root_fn() { let _ = 1 + 1; }")?;
+
+        let src = temp.path().join("src");
+        fs::create_dir_all(&src)?;
+        let lib = src.join("lib.rs");
+        fs::write(&lib, "pub fn lib_fn() { if true { 1 } else { 2 }; }")?;
+
+        let nested = src.join("nested");
+        fs::create_dir_all(&nested)?;
+        let deep = nested.join("deep.rs");
+        fs::write(&deep, "pub fn deep_fn() { for i in 0..3 { let _ = i; } }")?;
+
+        Ok((root, lib, deep))
+    }
+
+    #[test]
+    fn test_resolve_paths_with_globs_recursive_star_star() -> Result<()> {
+        let temp = TempDir::new()?;
+        make_rust_project(&temp)?;
+
+        let pattern = temp.path().join("**/*.rs");
+        let resolved = resolve_paths_with_globs(&[pattern]);
+
+        // Must find all 3 .rs files (root + nested + deep).
+        let rs_count = resolved
+            .iter()
+            .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("rs"))
+            .count();
+        assert_eq!(
+            rs_count, 3,
+            "expected 3 .rs files from **/*.rs, got {rs_count}: {resolved:?}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_resolve_paths_with_globs_shallow_star() -> Result<()> {
+        let temp = TempDir::new()?;
+        make_rust_project(&temp)?;
+
+        let pattern = temp.path().join("*.rs");
+        let resolved = resolve_paths_with_globs(&[pattern]);
+
+        let rs_files: Vec<_> = resolved
+            .iter()
+            .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("rs"))
+            .collect();
+        assert!(
+            !rs_files.is_empty(),
+            "expected at least 1 .rs file from *.rs, got 0: {resolved:?}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_resolve_paths_with_globs_dir_star_star() -> Result<()> {
+        let temp = TempDir::new()?;
+        make_rust_project(&temp)?;
+
+        // `src/**` is the "everything under src" pattern. The glob crate
+        // returns whatever entries match the literal glob; when composed with
+        // R17-2's `expand_paths_to_source_files` those dirs are walked.
+        // Standalone we assert the glob produced at least one entry — the
+        // pre-fix behavior returned zero because the literal pattern path did
+        // not exist on disk.
+        let pattern = temp.path().join("src").join("**");
+        let resolved = resolve_paths_with_globs(&[pattern]);
+
+        assert!(
+            !resolved.is_empty(),
+            "expected src/** to resolve to at least one entry, got {resolved:?}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_resolve_paths_with_globs_dir_star_star_ext() -> Result<()> {
+        let temp = TempDir::new()?;
+        make_rust_project(&temp)?;
+
+        let pattern = temp.path().join("src").join("**").join("*.rs");
+        let resolved = resolve_paths_with_globs(&[pattern]);
+
+        let rs_files: Vec<_> = resolved
+            .iter()
+            .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("rs"))
+            .collect();
+        assert_eq!(
+            rs_files.len(),
+            2,
+            "expected 2 .rs files from src/**/*.rs (lib + deep), got {}: {resolved:?}",
+            rs_files.len()
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_resolve_paths_with_globs_plain_path_passthrough() -> Result<()> {
+        let temp = TempDir::new()?;
+        let (root, _, _) = make_rust_project(&temp)?;
+
+        // A plain path (no glob metacharacters) must pass through unchanged,
+        // preserving composability with R17-2 expand_paths_to_source_files.
+        let resolved = resolve_paths_with_globs(std::slice::from_ref(&root));
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(resolved[0], root);
+        Ok(())
+    }
+
+    #[test]
+    fn test_resolve_paths_with_globs_no_match_drops_pattern() {
+        // A glob with no matches yields an empty Vec, not the literal pattern.
+        // Callers downstream will simply see 0 files, matching pre-fix UX.
+        let pattern = PathBuf::from("/tmp/pmat-r21-4-definitely-does-not-exist-*.rs");
+        let resolved = resolve_paths_with_globs(&[pattern]);
+        assert!(resolved.is_empty(), "expected empty, got {resolved:?}");
+    }
+
+    /// Integration: MCP `analyze_complexity` with `**/*.rs` must return
+    /// non-zero file_count across a nested Rust tree. Mirrors the R17-2 D82
+    /// directory-walking pattern.
+    #[tokio::test]
+    async fn test_analyze_complexity_with_double_star_glob() -> Result<()> {
+        let temp = TempDir::new()?;
+        make_rust_project(&temp)?;
+
+        let pattern = temp.path().join("**/*.rs");
+        let json = analyze_complexity(&[pattern], None, None).await?;
+
+        let total_files = json["results"]["total_files"].as_u64().unwrap_or(0);
+        assert!(
+            total_files >= 3,
+            "expected >=3 files from **/*.rs, got {total_files}; json={json}"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_analyze_satd_with_double_star_glob() -> Result<()> {
+        let temp = TempDir::new()?;
+        fs::write(
+            temp.path().join("root.rs"),
+            "// TODO: top-level debt\nfn root_fn() {}",
+        )?;
+        let src = temp.path().join("src");
+        fs::create_dir_all(&src)?;
+        fs::write(
+            src.join("nested.rs"),
+            "// FIXME: nested debt\nfn nested_fn() {}",
+        )?;
+
+        let pattern = temp.path().join("**/*.rs");
+        let json = analyze_satd(&[pattern], false).await?;
+
+        let total = json["results"]["total_satd"].as_u64().unwrap_or(0);
+        assert!(
+            total >= 2,
+            "expected >=2 SATD entries from **/*.rs walk, got {total}; json={json}"
+        );
+        Ok(())
+    }
+
+    /// When the input path is `src/**/*.rs` the composed pipeline —
+    /// `resolve_paths_with_globs` → `expand_paths_to_source_files` — must
+    /// find every `.rs` file below `src/`. This is a D98 acceptance case.
+    #[tokio::test]
+    async fn test_analyze_complexity_with_dir_star_star_glob() -> Result<()> {
+        let temp = TempDir::new()?;
+        make_rust_project(&temp)?;
+
+        let pattern = temp.path().join("src").join("**").join("*.rs");
+        let json = analyze_complexity(&[pattern], None, None).await?;
+
+        let total_files = json["results"]["total_files"].as_u64().unwrap_or(0);
+        assert!(
+            total_files >= 2,
+            "expected >=2 files from src/**/*.rs, got {total_files}; json={json}"
         );
         Ok(())
     }


### PR DESCRIPTION
## Summary

- Fix D98 (R20 #2 dogfood): MCP `analyze_*` handlers silently returned zeros for glob inputs like `**/*.rs`.
- Root cause: `paths` strings become `PathBuf` literals; R17-2's `expand_paths_to_source_files` (#358) only walks entries where `path.exists()` is true, so `"**/*.rs"` is dropped before any walk happens.
- Fix: new `resolve_paths_with_globs()` helper routes glob-containing inputs through `glob::glob_with` with `require_literal_separator = false`, expanding `**` across directory boundaries. `expand_paths_to_source_files` calls it before the existence check so `**/*.rs`, `src/**`, and `src/**/*.rs` all resolve correctly. Plain paths pass through unchanged, preserving R17-2 composition.

## Test plan

- [x] `cargo test --lib resolve_paths_with_globs` — 6/6 new helper unit tests pass
- [x] `cargo test --lib test_analyze_complexity_with_double_star_glob test_analyze_complexity_with_dir_star_star_glob test_analyze_satd_with_double_star_glob` — 3/3 MCP integration tests pass
- [x] `cargo test --lib -- mcp_pmcp::tool_functions` — 84/84 pass (full module suite, includes R17-2 D82 regressions + new D98 cases)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] Cases covered: `"*.rs"`, `"**/*.rs"`, `"src/**"`, `"src/**/*.rs"`, plain path passthrough, non-matching glob
- [x] Net LOC: +276 / -12 (70 functional + 201 tests + 5 doc lines)

Pre-push hook bypassed with `--no-verify` per [feedback_no_slow_prepush.md](memory): the hook runs full `cargo test --lib` which has 30 flaky tests in `parallel_git`/`hygiene_scorer`/`hooks_cache` unrelated to this change (they pass individually; they race in the parallel runner). CI's `ci / gate` and `workspace-test` will validate the real signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)