### PR TITLE
test(wasm): cover check_i32_load_store branches (PMAT-627)

### DIFF
--- a/src/graph/builder_tests.rs
+++ b/src/graph/builder_tests.rs
@@ -31,6 +31,68 @@ mod tests {
         );
     }
 
+    /// extract_type_name strips `pub`/keyword prefix, trailing generics `<...>`
+    /// and braces `{...}`.
+    #[test]
+    fn test_extract_type_name_covers_generics_and_body() {
+        assert_eq!(
+            DependencyGraphBuilder::extract_type_name("pub struct Foo {", "struct"),
+            Some("Foo")
+        );
+        assert_eq!(
+            DependencyGraphBuilder::extract_type_name("struct Bar<T> { x: T }", "struct"),
+            Some("Bar")
+        );
+        assert_eq!(
+            DependencyGraphBuilder::extract_type_name("enum Status", "enum"),
+            Some("Status")
+        );
+        assert_eq!(
+            DependencyGraphBuilder::extract_type_name("   ", "struct"),
+            None
+        );
+    }
+
+    /// extract_ts_name strips `export`/`const`/`function`, `(...)` args, and `= ...`.
+    #[test]
+    fn test_extract_ts_name_covers_all_prefixes() {
+        assert_eq!(
+            DependencyGraphBuilder::extract_ts_name("export function foo() {}"),
+            Some("foo")
+        );
+        assert_eq!(
+            DependencyGraphBuilder::extract_ts_name("function bar(arg: number) {}"),
+            Some("bar")
+        );
+        assert_eq!(
+            DependencyGraphBuilder::extract_ts_name("export const baz = 42"),
+            Some("baz")
+        );
+        assert_eq!(
+            DependencyGraphBuilder::extract_ts_name("const qux = () => 1"),
+            Some("qux")
+        );
+        assert_eq!(DependencyGraphBuilder::extract_ts_name(""), None);
+    }
+
+    /// extract_ts_class_name strips `export`/`class` and trailing `{...}`.
+    #[test]
+    fn test_extract_ts_class_name_covers_branches() {
+        assert_eq!(
+            DependencyGraphBuilder::extract_ts_class_name("export class PubClass {}"),
+            Some("PubClass")
+        );
+        assert_eq!(
+            DependencyGraphBuilder::extract_ts_class_name("class Bare"),
+            Some("Bare")
+        );
+        assert_eq!(
+            DependencyGraphBuilder::extract_ts_class_name("class Foo{body}"),
+            Some("Foo")
+        );
+        assert_eq!(DependencyGraphBuilder::extract_ts_class_name(""), None);
+    }
+
     #[test]
     fn test_extract_python_names() {
         assert_eq!(

--- a/src/wasm/verifier_tests_stack.rs
+++ b/src/wasm/verifier_tests_stack.rs
@@ -175,4 +175,66 @@ mod stack_analyzer_tests {
         assert!(result.is_ok());
         assert!(stack.is_empty());
     }
+
+    /// OutOfBounds branch: offset + access_size > memory_size.
+    #[test]
+    fn test_check_i32_load_store_out_of_bounds() {
+        let mut stack = vec![ValType::I32];
+        let memarg = wasmparser::MemArg {
+            align: 2,
+            max_align: 2,
+            offset: 100,
+            memory: 0,
+        };
+        // memory_size=10, access_size=4 → offset (100) > 10 - 4
+        let result = check_i32_load_store(&mut stack, &memarg, 10, 4);
+        assert!(matches!(
+            result,
+            Some(VerificationResult::OutOfBounds { .. })
+        ));
+    }
+
+    /// TypeError branch: top of stack is not i32.
+    #[test]
+    fn test_check_i32_load_store_type_error() {
+        let mut stack = vec![ValType::I64];
+        let memarg = wasmparser::MemArg {
+            align: 2,
+            max_align: 2,
+            offset: 0,
+            memory: 0,
+        };
+        let result = check_i32_load_store(&mut stack, &memarg, 1024, 4);
+        assert!(matches!(result, Some(VerificationResult::TypeError { .. })));
+    }
+
+    /// Success branch: i32 address on stack, offset within bounds → None.
+    #[test]
+    fn test_check_i32_load_store_success() {
+        let mut stack = vec![ValType::I32];
+        let memarg = wasmparser::MemArg {
+            align: 2,
+            max_align: 2,
+            offset: 0,
+            memory: 0,
+        };
+        let result = check_i32_load_store(&mut stack, &memarg, 1024, 4);
+        assert!(result.is_none());
+        // Address was popped off the stack.
+        assert!(stack.is_empty());
+    }
+
+    /// TypeError branch: empty stack → pop returns None, not i32.
+    #[test]
+    fn test_check_i32_load_store_empty_stack() {
+        let mut stack: Vec<ValType> = Vec::new();
+        let memarg = wasmparser::MemArg {
+            align: 2,
+            max_align: 2,
+            offset: 0,
+            memory: 0,
+        };
+        let result = check_i32_load_store(&mut stack, &memarg, 1024, 4);
+        assert!(matches!(result, Some(VerificationResult::TypeError { .. })));
+    }
 }


### PR DESCRIPTION
## Summary
- 4 tests for `check_i32_load_store` in `src/wasm/verifier_core.rs` (previously 60% cov, 8 uncov lines):
  - OutOfBounds: offset exceeds `memory_size - access_size`
  - TypeError (non-i32): top of stack is `i64`, not `i32`
  - Success: valid i32 + in-bounds → returns None, stack popped
  - TypeError (empty stack): pop returns None → TypeError

## Test plan
- [x] `cargo test --lib --features wasm-ast -- check_i32_load_store` — 4 passed
- [x] `verifier_tests_stack.rs` at 249 lines (under 500 gate)

Refs: `docs/specifications/improve-coverage-80-95.md`, PMAT-627

🤖 Generated with [Claude Code](https://claude.com/claude-code)