### PR TITLE
test(coverage): parse_rust_symbols if-let-None fall-through arms

### DIFF
--- a/src/graph/builder_tests.rs
+++ b/src/graph/builder_tests.rs
@@ -254,6 +254,25 @@ use std::collections::HashMap;
         assert!(builder.parse_rust_symbols("").unwrap().is_empty());
     }
 
+    /// builder_symbol_parsing.rs:47/56/65 — the three `if let Some(name) = ...`
+    /// None arms in parse_rust_symbols. Lines starting with `pub fn `/`fn `/
+    /// `pub struct ` where only whitespace follows make extract_function_name
+    /// or extract_type_name return None, so the symbol is NOT pushed and the
+    /// branch falls through. Existing tests only exercise the Some path.
+    #[test]
+    fn test_parse_rust_symbols_extract_none_fallthrough() {
+        let builder = DependencyGraphBuilder::new();
+        // Each line trips its starts_with guard but extract_* returns None,
+        // so no symbols are produced.
+        let content = "pub fn \nfn \npub struct \n";
+        let symbols = builder.parse_rust_symbols(content).unwrap();
+        assert!(
+            symbols.is_empty(),
+            "keyword-only lines must hit the None arms of extract_function_name / \
+             extract_type_name and produce no symbols, got: {symbols:?}"
+        );
+    }
+
     /// Parse Python: `def` (public), `def _` (private), `class`, and skipped lines.
     #[test]
     fn test_parse_python_symbols_covers_all_branches() {


### PR DESCRIPTION
## Summary
- Cover the three `if let Some(name) = Self::extract_*` None arms in `parse_rust_symbols` at `src/graph/builder_symbol_parsing.rs:47/56/65`
- Existing tests only exercise the Some path; feeding `pub fn `/`fn `/`pub struct ` with only whitespace after the keyword makes `extract_function_name` / `extract_type_name` return None, hitting the fall-through

## Test plan
- [x] `RUST_MIN_STACK=8388608 cargo test --lib test_parse_rust_symbols` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)