### PR TITLE
test(coverage): parse_vmrss_kb private helper

### DIFF
--- a/src/test_performance_unit_tests.rs
+++ b/src/test_performance_unit_tests.rs
@@ -149,6 +149,49 @@ mod tests {
         assert!(diff < 100); // Within 100MB variance
     }
 
+    // ============ parse_vmrss_kb Tests ============
+
+    #[test]
+    fn test_parse_vmrss_kb_real_status_format() {
+        let status = "Name:\tpmat\n\
+                      VmPeak:\t  123456 kB\n\
+                      VmSize:\t  100000 kB\n\
+                      VmRSS:\t    8192 kB\n\
+                      VmData:\t   50000 kB\n";
+        assert_eq!(parse_vmrss_kb(status), Some(8192));
+    }
+
+    #[test]
+    fn test_parse_vmrss_kb_missing_line() {
+        let status = "Name:\tpmat\nVmSize:\t  100000 kB\n";
+        assert_eq!(parse_vmrss_kb(status), None);
+    }
+
+    #[test]
+    fn test_parse_vmrss_kb_empty() {
+        assert_eq!(parse_vmrss_kb(""), None);
+    }
+
+    #[test]
+    fn test_parse_vmrss_kb_non_numeric_value() {
+        let status = "VmRSS:\tnot_a_number kB\n";
+        assert_eq!(parse_vmrss_kb(status), None);
+    }
+
+    #[test]
+    fn test_parse_vmrss_kb_prefix_match_not_exact() {
+        // Line must *start* with "VmRSS:" — a line containing it elsewhere is ignored.
+        let status = "Comment: VmRSS: 9999 kB\nVmRSS:\t  4096 kB\n";
+        assert_eq!(parse_vmrss_kb(status), Some(4096));
+    }
+
+    #[test]
+    fn test_parse_vmrss_kb_no_whitespace_fields() {
+        // Only "VmRSS:" with no second whitespace-separated token → nth(1) is None.
+        let status = "VmRSS:\n";
+        assert_eq!(parse_vmrss_kb(status), None);
+    }
+
     // ============ PerformanceTargets Field Tests ============
 
     #[test]


### PR DESCRIPTION
## Summary
Adds six unit tests for the private `parse_vmrss_kb` helper in `test_performance_suite.rs:267-273` — a pure string parser that extracts VmRSS kilobytes from a Linux `/proc/self/status` text blob.

Covers:
- real multi-line status with VmRSS present → `Some(kb)`
- missing VmRSS line → `None`
- empty string → `None`
- non-numeric kB value → `None`
- prefix-not-exact line ignored (`starts_with` anchors correctly)
- VmRSS with no whitespace fields → `None`

## Test plan
- [x] `cargo test --lib -- test_performance parse_vmrss_kb` — 6/6 passed
- [x] 78 tests total in `test_performance::tests`, 0 failures

Towards Task #101 (95% coverage gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)