### PR TITLE
test(coverage): cover Violation::to_op fall-through arm

### DIFF
--- a/src/models/refactor_tests_part2.rs
+++ b/src/models/refactor_tests_part2.rs
@@ -152,6 +152,40 @@
         }
     }
 
+    // Covers the `_` fall-through arm in Violation::to_op for ViolationType
+    // variants not explicitly matched (LongFunction, DeadCode, PoorNaming).
+    #[test]
+    fn test_violation_to_op_fallthrough_variants() {
+        for vtype in [
+            ViolationType::LongFunction,
+            ViolationType::DeadCode,
+            ViolationType::PoorNaming,
+        ] {
+            let violation = Violation {
+                violation_type: vtype.clone(),
+                location: Location {
+                    file: PathBuf::from("test.rs"),
+                    line: 1,
+                    column: 1,
+                },
+                severity: Severity::Low,
+                description: "Test".to_string(),
+                suggested_fix: None,
+            };
+
+            match violation.to_op() {
+                RefactorOp::SimplifyExpression { expr, simplified } => {
+                    assert_eq!(expr, "complex");
+                    assert_eq!(simplified, "simple");
+                }
+                other => panic!(
+                    "Expected SimplifyExpression fall-through for {:?}, got {:?}",
+                    vtype, other
+                ),
+            }
+        }
+    }
+
     // ========================================================================
     // SatdFix Tests
     // ========================================================================


### PR DESCRIPTION
## Summary

Adds `test_violation_to_op_fallthrough_variants` exercising the `_` wildcard arm in `Violation::to_op` (`src/models/refactor_impls.rs:267-270`) that emits `RefactorOp::SimplifyExpression` for `ViolationType` variants not explicitly matched: `LongFunction`, `DeadCode`, `PoorNaming`.

## Coverage impact

Before: `to_op` at 85.7% cov, 4 uncov lines (the fall-through arm body).

Existing tests already cover the `suggested_fix` `Some` branch and the three explicit `match` arms; this targets the remaining default arm.

## Test plan
- [x] `cargo test --lib -- test_violation_to_op_fallthrough_variants` — passes
- [ ] CI passes

Parent: Task #101 (95% coverage gate before v3.15.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)