### PR TITLE
test(polyglot): cover TypeScriptMapper/JavaScriptMapper map_source Ok arm

### DIFF
--- a/src/ast/polyglot/language_mapper_tests_js_csharp_ruby.rs
+++ b/src/ast/polyglot/language_mapper_tests_js_csharp_ruby.rs
@@ -124,6 +124,23 @@
         assert!(result.is_ok());
     }
 
+    /// language_mapper_web.rs:124 — JavaScriptMapper::map_source.
+    /// Prior tasks #139 / #164 claimed coverage but actually only exercised
+    /// map_file + process_javascript_specific — the async map_source entry
+    /// was 0% until now. Under default features (javascript-ast enabled),
+    /// analyze_javascript_source creates its own tokio Runtime and block_on's,
+    /// so this test uses futures::executor::block_on instead of #[tokio::test]
+    /// to avoid nested-runtime panic.
+    #[test]
+    fn test_javascript_mapper_map_source_ok_arm() {
+        let result = futures::executor::block_on(async {
+            let mapper = JavaScriptMapper::new();
+            let source = "class Greeter { constructor(name) { this.name = name; } }";
+            mapper.map_source(source, Path::new("greeter.js")).await
+        });
+        assert!(result.is_ok(), "map_source must return Ok, got {result:?}");
+    }
+
     // CSharpMapper Tests
 
     #[test]

--- a/src/ast/polyglot/language_mapper_tests_scala_typescript.rs
+++ b/src/ast/polyglot/language_mapper_tests_scala_typescript.rs
@@ -250,3 +250,20 @@
         assert!(result.is_ok());
     }
 
+    /// language_mapper_web.rs:52 — TypeScriptMapper::map_source.
+    /// Prior tasks #139 / #164 claimed coverage but actually only exercised
+    /// map_file + process_typescript_specific — the async map_source entry
+    /// was 0% until now. Under default features (typescript-ast enabled),
+    /// analyze_typescript_source creates its own tokio Runtime and block_on's,
+    /// so this test uses futures::executor::block_on instead of #[tokio::test]
+    /// to avoid nested-runtime panic.
+    #[test]
+    fn test_typescript_mapper_map_source_ok_arm() {
+        let result = futures::executor::block_on(async {
+            let mapper = TypeScriptMapper::new();
+            let source = "interface User { id: number; name: string; }";
+            mapper.map_source(source, Path::new("user.ts")).await
+        });
+        assert!(result.is_ok(), "map_source must return Ok, got {result:?}");
+    }
+


### PR DESCRIPTION
## Summary
- Adds direct coverage for `TypeScriptMapper::map_source` (language_mapper_web.rs:52) and `JavaScriptMapper::map_source` (language_mapper_web.rs:124).
- Both were reported as 0% by `pmat query --coverage-gaps` despite tasks #139/#164 being marked completed — those prior tasks only exercised `map_file` + `process_*_specific`, never the async `map_source` entry point.
- Uses `futures::executor::block_on` with `#[test]` (not `#[tokio::test]`) because under default features `analyze_typescript_source`/`analyze_javascript_source` internally call `tokio::runtime::Runtime::new().block_on(...)`, which panics with "Cannot start a runtime from within a runtime" if run inside `#[tokio::test]`.

## Test plan
- [x] `RUST_MIN_STACK=8388608 cargo test --lib -- map_source_ok_arm` → 2 passed
- [x] Both functions now hit the `Ok(items)` arm of `map_source`

🤖 Generated with [Claude Code](https://claude.com/claude-code)