### PR TITLE
test(models): cover ComplyConfig load_from_path error paths (PMAT-629)

### DIFF
--- a/src/models/comply_config_tests.rs
+++ b/src/models/comply_config_tests.rs
@@ -315,4 +315,34 @@ work: {}
             );
         }
     }
+
+    /// comply_config_impls.rs:87 — `std::fs::read_to_string(path).map_err(IoError)`
+    /// fires when the target path does not exist. Task #140 (roundtrip) only
+    /// exercises the success arm of read_to_string.
+    #[test]
+    fn test_load_from_path_returns_io_error_for_missing_file() {
+        let missing =
+            std::path::Path::new("/tmp/pmat_load_from_path_nonexistent_0xC0FFEE_xyz.yaml");
+        let result = PmatYamlConfig::load_from_path(missing);
+        match result {
+            Err(ConfigError::IoError(_)) => {}
+            other => panic!("expected IoError for missing path, got {other:?}"),
+        }
+    }
+
+    /// comply_config_impls.rs:89 — `serde_yaml_ng::from_str(...).map_err(ParseError)`
+    /// fires when the file content is syntactically invalid YAML.
+    #[test]
+    fn test_load_from_path_returns_parse_error_for_malformed_yaml() {
+        let tmp = tempfile::NamedTempFile::new().expect("create tempfile");
+        // Unbalanced braces + tab indent: not valid YAML.
+        std::fs::write(tmp.path(), "comply: {checks: [cb-050\n\tbroken: :")
+            .expect("write malformed yaml");
+
+        let result = PmatYamlConfig::load_from_path(tmp.path());
+        match result {
+            Err(ConfigError::ParseError(_)) => {}
+            other => panic!("expected ParseError for malformed yaml, got {other:?}"),
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- Covers `PmatYamlConfig::load_from_path` error arms at `src/models/comply_config_impls.rs:87-89`.
- Task #140 (load/save roundtrip) only exercised the success path.
- Adds two tests: missing-file triggers `ConfigError::IoError`, malformed YAML triggers `ConfigError::ParseError`.

## Test plan

- [x] `cargo test --lib -- test_load_from_path_returns_io_error_for_missing_file test_load_from_path_returns_parse_error_for_malformed_yaml` passes locally (2/2)
- [ ] CI `ci/gate` + `workspace-test` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)