### PR TITLE
test(models): cover ComplexityBound Display + CacheComplexity default (PMAT-629)

### DIFF
--- a/src/models/complexity_bound_tests.rs
+++ b/src/models/complexity_bound_tests.rs
@@ -141,6 +141,28 @@ mod tests {
         assert_eq!(bound.class, unknown.class);
         assert_eq!(bound.confidence, unknown.confidence);
     }
+
+    /// Display for ComplexityBound (core.rs:280) formats as
+    /// "{notation} ({confidence}% confidence)".
+    #[test]
+    fn test_complexity_bound_display_formats_notation_and_confidence() {
+        let bound = ComplexityBound::linear().with_confidence(85);
+        let rendered = format!("{bound}");
+        assert!(
+            rendered.contains("85%") && rendered.contains("confidence"),
+            "Display must include confidence number + label, got {rendered:?}"
+        );
+        assert_eq!(rendered, format!("{} (85% confidence)", bound.notation()));
+    }
+
+    /// CacheComplexity::default() (core.rs:301) delegates to new(0, 1, Unknown).
+    #[test]
+    fn test_cache_complexity_default_is_zero_miss_one_penalty_unknown() {
+        let cache: CacheComplexity = Default::default();
+        assert_eq!(cache.hit_ratio, 0);
+        assert_eq!(cache.miss_penalty, 1);
+        assert_eq!(cache.working_set, BigOClass::Unknown);
+    }
 }
 
 #[cfg_attr(coverage_nightly, coverage(off))]


### PR DESCRIPTION
## Summary
Two new tests in \`src/models/complexity_bound_tests.rs\`:

- \`test_complexity_bound_display_formats_notation_and_confidence\` — covers \`Display for ComplexityBound\` at \`complexity_bound_core.rs:280\`. Asserts the \"{notation} ({confidence}% confidence)\" format.
- \`test_cache_complexity_default_is_zero_miss_one_penalty_unknown\` — covers \`CacheComplexity::default()\` at \`complexity_bound_core.rs:301\`. Asserts it delegates to \`new(0, 1, Unknown)\`.

## Why this gap existed
PR #400 (task #116) covered \`Display for BigOClass\`, \`Display for InputVariable\`, and \`growth_factor\` in \`complexity_bound_impls.rs\`, but missed these two sibling impls in \`complexity_bound_core.rs\`.

## Test plan
- [x] \`cargo test --lib -- test_complexity_bound_display test_cache_complexity_default_is_zero\` — 2 passed
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)