### PR TITLE
test(wasm): cover pop_comparison_i32 underflow + type-error arms (PMAT-629)

### DIFF
--- a/src/wasm/verifier_tests_stack.rs
+++ b/src/wasm/verifier_tests_stack.rs
@@ -118,6 +118,36 @@ mod stack_analyzer_tests {
         assert_eq!(stack.len(), 1);
     }
 
+    /// verifier_stack.rs:123-125 — `if stack.len() < 2` underflow arm of
+    /// pop_comparison_i32. Dispatch via any i32 comparison operator with
+    /// fewer than 2 operands on the stack.
+    #[test]
+    fn test_stack_analyzer_i32_eq_underflow() {
+        let analyzer = StackAnalyzer::new();
+        let mut stack = vec![ValType::I32]; // only one operand
+        let op = Operator::I32Eq;
+        let result = analyzer.update_stack(&mut stack, &op);
+        assert!(
+            result.is_err(),
+            "i32.eq with <2 operands must hit the stack-underflow arm"
+        );
+    }
+
+    /// verifier_stack.rs:126-128 — wrong-type arm of pop_comparison_i32.
+    /// Two operands are present but at least one isn't i32, so the
+    /// `pop != Some(I32)` branch returns the type-error.
+    #[test]
+    fn test_stack_analyzer_i32_lt_type_error() {
+        let analyzer = StackAnalyzer::new();
+        let mut stack = vec![ValType::I32, ValType::I64]; // second operand is wrong type
+        let op = Operator::I32LtS;
+        let result = analyzer.update_stack(&mut stack, &op);
+        assert!(
+            result.is_err(),
+            "i32.lt_s with an i64 operand must hit the `expected i32` type-error arm"
+        );
+    }
+
     #[test]
     fn test_stack_analyzer_local_get() {
         let analyzer = StackAnalyzer::new();


### PR DESCRIPTION
## Summary
- Prior `test_stack_analyzer_i32_eq_valid` only exercised the success path of `pop_comparison_i32`, leaving two uncovered lines in verifier_stack.rs:123-128
- New `test_stack_analyzer_i32_eq_underflow` triggers the `stack.len() < 2` arm (single-operand stack)
- New `test_stack_analyzer_i32_lt_type_error` triggers the `pop != Some(I32)` arm (i64 mixed in)

## Test plan
- [x] `cargo test --lib --features wasm-ast stack_analyzer` passes locally (24 passed)
- [ ] CI green + auto-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)