### PR TITLE
test(coverage): run_pre_commit_checks !all_passed println arm

### DIFF
--- a/src/quality/git_hooks_tests.rs
+++ b/src/quality/git_hooks_tests.rs
@@ -304,4 +304,78 @@ mod tests {
 
         assert_eq!(checker.cache.len(), 2);
     }
+
+    /// git_hooks_validate.rs:44-51 — the `!all_passed` println! arm of
+    /// `run_pre_commit_checks`. Existing `test_run_pre_commit_checks`
+    /// just discards the result with `let _ =` and, because no git repo
+    /// exists under the tempdir, `validate_staged_files` returns an empty
+    /// `reports` vec → `all_passed` is vacuously true → the `if` at line
+    /// 44 never fires. Here we build a real git repo with a staged `.rs`
+    /// file containing a `TODO` word — `satd_tolerance: 0` in
+    /// `QualityThresholds::default()` guarantees `validate_module`
+    /// returns `Err(SatdDetected)`, forcing `report.passed = false` and
+    /// exercising the println! block.
+    ///
+    /// serial_test::serial because `validate_staged_files` shells out to
+    /// `git diff --cached` against the current working directory rather
+    /// than `self.repo_path` — concurrent tests changing CWD would race.
+    #[test]
+    #[serial_test::serial]
+    fn test_run_pre_commit_checks_prints_violations_and_returns_false() {
+        use std::process::Command;
+
+        let temp_dir = TempDir::new().unwrap();
+        let repo = temp_dir.path();
+
+        let git_init = Command::new("git")
+            .arg("init")
+            .arg("--quiet")
+            .current_dir(repo)
+            .status()
+            .expect("git init must run");
+        assert!(git_init.success(), "git init failed");
+
+        // Minimum config so `git add` doesn't refuse on fresh repos that
+        // require user.name/email (some CI runners).
+        for (k, v) in [("user.email", "t@t"), ("user.name", "t"), ("commit.gpgsign", "false")] {
+            Command::new("git")
+                .args(["config", k, v])
+                .current_dir(repo)
+                .status()
+                .expect("git config must run");
+        }
+
+        // Valid Rust AST + SATD TODO marker.  syn::parse_file succeeds,
+        // SatdDetector counts 1 `\bTODO\b`, exceeds satd_tolerance=0.
+        let rs_file = repo.join("offender.rs");
+        fs::write(&rs_file, "// TODO: resolve\nfn main() {}\n").unwrap();
+
+        let add = Command::new("git")
+            .args(["add", "offender.rs"])
+            .current_dir(repo)
+            .status()
+            .expect("git add must run");
+        assert!(add.success(), "git add failed");
+
+        // CWD guard: validate_staged_files uses `git diff --cached` against
+        // the *process* cwd, not self.repo_path. Capture original CWD and
+        // restore it even on assertion failure.
+        struct CwdGuard(PathBuf);
+        impl Drop for CwdGuard {
+            fn drop(&mut self) {
+                let _ = std::env::set_current_dir(&self.0);
+            }
+        }
+        let _g = CwdGuard(std::env::current_dir().unwrap());
+        std::env::set_current_dir(repo).unwrap();
+
+        let manager = GitHookManager::new(repo);
+        let result = manager
+            .run_pre_commit_checks()
+            .expect("pre-commit must not propagate — the SATD path returns Ok(false)");
+        assert!(
+            !result,
+            "staged .rs with a TODO must fail satd_tolerance=0 → Ok(false) via the !all_passed println! arm"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Cover the `if !all_passed { println!... }` arm of
`GitHookManager::run_pre_commit_checks` at `src/quality/git_hooks_validate.rs:44-51`.

The existing `test_run_pre_commit_checks` (git_hooks_tests.rs:271-277) just
discards the result with `let _ =` against a tempdir with no git repo, so
`validate_staged_files` returns an empty `reports` vec → `all_passed` is
vacuously `true` → the `if` at line 44 never fires.

## Fix

Build a real tempdir git repo, stage a `.rs` file containing a `TODO` word
(SatdDetector at `src/quality/satd.rs:10` matches `\bTODO\b`;
`satd_tolerance: 0` in `QualityThresholds::default` at
`src/quality/gate.rs:60` guarantees `validate_module` returns
`QualityViolation::SatdDetected`), chdir into it under
`#[serial_test::serial]`, and assert `run_pre_commit_checks` returns
`Ok(false)`. A `CwdGuard` restores the original working directory on drop.

`serial_test::serial` is mandatory because `validate_staged_files` shells
out to `git diff --cached` against the process CWD rather than
`self.repo_path` — concurrent tests that manipulate CWD would race.

## Verification

`❌ Quality gate violations found:` banner in the `--nocapture` output
confirms the println! block runs.

```
running 1 test
❌ Quality gate violations found:
  File: offender.rs
    - SATD detected: 1 occurrences of ["TODO"] at "offender.rs"
test quality::git_hooks::tests::test_run_pre_commit_checks_prints_violations_and_returns_false ... ok

test result: ok. 1 passed; 0 failed
```

All 24 git_hooks tests still pass.

## Test plan
- [x] `cargo test --lib -- quality::git_hooks` — 24/24 pass
- [x] Assertion on `Ok(false)` proves the !all_passed branch executed
- [x] `--nocapture` confirms the println! violation list fired

🤖 Generated with [Claude Code](https://claude.com/claude-code)