### PR TITLE
test(utils): cover PathValidator::get_valid_parent non-regular Invalid arm (PMAT-629)

### DIFF
--- a/src/utils/path_validator_tests.rs
+++ b/src/utils/path_validator_tests.rs
@@ -48,6 +48,21 @@ mod tests {
         Ok(())
     }
 
+    /// path_validator_checks.rs:151-154 — else arm (neither regular file nor directory)
+    /// returns Invalid. /dev/null is a character device: exists, but is_file() and
+    /// is_dir() both return false. Not tested by test_get_valid_parent (file) or
+    /// test_get_valid_parent_directory (dir) or test_get_valid_parent_nonexistent (NotFound).
+    #[cfg(unix)]
+    #[test]
+    fn test_get_valid_parent_on_non_regular_returns_invalid() {
+        let dev_null = Path::new("/dev/null");
+        let result = PathValidator::get_valid_parent(dev_null);
+        assert!(
+            matches!(result, Err(PathValidationError::Invalid { .. })),
+            "non-regular non-directory path must yield Invalid, got {result:?}"
+        );
+    }
+
     #[test]
     fn test_boolean_path_validators() -> Result<()> {
         let temp_dir = TempDir::new()?;


### PR DESCRIPTION
## Summary

Adds one targeted test for `PathValidator::get_valid_parent` in `src/utils/path_validator_checks.rs:151-154` — the `else` arm that returns `Invalid` when the path exists but is neither a regular file nor a directory.

Existing tests covered:
- `is_file` arm (\`test_get_valid_parent\`)
- \`is_dir\` arm (\`test_get_valid_parent_directory\`)
- \`NotFound\` (\`test_get_valid_parent_nonexistent\`)

Only the non-regular-path fall-through was uncov. Uses `/dev/null` under \`cfg(unix)\` — a character device that passes \`ensure_exists\` but fails both subsequent \`is_file\`/`is_dir` matches.

## Test plan

- [x] \`cargo test --lib test_get_valid_parent_on_non_regular_returns_invalid\` — passes
- [x] CI (gate + workspace-test) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)