### PR TITLE
test: cover visit_expr_call + evidence variants (PMAT-627)

### DIFF
--- a/src/models/debug_analysis_coverage_unit.rs
+++ b/src/models/debug_analysis_coverage_unit.rs
@@ -210,6 +210,26 @@
         assert!(evidence.value.get("notes").is_some());
     }
 
+    /// Covers the EvoScoreTrajectory branch in create_test_evidence.
+    #[test]
+    fn test_evidence_new_evoscore_trajectory() {
+        let evidence = create_test_evidence(EvidenceSource::EvoScoreTrajectory);
+
+        assert_eq!(evidence.source, EvidenceSource::EvoScoreTrajectory);
+        assert_eq!(evidence.metric, "evoscore_trajectory");
+        assert!(evidence.value.get("evoscore").is_some());
+    }
+
+    /// Covers the CoverageDelta branch in create_test_evidence.
+    #[test]
+    fn test_evidence_new_coverage_delta() {
+        let evidence = create_test_evidence(EvidenceSource::CoverageDelta);
+
+        assert_eq!(evidence.source, EvidenceSource::CoverageDelta);
+        assert_eq!(evidence.metric, "coverage_delta");
+        assert!(evidence.value.get("delta").is_some());
+    }
+
     #[test]
     fn test_evidence_serialization_roundtrip() {
         let evidence = create_test_evidence(EvidenceSource::Complexity);

--- a/src/quality/efficiency_tests.rs
+++ b/src/quality/efficiency_tests.rs
@@ -342,4 +342,63 @@ mod coverage_tests {
         assert_eq!(efficiency.time_complexity, "O(n log n)");
         assert_eq!(efficiency.space_complexity, "O(n)");
     }
+
+    /// visit_expr_call: direct function call whose name contains "vec"
+    /// hits the allocations += 1 branch.
+    #[test]
+    fn test_visit_expr_call_vec_name() {
+        let mut visitor = SpaceComplexityVisitor {
+            allocations: 0,
+            recursive_depth: 0,
+        };
+        let code = "fn t() { vec_new(); }";
+        let ast = syn::parse_file(code).unwrap();
+        syn::visit::visit_file(&mut visitor, &ast);
+        assert!(visitor.allocations >= 1);
+    }
+
+    /// visit_expr_call: direct function call whose name contains "Vec"
+    /// (capitalized) hits the allocations branch.
+    #[test]
+    fn test_visit_expr_call_capital_vec_name() {
+        let mut visitor = SpaceComplexityVisitor {
+            allocations: 0,
+            recursive_depth: 0,
+        };
+        let code = "fn t() { makeVec(); }";
+        let ast = syn::parse_file(code).unwrap();
+        syn::visit::visit_file(&mut visitor, &ast);
+        assert!(visitor.allocations >= 1);
+    }
+
+    /// visit_expr_call: direct function call whose name contains "alloc"
+    /// hits the allocations branch.
+    #[test]
+    fn test_visit_expr_call_alloc_name() {
+        let mut visitor = SpaceComplexityVisitor {
+            allocations: 0,
+            recursive_depth: 0,
+        };
+        let code = "fn t() { allocate(); }";
+        let ast = syn::parse_file(code).unwrap();
+        syn::visit::visit_file(&mut visitor, &ast);
+        assert!(visitor.allocations >= 1);
+    }
+
+    /// visit_expr_call: direct function call whose name does NOT match
+    /// any allocation keyword — allocations stays 0 from this call.
+    #[test]
+    fn test_visit_expr_call_no_match() {
+        let mut visitor = SpaceComplexityVisitor {
+            allocations: 0,
+            recursive_depth: 0,
+        };
+        let code = "fn t() { plain_fn(); }";
+        let ast = syn::parse_file(code).unwrap();
+        syn::visit::visit_file(&mut visitor, &ast);
+        // No allocation keyword matched from the call itself. Note that
+        // visit_local may still increment for the implicit fn body, but
+        // there are no locals in this snippet.
+        assert_eq!(visitor.allocations, 0);
+    }
 }


### PR DESCRIPTION
## Summary
- Cover `SpaceComplexityVisitor::visit_expr_call` vec/Vec/alloc branches (4 tests)
- Cover `Evidence::new` for EvoScoreTrajectory + CoverageDelta variants (2 tests)

## Coverage targets (PMAT-627)
- `src/quality/efficiency_analysis.rs::visit_expr_call` — was 54.5% (5 uncov)
- `src/models/debug_analysis_coverage_helpers.rs::create_test_evidence` — was 76.5% (12 uncov); Evidence variants now all exercised

## Test plan
- [x] `cargo test -p pmat --lib -- quality::efficiency_tests`
- [x] `cargo test -p pmat --lib -- debug_analysis_coverage_unit`
- [ ] CI gate