### PR TITLE
fix(work-complete): exclude pmat-owned state from dirty-file count (PMAT-154)

### DIFF
--- a/src/cli/handlers/work_falsification/core_checks.rs
+++ b/src/cli/handlers/work_falsification/core_checks.rs
@@ -2,6 +2,7 @@
 //! Core falsification checks: manifest, coverage, TDG, complexity, spec, roadmap, git.
 
 use crate::cli::handlers::work_contract::{EvidenceType, FalsificationResult, FileManifest};
+use crate::cli::handlers::work_falsification::pmat_owned_state::is_pmat_owned_state;
 use anyhow::{Context, Result};
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -466,11 +467,14 @@ pub(crate) fn test_github_sync(project_path: &Path) -> Result<FalsificationResul
         0
     };
 
-    // Count dirty files (exclude untracked ?? files -- they are not uncommitted changes)
+    // Count dirty files. Exclusions:
+    //   1. untracked `??` lines — not uncommitted changes (GH #224).
+    //   2. pmat-owned state files — PMAT-154 self-dirty loop.
     let dirty_count = status
         .lines()
         .skip(1)
         .filter(|l| !l.is_empty() && !l.starts_with("??"))
+        .filter(|l| !is_pmat_owned_state(l))
         .count();
 
     if ahead_count == 0 && dirty_count == 0 {

--- a/src/cli/handlers/work_falsification/mod.rs
+++ b/src/cli/handlers/work_falsification/mod.rs
@@ -14,6 +14,7 @@ pub mod cache;
 pub mod churn_checks;
 pub mod core_checks;
 pub mod formal_checks;
+pub mod pmat_owned_state;
 pub mod runner;
 pub mod supply_chain_checks;
 mod tests;

--- a/src/cli/handlers/work_falsification/pmat_owned_state.rs
+++ b/src/cli/handlers/work_falsification/pmat_owned_state.rs
@@ -1,0 +1,102 @@
+#![cfg_attr(coverage_nightly, coverage(off))]
+//! PMAT-154: pmat-owned state detection for the github-sync check.
+//!
+//! `pmat work complete` writes to `.pmat-work/ledger.jsonl`, `.pmat/context.db`,
+//! `.pmat/context.idx/*`, and `.pmat-metrics/commit-*.json` during its own
+//! execution. Counting these paths as "uncommitted changes" causes the
+//! github-sync falsifier to fail on retries — the self-dirty loop.
+//!
+//! This module enumerates the prefixes pmat is the sole author of, and exposes
+//! `is_pmat_owned_state()` for the `test_github_sync()` filter. User-owned
+//! files under look-alike paths (`.pmat-baseline.json`, `pmat/…`) are
+//! preserved.
+
+/// Prefixes of pmat-owned state paths to ignore when counting dirty files.
+pub(crate) const PMAT_OWNED_STATE_PREFIXES: &[&str] = &[".pmat/", ".pmat-work/", ".pmat-metrics/"];
+
+/// True if a `git status --porcelain -b` line refers to a pmat-owned state file.
+///
+/// Porcelain format is `XY PATH` (or `XY OLD -> NEW` for renames). The
+/// destination path is what the working tree actually carries, so we inspect
+/// it for rename lines.
+pub(crate) fn is_pmat_owned_state(porcelain_line: &str) -> bool {
+    let Some(after_status) = porcelain_line.get(3..) else {
+        return false;
+    };
+    let path = after_status
+        .rsplit(" -> ")
+        .next()
+        .unwrap_or(after_status)
+        .trim();
+    PMAT_OWNED_STATE_PREFIXES
+        .iter()
+        .any(|p| path.starts_with(p))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_pmat_owned_state;
+
+    #[test]
+    fn matches_owned_dirs() {
+        assert!(is_pmat_owned_state(" M .pmat/context.db"));
+        assert!(is_pmat_owned_state(" M .pmat/context.idx/manifest.json"));
+        assert!(is_pmat_owned_state(" M .pmat/project.toml"));
+        assert!(is_pmat_owned_state("M  .pmat-work/ledger.jsonl"));
+        assert!(is_pmat_owned_state("?? .pmat-work/PMAT-154/evidence.json"));
+        assert!(is_pmat_owned_state(
+            "A  .pmat-metrics/commit-abc123-meta.json"
+        ));
+    }
+
+    #[test]
+    fn skips_user_files() {
+        assert!(!is_pmat_owned_state(" M src/lib.rs"));
+        assert!(!is_pmat_owned_state("M  docs/roadmaps/roadmap.yaml"));
+        assert!(!is_pmat_owned_state(" M Cargo.toml"));
+        // Look-alike paths that aren't pmat-owned.
+        assert!(!is_pmat_owned_state(" M .pmat-baseline.json"));
+        assert!(!is_pmat_owned_state(" M pmat/context.db"));
+    }
+
+    #[test]
+    fn rename_destination() {
+        // `R  OLD -> NEW` — destination is what the worktree carries.
+        assert!(is_pmat_owned_state(
+            "R  src/old.rs -> .pmat-work/archived.rs"
+        ));
+        assert!(!is_pmat_owned_state("R  .pmat-work/old.rs -> src/new.rs"));
+    }
+
+    #[test]
+    fn short_line_defense() {
+        assert!(!is_pmat_owned_state(""));
+        assert!(!is_pmat_owned_state("XY"));
+        assert!(!is_pmat_owned_state("XY "));
+    }
+
+    #[test]
+    fn full_github_sync_scenario() {
+        // PMAT-154 full scenario: ledger + context + metrics files produced
+        // by pmat itself must not inflate dirty_count.
+        let status = concat!(
+            "## master...origin/master\n",
+            "M  .pmat-work/ledger.jsonl\n",
+            " M .pmat/context.db\n",
+            " M .pmat/context.idx/manifest.json\n",
+            "A  .pmat-metrics/commit-abc123-meta.json\n",
+            " M src/lib.rs\n",
+            "?? untracked.txt"
+        );
+        let dirty_count = status
+            .lines()
+            .skip(1)
+            .filter(|l| !l.is_empty() && !l.starts_with("??"))
+            .filter(|l| !is_pmat_owned_state(l))
+            .count();
+        assert_eq!(
+            dirty_count, 1,
+            "Only user-owned src/lib.rs should count; pmat state excluded"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the **self-dirty loop** in `pmat work complete` where `test_github_sync()` falsifies itself because `pmat` writes to `.pmat-work/ledger.jsonl`, `.pmat/context.db`, `.pmat/context.idx/*`, and `.pmat-metrics/commit-*.json` **during its own execution**. On retries, the github-sync check reports `N uncommitted file(s)` even though pmat authored every one of them.

## Root cause

`src/cli/handlers/work_handlers/core_handlers/handlers.rs`:
- L565: `run_contract_falsification()` — appends to `.pmat-work/ledger.jsonl` *inside* falsification
- L574: `service.save(&roadmap)` — writes `docs/roadmaps/roadmap.yaml` *after* falsification
- L591: `capture_commit_metadata()` — writes `.pmat-metrics/commit-*.json` *after* falsification

So a first run dirties pmat-owned files, succeeds, and leaves them uncommitted. A retry then fails F11 because those files are now uncommitted. The infra repo has hit this in production — see infra memory `feedback_pmat_complete_self_dirty.md` which documents the `--override-claims github-sync` workaround.

## Fix

Introduce `src/cli/handlers/work_falsification/pmat_owned_state.rs`:

- `PMAT_OWNED_STATE_PREFIXES: &[&str]` — the three dirs pmat solely owns (`.pmat/`, `.pmat-work/`, `.pmat-metrics/`)
- `is_pmat_owned_state(porcelain_line: &str) -> bool` — matches porcelain status lines against those prefixes; handles rename destinations (`R  OLD -> NEW`)

`test_github_sync()` gets a second filter:
```rust
.filter(|l| !l.is_empty() && !l.starts_with("??"))
.filter(|l| !is_pmat_owned_state(l))
```

User-owned files under look-alike paths (`.pmat-baseline.json`, `pmat/…`, `docs/roadmaps/roadmap.yaml`) are preserved by the prefix-with-trailing-slash invariant.

## Tests

5 unit tests in the new module cover:
- matched prefixes (`.pmat/`, `.pmat-work/`, `.pmat-metrics/` variants)
- user-file preservation (source files, look-alike paths)
- rename destination semantics
- short-line defense (`""`, `"XY"`, `"XY "` must not panic)
- full F11 scenario (ledger + context + metrics + 1 user file → `dirty_count == 1`)

All 8 `work_falsification` tests pass (`cargo test --lib pmat_owned_state work_falsification::tests::tests::test_github_sync`).

## Test plan

- [ ] `cargo test --lib` passes (15,702 tests; pre-existing long-running tests)
- [ ] `cargo clippy --all-targets -- -D warnings` clean
- [ ] Local reproduction: create `.pmat-work/foo.txt`, commit, modify; `pmat work complete` should NOT fail F11 on it

## Refs

- infra roadmap: **PMAT-154** (pmat self-dirty loop)
- infra memory: `feedback_pmat_complete_self_dirty.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)