### PR TITLE
test(coverage): Violation::to_op fall-through arm

### DIFF
--- a/src/models/refactor_tests_part2.rs
+++ b/src/models/refactor_tests_part2.rs
@@ -152,6 +152,43 @@
         }
     }
 
+    /// refactor_impls.rs:267-270 — Violation::to_op `_ =>` fall-through arm for
+    /// LongFunction / DeadCode / PoorNaming with suggested_fix=None. The three
+    /// explicit arms (HighComplexity, DeepNesting, SelfAdmittedTechDebt) are
+    /// tested above, but the three remaining variants land on the wildcard
+    /// that emits SimplifyExpression { expr: "complex", simplified: "simple" }.
+    /// Task #134 was marked complete but left the actual to_op() wildcard
+    /// untested — the state-machine test at line 349 uses HighComplexity.
+    #[test]
+    fn test_violation_to_op_fall_through_variants() {
+        for vtype in [
+            ViolationType::LongFunction,
+            ViolationType::DeadCode,
+            ViolationType::PoorNaming,
+        ] {
+            let violation = Violation {
+                violation_type: vtype,
+                location: Location {
+                    file: PathBuf::from("test.rs"),
+                    line: 1,
+                    column: 1,
+                },
+                severity: Severity::Medium,
+                description: "fall-through".to_string(),
+                suggested_fix: None,
+            };
+            match violation.to_op() {
+                RefactorOp::SimplifyExpression { expr, simplified } => {
+                    assert_eq!(expr, "complex");
+                    assert_eq!(simplified, "simple");
+                }
+                other => panic!(
+                    "fall-through arm must yield SimplifyExpression, got {other:?}"
+                ),
+            }
+        }
+    }
+
     // ========================================================================
     // SatdFix Tests
     // ========================================================================


### PR DESCRIPTION
## Summary
- Covers the `_ =>` wildcard in `Violation::to_op()` (refactor_impls.rs:267-270) for `LongFunction`, `DeadCode`, `PoorNaming` variants when `suggested_fix` is `None`.
- Task #134 was marked complete but tested the unwrap_or fallback in the state-machine `advance()` path, which uses `HighComplexity` (explicit arm) — the `to_op()` wildcard itself was untested.

## Why this was missed
`test_violation_to_op_*` covers HighComplexity, DeepNesting, SatdTechDebt, and the `suggested_fix = Some(...)` path. The three remaining variants (LongFunction/DeadCode/PoorNaming) with `suggested_fix = None` fall through to `SimplifyExpression { expr: "complex", simplified: "simple" }` and had no direct assertion.

## Test plan
- [x] `cargo test --lib test_violation_to_op` — 5/5 pass locally (including the new `test_violation_to_op_fall_through_variants`)
- [ ] CI `workspace-test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)