### PR TITLE
test(coverage): TypeScript/JavaScript Default impl + control-flow branch (Task #188)

### DIFF
--- a/src/ast/languages/typescript/tests.rs
+++ b/src/ast/languages/typescript/tests.rs
@@ -869,6 +869,39 @@ mod tests {
         assert!(imports.is_empty(), "Empty dag should have no imports");
     }
 
+    #[test]
+    fn test_typescript_strategy_default_impl() {
+        let strategy = <TypeScriptStrategy as Default>::default();
+        assert_eq!(strategy.language(), Language::TypeScript);
+    }
+
+    #[test]
+    fn test_javascript_strategy_default_impl() {
+        let strategy = <JavaScriptStrategy as Default>::default();
+        assert_eq!(strategy.language(), Language::JavaScript);
+    }
+
+    #[test]
+    fn test_typescript_complexity_counts_control_flow_flagged_nodes() {
+        use crate::ast::core::{AstKind, StmtKind, UnifiedAstNode};
+        let strategy = TypeScriptStrategy::new();
+        let mut dag = AstDag::new();
+
+        let mut if_node =
+            UnifiedAstNode::new(AstKind::Statement(StmtKind::If), Language::TypeScript);
+        if_node.flags.set(NodeFlags::CONTROL_FLOW);
+        dag.add_node(if_node);
+
+        let mut while_node =
+            UnifiedAstNode::new(AstKind::Statement(StmtKind::While), Language::TypeScript);
+        while_node.flags.set(NodeFlags::CONTROL_FLOW);
+        dag.add_node(while_node);
+
+        let (cyclomatic, cognitive) = strategy.calculate_complexity(&dag);
+        assert_eq!(cyclomatic, 3, "base 1 + 2 CONTROL_FLOW nodes");
+        assert_eq!(cognitive, 2, "1 per CONTROL_FLOW node");
+    }
+
     // ==================== File Extension Tests ====================
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Closes three uncovered lines in TypeScript/JavaScript AST strategies:

- **TypeScriptStrategy::default** (`strategy.rs:23-27`) — existing `test_typescript_strategy_default` constructed the unit struct directly (`TypeScriptStrategy`) rather than via `Default::default()`, so the impl body was never exercised. New test calls `<T as Default>::default()`.
- **JavaScriptStrategy::default** (`javascript.rs:22-26`) — same gap for the JS variant.
- **calculate_complexity CONTROL_FLOW branch** (`strategy.rs:148-151`) — unreachable from parse tests because the TypeScript tree-sitter visitor doesn't set `NodeFlags::CONTROL_FLOW` on emitted nodes. New test manually constructs an `AstDag` with two CONTROL_FLOW-flagged nodes to drive that branch.

## Test plan

- [x] `RUST_MIN_STACK=8388608 cargo test --lib -- ast::languages::typescript` — 60 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)