### PR TITLE
test(maintenance): cover extract_metadata Invalid-format ParseError arm (PMAT-629)

### DIFF
--- a/src/maintenance/ticket_tests.rs
+++ b/src/maintenance/ticket_tests.rs
@@ -32,6 +32,31 @@ mod tests {
         assert!(result.is_err());
     }
 
+    /// ticket_parsing.rs:37-39 — `ok_or_else(|| ParseError("Invalid metadata
+    /// format for {key}"))` fires when a line starts with `key` but the
+    /// remainder does not start with ":". `.strip_prefix(key)` succeeds but
+    /// `.and_then(|s| s.strip_prefix(":"))` returns None.
+    #[test]
+    fn test_extract_metadata_parse_error_when_key_missing_colon() {
+        let lines: Vec<&str> = vec!["**Status**Active"];
+        let result = extract_metadata(&lines, "**Status**");
+        match result {
+            Err(TicketError::ParseError(msg)) => {
+                assert!(
+                    msg.contains("Invalid metadata format"),
+                    "ParseError message must mention the invalid format, got {msg:?}"
+                );
+                assert!(
+                    msg.contains("**Status**"),
+                    "ParseError message must echo the key, got {msg:?}"
+                );
+            }
+            other => panic!(
+                "expected ParseError for key-without-colon line, got {other:?}"
+            ),
+        }
+    }
+
     #[test]
     fn test_extract_section_missing_header() {
         // No matching header → empty content → MissingField arm.


### PR DESCRIPTION
## Summary

- Covers `extract_metadata` ParseError arm at `src/maintenance/ticket_parsing.rs:37-39`.
- Fires when a line starts with `key` but the remainder does not begin with \":\" (e.g. \`\"**Status**Active\"\`).
- Existing tests cover only the MissingField arm at line 43.

## Test plan

- [x] \`cargo test --lib -- test_extract_metadata_parse_error_when_key_missing_colon\` passes locally
- [ ] CI \`ci/gate\` + \`workspace-test\` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)