### PR TITLE
test: cover calculate_pipeline_variation_score multi-match (PMAT-627)

### DIFF
--- a/src/entropy/pattern_extractor_ruchy_pipeline_tests.rs
+++ b/src/entropy/pattern_extractor_ruchy_pipeline_tests.rs
@@ -123,3 +123,45 @@ fn location_line_numbers_reflect_newline_positions() {
     let lines: Vec<usize> = pattern.locations.iter().map(|l| l.line).collect();
     assert_eq!(lines, vec![2, 3, 4, 5]);
 }
+
+// calculate_pipeline_variation_score — only len<2 branch was covered.
+// The multi-match branches (unique-set, identical ops, mixed) are below.
+
+#[test]
+fn test_calculate_pipeline_variation_score_all_distinct() {
+    use regex::Regex;
+    let extractor = PatternExtractor::new(EntropyConfig::default());
+    // Three distinct operators → unique_operations.len() == matches.len() → 1.0.
+    let content = "|>a |>b |>c";
+    let pattern = Regex::new(r"\|>\w").unwrap();
+    let matches: Vec<_> = pattern.find_iter(content).collect();
+    assert_eq!(matches.len(), 3);
+    let score = extractor.calculate_pipeline_variation_score(&matches, content);
+    assert!((score - 1.0).abs() < f64::EPSILON, "got {score}");
+}
+
+#[test]
+fn test_calculate_pipeline_variation_score_all_identical() {
+    use regex::Regex;
+    let extractor = PatternExtractor::new(EntropyConfig::default());
+    // All same operator text → unique_operations has one entry → 1/3 ≈ 0.333.
+    let content = "|>a |>a |>a";
+    let pattern = Regex::new(r"\|>\w").unwrap();
+    let matches: Vec<_> = pattern.find_iter(content).collect();
+    assert_eq!(matches.len(), 3);
+    let score = extractor.calculate_pipeline_variation_score(&matches, content);
+    assert!((score - (1.0 / 3.0)).abs() < 1e-9, "got {score}");
+}
+
+#[test]
+fn test_calculate_pipeline_variation_score_partial() {
+    use regex::Regex;
+    let extractor = PatternExtractor::new(EntropyConfig::default());
+    // Two distinct ops out of four matches → 0.5.
+    let content = "|>a |>b |>a |>b";
+    let pattern = Regex::new(r"\|>\w").unwrap();
+    let matches: Vec<_> = pattern.find_iter(content).collect();
+    assert_eq!(matches.len(), 4);
+    let score = extractor.calculate_pipeline_variation_score(&matches, content);
+    assert!((score - 0.5).abs() < 1e-9, "got {score}");
+}

--- a/src/models/debug_analysis_coverage_unit.rs
+++ b/src/models/debug_analysis_coverage_unit.rs
@@ -210,6 +210,26 @@
         assert!(evidence.value.get("notes").is_some());
     }
 
+    /// Covers the EvoScoreTrajectory branch in create_test_evidence.
+    #[test]
+    fn test_evidence_new_evoscore_trajectory() {
+        let evidence = create_test_evidence(EvidenceSource::EvoScoreTrajectory);
+
+        assert_eq!(evidence.source, EvidenceSource::EvoScoreTrajectory);
+        assert_eq!(evidence.metric, "evoscore_trajectory");
+        assert!(evidence.value.get("evoscore").is_some());
+    }
+
+    /// Covers the CoverageDelta branch in create_test_evidence.
+    #[test]
+    fn test_evidence_new_coverage_delta() {
+        let evidence = create_test_evidence(EvidenceSource::CoverageDelta);
+
+        assert_eq!(evidence.source, EvidenceSource::CoverageDelta);
+        assert_eq!(evidence.metric, "coverage_delta");
+        assert!(evidence.value.get("delta").is_some());
+    }
+
     #[test]
     fn test_evidence_serialization_roundtrip() {
         let evidence = create_test_evidence(EvidenceSource::Complexity);

--- a/src/quality/efficiency_tests.rs
+++ b/src/quality/efficiency_tests.rs
@@ -342,4 +342,63 @@ mod coverage_tests {
         assert_eq!(efficiency.time_complexity, "O(n log n)");
         assert_eq!(efficiency.space_complexity, "O(n)");
     }
+
+    /// visit_expr_call: direct function call whose name contains "vec"
+    /// hits the allocations += 1 branch.
+    #[test]
+    fn test_visit_expr_call_vec_name() {
+        let mut visitor = SpaceComplexityVisitor {
+            allocations: 0,
+            recursive_depth: 0,
+        };
+        let code = "fn t() { vec_new(); }";
+        let ast = syn::parse_file(code).unwrap();
+        syn::visit::visit_file(&mut visitor, &ast);
+        assert!(visitor.allocations >= 1);
+    }
+
+    /// visit_expr_call: direct function call whose name contains "Vec"
+    /// (capitalized) hits the allocations branch.
+    #[test]
+    fn test_visit_expr_call_capital_vec_name() {
+        let mut visitor = SpaceComplexityVisitor {
+            allocations: 0,
+            recursive_depth: 0,
+        };
+        let code = "fn t() { makeVec(); }";
+        let ast = syn::parse_file(code).unwrap();
+        syn::visit::visit_file(&mut visitor, &ast);
+        assert!(visitor.allocations >= 1);
+    }
+
+    /// visit_expr_call: direct function call whose name contains "alloc"
+    /// hits the allocations branch.
+    #[test]
+    fn test_visit_expr_call_alloc_name() {
+        let mut visitor = SpaceComplexityVisitor {
+            allocations: 0,
+            recursive_depth: 0,
+        };
+        let code = "fn t() { allocate(); }";
+        let ast = syn::parse_file(code).unwrap();
+        syn::visit::visit_file(&mut visitor, &ast);
+        assert!(visitor.allocations >= 1);
+    }
+
+    /// visit_expr_call: direct function call whose name does NOT match
+    /// any allocation keyword — allocations stays 0 from this call.
+    #[test]
+    fn test_visit_expr_call_no_match() {
+        let mut visitor = SpaceComplexityVisitor {
+            allocations: 0,
+            recursive_depth: 0,
+        };
+        let code = "fn t() { plain_fn(); }";
+        let ast = syn::parse_file(code).unwrap();
+        syn::visit::visit_file(&mut visitor, &ast);
+        // No allocation keyword matched from the call itself. Note that
+        // visit_local may still increment for the implicit fn body, but
+        // there are no locals in this snippet.
+        assert_eq!(visitor.allocations, 0);
+    }
 }


### PR DESCRIPTION
## Summary
- Adds 3 tests for `calculate_pipeline_variation_score` multi-match branches (all-distinct, all-identical, partial).
- Prior suite only covered the early-return `len<2 → 0.0` branch.

## Coverage target (PMAT-627)
- `src/entropy/pattern_extractor_ruchy.rs::calculate_pipeline_variation_score` — was 27.3% (8 uncov).

## Test plan
- [x] `cargo test --lib -- test_calculate_pipeline_variation_score` (4/4 pass)
- [ ] CI gate