### PR TITLE
test(bug_report): serialize tests sharing ~/.pmat/last_error.json

### DIFF
--- a/src/cli/handlers/bug_report_handler_tests.rs
+++ b/src/cli/handlers/bug_report_handler_tests.rs
@@ -5,8 +5,17 @@
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
+
+    // Tests below that call `capture_command_error*`, `clear_error`, or
+    // `handle_bug_report` all touch the same on-disk file at
+    // ~/.pmat/last_error.json. Under cargo's threaded runner they race —
+    // a capture test writing the file between `clear_error()` and
+    // `handle_bug_report()` flips the latter's expected Err into Ok.
+    // `#[serial(bug_report_error_file)]` pins them to one thread.
 
     #[tokio::test]
+    #[serial(bug_report_error_file)]
     async fn test_handle_bug_report_no_error() {
         // Clear any existing error first
         let _ = clear_error();
@@ -20,6 +29,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial(bug_report_error_file)]
     #[ignore = "Requires HOME directory to be set in test environment"]
     async fn test_handle_bug_report_clear() {
         // Clear should always succeed (no-op if file doesn't exist)
@@ -28,18 +38,21 @@ mod tests {
     }
 
     #[test]
+    #[serial(bug_report_error_file)]
     fn test_capture_command_error() {
         // This should not panic
         capture_command_error("pmat", &["test".to_string()], "test error");
     }
 
     #[test]
+    #[serial(bug_report_error_file)]
     fn test_capture_command_error_with_empty_args() {
         // Should handle empty args without panic
         capture_command_error("pmat", &[], "error with no args");
     }
 
     #[test]
+    #[serial(bug_report_error_file)]
     fn test_capture_command_error_with_multiple_args() {
         // Should handle multiple args
         capture_command_error(
@@ -54,6 +67,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(bug_report_error_file)]
     fn test_capture_command_error_with_long_error_message() {
         // Should handle long error messages
         let long_error = "A".repeat(10000);
@@ -61,36 +75,42 @@ mod tests {
     }
 
     #[test]
+    #[serial(bug_report_error_file)]
     fn test_capture_command_error_with_unicode() {
         // Should handle unicode in error messages
         capture_command_error("pmat", &["test".to_string()], "Error: 日本語 эррор 🚫");
     }
 
     #[test]
+    #[serial(bug_report_error_file)]
     fn test_capture_command_error_with_code() {
         // Test capturing error with exit code
         capture_command_error_with_code("pmat", &["work".to_string()], "exit error", 1);
     }
 
     #[test]
+    #[serial(bug_report_error_file)]
     fn test_capture_command_error_with_code_zero() {
         // Edge case: zero exit code
         capture_command_error_with_code("pmat", &["work".to_string()], "success but captured", 0);
     }
 
     #[test]
+    #[serial(bug_report_error_file)]
     fn test_capture_command_error_with_code_negative() {
         // Edge case: negative exit code (signal-based termination)
         capture_command_error_with_code("pmat", &["work".to_string()], "signal error", -9);
     }
 
     #[test]
+    #[serial(bug_report_error_file)]
     fn test_capture_command_error_with_code_large() {
         // Edge case: large exit code
         capture_command_error_with_code("pmat", &["work".to_string()], "error", 255);
     }
 
     #[test]
+    #[serial(bug_report_error_file)]
     fn test_capture_command_error_with_special_characters() {
         // Error message with special characters that might break markdown
         capture_command_error(
@@ -101,6 +121,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(bug_report_error_file)]
     fn test_capture_command_error_with_newlines() {
         // Error message with newlines (multi-line errors)
         capture_command_error(
@@ -111,6 +132,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(bug_report_error_file)]
     fn test_capture_command_error_with_tabs_and_whitespace() {
         // Error message with various whitespace
         capture_command_error(


### PR DESCRIPTION
## Summary

The `capture_command_error*` tests in `bug_report_handler_tests.rs` all write to a single on-disk file at `~/.pmat/last_error.json`, and `test_handle_bug_report_no_error` deletes it and expects the handler to fail with "No captured error found". Under cargo's threaded runner these raced — a capture test writing the file between the clear and the read flipped the expected `Err` back to `Ok`.

This flake has caused CI failures on **#368**, **#370** (both of which rebased through), and now **#371** (R21-5 cwd safety).

## Fix

Annotate all 13 tests that touch the shared file with `#[serial(bug_report_error_file)]`. `serial_test = "3.2"` was already a dev-dep — no new dependencies.

No production code changes. The shared-state accessor (`~/.pmat/last_error.json`) is intentional for user-facing error capture; tests just need to agree not to stomp on each other.

## Test plan
- [x] `cargo test --lib -- bug_report_handler::tests --test-threads=8` → **33 passed, 0 failed, 1 ignored**
- [x] `cargo check --tests --lib` clean

## Blocks
- PR #371 (R21-5) needs this merged + rebased to get a green ci/test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)