### PR TITLE
test(graph): cover from_workspace all extension arms (PMAT-627)

### DIFF
--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -3181,3 +3181,19 @@ roadmap:
   estimated_effort: null
   labels: []
   notes: null
+- id: PMAT-627
+  github_issue: null
+  item_type: task
+  title: Cover from_workspace + private symbol/import parsing branches
+  status: inprogress
+  priority: medium
+  assigned_to: null
+  created: 2026-04-21T17:30:07Z
+  updated: 2026-04-21T17:30:09.975200953+00:00
+  spec: null
+  acceptance_criteria: []
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels: []
+  notes: null

--- a/src/graph/builder_tests.rs
+++ b/src/graph/builder_tests.rs
@@ -441,4 +441,47 @@ let other = 5;
         assert_eq!(builder.graph.node_count(), 1);
         assert!(builder.graph.node_weight(node_id).is_some());
     }
+
+    /// Exercise `from_workspace` over every extension branch in
+    /// `build_file_symbols` and `resolve_file_dependencies`:
+    /// - `rs` (Rust arm)
+    /// - `py` (Python arm)
+    /// - `ts` (TypeScript arm)
+    /// - `go` (unsupported — fall-through `_ => vec![]`)
+    ///   Note: `.go` files pass `is_source_file` so they reach the parser
+    ///   dispatcher, where they hit the default arm in both functions.
+    #[test]
+    fn test_from_workspace_covers_all_extension_arms() {
+        use std::fs;
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path();
+
+        fs::write(
+            root.join("lib.rs"),
+            "use std::fmt;\npub fn rust_fn() {}\n",
+        )
+        .unwrap();
+        fs::write(
+            root.join("mod.py"),
+            "import os\ndef py_fn():\n    pass\n",
+        )
+        .unwrap();
+        fs::write(
+            root.join("app.ts"),
+            "import { x } from './x';\nexport function tsFn() {}\n",
+        )
+        .unwrap();
+        fs::write(
+            root.join("main.go"),
+            "package main\nfunc goFn() {}\n",
+        )
+        .unwrap();
+
+        let builder = DependencyGraphBuilder::from_workspace(root).unwrap();
+
+        // Four source files → four graph nodes regardless of parser coverage.
+        assert_eq!(builder.graph.node_count(), 4);
+    }
 }


### PR DESCRIPTION
## Summary

- Add `test_from_workspace_covers_all_extension_arms` in `src/graph/builder_tests.rs`
- Drives a tempdir workspace with `.rs`, `.py`, `.ts`, and `.go` files through `DependencyGraphBuilder::from_workspace`
- `.go` files pass `is_source_file` (which accepts go/java/c/cpp/cc/h/hpp) but hit the `_ => vec![]` fall-through arm in both private fns `build_file_symbols` and `resolve_file_dependencies`, covering the remaining uncovered branch in each
- No production changes

## Test plan

- [x] `cargo test --lib -- test_from_workspace_covers_all_extension_arms` passes
- [ ] `ci/coverage` gate passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)