### PR TITLE
test(coverage): Violation::to_op wildcard arm for LongFunction/DeadCode/PoorNaming

### DIFF
--- a/src/models/refactor_tests_part2.rs
+++ b/src/models/refactor_tests_part2.rs
@@ -152,6 +152,72 @@
         }
     }
 
+    #[test]
+    fn test_violation_to_op_long_function_wildcard() {
+        let violation = Violation {
+            violation_type: ViolationType::LongFunction,
+            location: Location {
+                file: PathBuf::from("test.rs"),
+                line: 10,
+                column: 1,
+            },
+            severity: Severity::Medium,
+            description: "Test".to_string(),
+            suggested_fix: None,
+        };
+
+        let op = violation.to_op();
+        match op {
+            RefactorOp::SimplifyExpression { expr, simplified } => {
+                assert_eq!(expr, "complex");
+                assert_eq!(simplified, "simple");
+            }
+            other => panic!("Expected SimplifyExpression for LongFunction wildcard, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_violation_to_op_dead_code_wildcard() {
+        let violation = Violation {
+            violation_type: ViolationType::DeadCode,
+            location: Location {
+                file: PathBuf::from("test.rs"),
+                line: 10,
+                column: 1,
+            },
+            severity: Severity::Low,
+            description: "Test".to_string(),
+            suggested_fix: None,
+        };
+
+        let op = violation.to_op();
+        match op {
+            RefactorOp::SimplifyExpression { .. } => {}
+            other => panic!("Expected SimplifyExpression for DeadCode wildcard, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_violation_to_op_poor_naming_wildcard() {
+        let violation = Violation {
+            violation_type: ViolationType::PoorNaming,
+            location: Location {
+                file: PathBuf::from("test.rs"),
+                line: 10,
+                column: 1,
+            },
+            severity: Severity::Low,
+            description: "Test".to_string(),
+            suggested_fix: None,
+        };
+
+        let op = violation.to_op();
+        match op {
+            RefactorOp::SimplifyExpression { .. } => {}
+            other => panic!("Expected SimplifyExpression for PoorNaming wildcard, got {other:?}"),
+        }
+    }
+
     // ========================================================================
     // SatdFix Tests
     // ========================================================================


### PR DESCRIPTION
## Summary

Covers the `_ => SimplifyExpression` wildcard arm at `src/models/refactor_impls.rs:267-270` — `to_op` was at 85.7% cov with 4 uncov lines per `pmat query --coverage-gaps`. No existing test exercises the wildcard; this PR adds three (LongFunction, DeadCode, PoorNaming).

Task #134 was marked complete but the test was never actually landed; this PR lands it.

## Test plan

- [x] `cargo test --lib -- test_violation_to_op` → 7 passed
- [x] Pre-commit hooks green (TDG baseline, O(1) gates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)