### PR TITLE
test(polyglot): cover resolve_against_name_map target-missing branch (PMAT-628)

### DIFF
--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -3197,3 +3197,19 @@ roadmap:
   estimated_effort: null
   labels: []
   notes: null
+- id: PMAT-628
+  github_issue: null
+  item_type: task
+  title: 'Coverage: resolve_against_name_map missing-target branch'
+  status: planned
+  priority: medium
+  assigned_to: null
+  created: 2026-04-21T17:39:22Z
+  updated: 2026-04-21T17:39:22Z
+  spec: null
+  acceptance_criteria: []
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels: []
+  notes: null

--- a/src/ast/polyglot/cross_lang_tests_part3.rs
+++ b/src/ast/polyglot/cross_lang_tests_part3.rs
@@ -358,4 +358,32 @@
         assert!(deps.is_empty());
     }
 
+    // Covers the `let Some(target_ids) = name_map.get(target_name) else { continue }`
+    // branch in `resolve_against_name_map` — an unresolved reference whose
+    // target name exists nowhere in the node set.
+    #[test]
+    fn test_resolve_against_name_map_target_missing_from_name_map() {
+        let mut java_node = create_test_node(
+            "Java:class:Orphan",
+            NodeKind::Class,
+            "Orphan",
+            "com.example.Orphan",
+            Language::Java,
+        );
+        // Reference to a name that is not in the node set at all.
+        java_node.add_reference(ReferenceKind::Uses, "NowhereType".to_string(), None);
+
+        let ts_node = create_test_node(
+            "TypeScript:class:Unrelated",
+            NodeKind::Class,
+            "Unrelated",
+            "Unrelated",
+            Language::TypeScript,
+        );
+
+        let deps = CrossLanguageDependencies::detect(&[java_node], &[ts_node]);
+        // Reference resolves to nothing → no cross-language dependency produced.
+        assert!(deps.is_empty());
+    }
+
     // Test different ReferenceKind types in DOT output


### PR DESCRIPTION
## Summary

- Add `test_resolve_against_name_map_target_missing_from_name_map` in `cross_lang_tests_part3.rs`
- Drives an unresolved reference whose target name exists nowhere in the node set
- Exercises the `let Some(target_ids) = name_map.get(target_name) else { continue }` fall-through at `cross_language_dependencies_resolution.rs:57`, closing one of the three remaining uncovered lines in `resolve_against_name_map`
- No production changes

## Test plan

- [x] `cargo test --lib -- test_resolve_against_name_map_target_missing_from_name_map` passes
- [ ] `ci/coverage` gate passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)