### PR TITLE
test(models): cover deserialize_bool_lenient error branches (PMAT-627)

### DIFF
--- a/src/models/roadmap_tests.rs
+++ b/src/models/roadmap_tests.rs
@@ -227,6 +227,35 @@ roadmap:
         assert!(roadmap.github_enabled);
     }
 
+    /// deserialize_bool_lenient rejects invalid string values. Exercises the
+    /// `_ => Err(...)` arm inside visit_str — uncovered until now.
+    #[test]
+    fn test_github_enabled_invalid_string_rejected() {
+        let yaml = "roadmap_version: '1.0'\ngithub_enabled: \"yes\"\nroadmap: []\n";
+        let err = serde_yaml_ng::from_str::<Roadmap>(yaml)
+            .expect_err("invalid bool string must fail");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("expected true/false") && msg.contains("yes"),
+            "error should name the invalid value, got: {msg}"
+        );
+    }
+
+    /// deserialize_bool_lenient rejects non-bool, non-string values (e.g. integer).
+    /// Exercises the visitor's `expecting` message surfaced by serde when no
+    /// visit_* method matches.
+    #[test]
+    fn test_github_enabled_integer_rejected() {
+        let yaml = "roadmap_version: '1.0'\ngithub_enabled: 1\nroadmap: []\n";
+        let err = serde_yaml_ng::from_str::<Roadmap>(yaml)
+            .expect_err("integer must not satisfy lenient bool deserializer");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("boolean") || msg.contains("true/false"),
+            "error should reference expected type, got: {msg}"
+        );
+    }
+
     // Part A: YAML Parsing Resilience - Status Alias Tests
     mod status_alias_tests {
         use super::*;


### PR DESCRIPTION
## Summary
- Adds 2 tests for uncovered branches in `deserialize_bool_lenient` at `src/models/roadmap_types.rs:34`
- `test_github_enabled_invalid_string_rejected` — exercises the `_` arm of `visit_str` (custom error for non-`true`/`false` strings)
- `test_github_enabled_integer_rejected` — exercises the visitor's `expecting` surfaced when an integer hits `deserialize_any`
- Coverage gap: 76.5% → 100% (4 uncovered lines closed)

## Test plan
- [x] `cargo test --lib -- test_github_enabled` — all 5 tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)