### PR TITLE
fix(release): drop cargo package --verify (removed flag)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,10 +122,11 @@ jobs:
       - name: Verify package tarball
         run: |
           CRATE="${{ needs.create-release.outputs.crate_name }}"
+          # Verification is default; modern cargo removed --verify (only --no-verify exists).
           if [ -n "$CRATE" ]; then
-            cargo package --verify -p "$CRATE"
+            cargo package -p "$CRATE"
           else
-            cargo package --verify
+            cargo package
           fi
 
   # ── Publish: OIDC trusted publishing to crates.io ──────


### PR DESCRIPTION
## Summary

- Remove `--verify` flag from `cargo package` invocations in release workflow
- Modern cargo removed `--verify` (verification is default; only `--no-verify` exists)
- Unblocks v3.15.0 publish — gate + create-release succeeded but verify failed with "unexpected argument '--verify' found"

## Root cause

The workflow generator `machines/clean-room/deploy-workflows.sh` emitted `cargo package --verify`. Modern cargo rejects this flag. Follow-up upstream patch needed so regeneration does not reintroduce.

## Test plan

- [x] Fix verified against `cargo package --help`
- [ ] Post-merge: retag v3.15.0 → release workflow runs end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)