### PR TITLE
feat(coverage): remove dead polyglot helpers + cover UnifiedAstNode::fmt

### DIFF
--- a/src/ast/polyglot/cross_language_dependencies.rs
+++ b/src/ast/polyglot/cross_language_dependencies.rs
@@ -184,8 +184,7 @@ impl CrossLanguageDependencies {
     }
 }
 
-// Detection: detect_between_language_groups, find_matching_targets,
-// detect_between_languages, is_reference_match, add_dependency
+// Detection: detect_between_language_groups, find_matching_targets, is_reference_match
 include!("cross_language_dependencies_detection.rs");
 
 // Resolution: resolve_references, build_name_map,

--- a/src/ast/polyglot/cross_language_dependencies_detection.rs
+++ b/src/ast/polyglot/cross_language_dependencies_detection.rs
@@ -60,29 +60,6 @@ impl CrossLanguageDependencies {
         }
     }
 
-    /// Detect dependencies between nodes of two specific languages
-    fn detect_between_languages(
-        &mut self,
-        nodes1: &[&UnifiedNode],
-        lang1: Language,
-        nodes2: &[&UnifiedNode],
-        lang2: Language,
-    ) {
-        // For each node in first language
-        for &source in nodes1 {
-            // For each reference in the node
-            for reference in &source.references {
-                // For each node in second language
-                for &target in nodes2 {
-                    // Check if reference matches target
-                    if self.is_reference_match(source, reference, target, lang1, lang2) {
-                        self.add_dependency(source, target, reference.kind, 1.0);
-                    }
-                }
-            }
-        }
-    }
-
     /// Check if a reference from one node matches a target node
     fn is_reference_match(
         &self,
@@ -110,26 +87,5 @@ impl CrossLanguageDependencies {
         }
 
         false
-    }
-
-    /// Add a dependency between two nodes
-    fn add_dependency(
-        &mut self,
-        source: &UnifiedNode,
-        target: &UnifiedNode,
-        kind: ReferenceKind,
-        confidence: f64,
-    ) {
-        let dependency = CrossLanguageDependency {
-            source_id: source.id.clone(),
-            target_id: target.id.clone(),
-            source_language: source.language,
-            target_language: target.language,
-            kind,
-            confidence,
-            metadata: HashMap::new(),
-        };
-
-        self.dependencies.push(dependency);
     }
 }

--- a/src/models/unified_ast_tests.rs
+++ b/src/models/unified_ast_tests.rs
@@ -429,6 +429,42 @@ fn test_unified_ast_node_languages() {
     assert_eq!(py_node.lang, Language::Python);
 }
 
+#[test]
+fn test_unified_ast_node_debug_format() {
+    let node = UnifiedAstNode::new(AstKind::Function(FunctionKind::Regular), Language::Rust);
+    let s = format!("{node:?}");
+    assert!(s.contains("UnifiedAstNode"));
+    assert!(s.contains("kind"));
+    assert!(s.contains("lang"));
+    assert!(s.contains("flags"));
+    assert!(s.contains("parent"));
+    assert!(s.contains("first_child"));
+    assert!(s.contains("next_sibling"));
+    assert!(s.contains("source_range"));
+    assert!(s.contains("semantic_hash"));
+    assert!(s.contains("structural_hash"));
+    assert!(s.contains("name_vector"));
+    assert!(s.contains("metadata_raw"));
+    assert!(s.contains("proof_annotations"));
+    assert!(s.contains("Rust"));
+}
+
+#[test]
+fn test_unified_ast_node_debug_format_populated() {
+    let mut node = UnifiedAstNode::new(AstKind::Class(ClassKind::Struct), Language::TypeScript);
+    node.parent = 42;
+    node.first_child = 7;
+    node.next_sibling = 13;
+    node.source_range = 100..200;
+    node.semantic_hash = 0xDEAD_BEEF;
+    node.structural_hash = 0xCAFE_BABE;
+    node.name_vector = 0xFEED_FACE;
+    let s = format!("{node:?}");
+    assert!(s.contains("42"));
+    assert!(s.contains("100..200"));
+    assert!(s.contains("TypeScript"));
+}
+
 #[cfg_attr(coverage_nightly, coverage(off))]
 #[cfg(test)]
 mod property_tests {


### PR DESCRIPTION
## Summary

Two Phase 1 wins identified via `pmat query --coverage-gaps --rank-by impact` now that PR #391 unblocked ingestion.

1. **Dead code** in `cross_language_dependencies_detection.rs`: `detect_between_languages` and `add_dependency` were only reachable from each other. Live code path (`detect_all`) uses the immutable `detect_between_language_groups` instead. Removes 32 lines of broad-coverage denominator.
2. **Debug fmt** for `UnifiedAstNode` (impact 9.9, previously 0% cov): two new tests exercise default + populated state, including the `unsafe { self.metadata.raw }` union read.

## Test plan
- [x] `cargo test --lib -- ast::polyglot::cross_language` — 50 passed
- [x] `cargo test --lib -- models::unified_ast` — 120 passed (was 118)
- [x] `cargo check --lib --features all-languages` — clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)