### PR TITLE
feat(mcp): migrate PdmtTool to generated schemas (#65 PoC, 1/19)

### DIFF
--- a/mcp_tool_schemas/pdmt_deterministic_todos.json
+++ b/mcp_tool_schemas/pdmt_deterministic_todos.json
@@ -1,0 +1,40 @@
+{
+  "name": "pdmt_deterministic_todos",
+  "description": "Generate deterministic, quality-enforced todo lists from a list of requirements.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "requirements": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "Requirements to convert into deterministic actionable todos"
+      },
+      "project_name": {
+        "type": "string",
+        "description": "Project or component name"
+      },
+      "granularity": {
+        "type": "string",
+        "enum": ["low", "medium", "high"],
+        "description": "Task detail level (default: high)"
+      },
+      "quality_config": {
+        "type": "object",
+        "description": "Quality enforcement config",
+        "properties": {
+          "enforcement_mode": {
+            "type": "string",
+            "enum": ["strict", "advisory", "auto_fix"]
+          },
+          "coverage_threshold": { "type": "number" },
+          "max_complexity": { "type": "integer" },
+          "require_doctests": { "type": "boolean" },
+          "require_property_tests": { "type": "boolean" },
+          "require_examples": { "type": "boolean" },
+          "zero_satd_tolerance": { "type": "boolean" }
+        }
+      }
+    },
+    "required": ["requirements"]
+  }
+}

--- a/src/mcp_pmcp/pdmt_handler.rs
+++ b/src/mcp_pmcp/pdmt_handler.rs
@@ -1,4 +1,4 @@
-use crate::mcp_pmcp::tool_schemas::build_tool_info;
+use crate::mcp_pmcp::tool_schemas_generated::tool_info_for;
 use crate::models::pdmt::{EnforcementMode, PdmtQualityConfig};
 use crate::services::pdmt_quality_integration::PdmtQualityEnforcer;
 use crate::services::pdmt_service::PdmtService;
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 use pmcp::types::ToolInfo;
 use pmcp::{Error, RequestHandlerExtra, Result, ToolHandler};
 use serde::{Deserialize, Serialize};
-use serde_json::{json, Value};
+use serde_json::Value;
 use tracing::{debug, error, info};
 
 /// Input parameters for the PDMT deterministic todos tool

--- a/src/mcp_pmcp/pdmt_handler_core.rs
+++ b/src/mcp_pmcp/pdmt_handler_core.rs
@@ -4,37 +4,7 @@
 #[async_trait]
 impl ToolHandler for PdmtTool {
     fn metadata(&self) -> Option<ToolInfo> {
-        let schema = json!({
-            "type": "object",
-            "properties": {
-                "requirements": {
-                    "type": "array",
-                    "items": { "type": "string" },
-                    "description": "Requirements to convert into deterministic actionable todos"
-                },
-                "project_name": { "type": "string", "description": "Project or component name" },
-                "granularity":  { "type": "string", "enum": ["low", "medium", "high"], "description": "Task detail level (default: high)" },
-                "quality_config": {
-                    "type": "object",
-                    "description": "Quality enforcement config",
-                    "properties": {
-                        "enforcement_mode":       { "type": "string", "enum": ["strict", "advisory", "auto_fix"] },
-                        "coverage_threshold":     { "type": "number"  },
-                        "max_complexity":         { "type": "integer" },
-                        "require_doctests":       { "type": "boolean" },
-                        "require_property_tests": { "type": "boolean" },
-                        "require_examples":       { "type": "boolean" },
-                        "zero_satd_tolerance":    { "type": "boolean" }
-                    }
-                }
-            },
-            "required": ["requirements"]
-        });
-        Some(build_tool_info(
-            "pdmt_deterministic_todos",
-            "Generate deterministic, quality-enforced todo lists from a list of requirements.",
-            schema,
-        ))
+        Some(tool_info_for("pdmt_deterministic_todos"))
     }
 
     async fn handle(&self, args: Value, _extra: RequestHandlerExtra) -> Result<Value> {


### PR DESCRIPTION
## Summary

Proof-of-concept migration for KAIZEN-0178 build-time tool-schema codegen (#65).
Extracts `PdmtTool`'s inputSchema into `mcp_tool_schemas/pdmt_deterministic_todos.json` and replaces inline `json!()` + `build_tool_info()` with a single `tool_info_for(name)` call.

**Net: -33 lines from handler, +40-line schema moved to JSON (single source of truth).**

## Architectural gap discovered

The `tool_metadata!("pdmt_deterministic_todos")` macro generated by `build.rs` **cannot be invoked from handlers that use `include!()` for their impl bodies**. Rust's `macro_expanded_macro_exports_accessed_by_absolute_paths` future-incompatible lint rejects `crate::__kaizen0178_schema_const!` references when the call site lives inside an `include!()`-expanded file.

**Workaround adopted**: call the generated `tool_info_for(name: &str) -> ToolInfo` runtime lookup function instead. Same JSON-file source of truth, no macro hygiene constraints. All 19 handlers can follow this pattern.

## Verification

- `cargo check --lib` clean (48s)
- `cargo test --lib pdmt` — 63 passed, 0 failed

## Remaining work (18 handlers)

Migration pattern for each:
1. Create `mcp_tool_schemas/<tool_name>.json` with schema + description
2. Replace handler's `metadata()` body with `Some(tool_info_for("<tool_name>"))`
3. Remove now-unused `build_tool_info` / `json!` imports

Refs #65, KAIZEN-0178.

## Test plan
- [ ] CI green on feat/65-tool-schemas-poc-pdmt
- [ ] `tools/list` via MCP stdio shows pdmt_deterministic_todos with full schema intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)