### PR TITLE
test(coverage): cover verify_function WASM OOB error branches

### DIFF
--- a/src/wasm/verifier_tests.rs
+++ b/src/wasm/verifier_tests.rs
@@ -187,6 +187,85 @@ mod coverage_tests {
         );
     }
 
+    // WASM module with i32.load at an out-of-bounds static offset.
+    // memory is 1 page (65536 bytes), access_size=4, so any offset >65532 is OOB.
+    // Offset 65533 LEB128 = 0xFD 0xFF 0x03 (3 bytes).
+    fn oob_load_wasm() -> Vec<u8> {
+        vec![
+            0x00, 0x61, 0x73, 0x6d, // magic
+            0x01, 0x00, 0x00, 0x00, // version
+            // Type section: () -> i32
+            0x01, 0x05, 0x01, 0x60, 0x00, 0x01, 0x7f,
+            // Function section
+            0x03, 0x02, 0x01, 0x00,
+            // Memory section: 1 page min
+            0x05, 0x03, 0x01, 0x00, 0x01,
+            // Code section
+            0x0a, 0x0b, // section size 11
+            0x01, // 1 body
+            0x09, // body size 9
+            0x00, // 0 locals
+            0x41, 0x00, // i32.const 0 (address)
+            0x28, 0x02, // i32.load align=2
+            0xfd, 0xff, 0x03, // offset=65533 (OOB: >65532)
+            0x0b, // end
+        ]
+    }
+
+    // WASM module with i32.store at OOB static offset.
+    fn oob_store_wasm() -> Vec<u8> {
+        vec![
+            0x00, 0x61, 0x73, 0x6d, // magic
+            0x01, 0x00, 0x00, 0x00, // version
+            // Type section: () -> ()
+            0x01, 0x04, 0x01, 0x60, 0x00, 0x00,
+            // Function section
+            0x03, 0x02, 0x01, 0x00,
+            // Memory section: 1 page
+            0x05, 0x03, 0x01, 0x00, 0x01,
+            // Code section
+            0x0a, 0x0d, // section size 13
+            0x01, // 1 body
+            0x0b, // body size 11
+            0x00, // 0 locals
+            0x41, 0x00, // i32.const 0 (address)
+            0x41, 0x2a, // i32.const 42 (value)
+            0x36, 0x02, // i32.store align=2
+            0xfd, 0xff, 0x03, // offset=65533 (OOB)
+            0x0b, // end
+        ]
+    }
+
+    #[test]
+    fn test_verify_i32_load_out_of_bounds() {
+        let verifier = IncrementalVerifier::new().unwrap();
+        let result = verifier
+            .verify_module(&oob_load_wasm())
+            .expect("parse should succeed");
+        match result {
+            VerificationResult::OutOfBounds { offset, size } => {
+                assert_eq!(offset, 65533);
+                assert_eq!(size, 65536);
+            }
+            other => panic!("expected OutOfBounds, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_verify_i32_store_out_of_bounds() {
+        let verifier = IncrementalVerifier::new().unwrap();
+        let result = verifier
+            .verify_module(&oob_store_wasm())
+            .expect("parse should succeed");
+        match result {
+            VerificationResult::OutOfBounds { offset, size } => {
+                assert_eq!(offset, 65533);
+                assert_eq!(size, 65536);
+            }
+            other => panic!("expected OutOfBounds, got {:?}", other),
+        }
+    }
+
     #[test]
     fn test_verify_invalid_wasm() {
         let verifier = IncrementalVerifier::new().unwrap();


### PR DESCRIPTION
## Summary

Adds two WASM fixtures and two tests that exercise the `VerificationResult::OutOfBounds` return branches in `verify_function` (`src/wasm/verifier_core.rs:36`) for both `Operator::I32Load` and `Operator::I32Store`.

Both fixtures use static offset 65533 — beyond `memory_size - access_size` (65536 - 4 = 65532) — so `check_i32_load_store` returns `Some(OutOfBounds)` and `verify_function` takes the early-return branches at lines 48 and 57.

## Coverage impact

Before:
- `verify_function`: 78.6% cov, 6 uncov lines
- `check_i32_load_store`: OOB branch not exercised from the module-verification path

The existing `test_verify_memory_load`/`test_verify_memory_store` cover only success paths; these new tests cover the complementary error paths.

## Test plan
- [x] `cargo test --lib --features wasm-ast -- test_verify_i32_load_out_of_bounds test_verify_i32_store_out_of_bounds` — both pass
- [ ] CI passes (coverage runs with all features, so these tests will be picked up)

Parent: Task #101 (95% coverage gate before v3.15.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)