### PR TITLE
test(entropy): cover deduplicate_violations keep-existing priority arm (PMAT-629)

### DIFF
--- a/src/entropy/violation_detector_detection_tests.rs
+++ b/src/entropy/violation_detector_detection_tests.rs
@@ -176,6 +176,54 @@ mod detection_tests {
         assert_eq!(deduped[0].priority_score, 10.0);
     }
 
+    /// violation_detector_impl.rs:312-314 — "keep existing" arm fires when the
+    /// newly-seen duplicate has priority_score <= existing. The prior test inserts
+    /// low-then-high (always replaces); this inserts high-then-low (always keeps).
+    #[test]
+    fn test_deduplicate_violations_keeps_existing_higher_priority() {
+        let detector = ViolationDetector::new(EntropyConfig::default());
+
+        let violations = vec![
+            ActionableViolation {
+                severity: Severity::High,
+                pattern: PatternSummary {
+                    pattern_type: PatternType::ErrorHandling,
+                    repetitions: 5,
+                    variation_score: 0.1,
+                    example_code: "code1".to_string(),
+                },
+                message: "higher_first".to_string(),
+                fix_suggestion: "fix1".to_string(),
+                estimated_loc_reduction: 20,
+                affected_files: vec![],
+                priority_score: 10.0, // Inserted first, must survive.
+            },
+            ActionableViolation {
+                severity: Severity::Medium,
+                pattern: PatternSummary {
+                    pattern_type: PatternType::ErrorHandling,
+                    repetitions: 5,
+                    variation_score: 0.1,
+                    example_code: "code1".to_string(), // Same dedupe key.
+                },
+                message: "lower_second".to_string(),
+                fix_suggestion: "fix2".to_string(),
+                estimated_loc_reduction: 10,
+                affected_files: vec![],
+                priority_score: 5.0, // Must be discarded via the keep-existing arm.
+            },
+        ];
+
+        let deduped = detector.deduplicate_violations(violations);
+
+        assert_eq!(deduped.len(), 1, "same key must collapse to one entry");
+        assert_eq!(
+            deduped[0].priority_score, 10.0,
+            "keep-existing arm must preserve the first (higher-priority) insert"
+        );
+        assert_eq!(deduped[0].message, "higher_first");
+    }
+
     #[test]
     fn test_violations_sorted_by_priority() {
         let config = EntropyConfig {


### PR DESCRIPTION
## Summary

`violation_detector_impl.rs:312-314` has a match guard \`Some(existing) if existing.priority_score >= violation.priority_score => { /* keep existing */ }\`. The prior \`test_deduplicate_violations\` inserts low-priority (5.0) first then high (10.0) — the guard is always false and only the replacement arm fires.

New test inserts high (10.0) first then low (5.0) with the same dedupe key (same pattern_type + repetitions + code length), forcing the keep-existing arm to execute.

## Test plan

- [x] \`cargo test --lib test_deduplicate_violations\` — 2 tests pass (1 existing + 1 new)
- [x] CI (gate + workspace-test) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)