### PR TITLE
test(wasm): cover pop_binary_i64 underflow arm (PMAT-629)

### DIFF
--- a/src/wasm/verifier_tests_stack.rs
+++ b/src/wasm/verifier_tests_stack.rs
@@ -88,6 +88,22 @@ mod stack_analyzer_tests {
         assert_eq!(stack[0], ValType::I64);
     }
 
+    /// verifier_stack.rs:112-114 — `if stack.len() < 2` underflow arm of
+    /// pop_binary_i64. The i32 sibling already has an underflow test; only
+    /// the i64 happy path was covered before, leaving the underflow branch
+    /// at 88.9% file coverage. Dispatch via any i64 binary op with <2 operands.
+    #[test]
+    fn test_stack_analyzer_i64_add_underflow() {
+        let analyzer = StackAnalyzer::new();
+        let mut stack = vec![ValType::I64]; // only one operand
+        let op = Operator::I64Add;
+        let result = analyzer.update_stack(&mut stack, &op);
+        assert!(
+            result.is_err(),
+            "i64.add with <2 operands must hit pop_binary_i64 stack-underflow arm"
+        );
+    }
+
     #[test]
     fn test_stack_analyzer_i32_eqz_valid() {
         let analyzer = StackAnalyzer::new();


### PR DESCRIPTION
## Summary

Covers `src/wasm/verifier_stack.rs:112-114` — the `if stack.len() < 2` underflow arm of `pop_binary_i64`, which was the sole uncovered line keeping the function at 88.9%.

The i32 sibling (`pop_binary_i32`) already had `test_stack_analyzer_i32_add_underflow`; this mirrors the same pattern for i64 via `Operator::I64Add` with a single-operand stack.

## Test plan
- [x] `cargo test --lib --features wasm-ast i64_add_underflow` — 1 pass
- [ ] `ci / gate` green

Refs: [PMAT-629]

🤖 Generated with [Claude Code](https://claude.com/claude-code)