### PR TITLE
test(coverage): extract_duration open-paren + reversed-parens arms

### DIFF
--- a/src/maintenance/roadmap_tests.rs
+++ b/src/maintenance/roadmap_tests.rs
@@ -50,6 +50,26 @@ mod tests {
         assert_eq!(extract_duration("Sprint (2-3 days) - COMPLETE"), "2-3 days");
     }
 
+    /// roadmap_parsing.rs:83 — when `(` is present but `)` is missing, the
+    /// inner `if let Some(end)` is false and execution falls through to
+    /// `"unknown".to_string()`. Previously only the outer `(` absent path
+    /// covered this sentinel; this covers the inner-None branch.
+    #[test]
+    fn test_extract_duration_open_paren_no_close() {
+        assert_eq!(extract_duration("Sprint (2-3 days - no close"), "unknown");
+    }
+
+    /// roadmap_parsing.rs:80 — when `)` appears before `(`, the slice
+    /// `start+1..end` is an invalid range and `text.get(..)` returns None,
+    /// making `unwrap_or_default()` yield an empty string. This exercises
+    /// the defensive `unwrap_or_default` branch on the Option returned by
+    /// the slice accessor.
+    #[test]
+    fn test_extract_duration_reversed_parens_empty() {
+        // ')' at index 5, '(' at index 9 → get(10..5) is None.
+        assert_eq!(extract_duration("abc )xyz(inverted"), "");
+    }
+
     #[test]
     fn test_parse_quality_gate_none_when_no_prefix() {
         // No leading "- " means not a quality-gate line.


### PR DESCRIPTION
## Summary
- `extract_duration` (src/maintenance/roadmap_parsing.rs:77) has two uncovered branches not hit by the existing happy-path or \"no parens\" tests:
  1. **Open paren, no close**: `(` present but `)` absent — `if let Some(end)` is false; falls to `\"unknown\".to_string()` via the outer `(` Some arm (distinct from the outer `(` None path).
  2. **Reversed parens**: `)` before `(` — `get(start+1..end)` returns None for an invalid range; `unwrap_or_default()` returns empty string.

## Before / after
- Before: 87.5% cov, 1 uncov line at roadmap_parsing.rs:80 or :83 (per \`pmat query --coverage-gaps\`).
- After: both arms exercised.

## Test plan
- [x] \`cargo test --lib test_extract_duration\` — 4/4 pass locally.
- [ ] CI passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)