### PR TITLE
test(coverage): explain.rs lookup + list_all + format_explanation

### DIFF
--- a/src/explain.rs
+++ b/src/explain.rs
@@ -300,3 +300,72 @@ pub static EXPLANATIONS: &[CheckExplanation] = &[
         see_also: &["TDG-C (Intermediate Target)", "pmat five-whys"],
     },
 ];
+
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_lookup_exact_match_case_insensitive() {
+        let results = lookup("cb-120");
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].id, "CB-120");
+    }
+
+    #[test]
+    fn test_lookup_prefix_match_returns_multiple() {
+        let results = lookup("CB-12");
+        assert!(results.len() >= 2, "CB-12 prefix should match CB-120, CB-121, CB-1200, ...");
+        for entry in &results {
+            assert!(entry.id.to_uppercase().starts_with("CB-12"));
+        }
+    }
+
+    #[test]
+    fn test_lookup_fuzzy_match_name_or_what() {
+        let results = lookup("lock poisoning");
+        assert!(
+            results.iter().any(|e| e.id == "CB-121"),
+            "fuzzy match on 'lock poisoning' should find CB-121"
+        );
+    }
+
+    #[test]
+    fn test_lookup_no_match_returns_empty() {
+        let results = lookup("totally-nonexistent-pattern-xyzzy");
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_list_all_groups_by_domain() {
+        let groups = list_all();
+        assert!(!groups.is_empty(), "list_all should return at least one domain");
+        let labels: Vec<_> = groups.iter().map(|(label, _)| *label).collect();
+        assert!(labels.contains(&"Compliance (CB-xxx)"));
+        assert!(labels.contains(&"TDG Grades"));
+        for (_, entries) in &groups {
+            assert!(!entries.is_empty(), "domains with zero matches must be filtered out");
+        }
+    }
+
+    #[test]
+    fn test_format_explanation_contains_all_sections() {
+        let entry = lookup("CB-120").into_iter().next().unwrap();
+        let formatted = format_explanation(entry);
+        assert!(formatted.contains("CB-120"));
+        assert!(formatted.contains("What it checks"));
+        assert!(formatted.contains("Why it matters"));
+        assert!(formatted.contains("FAIL when"));
+        assert!(formatted.contains("How to fix"));
+        assert!(formatted.contains("See also"));
+    }
+
+    #[test]
+    fn test_format_explanation_omits_empty_sections() {
+        let entry = lookup("TDG-A+").into_iter().next().unwrap();
+        let formatted = format_explanation(entry);
+        assert!(formatted.contains("TDG-A+"));
+        assert!(!formatted.contains("FAIL when"));
+    }
+}


### PR DESCRIPTION
## Summary

Adds the first tests for `src/explain.rs` (previously 0/15 lines covered):

- `lookup` exact-match (line 26), prefix-match (line 35), fuzzy-match (lines 44-47), and no-match paths.
- `list_all` domain grouping (lines 66-76) — verifies non-empty filter and presence of Compliance/TDG Grades labels.
- `format_explanation` covering both the full-section and empty-section (no fail_when / no see_also) paths.

Part of Task #101 (95% coverage gate before v3.15.0 publish).

## Test plan

- [x] `RUST_MIN_STACK=8388608 cargo test --lib -- explain::` — 7 new tests pass (11 total across explain modules)
- [ ] CI gate + workspace-test green

🤖 Generated with [Claude Code](https://claude.com/claude-code)