### PR TITLE
test(graph): cover parse_python/typescript/rust_imports branches

### DIFF
--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -3165,3 +3165,20 @@ roadmap:
   - phase1
   - pr-394
   notes: null
+- id: PMAT-626
+  github_issue: null
+  item_type: task
+  title: 'Phase 1: cover parse_python_imports + parse_typescript_imports + parse_rust_imports'
+  status: inprogress
+  priority: medium
+  assigned_to: null
+  created: 2026-04-21T13:14:04Z
+  updated: 2026-04-21T13:14:08.412846003+00:00
+  spec: null
+  acceptance_criteria:
+  - 'Close ~53 uncovered lines in src/graph/builder_import_parsing.rs (parse_typescript_imports 22 uncov, parse_python_imports 9 uncov, parse_rust_imports also uncovered). 6 tests covering all branches. Sibling to PR #397.'
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels: []
+  notes: null

--- a/src/graph/builder_tests.rs
+++ b/src/graph/builder_tests.rs
@@ -232,6 +232,85 @@ let other = 5;
         assert!(builder.parse_typescript_symbols("").unwrap().is_empty());
     }
 
+    /// Parse Rust: `use x;` (picked), `use y` (no semicolon, skipped),
+    /// `fn` (skipped). Covers strip_prefix/strip_suffix path.
+    #[test]
+    fn test_parse_rust_imports_covers_branches() {
+        let builder = DependencyGraphBuilder::new();
+        let content = "\
+use std::path::Path;
+use crate::graph::Node;
+  use indented::Import;
+use missing_semicolon
+fn main() {}
+// comment
+";
+        let imports = builder.parse_rust_imports(content).unwrap();
+        assert_eq!(imports.len(), 3);
+        assert_eq!(imports[0], "std::path::Path");
+        assert_eq!(imports[1], "crate::graph::Node");
+        assert_eq!(imports[2], "indented::Import");
+    }
+
+    #[test]
+    fn test_parse_rust_imports_empty_content() {
+        let builder = DependencyGraphBuilder::new();
+        assert!(builder.parse_rust_imports("").unwrap().is_empty());
+    }
+
+    /// Parse Python: `import` and `from` both picked;
+    /// other lines (def, comment, code) skipped.
+    #[test]
+    fn test_parse_python_imports_covers_branches() {
+        let builder = DependencyGraphBuilder::new();
+        let content = "\
+import os
+from pathlib import Path
+  from indented import Foo
+def main():
+    pass
+# a comment
+x = 1
+";
+        let imports = builder.parse_python_imports(content).unwrap();
+        assert_eq!(imports.len(), 3);
+        assert_eq!(imports[0], "import os");
+        assert_eq!(imports[1], "from pathlib import Path");
+        assert_eq!(imports[2], "from indented import Foo");
+    }
+
+    #[test]
+    fn test_parse_python_imports_empty_content() {
+        let builder = DependencyGraphBuilder::new();
+        assert!(builder.parse_python_imports("").unwrap().is_empty());
+    }
+
+    /// Parse TS/JS: `import ... from '...'` (picked, quote-stripped),
+    /// `import` with no `from` (skipped), `const X = require('...')` (picked),
+    /// `const` without require (skipped), other lines skipped.
+    #[test]
+    fn test_parse_typescript_imports_covers_branches() {
+        let builder = DependencyGraphBuilder::new();
+        let content = "\
+import { x } from 'lodash';
+import \"side-effect-only\";
+const fs = require('fs');
+const unused = 42;
+let other = 5;
+// comment
+";
+        let imports = builder.parse_typescript_imports(content).unwrap();
+        assert_eq!(imports.len(), 2);
+        assert_eq!(imports[0], "lodash");
+        assert_eq!(imports[1], "fs");
+    }
+
+    #[test]
+    fn test_parse_typescript_imports_empty_content() {
+        let builder = DependencyGraphBuilder::new();
+        assert!(builder.parse_typescript_imports("").unwrap().is_empty());
+    }
+
     /// Test first-time file analysis creates both node and hash entry
     /// Validates initialization path (lines 189-195)
     #[test]


### PR DESCRIPTION
## Summary

Closes ~53 uncovered lines across three 0%-covered import parsers in `src/graph/builder_import_parsing.rs`:

- `parse_rust_imports` (use-strip_prefix/suffix path)
- `parse_python_imports` (22 missed lines — `import` and `from`)
- `parse_typescript_imports` (22 missed lines — `import … from`, `const … = require`)

Plus empty-content guards so the iterator path runs with zero matches.

Sibling to [PR #397](https://github.com/paiml/paiml-mcp-agent-toolkit/pull/397) (symbol parsers in the same module). Part of the 95% broad-coverage push (`docs/specifications/improve-coverage-80-95.md`).

## Test plan

- [x] `cargo test --lib -- graph::builder::tests::test_parse_rust_imports graph::builder::tests::test_parse_python_imports graph::builder::tests::test_parse_typescript_imports` — all 6 pass locally
- [ ] CI green on workspace-test + gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)