### PR TITLE
fix(file-health): scan_directory exclusions match relative to root

### DIFF
--- a/src/services/file_health_baseline.rs
+++ b/src/services/file_health_baseline.rs
@@ -124,6 +124,7 @@ pub fn scan_directory(root: &Path, extensions: &[&str], exclude_patterns: &[&str
 
     fn visit_dir(
         dir: &Path,
+        root: &Path,
         extensions: &[&str],
         exclude_patterns: &[&str],
         files: &mut Vec<PathBuf>,
@@ -131,16 +132,20 @@ pub fn scan_directory(root: &Path, extensions: &[&str], exclude_patterns: &[&str
         if let Ok(entries) = fs::read_dir(dir) {
             for entry in entries.flatten() {
                 let path = entry.path();
-                let path_str = path.to_string_lossy();
+                // Match exclusions against the path relative to the scan root.
+                // Using the absolute path here would false-positive when the
+                // mount prefix itself contains a substring like `build/` or
+                // `_generated` (observed in CI clean-room containers).
+                let relative = path.strip_prefix(root).unwrap_or(&path);
+                let rel_str = relative.to_string_lossy();
 
-                // Check exclusions
-                let excluded = exclude_patterns.iter().any(|p| path_str.contains(p));
+                let excluded = exclude_patterns.iter().any(|p| rel_str.contains(p));
                 if excluded {
                     continue;
                 }
 
                 if path.is_dir() {
-                    visit_dir(&path, extensions, exclude_patterns, files);
+                    visit_dir(&path, root, extensions, exclude_patterns, files);
                 } else if path.is_file() {
                     if let Some(ext) = path.extension() {
                         if extensions.iter().any(|e| ext == *e) {
@@ -152,7 +157,7 @@ pub fn scan_directory(root: &Path, extensions: &[&str], exclude_patterns: &[&str
         }
     }
 
-    visit_dir(root, extensions, exclude_patterns, &mut files);
+    visit_dir(root, root, extensions, exclude_patterns, &mut files);
     files
 }
 

--- a/src/services/file_health_tests.rs
+++ b/src/services/file_health_tests.rs
@@ -311,6 +311,26 @@ mod tests {
     }
 
     #[test]
+    fn test_scan_directory_excludes_match_relative_to_root() {
+        // Regression: exclusion patterns were matched via substring against
+        // the absolute path, so a mount prefix containing `build/` or
+        // `_generated` (observed in CI clean-room containers) excluded the
+        // entire scan tree. Patterns must match relative to the scan root.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path().join("build").join("project");
+        std::fs::create_dir_all(&root).expect("mkdir");
+        let file = root.join("foo.rs");
+        std::fs::write(&file, "// test").expect("write");
+
+        let files = scan_directory(&root, &["rs"], DEFAULT_EXCLUDE_PATTERNS);
+        assert!(
+            files.iter().any(|p| p.ends_with("foo.rs")),
+            "scan_directory must find foo.rs even when absolute path contains an exclude substring (got {:?})",
+            files
+        );
+    }
+
+    #[test]
     fn test_health_zero_lines_tlr() {
         // Edge case: zero lines should give TLR of 1.0
         let metrics = FileHealthMetrics::calculate(PathBuf::from("empty.rs"), 0, 0, 0.0, 0);


### PR DESCRIPTION
## Summary
- `scan_directory` matched `DEFAULT_EXCLUDE_PATTERNS` via substring against each entry's **absolute** path. When the mount prefix contained any exclude substring (`build/`, `_generated`, `target/`, etc.), the *entire* scan tree was filtered out.
- Observed in the v3.15.0 release workflow clean-room container where `services::file_health::tests::test_scan_directory` panicked with `Should find Rust files in project directory`, causing `cpu-gates` to fail and blocking `publish` / `build-binaries` / `publish-release`. `v3.15.0` is currently tagged on master but **not published to crates.io**.
- Fix: strip the scan root before matching, so patterns evaluate against the path *inside* the scanned tree, not the mount prefix.
- Adds a regression test that constructs a path whose absolute form contains `build/` and asserts files are still found.

## Test plan
- [x] `cargo test --lib services::file_health::tests::test_scan_directory` — both tests pass locally
- [x] Diff against master limited to 2 files: `src/services/file_health_baseline.rs` + `src/services/file_health_tests.rs`
- [ ] CI `gate / cpu-gates` — expected to pass (was only failure on v3.15.0 release run 24632947416)
- [ ] After merge: retag v3.15.0 on new master → release workflow proceeds to `publish`

## Release-gate context
Prior v3.14.0 was manually published (same class of clean-room test failure). This PR closes the root cause so future releases don't need manual override. Follow-up after merge: delete draft `v3.15.0` tag + GitHub release, retag on new HEAD, push, monitor release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)