### PR TITLE
test: cover zero-coverage Default impls cluster (PMAT-627)

### DIFF
--- a/src/graph/types_tests.rs
+++ b/src/graph/types_tests.rs
@@ -147,6 +147,14 @@ mod tests {
     }
 
     #[test]
+    fn test_dependency_graph_default_delegates_to_new() {
+        // Exercise the Default impl (delegates to Self::new()).
+        let graph: DependencyGraph = Default::default();
+        assert_eq!(graph.node_count(), 0);
+        assert_eq!(graph.edge_count(), 0);
+    }
+
+    #[test]
     fn test_dependency_graph_add_node() {
         let mut graph = DependencyGraph::new();
         let id = graph.add_node(create_test_node(0));

--- a/src/models/complexity_bound_tests.rs
+++ b/src/models/complexity_bound_tests.rs
@@ -132,6 +132,15 @@ mod tests {
         assert!(solution.is_some());
         assert_eq!(solution.unwrap().class, BigOClass::Linearithmic);
     }
+
+    /// ComplexityBound::default() delegates to Self::unknown().
+    #[test]
+    fn test_complexity_bound_default_is_unknown() {
+        let bound: ComplexityBound = Default::default();
+        let unknown = ComplexityBound::unknown();
+        assert_eq!(bound.class, unknown.class);
+        assert_eq!(bound.confidence, unknown.confidence);
+    }
 }
 
 #[cfg_attr(coverage_nightly, coverage(off))]

--- a/src/quality/entropy_tests.rs
+++ b/src/quality/entropy_tests.rs
@@ -26,6 +26,14 @@ mod tests {
         let token_entropy = calculator.calculate_token_entropy(code);
         assert!(token_entropy > 0.0);
     }
+
+    #[test]
+    fn test_default_delegates_to_new() {
+        // Exercise the Default impl (delegates to Self::new()).
+        let calc: EntropyCalculator = Default::default();
+        let entropy = calc.calculate("abcdef");
+        assert!(entropy > 0.0);
+    }
 }
 
 #[cfg_attr(coverage_nightly, coverage(off))]

--- a/src/quality/satd_item.rs
+++ b/src/quality/satd_item.rs
@@ -115,8 +115,10 @@ mod coverage_tests {
     // SatdDetectorWithItems tests
     #[test]
     fn test_satd_detector_default() {
-        let detector = SatdDetectorWithItems;
-        let _ = detector;
+        // Exercise the Default impl (delegates to Self::new()).
+        let detector: SatdDetectorWithItems = Default::default();
+        // Should behave identically to a detector built via new().
+        assert!(detector.detect("// TODO: x").len() == 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Cluster PR covering four one-line \`Default\` impls that LCOV flagged at 0% coverage:
- \`SatdDetectorWithItems::default()\` — updated existing \`test_satd_detector_default\` to actually call \`Default::default()\` (it was constructing via unit-struct syntax, missing the Default impl).
- \`EntropyCalculator::default()\` — new test in \`entropy_tests.rs\`.
- \`DependencyGraph::default()\` — new test in \`types_tests.rs\`.
- \`ComplexityBound::default()\` — new test in \`complexity_bound_tests.rs\`, asserting it delegates to \`Self::unknown()\`.

Part of Task #101 (95% broad-coverage grind before v3.15.0).

## Test plan
- [x] \`cargo test --lib -- test_satd_detector_default test_default_delegates_to_new test_dependency_graph_default_delegates_to_new test_complexity_bound_default_is_unknown\` — 4/4 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)