### PR TITLE
ci: disable sccache — flaky OUT_DIR errors wedging queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,16 @@ jobs:
     uses: paiml/.github/.github/workflows/sovereign-ci.yml@main
     with:
       repo: ${{ github.event.repository.name }}
+      # 2026-04-22: re-disable after #386 restore. Runner image's
+      # rustc-sccache shim is triggering intermittent OUT_DIR failures
+      # on native C/asm deps (aws-lc-sys, zstd-sys) and "could not
+      # compile" errors on tokio/regex-automata. Master run 24779319051
+      # happened to pass but 17+ open PRs are wedged with BLOCKED state.
+      # Fallback `cargo clippy -p paiml-mcp-agent-toolkit` also always
+      # fails because our crate is named `pmat` (not repo name), so the
+      # sovereign-ci retry path can never succeed once the primary trips.
+      # Re-enable (delete this line) after upstream shim stabilizes.
+      enable_sccache: false
     secrets: inherit
 
   # Top-level gate satisfies the org ruleset "Green Main" which requires a


### PR DESCRIPTION
## Summary

- Re-disables sccache in our ci.yml after #386's restore proved unstable.
- Same narrow fix as #377 — runner image's `rustc-sccache` shim is triggering intermittent `OUT_DIR: No such file or directory` failures on native deps (aws-lc-sys, zstd-sys) and "could not compile" errors on tokio/regex-automata.

## Why this matters right now

17+ open coverage PRs (plus my #477) are all in **BLOCKED** state with `ci / lint`, `ci / coverage`, `ci / test` red. Master happened to land #476 when sccache was cooperating, but every feature PR since is failing intermittently on the same pattern.

The sovereign-ci fallback `cargo clippy -p paiml-mcp-agent-toolkit` **always fails** for us because our crate is named `pmat`, not the repo name — so once the primary clippy/build trips on the sccache shim, no retry path can succeed. That makes every transient sccache glitch a hard queue-stop.

## Test plan

- [ ] Merge and observe next round of PRs exit BLOCKED as their CI reruns
- [ ] Verify `ci / lint`, `ci / test`, `ci / coverage` all pass on a fresh PR against this branch
- [ ] Re-enable once upstream shim stabilizes in `sovereign-ci:stable` runner image (same cadence as #386 → this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)