### PR TITLE
fix(mcp): apply D99 cwd guard to live handlers/tools dispatcher (R22-1 / D101)

### DIFF
--- a/src/handlers/tools/core_tools.rs
+++ b/src/handlers/tools/core_tools.rs
@@ -20,6 +20,43 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tracing::{error, info};
 
+/// R22-1 / D101 — Reject missing, null, or empty/whitespace-only
+/// `project_path` arguments across MCP analysis handlers.
+///
+/// This is the parity fix for R21-5 / D99 (PR #371), which added the same
+/// guard to the `src/agent/mcp_server_protocol.rs` handlers. The live
+/// dispatcher in `src/handlers/tools/` was still silently defaulting to
+/// `std::env::current_dir()`, which lets a remote MCP client exfiltrate
+/// information about the server's launch directory by sending `{}` or
+/// `{"project_path": null}` / `{"project_path": ""}`.
+///
+/// The helper takes the already-deserialised `Option<String>` (since the
+/// handlers use typed arg structs like `AnalyzeComplexityArgs`) and returns
+/// a validated `PathBuf` or an error string that the caller maps to
+/// JSON-RPC `-32602` (Invalid params).
+///
+/// Mirrors the R21-1 / D100 fail-loud pattern already in
+/// `handle_analyze_dead_code`.
+fn require_project_path(project_path_arg: Option<String>) -> Result<PathBuf, String> {
+    let Some(raw) = project_path_arg else {
+        return Err(
+            "'project_path' is required and must be a non-empty string — \
+null/missing is rejected to avoid silently analyzing the server's current \
+directory (R22-1 / D101)"
+                .to_string(),
+        );
+    };
+    if raw.trim().is_empty() {
+        return Err(
+            "'project_path' must be a non-empty string — empty/whitespace values \
+are rejected to avoid silently analyzing the server's current directory \
+(R22-1 / D101)"
+                .to_string(),
+        );
+    }
+    Ok(PathBuf::from(raw))
+}
+
 // --- Tool call dispatch (routing, classification) ---
 include!("core_tools_dispatch.rs");
 

--- a/src/handlers/tools/core_tools_churn.rs
+++ b/src/handlers/tools/core_tools_churn.rs
@@ -22,8 +22,14 @@ async fn handle_analyze_code_churn(
         }
     };
 
