### PR TITLE
fix(entropy): cover ruchy pipeline regex + fix latent \> word-end bug

### DIFF
--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -3148,20 +3148,19 @@ roadmap:
 - id: PMAT-625
   github_issue: null
   item_type: task
-  title: 'Phase 1: cover deserialize_phases + 3 error branches (PR #394)'
-  status: inprogress
+  title: 'Phase 1: cover extract_ruchy_pipeline_patterns branches'
+  status: planned
   priority: medium
   assigned_to: null
-  created: 2026-04-21T11:57:46Z
-  updated: 2026-04-21T11:57:48.540881516+00:00
+  created: 2026-04-21T12:33:32Z
+  updated: 2026-04-21T12:33:32Z
   spec: null
   acceptance_criteria:
-  - 'Close 23 uncovered lines in src/models/roadmap_types.rs:204 via 7 tests exercising all 3 match arms in PhasesVisitor::visit_seq (String/Mapping/other) + edge cases. Split into roadmap_phases_tests.rs to stay under 500-line pre-commit gate. PR #394. Part of #101 (overall 95% broad coverage).'
+  - 'Target src/entropy/pattern_extractor_ruchy.rs:69 — 29 uncovered, 31% cov, impact 3.4. Existing test runs but skips asserting matches>3 branch. Add tests for: (a) >3 match path with AstPattern field assertions, (b) >15 matches triggering break, (c) pattern_type==DataTransformation + estimated_loc invariants.'
   phases: []
   subtasks: []
   estimated_effort: null
   labels:
   - coverage-95-push
   - phase1
-  - pr-394
   notes: null

--- a/src/entropy/pattern_extractor.rs
+++ b/src/entropy/pattern_extractor.rs
@@ -29,3 +29,9 @@ include!("pattern_extractor_ruchy.rs");
 #[cfg(test)]
 #[path = "pattern_extractor_tests.rs"]
 mod tests;
+
+// Additional ruchy pipeline tests split into their own file to keep
+// pattern_extractor_tests.rs from growing past the 500-line gate.
+#[cfg(test)]
+#[path = "pattern_extractor_ruchy_pipeline_tests.rs"]
+mod ruchy_pipeline_tests_mod;

