### PR TITLE
feat(coverage): cover deserialize_phases + 3 error branches

### DIFF
--- a/src/models/roadmap.rs
+++ b/src/models/roadmap.rs
@@ -17,3 +17,6 @@ include!("roadmap_impl.rs");
 
 #[cfg(test)]
 include!("roadmap_tests.rs");
+
+#[cfg(test)]
+include!("roadmap_phases_tests.rs");

--- a/src/models/roadmap_phases_tests.rs
+++ b/src/models/roadmap_phases_tests.rs
@@ -1,0 +1,123 @@
+// Tests for `deserialize_phases` in roadmap_types.rs — isolated into its own
+// file so `roadmap_tests.rs` stays under the 500-line pre-commit gate.
+//
+// Included by roadmap.rs — shares parent scope, no `use` imports needed.
+
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg(test)]
+mod deserialize_phases_tests {
+    use super::*;
+
+    fn parse_item(yaml: &str) -> Result<RoadmapItem, serde_yaml_ng::Error> {
+        serde_yaml_ng::from_str::<RoadmapItem>(yaml)
+    }
+
+    #[test]
+    fn test_phases_empty_sequence() {
+        let yaml = "\
+id: T-1
+title: t
+status: planned
+phases: []
+";
+        let item = parse_item(yaml).unwrap();
+        assert!(item.phases.is_empty());
+    }
+
+    #[test]
+    fn test_phases_omitted_defaults_empty() {
+        let yaml = "\
+id: T-1
+title: t
+status: planned
+";
+        let item = parse_item(yaml).unwrap();
+        assert!(item.phases.is_empty());
+    }
+
+    #[test]
+    fn test_phases_mapping_parsed() {
+        let yaml = "\
+id: T-1
+title: t
+status: planned
+phases:
+  - name: Phase A
+    status: planned
+  - name: Phase B
+    status: in_progress
+    estimated_effort: 2d
+    completion: 50
+";
+        let item = parse_item(yaml).unwrap();
+        assert_eq!(item.phases.len(), 2);
+        assert_eq!(item.phases[0].name, "Phase A");
+        assert_eq!(item.phases[0].status, ItemStatus::Planned);
+        assert_eq!(item.phases[0].completion, 0);
+        assert_eq!(item.phases[1].name, "Phase B");
+        assert_eq!(item.phases[1].estimated_effort.as_deref(), Some("2d"));
+        assert_eq!(item.phases[1].completion, 50);
+    }
+
+    #[test]
+    fn test_phases_string_rejected_with_helpful_message() {
+        let yaml = "\
+id: T-1
+title: t
+status: planned
+phases:
+  - Plan it
+";
+        let err = parse_item(yaml).unwrap_err().to_string();
+        assert!(err.contains("phases[0]"), "got: {err}");
+        assert!(err.contains("invalid type"), "got: {err}");
+        assert!(err.contains("Plan it"), "got: {err}");
+        assert!(err.contains("name:"), "got: {err}");
+    }
+
+    #[test]
+    fn test_phases_string_error_reports_index() {
+        let yaml = "\
+id: T-1
+title: t
+status: planned
+phases:
+  - name: ok
+    status: planned
+  - bad-string
+";
+        let err = parse_item(yaml).unwrap_err().to_string();
+        assert!(err.contains("phases[1]"), "got: {err}");
+        assert!(err.contains("bad-string"), "got: {err}");
+    }
+
+    #[test]
+    fn test_phases_non_mapping_non_string_rejected() {
+        let yaml = "\
+id: T-1
+title: t
+status: planned
+phases:
+  - 42
+";
+        let err = parse_item(yaml).unwrap_err().to_string();
+        assert!(err.contains("phases[0]"), "got: {err}");
+        assert!(err.contains("expected a Phase struct"), "got: {err}");
+    }
+
+    #[test]
+    fn test_phases_invalid_mapping_surfaces_inner_error() {
+        let yaml = "\
+id: T-1
+title: t
+status: planned
+phases:
+  - name: ok
+";
+        let err = parse_item(yaml).unwrap_err().to_string();
+        assert!(
+            err.contains("status") || err.contains("missing"),
+            "got: {err}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Adds 7 tests for `deserialize_phases` at `src/models/roadmap_types.rs:204` — the custom serde YAML deserializer attached to `RoadmapItem.phases` via `#[serde(default, deserialize_with = "deserialize_phases")]`.

## Coverage gap closed

Target from `pmat query --coverage-gaps --rank-by impact`:
- **Before**: 23 uncovered lines, 36.1% function coverage, impact 1.8
- **After**: all three match arms in `PhasesVisitor::visit_seq` exercised:
  - `Value::String` → helpful error with phase index + example YAML
  - `Value::Mapping` → parse into `Phase`
  - other (e.g. `Value::Number`) → "expected a Phase struct" error
- Plus edge cases: empty sequence, omitted field (default), invalid mapping (missing required field)

## Structural note

Tests live in a new file (`roadmap_phases_tests.rs`) included from `roadmap.rs`, rather than appended to `roadmap_tests.rs`. The existing test file is already at 413 lines and appending ~120 more lines would trip the 500-line pre-commit file-health gate. The include!() pattern mirrors how `roadmap_tests.rs` itself is wired in.

## Test plan

- [x] `cargo test --lib -- models::roadmap::deserialize_phases_tests` — 7/7 passing
- [x] `rustfmt --check --edition 2021` — clean on both modified files
- [x] Pre-commit hook passes (TDG + bashrs + file-health)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)