-    // Extract analysis parameters
-    let (project_path, period_days, format) = extract_churn_parameters(&args);
+    // R22-1 / D101: require explicit project_path; reject null/missing/empty.
+    let project_path = match require_project_path(args.project_path.clone()) {
+        Ok(p) => p,
+        Err(e) => return McpResponse::error(request_id, -32602, e),
+    };
+
+    // Extract remaining analysis parameters
+    let (period_days, format) = extract_churn_parameters(&args);
 
     info!(
         "Analyzing code churn for {:?} over {} days",
@@ -41,13 +47,11 @@ fn parse_code_churn_args(
     serde_json::from_value(arguments)
 }
 
-/// Toyota Way Helper: Extract churn analysis parameters
-fn extract_churn_parameters(args: &AnalyzeCodeChurnArgs) -> (PathBuf, u32, ChurnOutputFormat) {
-    let project_path = args.project_path.as_ref().map_or_else(
-        || std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
-        PathBuf::from,
-    );
-
+/// Toyota Way Helper: Extract churn analysis parameters (period_days + format).
+///
+/// R22-1 / D101: project_path is now validated separately via
+/// `require_project_path()` in the handler.
+fn extract_churn_parameters(args: &AnalyzeCodeChurnArgs) -> (u32, ChurnOutputFormat) {
     let period_days = args.period_days.unwrap_or(30);
 
     let format = args
@@ -56,7 +60,7 @@ fn extract_churn_parameters(args: &AnalyzeCodeChurnArgs) -> (PathBuf, u32, Churn
         .and_then(|f| f.parse::<ChurnOutputFormat>().ok())
         .unwrap_or(ChurnOutputFormat::Summary);
 
-    (project_path, period_days, format)
+    (period_days, format)
 }
 
 /// Toyota Way Helper: Run analysis and format response

--- a/src/handlers/tools/extended_tools_architecture.rs
+++ b/src/handlers/tools/extended_tools_architecture.rs
@@ -158,15 +158,17 @@ async fn handle_analyze_system_architecture(
 }
 
 /// Toyota Way: Extract Method - Parse architecture analysis arguments (complexity <=5)
+///
+/// R22-1 / D101: project_path is required. Missing, null, and
+/// empty/whitespace values are rejected with an error that the caller maps
+/// to JSON-RPC `-32602` — we never silently default to the server's cwd.
 fn parse_architecture_analysis_args(
     arguments: serde_json::Value,
 ) -> Result<(AnalyzeSystemArchitectureArgs, PathBuf), Box<dyn std::error::Error>> {
     let args: AnalyzeSystemArchitectureArgs = serde_json::from_value(arguments)?;
 
-    let project_path = args.project_path.as_ref().map_or_else(
-        || std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
-        PathBuf::from,
-    );
+    let project_path = require_project_path(args.project_path.clone())
+        .map_err(Box::<dyn std::error::Error>::from)?;
 
     Ok((args, project_path))
 }

--- a/src/handlers/tools/extended_tools_complexity.rs
+++ b/src/handlers/tools/extended_tools_complexity.rs
@@ -22,8 +22,13 @@ struct ComplexityAnalysisContext {
     _thresholds: crate::services::complexity::ComplexityThresholds,
 }
 
-fn prepare_complexity_analysis(args: &AnalyzeComplexityArgs) -> ComplexityAnalysisContext {
-    let project_path = resolve_project_path_complexity(args.project_path.clone());
+/// R22-1 / D101: project_path is now required and validated up-front in
+/// `handle_analyze_complexity`. This helper receives the already-validated
+/// `PathBuf` and fills in the remaining context.
+fn prepare_complexity_analysis(
+    args: &AnalyzeComplexityArgs,
+    project_path: PathBuf,
+) -> ComplexityAnalysisContext {
     let toolchain = detect_toolchain(&args.toolchain, &project_path);
     let thresholds = build_complexity_thresholds(args);
 
@@ -33,7 +38,6 @@ fn prepare_complexity_analysis(args: &AnalyzeComplexityArgs) -> ComplexityAnalys
         _thresholds: thresholds,
     }
 }
-
 
 async fn perform_complexity_analysis(
     context: &ComplexityAnalysisContext,
@@ -108,7 +112,13 @@ async fn handle_analyze_complexity(
         Err(e) => return McpResponse::error(request_id, -32602, e),
     };
 
-    let context = prepare_complexity_analysis(&args);
+    // R22-1 / D101: require explicit project_path; reject null/missing/empty.
+    let project_path = match require_project_path(args.project_path.clone()) {
+        Ok(p) => p,
+        Err(e) => return McpResponse::error(request_id, -32602, e),
+    };
+
+    let context = prepare_complexity_analysis(&args, project_path);
 
     info!(
         "Analyzing complexity for {:?} using {} toolchain",
@@ -128,13 +138,6 @@ async fn handle_analyze_complexity(
         &context.toolchain,
         file_count,
         &args,
-    )
-}
-
-fn resolve_project_path_complexity(project_path_arg: Option<String>) -> PathBuf {
-    project_path_arg.map_or_else(
-        || std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
-        PathBuf::from,
     )
 }
 

--- a/src/handlers/tools/extended_tools_context.rs
+++ b/src/handlers/tools/extended_tools_context.rs
@@ -48,15 +48,17 @@ async fn handle_generate_context(
 }
 
 /// Toyota Way: Extract Method - Parse context generation arguments (complexity <=5)
+///
+/// R22-1 / D101: project_path is required. Missing, null, and
+/// empty/whitespace values are rejected with an error that the caller maps
+/// to JSON-RPC `-32602` — we never silently default to the server's cwd.
 fn parse_generate_context_args(
     arguments: serde_json::Value,
 ) -> Result<(GenerateContextArgs, PathBuf), Box<dyn std::error::Error>> {
     let args: GenerateContextArgs = serde_json::from_value(arguments)?;
 
-    let project_path = args.project_path.as_ref().map_or_else(
-        || std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
-        PathBuf::from,
-    );
+    let project_path = require_project_path(args.project_path.clone())
+        .map_err(Box::<dyn std::error::Error>::from)?;
 
     Ok((args, project_path))
 }

--- a/src/handlers/tools/extended_tools_dag.rs
+++ b/src/handlers/tools/extended_tools_dag.rs
@@ -24,29 +24,33 @@ async fn handle_analyze_dag(
         }
     };
 
-    match execute_dag_analysis(&args).await {
+    // R22-1 / D101: require explicit project_path; reject null/missing/empty.
+    let project_path = match require_project_path(args.project_path.clone()) {
+        Ok(p) => p,
+        Err(e) => return McpResponse::error(request_id, -32602, e),
+    };
+
+    match execute_dag_analysis(&args, project_path).await {
         Ok(result) => McpResponse::success(request_id, result),
         Err(e) => McpResponse::error(request_id, -32000, format!("DAG analysis failed: {e}")),
     }
 }
 
 /// Toyota Way: Extract Method pattern for DAG analysis
-async fn execute_dag_analysis(args: &AnalyzeDagArgs) -> anyhow::Result<serde_json::Value> {
+///
+/// R22-1 / D101: project_path is now validated in the handler; this
+/// receives the already-validated PathBuf.
+async fn execute_dag_analysis(
+    args: &AnalyzeDagArgs,
+    project_path: PathBuf,
+) -> anyhow::Result<serde_json::Value> {
     use crate::services::context::analyze_project;
-    let project_path = resolve_project_path(&args.project_path);
     let project_context = analyze_project(&project_path, "rust").await?;
     let graph = build_dag_graph(&project_context);
     let dag_type = parse_dag_type(args.dag_type.as_deref());
     let filtered_graph = apply_dag_filters(graph, dag_type.clone());
     let output = generate_dag_output(&filtered_graph, args, dag_type);
     Ok(output)
-}
-
-fn resolve_project_path(project_path: &Option<String>) -> PathBuf {
-    project_path.as_ref().map_or_else(
-        || std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
-        PathBuf::from,
-    )
 }
 
 fn build_dag_graph(

--- a/src/handlers/tools/mod.rs
+++ b/src/handlers/tools/mod.rs
@@ -7,3 +7,147 @@ include!("extended_tools.rs");
 mod tests {
     // Tests from original file
 }
+
+// ============================================================================
+// R22-1 / D101 regression tests — cwd-exfiltration parity fix
+// ============================================================================
+//
+// Proves that the live `src/handlers/tools/` dispatcher now rejects missing,
+// null, and empty/whitespace `project_path` with JSON-RPC `-32602` across
+// every analysis handler that previously fell back to
+// `std::env::current_dir()`. Mirrors the R21-5 / D99 test layout in
+// `src/agent/mcp_server_tests.rs` (PR #371).
+
+#[cfg(test)]
+mod r22_1_d101_cwd_guard_tests {
+    use super::*;
+    use serde_json::json;
+
+    fn assert_invalid_params(response: &McpResponse, context: &str) {
+        assert!(
+            response.error.is_some(),
+            "{context}: expected an error response, got success: {response:?}"
+        );
+        let err = response.error.as_ref().unwrap();
+        assert_eq!(
+            err.code, -32602,
+            "{context}: expected JSON-RPC -32602 (Invalid params), got {}: message={}",
+            err.code, err.message
+        );
+        assert!(
+            err.message.contains("project_path"),
+            "{context}: error message should name the offending field: {}",
+            err.message
+        );
+    }
+
+    // --- handle_analyze_complexity ----------------------------------------
+
+    #[tokio::test]
+    async fn analyze_complexity_rejects_missing_project_path() {
+        let response = handle_analyze_complexity(json!(1), json!({})).await;
+        assert_invalid_params(&response, "analyze_complexity / missing");
+    }
+
+    #[tokio::test]
+    async fn analyze_complexity_rejects_null_project_path() {
+        let response = handle_analyze_complexity(json!(1), json!({ "project_path": null })).await;
+        assert_invalid_params(&response, "analyze_complexity / null");
+    }
+
+    #[tokio::test]
+    async fn analyze_complexity_rejects_empty_project_path() {
+        let response = handle_analyze_complexity(json!(1), json!({ "project_path": "" })).await;
+        assert_invalid_params(&response, "analyze_complexity / empty");
+    }
+
+    #[tokio::test]
+    async fn analyze_complexity_rejects_whitespace_project_path() {
+        let response = handle_analyze_complexity(json!(1), json!({ "project_path": "   " })).await;
+        assert_invalid_params(&response, "analyze_complexity / whitespace");
+    }
+
+    // --- handle_analyze_code_churn ----------------------------------------
+
+    #[tokio::test]
+    async fn analyze_code_churn_rejects_missing_project_path() {
+        let response = handle_analyze_code_churn(json!(1), json!({})).await;
+        assert_invalid_params(&response, "analyze_code_churn / missing");
+    }
+
+    #[tokio::test]
+    async fn analyze_code_churn_rejects_empty_project_path() {
+        let response = handle_analyze_code_churn(json!(1), json!({ "project_path": "" })).await;
+        assert_invalid_params(&response, "analyze_code_churn / empty");
+    }
+
+    // --- handle_analyze_dag -----------------------------------------------
+
+    #[tokio::test]
+    async fn analyze_dag_rejects_missing_project_path() {
+        let response = handle_analyze_dag(json!(1), json!({})).await;
+        assert_invalid_params(&response, "analyze_dag / missing");
+    }
+
+    #[tokio::test]
+    async fn analyze_dag_rejects_empty_project_path() {
+        let response = handle_analyze_dag(json!(1), json!({ "project_path": "" })).await;
+        assert_invalid_params(&response, "analyze_dag / empty");
+    }
+
+    // --- handle_generate_context ------------------------------------------
+
+    #[tokio::test]
+    async fn generate_context_rejects_missing_project_path() {
+        let response = handle_generate_context(json!(1), json!({})).await;
+        assert_invalid_params(&response, "generate_context / missing");
+    }
+
+    #[tokio::test]
+    async fn generate_context_rejects_empty_project_path() {
+        let response = handle_generate_context(json!(1), json!({ "project_path": "" })).await;
+        assert_invalid_params(&response, "generate_context / empty");
+    }
+
+    // --- handle_analyze_system_architecture -------------------------------
+
+    #[tokio::test]
+    async fn analyze_system_architecture_rejects_missing_project_path() {
+        let response = handle_analyze_system_architecture(json!(1), json!({})).await;
+        assert_invalid_params(&response, "analyze_system_architecture / missing");
+    }
+
+    #[tokio::test]
+    async fn analyze_system_architecture_rejects_empty_project_path() {
+        let response =
+            handle_analyze_system_architecture(json!(1), json!({ "project_path": "" })).await;
+        assert_invalid_params(&response, "analyze_system_architecture / empty");
+    }
+
+    // --- require_project_path helper --------------------------------------
+
+    #[test]
+    fn require_project_path_accepts_nonempty() {
+        let out = require_project_path(Some("/tmp/x".to_string())).unwrap();
+        assert_eq!(out, std::path::PathBuf::from("/tmp/x"));
+    }
+
+    #[test]
+    fn require_project_path_rejects_none() {
+        let err = require_project_path(None).unwrap_err();
+        assert!(err.contains("project_path"), "{err}");
+        assert!(err.contains("D101"), "{err}");
+    }
+
+    #[test]
+    fn require_project_path_rejects_empty() {
+        let err = require_project_path(Some(String::new())).unwrap_err();
+        assert!(err.contains("non-empty"), "{err}");
+    }
+
+    #[test]
+    fn require_project_path_rejects_whitespace() {
+        let err = require_project_path(Some("  \n\t ".to_string())).unwrap_err();
+        assert!(err.contains("non-empty"), "{err}");
+    }
+}

--- a/src/handlers/tools_advanced_part1.rs
+++ b/src/handlers/tools_advanced_part1.rs
@@ -10,6 +10,54 @@ use serde_json::json;
 use std::path::{Path, PathBuf};
 use tracing::{error, info};
 
+/// R22-1 / D101 — Reject missing, null, or empty/whitespace-only
+/// `project_path` arguments across MCP advanced-analysis handlers.
+///
+/// This is the parity fix for R21-5 / D99 (PR #371), which added the same
+/// guard to the `src/agent/mcp_server_protocol.rs` handlers. The live
+/// dispatcher in `src/handlers/tools_advanced*` was still silently
+/// defaulting to `std::env::current_dir()`, which lets a remote MCP client
+/// exfiltrate information about the server's launch directory by sending
+/// `{}` / `{"project_path": null}` / `{"project_path": ""}`.
+///
+/// Mirrors the R21-1 / D100 fail-loud pattern already used by
+/// `handle_analyze_dead_code`. Returns an error string tagged for the
+/// caller to wrap in JSON-RPC `-32602` (Invalid params).
+fn require_project_path_advanced(project_path_arg: Option<String>) -> Result<PathBuf, String> {
+    let Some(raw) = project_path_arg else {
+        return Err(
+            "'project_path' is required and must be a non-empty string — \
+null/missing is rejected to avoid silently analyzing the server's current \
+directory (R22-1 / D101)"
+                .to_string(),
+        );
+    };
+    if raw.trim().is_empty() {
+        return Err(
+            "'project_path' must be a non-empty string — empty/whitespace values \
+are rejected to avoid silently analyzing the server's current directory \
+(R22-1 / D101)"
+                .to_string(),
+        );
+    }
+    Ok(PathBuf::from(raw))
+}
+
+/// R22-1 / D101 — String-taking variant of `require_project_path_advanced`
+/// for handlers whose arg struct uses `project_path: String` (typically via
+/// `#[serde(default = "default_project_path")]`). Rejects empty/whitespace
+/// values; missing/null case is handled by serde before we get here.
+fn require_non_empty_path(raw: &str, field_name: &str) -> Result<PathBuf, String> {
+    if raw.trim().is_empty() {
+        return Err(format!(
+            "'{field_name}' must be a non-empty string — empty/whitespace values \
+are rejected to avoid silently analyzing the server's current directory \
+(R22-1 / D101)"
+        ));
+    }
+    Ok(PathBuf::from(raw))
+}
+
 #[derive(Debug, Deserialize, Serialize)]
 struct AnalyzeDefectProbabilityArgs {
     project_path: Option<String>,
@@ -157,15 +205,17 @@ pub(crate) async fn handle_analyze_defect_probability(
 }
 
 /// Toyota Way: Extract Method - Parse defect probability arguments (complexity ≤5)
+///
+/// R22-1 / D101: project_path is required. Missing, null, and
+/// empty/whitespace values are rejected with an error that the caller maps
+/// to JSON-RPC `-32602` — we never silently default to the server's cwd.
 fn parse_defect_probability_args(
     arguments: serde_json::Value,
 ) -> Result<(AnalyzeDefectProbabilityArgs, PathBuf), Box<dyn std::error::Error>> {
     let args: AnalyzeDefectProbabilityArgs = serde_json::from_value(arguments)?;
 
-    let project_path = args.project_path.as_ref().map_or_else(
-        || std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
-        PathBuf::from,
-    );
+    let project_path = require_project_path_advanced(args.project_path.clone())
+        .map_err(Box::<dyn std::error::Error>::from)?;
 
     Ok((args, project_path))
 }

--- a/src/handlers/tools_advanced_part2.rs
+++ b/src/handlers/tools_advanced_part2.rs
@@ -1,4 +1,3 @@
-
 /// Toyota Way: Extract Method - Format top files with dead code (complexity ≤8)
 fn format_top_dead_code_files(
     output: &mut String,
@@ -267,8 +266,11 @@ pub(crate) async fn handle_analyze_tdg(
         }
     };
 
-    // Extract project path
-    let project_path = extract_tdg_project_path(&args);
+    // R22-1 / D101: require explicit project_path; reject null/missing/empty.
+    let project_path = match require_project_path_advanced(args.project_path.clone()) {
+        Ok(p) => p,
+        Err(e) => return McpResponse::error(request_id, -32602, e),
+    };
     info!("Analyzing Technical Debt Gradient for {:?}", project_path);
 
     // Run analysis and format response
@@ -278,14 +280,6 @@ pub(crate) async fn handle_analyze_tdg(
 /// Toyota Way Helper: Parse TDG arguments
 fn parse_tdg_args(arguments: serde_json::Value) -> Result<AnalyzeTdgArgs, serde_json::Error> {
     serde_json::from_value(arguments)
-}
-
-/// Toyota Way Helper: Extract TDG project path
-fn extract_tdg_project_path(args: &AnalyzeTdgArgs) -> PathBuf {
-    args.project_path.as_ref().map_or_else(
-        || std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
-        PathBuf::from,
-    )
 }
 
 /// Toyota Way Helper: Run TDG analysis and format response

--- a/src/handlers/tools_advanced_part3.rs
+++ b/src/handlers/tools_advanced_part3.rs
@@ -1,4 +1,3 @@
-
 #[provable_contracts_macros::contract("pmat-core.yaml", equation = "check_compliance")]
 pub(crate) async fn handle_analyze_deep_context(
     request_id: serde_json::Value,
@@ -9,7 +8,11 @@ pub(crate) async fn handle_analyze_deep_context(
         Err(e) => return McpResponse::error(request_id, -32602, e),
     };
 
-    let project_path = resolve_deep_context_project_path(args.project_path.clone());
+    // R22-1 / D101: require explicit project_path; reject null/missing/empty.
+    let project_path = match require_project_path_advanced(args.project_path.clone()) {
+        Ok(p) => p,
+        Err(e) => return McpResponse::error(request_id, -32602, e),
+    };
     info!("Running deep context analysis for {:?}", project_path);
 
     let config = build_deep_context_config(&args);
@@ -32,15 +35,13 @@ fn parse_deep_context_args(arguments: serde_json::Value) -> Result<AnalyzeDeepCo
         .map_err(|e| format!("Invalid analyze_deep_context arguments: {e}"))
 }
 
-fn resolve_deep_context_project_path(project_path: Option<String>) -> PathBuf {
-    project_path.map_or_else(
-        || std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
-        PathBuf::from,
-    )
-}
-
+/// R22-1 / D101: `default_project_path` is retained as a serde default
+/// sentinel ONLY. The actual handlers (`handle_analyze_satd`,
+/// `handle_analyze_lint_hotspot`) call `require_non_empty_path` after
+/// parsing to reject any value that falls through to this default, so it is
+/// never used as a live cwd fallback.
 fn default_project_path() -> String {
-    ".".to_string()
+    String::new()
 }
 
 fn default_top_files() -> usize {
@@ -386,7 +387,13 @@ pub(crate) async fn handle_analyze_makefile_lint(
         Err(e) => return McpResponse::error(request_id, -32602, e),
     };
 
-    let makefile_path = std::path::Path::new(&args.path);
+    // R22-1 / D101: reject empty/whitespace path to avoid silently linting
+    // a Makefile from the server's cwd.
+    let makefile_path_buf = match require_non_empty_path(&args.path, "path") {
+        Ok(p) => p,
+        Err(e) => return McpResponse::error(request_id, -32602, e),
+    };
+    let makefile_path = makefile_path_buf.as_path();
     info!("Analyzing Makefile at {:?}", makefile_path);
 
     let lint_result = match execute_makefile_linting(makefile_path).await {
@@ -431,6 +438,12 @@ pub(crate) async fn handle_analyze_provability(
             );
         }
     };
+
+    // R22-1 / D101: reject empty/whitespace project_path to avoid silently
+    // analyzing the server's cwd.
+    if let Err(e) = require_non_empty_path(&args.project_path, "project_path") {
+        return McpResponse::error(request_id, -32602, e);
+    }
 
     info!("Analyzing provability for project: {:?}", args.project_path);
 

--- a/src/handlers/tools_advanced_part4.rs
+++ b/src/handlers/tools_advanced_part4.rs
@@ -185,6 +185,14 @@ pub(crate) async fn handle_analyze_satd(
         Err(e) => return McpResponse::error(request_id, -32602, e),
     };
 
+    // R22-1 / D101: reject missing/empty/whitespace project_path to avoid
+    // silently analyzing the server's cwd. `SatdArgs.project_path` uses
+    // `#[serde(default = "default_project_path")]` which now yields ""; the
+    // empty-string check catches both "missing" and "empty".
+    if let Err(e) = require_non_empty_path(&args.project_path, "project_path") {
+        return McpResponse::error(request_id, -32602, e);
+    }
+
     info!("Analyzing SATD for project: {:?}", args.project_path);
 
     let result = match execute_satd_analysis(&args).await {
@@ -361,12 +369,17 @@ pub(crate) async fn handle_analyze_lint_hotspot(
         Err(e) => return McpResponse::error(request_id, -32602, e),
     };
 
+    // R22-1 / D101: reject missing/empty/whitespace project_path to avoid
+    // silently running clippy on the server's cwd.
+    let project_path = match require_non_empty_path(&args.project_path, "project_path") {
+        Ok(p) => p,
+        Err(e) => return McpResponse::error(request_id, -32602, e),
+    };
+
     info!(
         "Analyzing lint hotspots for project: {:?}",
         args.project_path
     );
-
-    let project_path = std::path::PathBuf::from(args.project_path.clone());
 
     let result = match execute_lint_hotspot_analysis(&project_path).await {
         Ok(r) => r,
@@ -559,5 +572,188 @@ mod d91_r21_3_tests {
             !serialized.contains("Failed to create temporary file"),
             "D91 regression: handler still creates a tempfile: {serialized}"
         );
+    }
+}
+
+// ============================================================================
+// R22-1 / D101 regression tests — cwd-exfiltration parity fix
+// ============================================================================
+//
+// These tests mirror the R21-5 / D99 test layout in
+// `src/agent/mcp_server_tests.rs` and prove that every advanced-analysis
+// MCP handler in the live `src/handlers/tools_advanced*` tree now rejects
+// missing/null/empty `project_path` with JSON-RPC `-32602` instead of
+// silently defaulting to `std::env::current_dir()`.
+
+#[cfg(test)]
+mod r22_1_d101_cwd_guard_tests {
+    use super::*;
+    use serde_json::json;
+
+    // --- helpers ------------------------------------------------------------
+
+    fn assert_invalid_params(response: &McpResponse, context: &str) {
+        assert!(
+            response.error.is_some(),
+            "{context}: expected an error response, got success: {response:?}"
+        );
+        let err = response.error.as_ref().unwrap();
+        assert_eq!(
+            err.code, -32602,
+            "{context}: expected JSON-RPC -32602 (Invalid params), got {}: message={}",
+            err.code, err.message
+        );
+        assert!(
+            err.message.contains("project_path") || err.message.contains("path"),
+            "{context}: error message should name the offending field: {}",
+            err.message
+        );
+    }
+
+    // --- handle_analyze_tdg ------------------------------------------------
+
+    #[tokio::test]
+    async fn analyze_tdg_rejects_missing_project_path() {
+        let response = handle_analyze_tdg(json!(1), json!({})).await;
+        assert_invalid_params(&response, "analyze_tdg / missing project_path");
+    }
+
+    #[tokio::test]
+    async fn analyze_tdg_rejects_null_project_path() {
+        let response = handle_analyze_tdg(json!(1), json!({ "project_path": null })).await;
+        assert_invalid_params(&response, "analyze_tdg / null project_path");
+    }
+
+    #[tokio::test]
+    async fn analyze_tdg_rejects_empty_project_path() {
+        let response = handle_analyze_tdg(json!(1), json!({ "project_path": "" })).await;
+        assert_invalid_params(&response, "analyze_tdg / empty project_path");
+    }
+
+    #[tokio::test]
+    async fn analyze_tdg_rejects_whitespace_project_path() {
+        let response = handle_analyze_tdg(json!(1), json!({ "project_path": "   " })).await;
+        assert_invalid_params(&response, "analyze_tdg / whitespace project_path");
+    }
+
+    // --- handle_analyze_defect_probability --------------------------------
+
+    #[tokio::test]
+    async fn analyze_defect_probability_rejects_missing_project_path() {
+        let response = handle_analyze_defect_probability(json!(1), json!({})).await;
+        assert_invalid_params(&response, "analyze_defect_probability / missing");
+    }
+
+    #[tokio::test]
+    async fn analyze_defect_probability_rejects_empty_project_path() {
+        let response =
+            handle_analyze_defect_probability(json!(1), json!({ "project_path": "" })).await;
+        assert_invalid_params(&response, "analyze_defect_probability / empty");
+    }
+
+    // --- handle_analyze_deep_context --------------------------------------
+
+    #[tokio::test]
+    async fn analyze_deep_context_rejects_missing_project_path() {
+        let response = handle_analyze_deep_context(json!(1), json!({})).await;
+        assert_invalid_params(&response, "analyze_deep_context / missing");
+    }
+
+    #[tokio::test]
+    async fn analyze_deep_context_rejects_empty_project_path() {
+        let response = handle_analyze_deep_context(json!(1), json!({ "project_path": "" })).await;
+        assert_invalid_params(&response, "analyze_deep_context / empty");
+    }
+
+    // --- handle_analyze_provability ---------------------------------------
+
+    #[tokio::test]
+    async fn analyze_provability_rejects_empty_project_path() {
+        let response =
+            handle_analyze_provability(json!(1), Some(json!({ "project_path": "" }))).await;
+        assert_invalid_params(&response, "analyze_provability / empty");
+    }
+
+    #[tokio::test]
+    async fn analyze_provability_rejects_whitespace_project_path() {
+        let response =
+            handle_analyze_provability(json!(1), Some(json!({ "project_path": " " }))).await;
+        assert_invalid_params(&response, "analyze_provability / whitespace");
+    }
+
+    // --- handle_analyze_makefile_lint -------------------------------------
+
+    #[tokio::test]
+    async fn analyze_makefile_lint_rejects_empty_path() {
+        let response = handle_analyze_makefile_lint(json!(1), Some(json!({ "path": "" }))).await;
+        assert_invalid_params(&response, "analyze_makefile_lint / empty path");
+    }
+
+    // --- handle_analyze_satd ----------------------------------------------
+
+    #[tokio::test]
+    async fn analyze_satd_rejects_missing_project_path() {
+        let response = handle_analyze_satd(json!(1), json!({})).await;
+        assert_invalid_params(&response, "analyze_satd / missing (via serde default=\"\")");
+    }
+
+    #[tokio::test]
+    async fn analyze_satd_rejects_empty_project_path() {
+        let response = handle_analyze_satd(json!(1), json!({ "project_path": "" })).await;
+        assert_invalid_params(&response, "analyze_satd / empty");
+    }
+
+    // --- handle_analyze_lint_hotspot --------------------------------------
+
+    #[tokio::test]
+    async fn analyze_lint_hotspot_rejects_missing_project_path() {
+        let response = handle_analyze_lint_hotspot(json!(1), json!({})).await;
+        assert_invalid_params(&response, "analyze_lint_hotspot / missing");
+    }
+
+    #[tokio::test]
+    async fn analyze_lint_hotspot_rejects_empty_project_path() {
+        let response = handle_analyze_lint_hotspot(json!(1), json!({ "project_path": "" })).await;
+        assert_invalid_params(&response, "analyze_lint_hotspot / empty");
+    }
+
+    // --- require_project_path_advanced helper ------------------------------
+
+    #[test]
+    fn require_project_path_advanced_accepts_nonempty() {
+        let out = require_project_path_advanced(Some("/tmp/x".to_string())).unwrap();
+        assert_eq!(out, PathBuf::from("/tmp/x"));
+    }
+
+    #[test]
+    fn require_project_path_advanced_rejects_none() {
+        let err = require_project_path_advanced(None).unwrap_err();
+        assert!(err.contains("project_path"), "{err}");
+        assert!(err.contains("D101"), "{err}");
+    }
+
+    #[test]
+    fn require_project_path_advanced_rejects_empty() {
+        let err = require_project_path_advanced(Some(String::new())).unwrap_err();
+        assert!(err.contains("non-empty"), "{err}");
+    }
+
+    #[test]
+    fn require_project_path_advanced_rejects_whitespace() {
+        let err = require_project_path_advanced(Some("  \t ".to_string())).unwrap_err();
+        assert!(err.contains("non-empty"), "{err}");
+    }
+
+    #[test]
+    fn require_non_empty_path_rejects_empty() {
+        let err = require_non_empty_path("", "project_path").unwrap_err();
+        assert!(err.contains("project_path"), "{err}");
+        assert!(err.contains("D101"), "{err}");
+    }
+
+    #[test]
+    fn require_non_empty_path_accepts_value() {
+        let out = require_non_empty_path("/some/path", "project_path").unwrap();
+        assert_eq!(out, PathBuf::from("/some/path"));
     }
 }


### PR DESCRIPTION
## Summary

R21-5 / D99 (PR #371) added a `project_path` cwd-exfiltration guard to the handlers in `src/agent/mcp_server_protocol.rs`, but the **live** MCP tool dispatcher used by `pmat serve --mode mcp` lives at `src/handlers/tools/` + `src/handlers/tools_advanced*` (routed via `core_tools_dispatch.rs`). Those handlers were still silently defaulting missing / null / empty `project_path` to `std::env::current_dir()` — the exact cwd-exfiltration hole D99 was meant to close, just not closed in the tree a remote MCP client actually talks to. This parity gap was exposed by the Phase 3 v3.15.0 dogfood NO-GO verdict.

This change ports the R21-1 / R21-5 fail-loud pattern to every analysis handler in the live tree.

## Before / After

| Request body | Before (silent cwd) | After (R22-1 / D101) |
|---|---|---|
| `{}` | falls back to `current_dir()` | `-32602 'project_path' is required` |
| `{\"project_path\": null}` | falls back to `current_dir()` | `-32602 'project_path' is required` |
| `{\"project_path\": \"\"}` | falls back to `current_dir()` | `-32602 'project_path' must be non-empty` |
| `{\"project_path\": \"   \"}` | falls back to `current_dir()` | `-32602 'project_path' must be non-empty` |
| `{\"project_path\": \"/tmp/x\"}` | ok | ok (unchanged) |

## Handlers audited & fixed

**`src/handlers/tools/`:**
- `handle_analyze_code_churn` (core_tools_churn.rs)
- `handle_analyze_complexity` (extended_tools_complexity.rs)
- `handle_analyze_system_architecture` (extended_tools_architecture.rs)
- `handle_generate_context` (extended_tools_context.rs)
- `handle_analyze_dag` (extended_tools_dag.rs)
- `handle_analyze_dead_code` (already guarded by R21-1 / D100 — unchanged)

**`src/handlers/tools_advanced_part*.rs`:**
- `handle_analyze_defect_probability` (part1)
- `handle_analyze_tdg` (part2)
- `handle_analyze_deep_context` (part3)
- `handle_analyze_makefile_lint` (part3)
- `handle_analyze_provability` (part3)
- `handle_analyze_satd` (part4)
- `handle_analyze_lint_hotspot` (part4)

## Shared helpers added

- `require_project_path` in `src/handlers/tools/core_tools.rs` — for `Option<String>` fields.
- `require_project_path_advanced` + `require_non_empty_path` in `src/handlers/tools_advanced_part1.rs` — same for the advanced tree, plus a `&str`-taking variant for handlers whose serde structs use `project_path: String` with a `default = \"default_project_path\"` sentinel. `default_project_path` now returns `\"\"` instead of `\".\"` so the fallthrough hits the empty-string guard instead of silently pointing at cwd.

## Test plan

- [x] 37 new regression tests in `src/handlers/tools/mod.rs` (16) and `src/handlers/tools_advanced_part4.rs` (21) — each asserts `-32602` on missing / null / empty / whitespace `project_path`
- [x] `cargo check --lib -p pmat` clean
- [x] `cargo clippy --lib -p pmat -- -D warnings` clean
- [x] `cargo test --lib -p pmat -- handlers::tools` — 45/45 pass (8 pre-existing + 37 new)
- [x] `src/mcp_pmcp/` and `src/agent/mcp_server_protocol.rs` untouched (D102 / D99 scope preserved)

## Scope discipline

- Does **not** touch `src/mcp_pmcp/` (D102 is separate)
- Does **not** touch `src/agent/mcp_server_protocol.rs` (R21-5 / D99 already landed there in PR #371)
- Does **not** touch D103, does **not** bump version, does **not** tag v3.15.0

## Refs

- R21-5 / D99: PR #371 (partial fix — agent tree only)
- R22-1 / D101: this PR (parity fix — live dispatcher tree)
- Phase 3 v3.15.0 dogfood NO-GO verdict (identified the gap)