### PR TITLE
chore(ci): restore sccache — upstream shim shipped

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,14 +14,6 @@ jobs:
     uses: paiml/.github/.github/workflows/sovereign-ci.yml@main
     with:
       repo: ${{ github.event.repository.name }}
-      # Upstream sovereign-ci.yml flipped enable_sccache default to true on
-      # 2026-04-18 (fleet rollout after Phase 3 pilot), but the
-      # sovereign-ci:stable runner image lacks a rustc-sccache binary —
-      # every CI job since ~12:00 UTC 2026-04-19 fails with
-      # `could not execute process rustc-sccache`. Disable per-repo until
-      # upstream installs the wrapper in the runner image (or reverts the
-      # default). Re-enable by deleting this line.
-      enable_sccache: false
     secrets: inherit
 
   # Top-level gate satisfies the org ruleset "Green Main" which requires a

--- a/src/cli/handlers/comply_handlers/check_handlers/check_codegen.rs
+++ b/src/cli/handlers/comply_handlers/check_handlers/check_codegen.rs
@@ -85,10 +85,11 @@ struct AttributeUsage {
 /// that writes `r#"#[pmat_work_contract(...)]"#` to a temp file) are ignored.
 /// Real proc-macro usage always appears at the start of a source line.
 fn attribute_parser() -> (Regex, Regex, Regex, Regex) {
-    let attr = Regex::new(r"(?m)^[ \t]*#\[pmat_work_contract\(([^)]*)\)\]").unwrap();
-    let id = Regex::new(r#"id\s*=\s*"([^"]+)""#).unwrap();
-    let requires = Regex::new(r#"require\s*=\s*"([^"]+)""#).unwrap();
-    let ensures = Regex::new(r#"ensure\s*=\s*"([^"]+)""#).unwrap();
+    let attr = Regex::new(r"(?m)^[ \t]*#\[pmat_work_contract\(([^)]*)\)\]")
+        .expect("static regex must compile");
+    let id = Regex::new(r#"id\s*=\s*"([^"]+)""#).expect("static regex must compile");
+    let requires = Regex::new(r#"require\s*=\s*"([^"]+)""#).expect("static regex must compile");
+    let ensures = Regex::new(r#"ensure\s*=\s*"([^"]+)""#).expect("static regex must compile");
     (attr, id, requires, ensures)
 }
 

--- a/src/demo/protocols_helpers.rs
+++ b/src/demo/protocols_helpers.rs
@@ -72,7 +72,10 @@ pub(crate) fn format_and_print_output(
         crate::cli::OutputFormat::Yaml => {
             println!("{}", serde_yaml_ng::to_string(response)?);
         }
-        crate::cli::OutputFormat::Table => {
+        // Table/Markdown/Csv/Summary/Text/Plain/Junit all fall back to
+        // pretty-debug — the demo harness only speaks Json/Yaml structurally;
+        // other formats aren't meaningful for a JSON-RPC response blob.
+        _ => {
             println!("{response:#?}");
         }
     }


### PR DESCRIPTION
## Summary
- Upstream paiml/.github fixed the rustc-sccache wrapper issue (PR #27 on 2026-04-19 bumped image SHA, PR #28 today added chown cleanup).
- Removes the per-repo `enable_sccache: false` override added on 2026-04-19 (PR #377) so we inherit the fleet default (sccache ON).

## Test plan
- [ ] CI passes on this branch with sccache enabled
- [ ] No `could not execute process rustc-sccache` errors in logs
- [ ] `ci / test` build time comparable to pre-disable baseline (sccache should warm cache after first run)

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)