--- a/src/entropy/pattern_extractor_ruchy.rs
+++ b/src/entropy/pattern_extractor_ruchy.rs
@@ -75,8 +75,10 @@ impl PatternExtractor {
         use regex::Regex;
 
         // Pattern: pipeline operators |>
+        // NOTE: `>` must not be escaped — `\>` is a word-end assertion in Rust
+        // `regex`, not a literal. Prior form `\|\>` matched nothing.
         let pipeline_pattern =
-            Regex::new(r"(?m)\s*\|\>\s*\w+\(").expect("Hardcoded regex pattern must be valid");
+            Regex::new(r"(?m)\s*\|>\s*\w+\(").expect("Hardcoded regex pattern must be valid");
         let matches: Vec<_> = pipeline_pattern.find_iter(content).collect();
 
         if matches.len() > 3 {

--- a/src/entropy/pattern_extractor_ruchy_pipeline_tests.rs
+++ b/src/entropy/pattern_extractor_ruchy_pipeline_tests.rs
@@ -1,0 +1,125 @@
+// Tests for `extract_ruchy_pipeline_patterns` in pattern_extractor_ruchy.rs —
+// isolated into its own file so `pattern_extractor_tests.rs` stays under the
+// 500-line pre-commit gate (it's already at 982; any growth is blocked).
+//
+// Attached via `#[path]` + `mod` from pattern_extractor.rs, so this file IS
+// the module body — use `super::*;` like pattern_extractor_tests.rs does.
+
+use super::*;
+use std::path::PathBuf;
+
+fn run_pipeline(content: &str) -> PatternCollection {
+    let extractor = PatternExtractor::new(EntropyConfig::default());
+    let file_path = PathBuf::from("pipeline.ruchy");
+    let mut collection = PatternCollection::new();
+    extractor
+        .extract_ruchy_pipeline_patterns(&file_path, content, &mut collection)
+        .expect("extract_ruchy_pipeline_patterns should not error");
+    collection
+}
+
+#[test]
+fn four_pipeline_ops_create_data_transformation_pattern() {
+    // matches.len() > 3 branch: exactly 4 operators must fire the extractor.
+    let content = "x |> a() |> b() |> c() |> d()";
+    let collection = run_pipeline(content);
+    assert_eq!(
+        collection.patterns.len(),
+        1,
+        "4 pipeline ops should produce exactly one pattern"
+    );
+    let pattern = collection.patterns.values().next().unwrap();
+    assert_eq!(pattern.pattern_type, PatternType::DataTransformation);
+    assert_eq!(pattern.frequency, 4);
+    assert_eq!(
+        pattern.estimated_loc, 8,
+        "estimated_loc = matches.len() * 2"
+    );
+    assert_eq!(pattern.locations.len(), 4);
+    for loc in &pattern.locations {
+        assert_eq!(loc.file, PathBuf::from("pipeline.ruchy"));
+        assert_eq!(loc.column, 1);
+    }
+}
+
+#[test]
+fn three_pipeline_ops_produce_no_pattern() {
+    // matches.len() == 3 is NOT > 3 → early return, no pattern added.
+    let content = "x |> a() |> b() |> c()";
+    let collection = run_pipeline(content);
+    assert!(
+        collection.patterns.is_empty(),
+        "3 pipeline ops should not trigger pattern extraction"
+    );
+}
+
+#[test]
+fn zero_pipeline_ops_produce_no_pattern() {
+    let content = "let x = foo(bar, baz); // no pipelines here";
+    let collection = run_pipeline(content);
+    assert!(collection.patterns.is_empty());
+}
+
+#[test]
+fn twenty_pipeline_ops_truncate_locations_at_sixteen() {
+    // Build 20 pipeline operations. The loop breaks when i >= 15, AFTER
+    // pushing — so locations ends up with 16 entries (indices 0..=15).
+    // frequency still reflects all 20 matches.
+    let ops = (0..20).map(|i| format!(" |> f{}()", i)).collect::<String>();
+    let content = format!("seed{}", ops);
+    let collection = run_pipeline(&content);
+    assert_eq!(collection.patterns.len(), 1);
+    let pattern = collection.patterns.values().next().unwrap();
+    assert_eq!(
+        pattern.frequency, 20,
+        "frequency = total matches, not capped"
+    );
+    assert_eq!(
+        pattern.locations.len(),
+        16,
+        "locations capped by `if i >= 15 {{ break; }}` after push"
+    );
+    assert_eq!(pattern.estimated_loc, 40, "estimated_loc = 20 * 2");
+}
+
+#[test]
+fn pattern_hash_is_file_path_scoped() {
+    // Same content in two different files should produce different hashes
+    // because hash_pattern is called with `ruchy_pipeline_{file_path}`.
+    let extractor = PatternExtractor::new(EntropyConfig::default());
+    let content = "x |> a() |> b() |> c() |> d()";
+    let mut c1 = PatternCollection::new();
+    let mut c2 = PatternCollection::new();
+    extractor
+        .extract_ruchy_pipeline_patterns(&PathBuf::from("alpha.ruchy"), content, &mut c1)
+        .unwrap();
+    extractor
+        .extract_ruchy_pipeline_patterns(&PathBuf::from("beta.ruchy"), content, &mut c2)
+        .unwrap();
+    let h1 = c1.patterns.keys().next().unwrap().clone();
+    let h2 = c2.patterns.keys().next().unwrap().clone();
+    assert_ne!(h1, h2, "pattern hash should vary by file path");
+}
+
+#[test]
+fn example_code_captured_around_first_match() {
+    // example_code slices content[start.saturating_sub(20) .. end.min(start+100)].
+    let content = "leading_padding_here x |> transform_alpha() |> b() |> c() |> d()";
+    let collection = run_pipeline(content);
+    let pattern = collection.patterns.values().next().unwrap();
+    assert!(
+        pattern.example_code.contains("|> transform_alpha("),
+        "example_code should include first match: got {:?}",
+        pattern.example_code
+    );
+}
+
+#[test]
+fn location_line_numbers_reflect_newline_positions() {
+    // Put each pipeline op on its own line so line numbers are deterministic.
+    let content = "seed\n |> a()\n |> b()\n |> c()\n |> d()";
+    let collection = run_pipeline(content);
+    let pattern = collection.patterns.values().next().unwrap();
+    let lines: Vec<usize> = pattern.locations.iter().map(|l| l.line).collect();
+    assert_eq!(lines, vec![2, 3, 4, 5]);
+}

--- a/src/entropy/pattern_extractor_tests.rs
+++ b/src/entropy/pattern_extractor_tests.rs
@@ -665,16 +665,15 @@ fn test_extract_ruchy_pipeline_patterns() {
             .collect::<Vec<_>>()
     );
 
-    // The function's regex: \s*\|\>\s*\w+\(
-    // Since this uses \> which in Rust regex may be interpreted differently,
-    // just verify the function completes without error
+    // Function regex `\s*\|>\s*\w+\(` (post-fix: `\>` was a word-end
+    // assertion, not a literal) matches 5 pipeline ops here, so a pattern
+    // must be produced.
     let mut collection = PatternCollection::new();
     extractor
         .extract_ruchy_pipeline_patterns(&file_path, content, &mut collection)
         .expect("Should extract patterns");
 
-    // The function may not find patterns due to regex escaping of >
-    // This is acceptable behavior - the function runs without error
+    assert!(!collection.patterns.is_empty(), "must produce pattern");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- **Bug fix**: `extract_ruchy_pipeline_patterns` used regex `\s*\|\>\s*\w+\(`. In Rust `regex`, `\>` is a word-end assertion, not a literal `>`. The `matches.len() > 3` branch was therefore unreachable in production — every Ruchy file silently skipped pipeline pattern detection. Changed to `\s*\|>\s*\w+\(` so `|>` matches literally.
- **Coverage**: Function was 31% cov with 29 uncovered lines (impact 3.4). Added 7 tests in a new sibling file covering the `> 3` path, the `> 15` truncation path, per-file hash scoping, example_code slicing, line-number correctness, and the ≤3 no-op branch.
- **Existing test tightened**: `test_extract_ruchy_pipeline_patterns` previously ran the function and asserted nothing (comment even said "may not find patterns due to regex escaping of >"); now it asserts a pattern is produced.

## Why a new test file?

`pattern_extractor_tests.rs` is already 981 lines; the pre-commit file-health gate blocks any growth past 500 for files already over it. New file `pattern_extractor_ruchy_pipeline_tests.rs` is wired in via `#[path]` mod, same pattern as the sibling `roadmap_phases_tests.rs` split on PR #394.

## Test plan

- [x] `cargo test -p pmat --lib -- pipeline` — 26 passed, 0 failed
- [x] `rustfmt --check` on all touched files
- [x] Confirmed existing `test_extract_ruchy_pipeline_patterns` now asserts meaningfully (not a silent no-op)
- [ ] CI green on `ci/test`, `ci/lint`, `ci/coverage`, `pmat score`

Tracks PMAT-625.

🤖 Generated with [Claude Code](https://claude.com/claude-code)