### PR TITLE
test(coverage): scaffold/mod.rs private helpers (Phase 1)

### DIFF
--- a/src/scaffold/tests.rs
+++ b/src/scaffold/tests.rs
@@ -350,3 +350,192 @@ fn test_scaffold_wasm_installs_hooks() {
     assert!(hook_content.contains("cargo test"));
     assert!(hook_content.contains("wasm32-unknown-unknown"));
 }
+
+// Phase 1 coverage push (spec §5): scaffold/mod.rs private helpers.
+// These exercise the internal orchestration fns without CWD mutation,
+// which is why the pre-existing full-workflow tests are #[ignore]'d.
+
+#[test]
+fn test_scaffold_engine_default_delegates_to_new() {
+    // Default impl must yield an equivalent engine; validate_config on an
+    // identical config must agree between Default and new().
+    let engine_default: ScaffoldEngine = Default::default();
+    let engine_new = ScaffoldEngine::new().unwrap();
+    let config = ScaffoldConfig {
+        project_name: "ok-name".into(),
+        template_type: TemplateType::Library,
+        features: vec![],
+        quality_gates: QualityGateConfig::default(),
+    };
+    assert!(engine_default.validate_config(&config).is_ok());
+    assert!(engine_new.validate_config(&config).is_ok());
+}
+
+#[test]
+fn test_prepare_template_vars_has_required_keys() {
+    let engine = ScaffoldEngine::new().unwrap();
+    let config = ScaffoldConfig {
+        project_name: "my-scaffold".into(),
+        template_type: TemplateType::Library,
+        features: vec![],
+        quality_gates: QualityGateConfig::default(),
+    };
+    let vars = engine.prepare_template_vars(&config);
+    assert_eq!(vars.get("project_name").map(String::as_str), Some("my-scaffold"));
+    assert!(vars.contains_key("author"));
+    assert!(vars.get("description").unwrap().contains("my-scaffold"));
+    assert!(vars.contains_key("handler_name"));
+    assert!(vars.contains_key("handler_description"));
+}
+
+#[test]
+fn test_get_file_path_known_template_names() {
+    let engine = ScaffoldEngine::new().unwrap();
+    let base = std::path::Path::new("/tmp/proj");
+    let tt = TemplateType::Library;
+
+    assert_eq!(
+        engine.get_file_path(base, "pforge.yaml", &tt),
+        base.join("pforge.yaml")
+    );
+    assert_eq!(
+        engine.get_file_path(base, "Cargo.toml", &tt),
+        base.join("Cargo.toml")
+    );
+    assert_eq!(
+        engine.get_file_path(base, "Makefile", &tt),
+        base.join("Makefile")
+    );
+    assert_eq!(
+        engine.get_file_path(base, "README.md", &tt),
+        base.join("README.md")
+    );
+    assert_eq!(
+        engine.get_file_path(base, "handler.rs", &tt),
+        base.join("src/handlers/example.rs")
+    );
+    assert_eq!(
+        engine.get_file_path(base, "lib.rs", &tt),
+        base.join("src/lib.rs")
+    );
+    assert_eq!(
+        engine.get_file_path(base, "vfs.rs", &tt),
+        base.join("src/vfs.rs")
+    );
+}
+
+#[test]
+fn test_get_file_path_unknown_name_falls_through() {
+    let engine = ScaffoldEngine::new().unwrap();
+    let base = std::path::Path::new("/tmp/proj");
+    let tt = TemplateType::Library;
+    // Unknown template name falls through to project_dir.join(name).
+    assert_eq!(
+        engine.get_file_path(base, "CUSTOM.whatever", &tt),
+        base.join("CUSTOM.whatever")
+    );
+}
+
+#[test]
+fn test_get_template_registry_agent_returns_pforge() {
+    let engine = ScaffoldEngine::new().unwrap();
+    let tt = TemplateType::Agent {
+        based_on: AgentFramework::Pforge,
+    };
+    let reg = engine.get_template_registry(&tt);
+    // pforge registry lists the expected template set.
+    let names = reg.list();
+    assert!(
+        names.iter().any(|n| n == "pforge.yaml"),
+        "pforge registry must include pforge.yaml, got {names:?}"
+    );
+}
+
+#[test]
+fn test_get_template_registry_wasm_returns_wasm_templates() {
+    let engine = ScaffoldEngine::new().unwrap();
+    let tt = TemplateType::Wasm {
+        based_on: WasmFramework::WasmLabs,
+    };
+    let reg = engine.get_template_registry(&tt);
+    let names = reg.list();
+    assert!(
+        names.iter().any(|n| n == "lib.rs" || n == "Cargo.toml"),
+        "wasm registry must include lib.rs or Cargo.toml, got {names:?}"
+    );
+}
+
+#[test]
+fn test_get_template_registry_library_falls_through_to_empty() {
+    let engine = ScaffoldEngine::new().unwrap();
+    let tt = TemplateType::Library;
+    let reg = engine.get_template_registry(&tt);
+    // `_ => TemplateRegistry::new()` path — empty registry.
+    assert!(reg.list().is_empty());
+}
+
+#[test]
+fn test_get_template_registry_custom_falls_through_to_empty() {
+    let engine = ScaffoldEngine::new().unwrap();
+    let tt = TemplateType::Custom {
+        path: std::path::PathBuf::from("/tmp/custom"),
+    };
+    let reg = engine.get_template_registry(&tt);
+    assert!(reg.list().is_empty());
+}
+
+#[test]
+fn test_generate_files_writes_all_pforge_templates() {
+    let temp_dir = TempDir::new().unwrap();
+    let engine = ScaffoldEngine::new().unwrap();
+    let config = ScaffoldConfig {
+        project_name: "gen-test".into(),
+        template_type: TemplateType::Agent {
+            based_on: AgentFramework::Pforge,
+        },
+        features: vec![],
+        quality_gates: QualityGateConfig::default(),
+    };
+    // Pre-create structure that generate_files expects.
+    engine
+        .create_project_structure(temp_dir.path(), &config.template_type)
+        .unwrap();
+    let registry = engine.get_template_registry(&config.template_type);
+    let result = engine.generate_files(temp_dir.path(), &registry, &config);
+    assert!(result.is_ok(), "generate_files returned {:?}", result);
+    assert!(temp_dir.path().join("pforge.yaml").exists());
+    assert!(temp_dir.path().join("Cargo.toml").exists());
+    let cargo = std::fs::read_to_string(temp_dir.path().join("Cargo.toml")).unwrap();
+    assert!(cargo.contains("gen-test"));
+}
+
+#[test]
+fn test_install_hooks_writes_pre_commit_script() {
+    let temp_dir = TempDir::new().unwrap();
+    // install_hooks expects .git/hooks to exist.
+    std::fs::create_dir_all(temp_dir.path().join(".git/hooks")).unwrap();
+    let engine = ScaffoldEngine::new().unwrap();
+    let config = ScaffoldConfig {
+        project_name: "hook-unit".into(),
+        template_type: TemplateType::Agent {
+            based_on: AgentFramework::Pforge,
+        },
+        features: vec![],
+        quality_gates: QualityGateConfig::default(),
+    };
+    engine.install_hooks(temp_dir.path(), &config).unwrap();
+    let hook = temp_dir.path().join(".git/hooks/pre-commit");
+    assert!(hook.exists(), "pre-commit hook missing");
+    let body = std::fs::read_to_string(&hook).unwrap();
+    assert!(body.starts_with("#!/bin/bash"));
+}
+
+#[test]
+fn test_write_file_overwrites_existing_content() {
+    let temp_dir = TempDir::new().unwrap();
+    let engine = ScaffoldEngine::new().unwrap();
+    let path = temp_dir.path().join("overwrite.txt");
+    engine.write_file(&path, "first").unwrap();
+    engine.write_file(&path, "second").unwrap();
+    assert_eq!(std::fs::read_to_string(&path).unwrap(), "second");
+}


### PR DESCRIPTION
## Summary
- Adds 11 tests exercising private helpers in `src/scaffold/mod.rs` that were previously unreachable without `std::env::set_current_dir` mutation (the reason the pre-existing full-workflow tests are `#[ignore]`'d).
- Covers: `Default` impl, `prepare_template_vars`, `get_file_path` (all 7 known arms + fallthrough), `get_template_registry` (all 4 variants), `generate_files`, `install_hooks`, `write_file` overwrite.
- Phase 1 of `docs/specifications/improve-coverage-80-95.md`. `scaffold/mod.rs` was the cleanest actionable Phase 1 bullet at 27.12% baseline; other Phase 1 bullets (dead-code sweep, unskip cli_integration_tests, dispatch collapse) were confirmed dead ends in prior investigation.

## Test plan
- [x] `cargo test --lib --features all-languages -- scaffold::tests` — 42 passed, 0 failed, 5 ignored
- [ ] CI `gate` green
- [ ] Broad coverage moves upward (verify post-merge via `make coverage-broad`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)