### PR TITLE
test(models): cover deserialize_phases expecting() path (PMAT-628)

### DIFF
--- a/src/models/roadmap_phases_tests.rs
+++ b/src/models/roadmap_phases_tests.rs
@@ -120,4 +120,24 @@ phases:
             "got: {err}"
         );
     }
+
+    /// Exercise `PhasesVisitor::expecting` by feeding a non-sequence value.
+    /// serde_yaml_ng calls the visitor's `expecting` when reporting the
+    /// type mismatch, so the resulting error message must reference the
+    /// description returned by that method.
+    #[test]
+    fn test_phases_non_sequence_triggers_expecting() {
+        let yaml = "\
+id: T-1
+title: t
+status: planned
+phases:
+  not_a_sequence: 1
+";
+        let err = parse_item(yaml).unwrap_err().to_string();
+        assert!(
+            err.contains("sequence of Phase structs"),
+            "expected `expecting()` message in error; got: {err}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Add `test_phases_non_sequence_triggers_expecting` in `roadmap_phases_tests.rs`
- Feeds YAML where `phases` is a mapping (not a sequence); serde_yaml_ng calls `PhasesVisitor::expecting` when reporting the type mismatch
- Error string contains "sequence of Phase structs" — exercising the `expecting` method at `roadmap_types.rs:216-218` that existing tests skip
- No production changes

## Test plan

- [x] `cargo test --lib -- test_phases_non_sequence_triggers_expecting` passes
- [ ] `ci/coverage` gate passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)