### PR TITLE
fix(demo): exhaustive OutputFormat match — unblocks cargo doc (#384)

### DIFF
--- a/src/cli/handlers/comply_handlers/check_handlers/check_codegen.rs
+++ b/src/cli/handlers/comply_handlers/check_handlers/check_codegen.rs
@@ -85,10 +85,11 @@ struct AttributeUsage {
 /// that writes `r#"#[pmat_work_contract(...)]"#` to a temp file) are ignored.
 /// Real proc-macro usage always appears at the start of a source line.
 fn attribute_parser() -> (Regex, Regex, Regex, Regex) {
-    let attr = Regex::new(r"(?m)^[ \t]*#\[pmat_work_contract\(([^)]*)\)\]").unwrap();
-    let id = Regex::new(r#"id\s*=\s*"([^"]+)""#).unwrap();
-    let requires = Regex::new(r#"require\s*=\s*"([^"]+)""#).unwrap();
-    let ensures = Regex::new(r#"ensure\s*=\s*"([^"]+)""#).unwrap();
+    let attr = Regex::new(r"(?m)^[ \t]*#\[pmat_work_contract\(([^)]*)\)\]")
+        .expect("static regex must compile");
+    let id = Regex::new(r#"id\s*=\s*"([^"]+)""#).expect("static regex must compile");
+    let requires = Regex::new(r#"require\s*=\s*"([^"]+)""#).expect("static regex must compile");
+    let ensures = Regex::new(r#"ensure\s*=\s*"([^"]+)""#).expect("static regex must compile");
     (attr, id, requires, ensures)
 }
 

--- a/src/demo/protocols_helpers.rs
+++ b/src/demo/protocols_helpers.rs
@@ -72,7 +72,10 @@ pub(crate) fn format_and_print_output(
         crate::cli::OutputFormat::Yaml => {
             println!("{}", serde_yaml_ng::to_string(response)?);
         }
-        crate::cli::OutputFormat::Table => {
+        // Table/Markdown/Csv/Summary/Text/Plain/Junit all fall back to
+        // pretty-debug — the demo harness only speaks Json/Yaml structurally;
+        // other formats aren't meaningful for a JSON-RPC response blob.
+        _ => {
             println!("{response:#?}");
         }
     }


### PR DESCRIPTION
## Summary
- Fixes non-exhaustive `OutputFormat` match in `format_and_print_output` that blocked `cargo check` / `cargo doc` with `--features 'mutation-testing tdg-explain demo'`.
- Adds catch-all arm that falls back to pretty-debug — the demo harness only speaks Json/Yaml structurally; other variants aren't meaningful for a JSON-RPC response blob.
- Also bundles the check_codegen.rs F-grade unblocker (static-regex `.unwrap` → `.expect`) so pre-commit TDG gate passes.

## Reframing #384
Initial triage suggested 5 root causes. Verification proved only **1 real pmat-side bug**:
- `--features analytics-simd` alone → compiles clean.
- `--features 'mutation-testing tdg-explain demo'` → 1 pmat error (E0004 on `OutputFormat`).
- `--all-features` → aprender-compute 0.30.0 transitive E0599 on `iter` (NOT a pmat bug).

## Test plan
- [x] `cargo check --features 'mutation-testing tdg-explain demo' --no-default-features` → clean
- [x] `cargo doc --features 'mutation-testing tdg-explain demo' --no-default-features --no-deps --lib` → clean
- [x] TDG quality gate passes (2256 A- / 29 B+ / no F)
- [ ] CI gate passes

Closes #384

🤖 Generated with [Claude Code](https://claude.com/claude-code)