### PR TITLE
test(PMAT-628): cover PmatYamlConfig load/save paths

### DIFF
--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -3197,3 +3197,19 @@ roadmap:
   estimated_effort: null
   labels: []
   notes: null
+- id: PMAT-628
+  github_issue: null
+  item_type: task
+  title: 'Coverage: ComplyConfig load/save roundtrip'
+  status: planned
+  priority: medium
+  assigned_to: null
+  created: 2026-04-21T18:00:25Z
+  updated: 2026-04-21T18:00:25Z
+  spec: null
+  acceptance_criteria: []
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels: []
+  notes: null

--- a/src/models/comply_config_tests.rs
+++ b/src/models/comply_config_tests.rs
@@ -315,4 +315,56 @@ work: {}
             );
         }
     }
+
+    #[test]
+    fn test_save_and_load_roundtrip() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let cfg = PmatYamlConfig::default();
+
+        cfg.save(temp_dir.path()).unwrap();
+
+        let config_path = temp_dir.path().join(".pmat.yaml");
+        assert!(config_path.exists());
+
+        let loaded = PmatYamlConfig::load(temp_dir.path()).unwrap();
+        assert_eq!(
+            loaded.comply.thresholds.coverage,
+            cfg.comply.thresholds.coverage
+        );
+    }
+
+    #[test]
+    fn test_load_from_path_missing_file_errors() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let missing = temp_dir.path().join("does-not-exist.yaml");
+
+        let err = PmatYamlConfig::load_from_path(&missing).unwrap_err();
+        assert!(matches!(err, ConfigError::IoError(_)));
+    }
+
+    #[test]
+    fn test_load_from_path_malformed_yaml_errors() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let path = temp_dir.path().join("bad.yaml");
+        // Non-mapping at top level fails PmatYamlConfig deserialization.
+        std::fs::write(&path, "not: valid: yaml: here\n  broken").unwrap();
+
+        let err = PmatYamlConfig::load_from_path(&path).unwrap_err();
+        assert!(matches!(err, ConfigError::ParseError(_)));
+    }
+
+    #[test]
+    fn test_load_prefers_pmat_yml_when_pmat_yaml_missing() {
+        // Covers the `.pmat.yml` fallback branch in load().
+        let temp_dir = tempfile::tempdir().unwrap();
+        let yml_path = temp_dir.path().join(".pmat.yml");
+        let cfg = PmatYamlConfig::default();
+        std::fs::write(&yml_path, serde_yaml_ng::to_string(&cfg).unwrap()).unwrap();
+
+        let loaded = PmatYamlConfig::load(temp_dir.path()).unwrap();
+        assert_eq!(
+            loaded.comply.thresholds.complexity,
+            cfg.comply.thresholds.complexity
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Adds 4 tests for previously 0%-covered roundtrip and error paths in `src/models/comply_config_impls.rs`:

- `test_save_and_load_roundtrip` — save() → load() happy path via `.pmat.yaml`
- `test_load_from_path_missing_file_errors` — IoError branch at `:87`
- `test_load_from_path_malformed_yaml_errors` — ParseError branch at `:89`
- `test_load_prefers_pmat_yml_when_pmat_yaml_missing` — `.pmat.yml` fallback in `load()`

## Test plan
- [x] `cargo test --lib` — 4/4 new tests pass
- [ ] CI `coverage/broad` lift on `comply_config_impls.rs`
- [ ] `ci / gate` green

Refs: [PMAT-628]

🤖 Generated with [Claude Code](https://claude.com/claude-code)