### PR TITLE
test(coverage): PmatYamlConfig::save roundtrip

### DIFF
--- a/src/models/comply_config_tests.rs
+++ b/src/models/comply_config_tests.rs
@@ -345,4 +345,33 @@ work: {}
             other => panic!("expected ParseError for malformed yaml, got {other:?}"),
         }
     }
+
+    /// comply_config_impls.rs:94 — PmatYamlConfig::save roundtrip. Prior
+    /// coverage work only exercised load/load_from_path; the serialize +
+    /// fs::write arms at lines 97-99 were never hit. Verify the file lands
+    /// at `.pmat.yaml`, contains YAML, and round-trips back via load().
+    #[test]
+    fn test_save_roundtrip_writes_pmat_yaml_and_reloads() {
+        let tmp = tempfile::TempDir::new().expect("create tempdir");
+        let config = PmatYamlConfig::default();
+
+        config.save(tmp.path()).expect("save must succeed");
+
+        let written = tmp.path().join(".pmat.yaml");
+        assert!(written.exists(), ".pmat.yaml must exist after save");
+
+        let content = std::fs::read_to_string(&written).expect("read back");
+        assert!(!content.is_empty(), "saved YAML must not be empty");
+        assert!(
+            content.contains("comply:"),
+            "serialized YAML must include comply section, got: {content}"
+        );
+
+        let reloaded = PmatYamlConfig::load(tmp.path()).expect("load must succeed");
+        assert_eq!(
+            reloaded.comply.thresholds.coverage,
+            config.comply.thresholds.coverage,
+            "roundtrip must preserve coverage threshold"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- `comply_config_impls.rs:94` `PmatYamlConfig::save` was 0% covered — the `serde_yaml_ng::to_string` + `std::fs::write` arms at lines 97-99 had no test
- Prior task #140 ("ComplyConfig load/save roundtrip") only exercised `load_from_path`; `save` was never called
- Added `test_save_roundtrip_writes_pmat_yaml_and_reloads`: save to tempdir → assert `.pmat.yaml` exists with non-empty YAML → reload via `load()` → assert coverage threshold survives

## Test plan
- [x] `RUST_MIN_STACK=8388608 cargo test --lib -- comply_config` — 24/24 pass