### PR TITLE
test(coverage): re-enable c_cpp_tests module (Task #186)

### DIFF
--- a/src/ast/languages/c_cpp/c_cpp_tests.rs
+++ b/src/ast/languages/c_cpp/c_cpp_tests.rs
@@ -3,7 +3,7 @@
 #[cfg_attr(coverage_nightly, coverage(off))]
 #[cfg(test)]
 mod coverage_tests {
-    use super::c_cpp_strategy::{CStrategy, CppStrategy};
+    use super::super::c_cpp_strategy::{CStrategy, CppStrategy};
     use crate::ast::core::{
         AstDag, AstKind, ClassKind, FunctionKind, ImportKind, Language, NodeFlags, StmtKind,
         UnifiedAstNode,

--- a/src/ast/languages/c_cpp/mod.rs
+++ b/src/ast/languages/c_cpp/mod.rs
@@ -4,10 +4,9 @@
 //! Split into parts for CB-040 compliance.
 
 mod c_cpp_strategy;
-// TEMPORARILY DISABLED: File splitting broke syntax (missing c_cpp_strategy import path)
-#[cfg(all(test, feature = "broken-tests"))]
+#[cfg(test)]
 mod c_cpp_tests;
-#[cfg(all(test, feature = "broken-tests"))]
+#[cfg(all(test, feature = "c-ast", feature = "broken-tests"))]
 mod c_cpp_tests_feature;
 mod c_cpp_visitor;
 


### PR DESCRIPTION
## Summary

Re-enables the `c_cpp_tests` module that was gated behind `feature = "broken-tests"`. The mod.rs comment said *"TEMPORARILY DISABLED: File splitting broke syntax (missing c_cpp_strategy import path)"* — this is the one-line fix that was needed.

- Remove `feature = "broken-tests"` gate on `mod c_cpp_tests`
- Fix `super::c_cpp_strategy` → `super::super::c_cpp_strategy` (tests live inside a nested `mod coverage_tests`, so one extra `super` was needed)
- Leaves `c_cpp_tests_feature` still gated (references private methods that were refactored away — would need a larger rewrite)

Enables 35 existing tests covering `CStrategy` and `CppStrategy`: `new`, `default`, `can_parse`, `extract_imports/functions/types`, `calculate_complexity`.

## Test plan

- [x] `RUST_MIN_STACK=8388608 cargo test --lib -- c_cpp` — 55 passed
- [x] Pre-commit hooks pass (TDG baseline updated, avg 95.6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)