### PR TITLE
test(coverage): EvidenceSummary EvoScoreTrajectory + CoverageDelta arms

### DIFF
--- a/src/models/debug_analysis_tests.rs
+++ b/src/models/debug_analysis_tests.rs
@@ -41,3 +41,73 @@
         assert_eq!(summary.complexity_violations, 1);
         assert_eq!(summary.satd_markers, 3);
     }
+
+    /// debug_analysis.rs:224-229 — the `EvidenceSource::EvoScoreTrajectory` arm
+    /// of process_evidence. CB-142 field, only populated by its own arm. Existing
+    /// tests only drive Complexity + SATD, so EvoScoreTrajectory stayed at 0%.
+    #[test]
+    fn test_evidence_summary_picks_up_evoscore_trajectory() {
+        let mut why = WhyIteration::new(1, "Why?".to_string(), "Hypothesis".to_string());
+        why.add_evidence(Evidence::new(
+            EvidenceSource::EvoScoreTrajectory,
+            PathBuf::from("src/evo.rs"),
+            "evoscore_delta".to_string(),
+            serde_json::json!({"evoscore": -1.75}),
+            "EvoScore is regressing".to_string(),
+        ));
+
+        let summary = EvidenceSummary::from_whys(&[why]);
+        assert!(
+            (summary.evoscore_trajectory - (-1.75)).abs() < f64::EPSILON,
+            "evoscore field on the nested object must be read via .get(\"evoscore\").as_f64(), \
+             got {}",
+            summary.evoscore_trajectory
+        );
+    }
+
+    /// debug_analysis.rs:231-236 — the `EvidenceSource::CoverageDelta` arm of
+    /// process_evidence. Positive delta = coverage increased; the value lives
+    /// under the nested "delta" key.
+    #[test]
+    fn test_evidence_summary_picks_up_coverage_delta() {
+        let mut why = WhyIteration::new(1, "Why?".to_string(), "Hypothesis".to_string());
+        why.add_evidence(Evidence::new(
+            EvidenceSource::CoverageDelta,
+            PathBuf::from("src/lib.rs"),
+            "line_coverage_delta".to_string(),
+            serde_json::json!({"delta": 3.25}),
+            "Coverage up 3.25%".to_string(),
+        ));
+
+        let summary = EvidenceSummary::from_whys(&[why]);
+        assert!(
+            (summary.coverage_delta - 3.25).abs() < f64::EPSILON,
+            "delta field must be read via .get(\"delta\").as_f64(), got {}",
+            summary.coverage_delta
+        );
+    }
+
+    /// Both the EvoScoreTrajectory and CoverageDelta arms also cover their
+    /// `.unwrap_or(0.0)` fallbacks when the expected nested key is missing.
+    #[test]
+    fn test_evidence_summary_evoscore_and_coverage_missing_keys_default_to_zero() {
+        let mut why = WhyIteration::new(1, "Why?".to_string(), "Hypothesis".to_string());
+        why.add_evidence(Evidence::new(
+            EvidenceSource::EvoScoreTrajectory,
+            PathBuf::from("x.rs"),
+            "evo".to_string(),
+            serde_json::json!({"wrong_key": 7.5}),
+            "noise".to_string(),
+        ));
+        why.add_evidence(Evidence::new(
+            EvidenceSource::CoverageDelta,
+            PathBuf::from("x.rs"),
+            "cov".to_string(),
+            serde_json::json!({"also_wrong": 9.9}),
+            "noise".to_string(),
+        ));
+
+        let summary = EvidenceSummary::from_whys(&[why]);
+        assert_eq!(summary.evoscore_trajectory, 0.0);
+        assert_eq!(summary.coverage_delta, 0.0);
+    }


### PR DESCRIPTION
## Summary

Cover `src/models/debug_analysis.rs:224-236` — the `EvoScoreTrajectory` and `CoverageDelta` arms of `EvidenceSummary::process_evidence`. Both are CB-142 fields, populated only by their own variant, and existing tests only drive `Complexity` + `SATD` — so these arms stayed at 0% coverage.

Three new tests:
- picks up `EvoScoreTrajectory`'s nested `evoscore` key
- picks up `CoverageDelta`'s nested `delta` key
- `unwrap_or(0.0)` fallback when the nested key is missing (covers both arms' else branches)

File coverage: 79.31% → 100% (10 missed lines → 0). Part of the 95% broad-coverage push (#101).

## Test plan

- [x] `RUST_MIN_STACK=8388608 cargo test --lib -- models::debug_analysis` — all 73 tests pass (3 new + 70 existing)
- [x] No production code changed; tests only
- [x] CI gate must pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)