### PR TITLE
test(coverage): OperatorMatcher::matches CallIndirect arm

### DIFF
--- a/src/wasm/security_tests_matcher.rs
+++ b/src/wasm/security_tests_matcher.rs
@@ -88,6 +88,16 @@ mod coverage_tests_matcher {
     }
 
     #[test]
+    fn test_operator_matcher_call_indirect() {
+        let op = Operator::CallIndirect {
+            type_index: 0,
+            table_index: 0,
+        };
+        assert!(OperatorMatcher::CallIndirect.matches(&op));
+        assert!(!OperatorMatcher::Call.matches(&op));
+    }
+
+    #[test]
     fn test_operator_matcher_memory_growth() {
         assert!(OperatorMatcher::MemoryGrow.matches(&Operator::MemoryGrow { mem: 0 }));
         assert!(OperatorMatcher::MemorySize.matches(&Operator::MemorySize { mem: 0 }));


### PR DESCRIPTION
## Summary

Covers the `(M::CallIndirect, CallIndirect { .. }) => true` arm at `src/wasm/security_matcher.rs:40` — 1 uncov line. The existing `test_operator_matcher_control_flow` tests `BrIf`, `Br`, and `Call` but not `CallIndirect`.

Identified via `pmat query --coverage-gaps --rank-by impact --exclude-tests` (gap #47, `matches` at 96.9%).

Part of Phase 1 of `docs/specifications/improve-coverage-80-95.md` — broad coverage push toward 80%.

## Test plan

- [x] `cargo test --lib --features wasm-ast -- test_operator_matcher_call_indirect` passes
- [x] Pre-commit hooks green (TDG baseline, O(1) gates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)