### PR TITLE
test: cover NodeMetadata::clone, UndirectedGraph::node_references, InvariantChecker::check_all

### DIFF
--- a/src/graph/types_tests.rs
+++ b/src/graph/types_tests.rs
@@ -283,6 +283,21 @@ mod tests {
         assert_eq!(graph.edge_weight(n1, n0), Some(1.5));
     }
 
+    #[test]
+    fn test_undirected_graph_node_references_iterates_all_nodes() {
+        let mut graph = UndirectedGraph::new();
+        let n0 = graph.add_node(create_test_node(0));
+        let n1 = graph.add_node(create_test_node(1));
+        let n2 = graph.add_node(create_test_node(2));
+
+        let refs: Vec<_> = graph.node_references().collect();
+        assert_eq!(refs.len(), 3);
+        let ids: std::collections::HashSet<_> = refs.iter().map(|(id, _)| *id).collect();
+        assert!(ids.contains(&n0));
+        assert!(ids.contains(&n1));
+        assert!(ids.contains(&n2));
+    }
+
     // ============================================================
     // EdgeData Tests
     // ============================================================

--- a/src/models/unified_ast_types_tests.rs
+++ b/src/models/unified_ast_types_tests.rs
@@ -616,7 +616,9 @@ mod unified_ast_types_tests {
     #[test]
     fn test_node_metadata_clone() {
         let metadata = NodeMetadata { complexity: 42 };
-        let cloned = metadata;
+        // Invoke the explicit Clone impl (not the implicit Copy) so the
+        // `impl Clone for NodeMetadata` body is exercised for coverage.
+        let cloned: NodeMetadata = Clone::clone(&metadata);
         // SAFETY: Test-only: reading the same union field (`complexity`) that was just written, no UB.
         unsafe {
             assert_eq!(metadata.complexity, cloned.complexity);

--- a/src/wasm/verifier_tests.rs
+++ b/src/wasm/verifier_tests.rs
@@ -366,4 +366,12 @@ mod coverage_tests {
         // Verify default invariants are created
         assert_eq!(checker.invariants.len(), 4);
     }
+
+    #[test]
+    fn test_invariant_checker_check_all_returns_empty_vec() {
+        let checker = InvariantChecker::new();
+        let violations = checker.check_all(&[0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00]);
+        // Current impl is a placeholder that always returns an empty Vec.
+        assert!(violations.is_empty());
+    }
 }


### PR DESCRIPTION
## Summary
Three small zero-coverage functions from the fresh LCOV gap list:

- \`NodeMetadata::clone\` — existing test used implicit \`Copy\` (\`let cloned = metadata\`), which doesn't invoke the explicit \`impl Clone\`. Switched to \`Clone::clone(&metadata)\` so the impl body runs.
- \`UndirectedGraph::node_references\` — new test asserts the iterator yields every node inserted.
- \`InvariantChecker::check_all\` — new test covers the placeholder impl that always returns an empty Vec (behind \`wasm-ast\` feature).

Part of Task #101 (95% broad-coverage grind before v3.15.0).

## Test plan
- [x] \`cargo test --lib -- test_node_metadata_clone test_undirected_graph_node_references_iterates_all_nodes\` — pass
- [x] \`cargo test --lib --features wasm-ast -- test_invariant_checker_check_all_returns_empty_vec\` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)