### PR TITLE
fix(build): restore --no-default-features --features core-languages,viz (R22-3 / D103)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -331,7 +331,16 @@ standard-deps = [
 ]
 
 # Convenience bundles
-core-languages = ["rust-ast", "typescript-ast", "javascript-ast", "python-ast", "lua-ast", "lean-ast", "c-ast", "cpp-ast"]  # Most common: Rust + JS/TS + Python + Lua + Lean + C/C++
+#
+# `core-languages` implies `standard-deps` because the analysis pipeline is
+# pervasively coupled to the crates in `standard-deps` (walkdir, toml,
+# async-trait, uuid, dashmap, rusqlite, parking_lot, globset, futures,
+# num_cpus, dirs, ignore, tempfile, serde_yaml_ng, glob, rustc-hash, sha2,
+# bincode, roaring, etc.). Carving them out of `--features core-languages,viz`
+# breaks ~900 compile errors across ~400 files (D103). Users who want a truly
+# minimal build with no language AST parsers should use `--features rust-only`
+# or wait for a dedicated `minimal` feature with proper cfg gating.
+core-languages = ["standard-deps", "rust-ast", "typescript-ast", "javascript-ast", "python-ast", "lua-ast", "lean-ast", "c-ast", "cpp-ast"]  # Most common: Rust + JS/TS + Python + Lua + Lean + C/C++
 extended-languages = ["go-ast", "c-ast", "cpp-ast", "shell-ast", "php-ast", "swift-ast", "lean-ast"]  # Additional languages
 advanced-analysis = ["analytics-simd", "mutation-testing", "tdg-explain", "demo"]  # Heavy features
 full = ["all-languages", "polyglot-ast", "advanced-analysis", "doc-indexing"]  # Equivalent to old defaults


### PR DESCRIPTION
## Summary
- Fixes D103: `cargo build --no-default-features --features core-languages,viz` was failing with **911 compile errors** across 401 files — unresolved modules for 28 crates that live in the `standard-deps` bundle but are used pervasively across the library without `#[cfg(feature = "standard-deps")]` guards.
- Phase 3 v3.15.0 dogfood verdict: **NO-GO**. The release plan promises "core-languages + viz" is a minimal useful slice, but today it doesn't compile at all.
- Cites sibling fix: **R21-2 (#369)** fixed the same family of errors in `build.rs`. This PR is the **orthogonal library-side counterpart** — R21-2 alone unblocked the build script; the library still failed with 911 errors.

## Reproducer

```console
$ cargo build --no-default-features --features core-languages,viz
# Before: 911 errors (E0432/E0433 unresolved crates)
# After:  OK (81s)
```

## Fix strategy — Option B (strategic dependency promotion)

Single-line Cargo.toml change: make `core-languages` imply `standard-deps`.

```toml
core-languages = ["standard-deps", "rust-ast", "typescript-ast", ...]
```

This respects the Sovereign AI 80/20 budget — **zero new external crates**; we're acknowledging that the crates already in `standard-deps` are foundational to every code path a "core-languages" user would hit.

### Why not Option A (cfg-gate per file)?
- 401 files affected, 911 errors.
- Gating each call site requires `#[cfg(feature = "standard-deps")]` on function bodies, module declarations, use statements, and struct fields across cache/index/context/deep-context/tdg/dead-code/mcp/handlers/services.
- Estimated >10 hours of churn, high regression risk, ongoing maintenance tax for every new analysis module.

### Why not Option C (remove crates)?
- `walkdir`, `rayon`, `async-trait`, `rusqlite`, `parking_lot`, `dashmap` etc. are foundational. No batuta alternatives.

## Missing-crate table

All 28 crates are already declared as `optional = true` in `[dependencies]` and listed in the `standard-deps` feature. This PR promotes the bundle; no other changes needed.

| Crate family | Errors | Fix strategy | Files touched |
|--------------|--------|--------------|---------------|
| walkdir | 161 | promote via standard-deps | Cargo.toml (1 line) |
| toml | 154 | promote via standard-deps | Cargo.toml (1 line) |
| async-trait | 119 | promote via standard-deps | Cargo.toml (1 line) |
| serde_yaml_ng | 74 | promote via standard-deps | Cargo.toml (1 line) |
| rusqlite | 59 | promote via standard-deps | Cargo.toml (1 line) |
| glob | 52 | promote via standard-deps | Cargo.toml (1 line) |
| rustc-hash | 47 | promote via standard-deps | Cargo.toml (1 line) |
| parking_lot | 35 | promote via standard-deps | Cargo.toml (1 line) |
| uuid | 33 | promote via standard-deps | Cargo.toml (1 line) |
| rayon, num_cpus, dashmap | 26+26+26 | promote via standard-deps | Cargo.toml (1 line) |
| futures, dirs, ignore | 24+18+17 | promote via standard-deps | Cargo.toml (1 line) |
| trueno-rag, tempfile, minijinja, globset | 16+13+13+13 | promote via standard-deps | Cargo.toml (1 line) |
| roaring, rand, lazy_static | 12+10+9 | promote via standard-deps | Cargo.toml (1 line) |
| lru, xxhash-rust, bincode | 7+6+6 | promote via standard-deps | Cargo.toml (1 line) |
| crossbeam-channel, semver, url, pulldown-cmark | 3+2+1+1 | promote via standard-deps | Cargo.toml (1 line) |

## Relationship to R21-2 (#369)

R21-2 fixed `build.rs` (the build script) for the same command line — it gated three call sites (`calculate_templates_hash`, `calculate_file_hash`, `generate_stub_compressed_templates`) behind `#[cfg(feature = "standard-deps")]`. D103 is **orthogonal**: the library (`src/`) was never touched. This PR completes the fix for the library.

## Phase 3 v3.15.0 NO-GO verdict

Cited in task brief. This PR clears the library-build blocker; the verdict should be revisited after CI validates all gates.

## Future work

A proper minimal build (e.g. `--features rust-only` with no `standard-deps`) that carves out only the Rust AST pipeline is a future KAIZEN ticket. The docblock on `core-languages` calls this out. Recommended ticket: **KAIZEN-D103-followup: systematic cfg-gating for minimal slice**.

## Test plan
- [x] `cargo build` (default features) — OK (2m 18s)
- [x] `cargo build --no-default-features --features core-languages,viz` — OK (1m 21s), previously 911 errors
- [x] `cargo test --lib --no-run` — OK, 15,782 tests compile
- [x] `cargo fmt --all -- --check` — pre-existing drift in `examples/mcp_agent_context_demo.rs` and `src/mcp_pmcp/` unrelated to this change (confirmed by `git diff --stat`: only `Cargo.toml` touched)
- [ ] CI must validate full test suite before merge

## Parallel work (do not touch)
- D101 (cwd) — owned by parallel agent
- D102 (glob) — owned by parallel agent

## Do not tag v3.15.0 or publish on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)