### PR TITLE
test(coverage): visit_local no-init None branch

### DIFF
--- a/src/quality/efficiency_enhanced_tests_part2.rs
+++ b/src/quality/efficiency_enhanced_tests_part2.rs
@@ -495,6 +495,26 @@ mod tests_part2 {
         );
     }
 
+    /// efficiency_enhanced_space_analysis.rs:114 — closing arm of
+    /// `if let Some(local_init) = &node.init`. Fires when `node.init` is
+    /// None, i.e. a `let x;` statement with no initializer. Existing tests
+    /// all supply initializers, so this branch is otherwise uncovered.
+    #[test]
+    fn test_space_complexity_let_without_init() {
+        let code = r#"
+            fn no_init() {
+                let _x: i32;
+            }
+        "#;
+        let ast = syn::parse_file(code).unwrap();
+        let mut analyzer = SpaceComplexityAnalyzer::new();
+        let _complexity = analyzer.analyze(&ast);
+        assert!(
+            analyzer.allocations.is_empty(),
+            "let without initializer must not record any allocation"
+        );
+    }
+
     #[test]
     fn test_space_complexity_multiple_allocations() {
         let code = r#"


### PR DESCRIPTION
## Summary
- Covers uncovered line at `src/quality/efficiency_enhanced_space_analysis.rs:114` — fall-through when `node.init` is `None` in `SpaceComplexityAnalyzer::visit_local`
- Triggered by a `let _x: i32;` statement with no initializer; existing tests all supply initializers
- One new test in `src/quality/efficiency_enhanced_tests_part2.rs`

## Test plan
- [x] `cargo test --lib -- test_space_complexity` — 11 passed, 0 failed
- [x] Exact uncov line (114) confirmed via `.pmat/coverage-cache.json`
- [x] No production code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)