### PR TITLE
test(coverage): TypeScriptMapper + JavaScriptMapper map_source (PMAT-629)

### DIFF
--- a/src/ast/polyglot/language_mapper_tests_js_csharp_ruby.rs
+++ b/src/ast/polyglot/language_mapper_tests_js_csharp_ruby.rs
@@ -124,6 +124,49 @@
         assert!(result.is_ok());
     }
 
+    /// language_mapper_web.rs:124 — JavaScriptMapper::map_source.
+    /// Cannot use `#[tokio::test]`: map_source calls JavaScriptAstVisitor::
+    /// analyze_javascript_source which builds its own tokio Runtime::new(),
+    /// and nested runtimes panic. map_source body is sync-under-async
+    /// (no .await points), so a single noop-poll drives it to completion.
+    #[test]
+    fn test_javascript_mapper_map_source_executes() {
+        use std::future::Future;
+        use std::pin::Pin;
+        use std::task::{Context, Poll};
+
+        let mapper = JavaScriptMapper::new();
+        let source = "class Widget {}\nconst arrow = () => 42;\nfunction plain() {}\n";
+        let fut = mapper.map_source(source, Path::new("widget.js"));
+        let mut fut = Box::pin(fut);
+        let waker = futures_test::task::noop_waker();
+        let mut cx = Context::from_waker(&waker);
+        match Pin::as_mut(&mut fut).poll(&mut cx) {
+            Poll::Ready(_) => {}
+            Poll::Pending => panic!("map_source must complete in one poll"),
+        }
+    }
+
+    /// language_mapper_web.rs:124 — JavaScriptMapper::map_source with garbage
+    /// input. Drives the function body + match regardless of Ok/Err variant.
+    #[test]
+    fn test_javascript_mapper_map_source_invalid_source() {
+        use std::future::Future;
+        use std::pin::Pin;
+        use std::task::{Context, Poll};
+
+        let mapper = JavaScriptMapper::new();
+        let source = "@@@ function ((( { unterminated";
+        let fut = mapper.map_source(source, Path::new("bad.js"));
+        let mut fut = Box::pin(fut);
+        let waker = futures_test::task::noop_waker();
+        let mut cx = Context::from_waker(&waker);
+        match Pin::as_mut(&mut fut).poll(&mut cx) {
+            Poll::Ready(_) => {}
+            Poll::Pending => panic!("map_source must complete in one poll"),
+        }
+    }
+
     // CSharpMapper Tests
 
     #[test]

--- a/src/ast/polyglot/language_mapper_tests_scala_typescript.rs
+++ b/src/ast/polyglot/language_mapper_tests_scala_typescript.rs
@@ -250,3 +250,49 @@
         assert!(result.is_ok());
     }
 
+    /// language_mapper_web.rs:52 — TypeScriptMapper::map_source.
+    /// Cannot use `#[tokio::test]`: map_source calls TypeScriptAstVisitor::
+    /// analyze_typescript_source which builds its own tokio Runtime::new(),
+    /// and nested runtimes panic. map_source has no .await points (body is
+    /// fully sync under the async facade), so we drive it to completion with
+    /// a single poll using futures_test's noop_context from a plain #[test].
+    #[test]
+    fn test_typescript_mapper_map_source_executes() {
+        use std::future::Future;
+        use std::pin::Pin;
+        use std::task::{Context, Poll};
+
+        let mapper = TypeScriptMapper::new();
+        let source = "export interface User { name: string; }\nexport function greet() {}\n";
+        let fut = mapper.map_source(source, Path::new("user.ts"));
+        let mut fut = Box::pin(fut);
+        let waker = futures_test::task::noop_waker();
+        let mut cx = Context::from_waker(&waker);
+        // map_source body is sync-under-async — single poll completes it.
+        match Pin::as_mut(&mut fut).poll(&mut cx) {
+            Poll::Ready(_) => {}
+            Poll::Pending => panic!("map_source must complete in one poll — body has no .await"),
+        }
+    }
+
+    /// language_mapper_web.rs:52 — TypeScriptMapper::map_source with garbage
+    /// input. tree-sitter is error-tolerant so Err may or may not fire; this
+    /// test exists to drive the function entry + match regardless of variant.
+    #[test]
+    fn test_typescript_mapper_map_source_invalid_source() {
+        use std::future::Future;
+        use std::pin::Pin;
+        use std::task::{Context, Poll};
+
+        let mapper = TypeScriptMapper::new();
+        let source = "@@@ import from \"unterminated\n{ class ??? {";
+        let fut = mapper.map_source(source, Path::new("bad.ts"));
+        let mut fut = Box::pin(fut);
+        let waker = futures_test::task::noop_waker();
+        let mut cx = Context::from_waker(&waker);
+        match Pin::as_mut(&mut fut).poll(&mut cx) {
+            Poll::Ready(_) => {}
+            Poll::Pending => panic!("map_source must complete in one poll"),
+        }
+    }
+


### PR DESCRIPTION
## Summary
- Covers `language_mapper_web.rs:52` (TypeScriptMapper) and `:124` (JavaScriptMapper) — both `map_source` impls were at 0% coverage
- Existing tests cover Scala/C#/Ruby/Stub map_source but the TS/JS parser path was never exercised

## Why not `#[tokio::test]`
`TypeScriptAstVisitor::analyze_typescript_source` and `JavaScriptAstVisitor::analyze_javascript_source` each build their own `tokio::runtime::Runtime::new()` internally. Running inside `#[tokio::test]`'s ambient runtime panics with "Cannot start a runtime from within a runtime."

`map_source` bodies have no `.await` points (async is purely a trait-matching concern), so a single noop-waker poll drives the future to completion from a plain `#[test]` — no runtime needed.

## Test plan
- [x] `RUST_MIN_STACK=8388608 cargo test --lib -- test_typescript_mapper_map_source_executes test_typescript_mapper_map_source_invalid_source test_javascript_mapper_map_source_executes test_javascript_mapper_map_source_invalid_source` → 4 passed
- [ ] CI gate passes

PMAT-629

🤖 Generated with [Claude Code](https://claude.com/claude-code)