### PR TITLE
docs(coverage): Phase 0 honesty baseline — COVERAGE_POLICY.md + coverage-broad

### DIFF
--- a/COVERAGE_POLICY.md
+++ b/COVERAGE_POLICY.md
@@ -1,0 +1,118 @@
+# Coverage Policy
+
+> **Status**: Phase 0 honesty baseline (v3.15.1)
+> **Related spec**: [`docs/specifications/improve-coverage-80-95.md`](docs/specifications/improve-coverage-80-95.md)
+> **Last updated**: 2026-04-21
+
+## 1. Two Numbers, One Project
+
+PMAT has two coverage numbers. Both are real; they measure different slices.
+
+| Scope | Target | Lines measured | % | Gate? |
+|-------|--------|----------------|---|-------|
+| **Narrow** (`make coverage`) | ≥95% | 20,394 | 96.03% | ✅ Blocking |
+| **Broad** (`make coverage-broad`) | ≥95% | 324,456 | 73.14% | ⚠️ Informational |
+
+The narrow number gates CI today. The broad number is the honest project-wide baseline; closing the gap is the `improve-coverage-80-95.md` roadmap.
+
+## 2. Canonical Commands
+
+```bash
+make coverage          # Narrow slice, gated at COV_THRESHOLD=95%, ~5 min
+make coverage-broad    # Honest project baseline, informational, ~8 min
+make coverage-quick    # Fast inner loop, no threshold, ~2-3 min
+make coverage-html     # Render last run as HTML
+```
+
+**Never use `cargo tarpaulin`.** CB-127 policy: stack-wide `cargo-llvm-cov` only. Tarpaulin hangs on PMAT and has cache bugs.
+
+**Never use `cargo nextest` for coverage.** CB-127-A: nextest writes one profraw per test (≈15k files) and the merge step becomes the bottleneck. Use `cargo llvm-cov test` (one profraw per binary).
+
+**`PROPTEST_CASES` during coverage runs**: `2` for `make coverage` (gate), `3` for `make coverage-quick`. Proptest default (256) multiplies wall-clock by ~50× without adding coverage — the boundary cases are already hit in the first few iterations.
+
+## 3. What the Narrow Gate Excludes (and Why)
+
+`COVERAGE_EXCLUDE` (Makefile line 47) drops the following from `make coverage`. Each entry is listed with the reason it is currently excluded and the plan for re-including it under `improve-coverage-80-95.md`.
+
+### 3.1 Unconditional excludes (stay out — LLVM can't or shouldn't instrument)
+
+| Pattern | Reason | Status |
+|---------|--------|--------|
+| `_tests?\.rs` | Test files measure other code; self-coverage is meaningless | Permanent |
+| `/(tests\|benches\|examples\|fixtures)/` | Test/bench/example/fixture directories | Permanent |
+| `main.rs` | Binary entrypoint — integration tests spawn subprocesses (out of instrumentation scope) | Permanent |
+| `test_performance_suite.rs` | Benchmark scaffold, not production | Permanent |
+
+### 3.2 Selection-bias excludes (must be re-included per the roadmap)
+
+These directories hold live production code that currently dodges the gate. The broad number in §1 is the result of un-excluding them. Each has a Phase and an exit condition.
+
+| Pattern | Lines | Current broad cov | Re-include in | Exit condition |
+|---------|-------|-------------------|---------------|----------------|
+| `/cli/` | ~91k | ~65% | Phase 1 (v3.16.0) | CLI integration tests un-skipped; dispatch collapsed via macro |
+| `/handlers/` | ~3.2k | ~36% | Phase 2 (v3.17.0) | Parity tests for every tool (D101/D102/D103 pattern) |
+| `/services/` | ~75k | ~80% | Phase 2 (v3.17.0) | TDD on hot paths ranked by `--rank-by impact` |
+| `/tdg/` | ~13k | ~78% | Phase 2 (v3.17.0) | Co-equal to services/ |
+| `/roadmap/` | | ~32% | Phase 1 (v3.16.0) | Delete dead code; contract-gate live surface |
+| `/scaffold/` | | ~0% | Phase 1 (v3.16.0) | `insta` snapshot tests per generator |
+| `/workflow/` | | | Phase 3 (v3.18.0) | Contract-driven + mutation-forced |
+| `/contracts/` | | | Phase 3 (v3.18.0) | Contract-driven + mutation-forced |
+| `/red_team/` | | | Phase 2 (v3.17.0) | TDD on hot paths |
+| `/qdd/` | | | Phase 2 (v3.17.0) | TDD on hot paths |
+| `/unified_quality/` | | | Phase 2 (v3.17.0) | TDD on hot paths |
+| `/state/` | | | Phase 2 (v3.17.0) | TDD on hot paths |
+| `/protocol/` | | | Phase 2 (v3.17.0) | TDD on hot paths |
+| `/docs_enforcement/` | | | Phase 2 (v3.17.0) | TDD on hot paths |
+| `/provable-contracts/` | | | Phase 3 (v3.18.0) | Contract-driven — covered by the contract harness itself |
+| `explain.rs` | | | Phase 2 (v3.17.0) | TDD |
+
+### 3.3 Network-dependent excludes (re-include in contract tests, not unit tests)
+
+| Pattern | Reason |
+|---------|--------|
+| `/mcp[^/]*/` | MCP transports require live stdio/HTTP servers. Covered by MCP integration tests (see `tests/mcp_*`), not unit coverage. Plan: cross-protocol integration suite in Phase 3. |
+
+### 3.4 Skipped at runtime (not regex-excluded)
+
+`make coverage` also passes `--skip libsql --skip cli_integration_tests` to the test runner:
+
+- `libsql` — optional SQL backend, network/disk-dependent, covered by dedicated integration suite.
+- `cli_integration_tests` — these test the CLI dispatch surface (`/cli/` above). Un-skipping these is the highest-ROI Phase 1 action per `improve-coverage-80-95.md` §3.1.
+
+## 4. Source-Level `#[coverage(off)]`
+
+PMAT uses module-level `#![cfg_attr(coverage_nightly, coverage(off))]` in ~250 files. Total attribute occurrences: 2,831 across 1,967 files; function-level `coverage(off)` drops roughly 8,097 functions from measurement.
+
+**The current `make coverage` target sets `--no-cfg-coverage --no-cfg-coverage-nightly`**, which disables the `cfg(coverage_nightly)` predicate. That means the narrow gate *does* measure these modules despite the attribute — the exclusion comes from the regex in §3, not the attribute. `make coverage-broad` drops the regex so the attribute also has no effect.
+
+Rationale categories (to be audited in Phase 3):
+
+1. **Justified** — test scaffolding, unreachable polyfills, LLVM-can't-instrument (WASM shim, any future GPU shaders). These stay.
+2. **Cargo-culted** — `#![cfg_attr(coverage_nightly, coverage(off))]` copy-pasted into every new module. Most of these should be removed.
+3. **Masking low coverage** — attribute applied to hide a file that legitimately needs tests. These are the Phase 3 targets.
+
+The Phase 3 audit in `improve-coverage-80-95.md` §5 will categorize every remaining attribute into these three buckets and justify or remove each.
+
+## 5. CI Integration
+
+**Current (v3.15.x)**: Sovereign CI (`.github/workflows/ci.yml` → `paiml/.github/sovereign-ci.yml`) runs `make coverage` as a gated job. The broad number is not yet reported.
+
+**Phase 0.1 follow-up** (pending upstream `paiml/.github` change): sovereign-ci adds a non-gating `coverage-broad` step that reports the honest number for visibility. Blocked by upstream workflow edit; tracked separately.
+
+## 6. Philosophy (Toyota Way — Jidoka)
+
+**The narrow number is not a lie — it's a partial measurement.** Hiding code from a coverage gate is a form of selection bias. The path to honesty is three-phased:
+
+- **Phase 0 (this doc)** — make the selection bias visible and justified per entry.
+- **Phases 1–2** — delete dead code, un-skip integration tests, write tests for modules currently hidden by regex. Lower the delta between narrow and broad to ≤2%.
+- **Phase 3** — audit every `coverage(off)` attribute; remove unjustified ones; couple with mutation testing so 100% line coverage cannot survive weak assertions.
+
+The deliverable is *one honestly-measured number ≥95%*, not two numbers with a plausible story about the gap.
+
+## 7. References
+
+- [`docs/specifications/improve-coverage-80-95.md`](docs/specifications/improve-coverage-80-95.md) — the roadmap
+- [trueno `COVERAGE_POLICY.md`](https://github.com/paiml/trueno/blob/main/COVERAGE_POLICY.md) — pattern template
+- `Makefile` — `coverage`, `coverage-broad`, `coverage-quick` targets
+- [CB-127 (stack-wide tarpaulin ban)](docs/specifications/quick-test-build-O(1)-checking.md)
+- rust-lang/rust#84605 — `coverage_attribute` stabilization (still open on nightly 2026-04-18)

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@
 # Delete partially-built files on error for safety (bashrs lint compliance)
 .DELETE_ON_ERROR:
 
-.PHONY: all validate format lint lint-main check test test-doc test-fast coverage coverage-ci coverage-summary coverage-open coverage-clean clean-coverage build release clean clean-tmp install install-latest reinstall status check-rebuild uninstall help format-scripts lint-scripts check-scripts test-scripts lint-makefile fix validate-docs ci-status validate-naming validate-book context setup audit docs run-mcp run-mcp-test test-actions install-act check-act deps-validate dogfood dogfood-ci update-rust-docs size-report size-track size-check size-compare test-all-interfaces test-feature-all-interfaces test-interface-consistency benchmark-all-interfaces load-test-interfaces context-json context-sarif context-llm context-legacy context-benchmark analyze-top-files analyze-composite analyze-health-dashboard profile-binary-performance profile-deep-context analyze-memory-usage analyze-scaling kaizen test-slow-integration test-safe test-dogfood test-critical-scripts coverage-scripts test-workflow-dag test-workflow-dag-verbose context-root context-simple context-json-root context-benchmark-legacy local-install server-build-binary server-build-docker server-run-mcp server-run-mcp-test server-benchmark server-test server-test-all server-outdated server-tokei build-target cargo-doc cargo-geiger update-deps update-deps-aggressive update-deps-security upgrade-deps audit-fix benchmark coverage-report outdated test-all-features clippy-strict server-build-release create-release test-curl-install cargo-rustdoc install-dev-tools tokei quickstart context-fast clear-swap config-swap overnight-improve overnight-monitor overnight-swap-cron test-unit test-services test-protocols test-e2e test-performance test-property test-property-slow test-all test-stratified coverage-stratified crate-release crate-docs dev commit sprint-close setup-quality quality-gate-full help-toyota-way test-examples examples example clean-quick clean-deep validate-doc-links validate-contracts release-dry release-verify coverage-fast coverage-invalidate coverage-full check-install
+.PHONY: all validate format lint lint-main check test test-doc test-fast coverage coverage-ci coverage-summary coverage-open coverage-clean clean-coverage build release clean clean-tmp install install-latest reinstall status check-rebuild uninstall help format-scripts lint-scripts check-scripts test-scripts lint-makefile fix validate-docs ci-status validate-naming validate-book context setup audit docs run-mcp run-mcp-test test-actions install-act check-act deps-validate dogfood dogfood-ci update-rust-docs size-report size-track size-check size-compare test-all-interfaces test-feature-all-interfaces test-interface-consistency benchmark-all-interfaces load-test-interfaces context-json context-sarif context-llm context-legacy context-benchmark analyze-top-files analyze-composite analyze-health-dashboard profile-binary-performance profile-deep-context analyze-memory-usage analyze-scaling kaizen test-slow-integration test-safe test-dogfood test-critical-scripts coverage-scripts test-workflow-dag test-workflow-dag-verbose context-root context-simple context-json-root context-benchmark-legacy local-install server-build-binary server-build-docker server-run-mcp server-run-mcp-test server-benchmark server-test server-test-all server-outdated server-tokei build-target cargo-doc cargo-geiger update-deps update-deps-aggressive update-deps-security upgrade-deps audit-fix benchmark coverage-report outdated test-all-features clippy-strict server-build-release create-release test-curl-install cargo-rustdoc install-dev-tools tokei quickstart context-fast clear-swap config-swap overnight-improve overnight-monitor overnight-swap-cron test-unit test-services test-protocols test-e2e test-performance test-property test-property-slow test-all test-stratified coverage-stratified crate-release crate-docs dev commit sprint-close setup-quality quality-gate-full help-toyota-way test-examples examples example clean-quick clean-deep validate-doc-links validate-contracts release-dry release-verify coverage-fast coverage-invalidate coverage-full coverage-broad check-install
 
 # Define sub-projects
 # NOTE: client project will be added when implemented
@@ -492,6 +492,26 @@ coverage: ## Coverage summary + threshold check (<5 min)
 	else \
 		echo "✅ Coverage $${COV_PCT}% meets threshold $(COV_THRESHOLD)%"; \
 	fi
+
+coverage-broad: ## Honest project-wide coverage (no regex, no --skip, no coverage(off)). Informational.
+	@echo "📊 Running broad coverage (honest baseline, no exclusions)..."
+	@echo "   See COVERAGE_POLICY.md for why this differs from 'make coverage'"
+	@which cargo-llvm-cov > /dev/null 2>&1 || { cargo install cargo-llvm-cov --locked || exit 1; }
+	@mkdir -p target/coverage-broad
+	@cargo +nightly llvm-cov clean --workspace
+	@echo "🧪 Running tests (no --skip, attributes disabled, no regex exclusions)..."
+	@env RUSTC_WRAPPER= PROPTEST_CASES=3 RUST_MIN_STACK=33554432 cargo +nightly llvm-cov test \
+		--lib \
+		--features all-languages \
+		--no-cfg-coverage --no-cfg-coverage-nightly \
+		-- --test-threads=$$(nproc) \
+		|| true
+	@echo "📊 Generating broad report (informational)..."
+	@cargo +nightly llvm-cov report --summary-only | tee target/coverage-broad/summary.txt | grep -E "^TOTAL"
+	@COV_PCT=$$(grep -E '^TOTAL' target/coverage-broad/summary.txt | awk '{n=0; for(i=1;i<=NF;i++){if($$i ~ /[0-9]+\.[0-9]+%/){n++; if(n==3){gsub(/%/,"",$$i);print $$i;exit}}}}'); \
+	echo ""; \
+	echo "ℹ️  Broad coverage: $${COV_PCT}% (informational, not gated)"; \
+	echo "ℹ️  Target: 95% per docs/specifications/improve-coverage-80-95.md"
 
 coverage-html: ## Generate HTML report from last coverage run
 	@echo "📊 Generating HTML report..."
@@ -1601,6 +1621,7 @@ help:
 	@echo "  test-safe    - Run tests with manual thread control (THREADS=n)"
 	@echo "  coverage     - Generate HTML coverage report (<10 min)"
 	@echo "  coverage-ci  - Generate LCOV for CI"
+	@echo "  coverage-broad - Honest project-wide coverage (no exclusions, informational)"
 	@echo "  coverage-open - Open HTML coverage in browser"
 	@echo "  coverage-clean - Clean coverage artifacts"
 	@echo "  audit        - Run security audit on all projects"


### PR DESCRIPTION
## Summary

Phase 0 of [improve-coverage-80-95.md](docs/specifications/improve-coverage-80-95.md). Makes the narrow-vs-broad coverage selection bias visible and justified without changing the existing gate.

- `COVERAGE_POLICY.md` — catalogues every `COVERAGE_EXCLUDE` regex entry with its reason (permanent / selection-bias / network-dependent) and the Phase that retires it.
- `make coverage-broad` — honest project-wide coverage (no regex, no `--skip`, no `coverage(off)`). Reports the ~73% honest baseline vs the narrow gate's ~96%. **Informational only; does not gate.**
- Documents `PROPTEST_CASES=3` guidance and the stack-wide tarpaulin/nextest bans (CB-127, CB-127-A).

Narrow `make coverage` target is **unchanged** — still gates at `COV_THRESHOLD=95%`.

## Test plan
- [x] `make -n coverage-broad` parses cleanly
- [x] `make help` shows the new target
- [ ] CI green (narrow gate unchanged)

## Next steps (not in this PR)
- Phase 0.1: upstream `paiml/.github/sovereign-ci.yml` change to emit both numbers in CI (blocked by separate repo edit).
- Phase 1: delete dead code, un-skip `cli_integration_tests`, snapshot-test `src/scaffold/**`. Target broad ≥80%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)