### PR TITLE
test(models): cover default_dead_code_weight serde default (PMAT-629)

### DIFF
--- a/src/models/tdg_tests.rs
+++ b/src/models/tdg_tests.rs
@@ -404,4 +404,28 @@ mod new_tests {
         assert_eq!(original.components, deserialized.components);
         assert_eq!(original.severity, deserialized.severity);
     }
+
+    /// Deserializing TDGConfig without `dead_code_weight` must invoke
+    /// `default_dead_code_weight()` (tdg_impls.rs:26) and yield 0.20.
+    #[test]
+    fn test_tdg_config_deserialize_omits_dead_code_weight_uses_default() {
+        let json = r#"{
+            "complexity_weight": 0.25,
+            "churn_weight": 0.20,
+            "coupling_weight": 0.15,
+            "domain_risk_weight": 0.10,
+            "duplication_weight": 0.10,
+            "critical_threshold": 2.5,
+            "warning_threshold": 1.5
+        }"#;
+
+        let config: TDGConfig = serde_json::from_str(json)
+            .expect("partial TDGConfig must deserialize via serde default");
+
+        assert!(
+            (config.dead_code_weight - 0.20).abs() < f64::EPSILON,
+            "missing dead_code_weight must fall back to default_dead_code_weight() = 0.20, got {}",
+            config.dead_code_weight
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- Adds a single test that deserializes a partial `TDGConfig` JSON (with `dead_code_weight` omitted) and asserts the field falls back to `default_dead_code_weight() = 0.20`.
- Covers `src/models/tdg_impls.rs:26` — a serde default helper that was 0% covered despite `TDGConfig` being exercised in other tests via direct struct construction.

## Why this gap existed
All existing `TDGConfig` tests build the struct directly, never going through serde deserialization with a missing `dead_code_weight` field. The `#[serde(default = "default_dead_code_weight")]` attribute on the field was therefore never fired.

## Test plan
- [x] `cargo test --lib -- test_tdg_config_deserialize_omits_dead_code_weight_uses_default` passes locally
- [x] `cargo test --lib -- tdg` full suite passes (1733 / 0 failed)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)