### PR TITLE
feat(mcp): forward ToolInfo metadata for 4 pmat_* handlers (#65)

### DIFF
--- a/mcp_tool_schemas/pmat_find_similar.json
+++ b/mcp_tool_schemas/pmat_find_similar.json
@@ -1,0 +1,28 @@
+{
+  "name": "pmat_find_similar",
+  "description": "Find functions similar to a reference function. Useful for finding related code, potential duplicates, or implementations of similar patterns.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "function_id": {
+        "type": "string",
+        "description": "Function ID to find similar functions for"
+      },
+      "limit": {
+        "type": "integer",
+        "description": "Maximum number of similar functions (default: 5, max: 20)",
+        "minimum": 1,
+        "maximum": 20,
+        "default": 5
+      },
+      "min_similarity": {
+        "type": "number",
+        "description": "Minimum similarity score (0.0-1.0, default: 0.3)",
+        "minimum": 0.0,
+        "maximum": 1.0,
+        "default": 0.3
+      }
+    },
+    "required": ["function_id"]
+  }
+}

--- a/mcp_tool_schemas/pmat_get_function.json
+++ b/mcp_tool_schemas/pmat_get_function.json
@@ -1,0 +1,19 @@
+{
+  "name": "pmat_get_function",
+  "description": "Get detailed information about a specific function by its ID. Returns full function metadata including source code, quality metrics, and SATD markers.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "function_id": {
+        "type": "string",
+        "description": "Function ID from pmat_query_code results (e.g., 'src/handlers/auth.rs::handle_login')"
+      },
+      "include_source": {
+        "type": "boolean",
+        "description": "Include full source code (default: true)",
+        "default": true
+      }
+    },
+    "required": ["function_id"]
+  }
+}

--- a/mcp_tool_schemas/pmat_index_stats.json
+++ b/mcp_tool_schemas/pmat_index_stats.json
@@ -1,0 +1,14 @@
+{
+  "name": "pmat_index_stats",
+  "description": "Get statistics about the code index including function counts, quality distribution, and index health.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "rebuild": {
+        "type": "boolean",
+        "description": "Rebuild the index before returning stats (default: false)",
+        "default": false
+      }
+    }
+  }
+}

--- a/src/mcp_pmcp/agent_context_handlers.rs
+++ b/src/mcp_pmcp/agent_context_handlers.rs
@@ -6,6 +6,11 @@
 //! `handle(Value, RequestHandlerExtra) -> pmcp::Result<Value>`. These thin
 //! newtype wrappers adapt one to the other so the 4 tools appear in the live
 //! MCP stdio tools/list.
+//!
+//! Each wrapper also forwards `metadata()` to return a `pmcp::types::ToolInfo`
+//! sourced from `mcp_tool_schemas/<tool_name>.json` via the KAIZEN-0178
+//! build.rs codegen, so tools/list advertises proper description + inputSchema
+//! instead of empty metadata.
 
 use crate::mcp::tools::agent_context_tools::{
     FindSimilarTool, GetFunctionTool, IndexManager, IndexStatsTool, McpTool as InnerMcpTool,
@@ -17,7 +22,7 @@ use serde_json::Value;
 use std::sync::Arc;
 
 macro_rules! impl_pmat_handler {
-    ($wrapper:ident, $inner:ident) => {
+    ($wrapper:ident, $inner:ident, $tool_name:expr) => {
         pub struct $wrapper {
             inner: $inner,
         }
@@ -39,11 +44,17 @@ macro_rules! impl_pmat_handler {
             ) -> PmcpResult<Value> {
                 self.inner.execute(args).await.map_err(PmcpError::internal)
             }
+
+            fn metadata(&self) -> Option<pmcp::types::ToolInfo> {
+                Some(crate::mcp_pmcp::tool_schemas_generated::tool_info_for(
+                    $tool_name,
+                ))
+            }
         }
     };
 }
 
-impl_pmat_handler!(PmatQueryCodeHandler, QueryCodeTool);
-impl_pmat_handler!(PmatGetFunctionHandler, GetFunctionTool);
-impl_pmat_handler!(PmatFindSimilarHandler, FindSimilarTool);
-impl_pmat_handler!(PmatIndexStatsHandler, IndexStatsTool);
+impl_pmat_handler!(PmatQueryCodeHandler, QueryCodeTool, "pmat_query_code");
+impl_pmat_handler!(PmatGetFunctionHandler, GetFunctionTool, "pmat_get_function");
+impl_pmat_handler!(PmatFindSimilarHandler, FindSimilarTool, "pmat_find_similar");
+impl_pmat_handler!(PmatIndexStatsHandler, IndexStatsTool, "pmat_index_stats");


### PR DESCRIPTION
## Summary

Extends the `impl_pmat_handler!` macro in `src/mcp_pmcp/agent_context_handlers.rs` so the 4 `pmat_*` MCP tool handlers (`pmat_query_code`, `pmat_get_function`, `pmat_find_similar`, `pmat_index_stats`) forward a proper `pmcp::types::ToolInfo` from `metadata()`, sourced from the KAIZEN-0178 build.rs-generated registry (`tool_info_for(name)`).

Without this change the adapters only implemented `handle()`, so pmcp's default `metadata()` returned `None` — MCP `tools/list` advertised these tools with empty `description` / `inputSchema`. This matches the pattern merged in PoC #387 (`pdmt_handler`).

## Changes

- `mcp_tool_schemas/pmat_get_function.json` (new) — extracted from `GetFunctionTool::schema()`, renamed `parameters` -> `inputSchema`
- `mcp_tool_schemas/pmat_find_similar.json` (new) — extracted from `FindSimilarTool::schema()`
- `mcp_tool_schemas/pmat_index_stats.json` (new) — extracted from `IndexStatsTool::schema()`
- `src/mcp_pmcp/agent_context_handlers.rs` — macro gains a third `$tool_name:expr` arg and emits `fn metadata(&self) -> Option<ToolInfo>` calling `tool_info_for($tool_name)`; all 4 invocation sites updated

## Test plan

- [x] `cargo check -p pmat` passes
- [x] `cargo build -p pmat` succeeds (build.rs reports `KAIZEN-0178: generated 6 MCP tool schema(s)`, up from 3)
- [x] `cargo test -p pmat --lib -- tool_schemas_generated` — all 7 tests pass, including `every_schema_parses_and_has_object_input` which validates the 3 new schemas parse and have `type: object` input
- [ ] CI: full workspace build + lint + test-fast
- [ ] Manual: `pmat mcp` over stdio, send `tools/list`, verify the 4 handlers now surface their descriptions and input schemas (not empty)

Ticket: #65 (KAIZEN-0174 follow-up to #387)

Generated with Claude Code