### PR TITLE
test(coverage): CognitiveVisitor visit_expr_while (Task #187)

### DIFF
--- a/src/quality/complexity.rs
+++ b/src/quality/complexity.rs
@@ -333,6 +333,31 @@ mod coverage_tests {
     }
 
     #[test]
+    fn test_calculate_cognitive_with_while() {
+        let analyzer = ComplexityAnalyzer::new();
+        let code = "fn with_while() { while true { } }";
+        let ast = syn::parse_file(code).unwrap();
+        let cognitive = analyzer.calculate_cognitive(&ast);
+        assert_eq!(cognitive, 1); // +1 for while at nesting 0
+    }
+
+    #[test]
+    fn test_calculate_cognitive_with_nested_while() {
+        let analyzer = ComplexityAnalyzer::new();
+        let code = r#"
+            fn nested_while() {
+                while true {
+                    while false { }
+                }
+            }
+        "#;
+        let ast = syn::parse_file(code).unwrap();
+        let cognitive = analyzer.calculate_cognitive(&ast);
+        // outer while = 1, inner while = 1 + nesting_depth(1) = 2, total = 3
+        assert_eq!(cognitive, 3);
+    }
+
+    #[test]
     fn test_analyze_string_success() {
         let analyzer = ComplexityAnalyzer::new();
         let code = "fn test() { if true { } }";


### PR DESCRIPTION
## Summary

`CognitiveVisitor::visit_expr_while` (src/quality/complexity.rs:175-180) was the only control-flow visitor method in the cognitive pass without a direct test. Existing tests covered `while` only for cyclomatic, and cognitive only for `if`/`break`/`continue`/`for`.

- Adds `test_calculate_cognitive_with_while` — flat `while` at nesting 0 → cognitive = 1
- Adds `test_calculate_cognitive_with_nested_while` — outer while = 1, inner while = 1 + nesting_depth(1) = 2, total = 3

## Test plan

- [x] \`RUST_MIN_STACK=8388608 cargo test --lib -- quality::complexity\` — 29 passed
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)