### PR TITLE
test(coverage): check_call_allocation None arm

### DIFF
--- a/src/quality/efficiency_enhanced_tests_part2.rs
+++ b/src/quality/efficiency_enhanced_tests_part2.rs
@@ -451,6 +451,29 @@ mod tests_part2 {
         assert!(!analyzer.allocations.is_empty());
     }
 
+    /// efficiency_enhanced_space_analysis.rs:70 — fall-through `None` of
+    /// check_call_allocation. Existing tests (with_vec / with_string_new /
+    /// multiple_allocations) only exercise the `contains("Vec")` and
+    /// `contains("String")` arms. HashMap::new() is a Path call whose
+    /// path_str contains neither, so the function must return None and
+    /// nothing gets pushed onto `analyzer.allocations`.
+    #[test]
+    fn test_space_complexity_non_alloc_call() {
+        let code = r#"
+            fn with_hashmap() {
+                let m = HashMap::new();
+            }
+        "#;
+        let ast = syn::parse_file(code).unwrap();
+        let mut analyzer = SpaceComplexityAnalyzer::new();
+        let _complexity = analyzer.analyze(&ast);
+        assert!(
+            analyzer.allocations.is_empty(),
+            "HashMap::new() path contains neither `Vec` nor `String` — \
+             check_call_allocation must return None and record no allocation"
+        );
+    }
+
     /// efficiency_enhanced_space_analysis.rs:87-89 — `else { None }` arm of
     /// check_macro_allocation. The `vec` arm is covered above; this exercises
     /// the fallthrough where the macro name is neither `"vec"` nor contains


### PR DESCRIPTION
## Summary
- Cover the fall-through `None` arm of `check_call_allocation` at `src/quality/efficiency_enhanced_space_analysis.rs:70`
- Existing tests exercise the `Vec`/`String` path arms; `HashMap::new()` is a Path call whose path_str contains neither, so it routes to the `None` arm and records no allocation

## Test plan
- [x] `RUST_MIN_STACK=8388608 cargo test --lib test_space_complexity_non_alloc` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)