### PR TITLE
ci: disable sccache pilot to unblock runner regression

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,14 @@ jobs:
     uses: paiml/.github/.github/workflows/sovereign-ci.yml@main
     with:
       repo: ${{ github.event.repository.name }}
+      # Upstream sovereign-ci.yml flipped enable_sccache default to true on
+      # 2026-04-18 (fleet rollout after Phase 3 pilot), but the
+      # sovereign-ci:stable runner image lacks a rustc-sccache binary —
+      # every CI job since ~12:00 UTC 2026-04-19 fails with
+      # `could not execute process rustc-sccache`. Disable per-repo until
+      # upstream installs the wrapper in the runner image (or reverts the
+      # default). Re-enable by deleting this line.
+      enable_sccache: false
     secrets: inherit
 
   # Top-level gate satisfies the org ruleset "Green Main" which requires a


### PR DESCRIPTION
## Summary

Disable the upstream sccache pilot (one added line) to restore a green CI on every PR.

## Root cause

Upstream `paiml/.github/.github/workflows/sovereign-ci.yml@main` flipped `enable_sccache`'s default from `false` to `true` on 2026-04-18 (fleet rollout after the Phase 3 pilot — see the input's description block). The change propagated to every repo that calls the reusable workflow without an explicit override. It sets `RUSTC_WRAPPER=rustc-sccache`, but the `sovereign-ci:stable` runner image does not contain a `rustc-sccache` binary. Every CI job since ~12:00 UTC 2026-04-19 aborts with:

```
error: could not execute process `rustc-sccache …/rustc -vV` (never executed)
Caused by: No such file or directory (os error 2)
```

The failure fires **before any compilation runs**, so it affects `ci/test`, `ci/lint`, and `ci/coverage` equally regardless of PR contents.

## Impact

Currently blocked (all MERGEABLE, diff validated locally):
- #374 — R22-3 / D103 minimal-build feature gate
- #375 — R22-1 / D101 cwd-guard dispatcher parity
- #376 — R22-2 / D102 glob `**` dispatcher parity

These three are the dispatcher-parity fixes that close the v3.15.0 ship gate.

## Change

One line added to `.github/workflows/ci.yml`:

```yaml
enable_sccache: false
```

Plus a comment block explaining when to re-enable (upstream installs the wrapper in the runner image, or reverts the fleet default).

## Test plan

- [ ] This PR's own CI passes (proves the disable takes effect — if CI is still failing, a deeper fix is needed).
- [ ] After merge, re-run CI on #374 / #375 / #376 and confirm they turn green.
- [ ] Once upstream is healthy, file a follow-up to delete the `enable_sccache: false` line and restore the fleet default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)