### PR TITLE
fix(coverage): emit LCOV from make coverage/coverage-broad for pmat query

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -484,6 +484,8 @@ coverage: ## Coverage summary + threshold check (<5 min)
 		|| true
 	@echo "📊 Generating report..."
 	@cargo +nightly llvm-cov report --summary-only $(COVERAGE_EXCLUDE) | tee target/coverage/summary.txt | grep -E "^TOTAL"
+	@# Emit LCOV at target/coverage/lcov.info so `pmat query --coverage-gaps` auto-discovers it.
+	@cargo +nightly llvm-cov report --lcov --output-path target/coverage/lcov.info $(COVERAGE_EXCLUDE) >/dev/null 2>&1 || true
 	@./scripts/record-metric.sh coverage
 	@COV_PCT=$$(grep -E '^TOTAL' target/coverage/summary.txt | awk '{n=0; for(i=1;i<=NF;i++){if($$i ~ /[0-9]+\.[0-9]+%/){n++; if(n==3){gsub(/%/,"",$$i);print $$i;exit}}}}'); \
 	if [ -n "$$COV_PCT" ] && [ $$(echo "$$COV_PCT < $(COV_THRESHOLD)" | bc -l) -eq 1 ]; then \
@@ -508,9 +510,13 @@ coverage-broad: ## Honest project-wide coverage (no regex, no --skip, no coverag
 		|| true
 	@echo "📊 Generating broad report (informational)..."
 	@cargo +nightly llvm-cov report --summary-only | tee target/coverage-broad/summary.txt | grep -E "^TOTAL"
+	@# Emit LCOV at target/coverage/lcov.info so `pmat query --coverage-gaps` auto-discovers it.
+	@mkdir -p target/coverage
+	@cargo +nightly llvm-cov report --lcov --output-path target/coverage/lcov.info >/dev/null 2>&1 || true
 	@COV_PCT=$$(grep -E '^TOTAL' target/coverage-broad/summary.txt | awk '{n=0; for(i=1;i<=NF;i++){if($$i ~ /[0-9]+\.[0-9]+%/){n++; if(n==3){gsub(/%/,"",$$i);print $$i;exit}}}}'); \
 	echo ""; \
 	echo "ℹ️  Broad coverage: $${COV_PCT}% (informational, not gated)"; \
+	echo "ℹ️  LCOV: target/coverage/lcov.info — feeds 'pmat query --coverage-gaps'"; \
 	echo "ℹ️  Target: 95% per docs/specifications/improve-coverage-80-95.md"
 
 coverage-html: ## Generate HTML report from last coverage run


### PR DESCRIPTION
## Summary

Unblocks Phase 2 of [improve-coverage-80-95.md](docs/specifications/improve-coverage-80-95.md). `pmat query --coverage-gaps --rank-by impact` was returning "Showing functions without coverage enrichment" after either `make coverage` or `make coverage-broad`.

**Root cause:** neither target emitted LCOV — only `target/coverage/summary.txt`. pmat auto-discovers `target/coverage/lcov.info` but not the summary text. pmat's subprocess fallback (`cargo llvm-cov report --json`) also fails on nightly because it re-triggers the E0658 issue that `--no-cfg-coverage*` works around.

**Fix:** after each target's summary report, emit LCOV to `target/coverage/lcov.info` — one of pmat's auto-discovery paths. The narrow target uses `$(COVERAGE_EXCLUDE)`; the broad target does not (consistent with each target's measurement scope).

## Verification

After `make coverage-broad`, `pmat query --coverage-gaps --rank-by impact --limit 10 --exclude-tests` returns real ranked gaps with impact scores:

| Rank | Function | Impact |
|------|----------|--------|
| 1 | src/models/unified_ast_node.rs:325 `fmt` | 9.9 |
| 2 | src/ast/polyglot/cross_language_dependencies_detection.rs:116 `add_dependency` | 8.5 |
| 3 | src/entropy/pattern_extractor_ruchy.rs:69 `extract_ruchy_pipeline_patterns` | 3.4 |

These become Phase 2's TDD targets ("hot paths ranked by impact" per spec §5).

## Test plan
- [x] Emit step uses existing nightly profdata; no new test run needed
- [x] `pmat query --coverage-gaps` returns ranked gaps after `make coverage-broad`
- [ ] CI green (Makefile-only change; narrow gate threshold logic untouched)

## Narrow gate
Logic untouched — still runs `record-metric.sh coverage` and enforces `COV_THRESHOLD=95%`. Only adds a parallel LCOV emission so pmat query works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)