### PR TITLE
test(models): cover ConfigError Display variants (PMAT-627)

### DIFF
--- a/src/models/comply_config_tests.rs
+++ b/src/models/comply_config_tests.rs
@@ -256,4 +256,24 @@ scoring:
         let config = ComplyConfig::default();
         assert_eq!(config.get_severity("cb-200"), CheckSeverity::Error);
     }
+
+    /// Display for ConfigError covers all three variants.
+    #[test]
+    fn test_config_error_display_all_variants() {
+        let io = ConfigError::IoError("disk gone".to_string());
+        assert_eq!(format!("{io}"), "IO error loading config: disk gone");
+
+        let parse = ConfigError::ParseError("bad yaml".to_string());
+        assert_eq!(format!("{parse}"), "Parse error in .pmat.yaml: bad yaml");
+
+        let ser = ConfigError::SerializeError("non-utf8".to_string());
+        assert_eq!(format!("{ser}"), "Serialization error: non-utf8");
+    }
+
+    /// ConfigError implements std::error::Error so it can be boxed as dyn Error.
+    #[test]
+    fn test_config_error_is_std_error() {
+        let err: Box<dyn std::error::Error> = Box::new(ConfigError::IoError("fail".to_string()));
+        assert!(err.to_string().contains("fail"));
+    }
 }


### PR DESCRIPTION
## Summary
- 2 tests for `ConfigError` Display impl at `src/models/comply_config_impls.rs:202` (previously 0% covered, 6 uncov lines):
  - All 3 variants (IoError/ParseError/SerializeError) format correctly
  - Boxed as `dyn std::error::Error` round-trips

## Test plan
- [x] `cargo test --lib -- config_error` — 5 passed
- [x] `comply_config_tests.rs` at 280 lines (under 500 gate)

Refs: `docs/specifications/improve-coverage-80-95.md`, PMAT-627

🤖 Generated with [Claude Code](https://claude.com/claude-code)