### PR TITLE
test(coverage): cover rust_wasm_analyzer::analyze_impl_method branches (PMAT-629)

### DIFF
--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -3149,11 +3149,11 @@ roadmap:
   github_issue: null
   item_type: task
   title: 'Phase 1: cover extract_ruchy_pipeline_patterns branches'
-  status: planned
+  status: completed
   priority: medium
   assigned_to: null
   created: 2026-04-21T12:33:32Z
-  updated: 2026-04-21T12:33:32Z
+  updated: 2026-04-23T13:23:17Z
   spec: null
   acceptance_criteria:
   - 'Target src/entropy/pattern_extractor_ruchy.rs:69 — 29 uncovered, 31% cov, impact 3.4. Existing test runs but skips asserting matches>3 branch. Add tests for: (a) >3 match path with AstPattern field assertions, (b) >15 matches triggering break, (c) pattern_type==DataTransformation + estimated_loc invariants.'
@@ -3168,11 +3168,11 @@ roadmap:
   github_issue: null
   item_type: task
   title: 'Phase 1: cover parse_python_imports + parse_typescript_imports + parse_rust_imports'
-  status: inprogress
+  status: completed
   priority: medium
   assigned_to: null
   created: 2026-04-21T13:14:04Z
-  updated: 2026-04-21T13:14:08.412846003+00:00
+  updated: 2026-04-23T13:23:13Z
   spec: null
   acceptance_criteria:
   - 'Close ~53 uncovered lines in src/graph/builder_import_parsing.rs (parse_typescript_imports 22 uncov, parse_python_imports 9 uncov, parse_rust_imports also uncovered). 6 tests covering all branches. Sibling to PR #397.'
@@ -3185,11 +3185,11 @@ roadmap:
   github_issue: null
   item_type: task
   title: Cover polyglot NameResolver can_resolve branches
-  status: inprogress
+  status: completed
   priority: medium
   assigned_to: null
   created: 2026-04-21T17:14:33Z
-  updated: 2026-04-21T17:14:36.232270027+00:00
+  updated: 2026-04-23T13:23:19Z
   spec: null
   acceptance_criteria: []
   phases: []
@@ -3201,13 +3201,30 @@ roadmap:
   github_issue: null
   item_type: task
   title: 'Coverage: resolve_against_name_map missing-target branch'
-  status: planned
+  status: completed
   priority: medium
   assigned_to: null
   created: 2026-04-21T17:39:22Z
-  updated: 2026-04-21T17:39:22Z
+  updated: 2026-04-23T13:23:17Z
   spec: null
   acceptance_criteria: []
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels: []
+  notes: null
+- id: PMAT-629
+  github_issue: null
+  item_type: task
+  title: 'Phase 1: cover rust_wasm_analyzer::analyze_impl_method branches'
+  status: inprogress
+  priority: medium
+  assigned_to: null
+  created: 2026-04-23T16:58:28Z
+  updated: 2026-04-23T16:58:37Z
+  spec: null
+  acceptance_criteria:
+  - 'Target src/services/rust_wasm_analyzer.rs analyze_impl_method (lines 114-141). Previously untested: the method_attr || impl_attr disjunction at line 120 and the !is_wasm_bindgen && !is_no_mangle && !is_extern_c guard at line 124. Add 6 tests: bindgen on method, bindgen on impl-block (inheritance), non-boundary None, extern C ABI, no_mangle only, and full-file dispatcher picks up impl methods. Module is feature-gated behind deep-wasm.'
   phases: []
   subtasks: []
   estimated_effort: null

--- a/docs/specifications/improve-coverage-80-95.md
+++ b/docs/specifications/improve-coverage-80-95.md
@@ -197,6 +197,18 @@ Each phase is independently shippable. Do not chase the next phase until the cur
 
 Exit criteria: `make coverage-broad` reports ≥80% and `make coverage` (gate) stays ≥95%.
 
+#### Phase 1 drip-feed log (appended per PR; keeps intent durable between sessions)
+
+| PR / commit | PMAT ticket | Surface | Line/branch targets |
+|-------------|-------------|---------|---------------------|
+| #394, #396 | PMAT-625 | `src/entropy/pattern_extractor_ruchy.rs` | pipeline-regex + `>3` / `>15` break, location capping, score variation |
+| #398 | PMAT-626 | `src/graph/builder_import_parsing.rs` | `parse_rust_imports` + `parse_python_imports` + `parse_typescript_imports` branches |
+| #415 | PMAT-627 | polyglot `NameResolver` | `can_resolve` fall-through branches |
+| #420 | PMAT-628 | polyglot `resolve_against_name_map` | target-missing-from-name-map branch |
+| next | PMAT-629 | `src/services/rust_wasm_analyzer.rs` (`deep-wasm`-gated) | `analyze_impl_method` — method_attr ∥ impl_attr disjunction, `!bindgen && !no_mangle && !extern_c` guard, full-file dispatcher pickup |
+
+Pattern for pickers (per-session loop): run `pmat query --coverage-gaps --rank-by impact --limit 30 --exclude-tests`, skip feature-gated code unless its feature is on in the coverage invocation, skip `coverage(off)` modules, prefer high-impact branch-heavy single functions (these are the mutation-testing sweet spot), keep PRs to one surface.
+
 ### Phase 2 — 80% → 90% (3 weeks, v3.17.0)
 
 **Strategy: TDD on hot paths ranked by impact.**

--- a/src/services/rust_wasm_analyzer.rs
+++ b/src/services/rust_wasm_analyzer.rs
@@ -376,4 +376,131 @@ mod tests {
         assert_eq!(analysis.boundary_functions.len(), 2);
         assert_eq!(analysis.extern_blocks.len(), 1);
     }
+
+    // analyze_impl_method guard at line 124:
+    //   if !is_wasm_bindgen && !is_no_mangle && !is_extern_c { return None; }
+    // and the `method_attr || impl_attr` disjunction at line 120.
+
+    fn parse_impl(code: proc_macro2::TokenStream) -> syn::ItemImpl {
+        syn::parse2(code).expect("parse impl")
+    }
+
+    fn first_method(item_impl: &syn::ItemImpl) -> &syn::ImplItemFn {
+        item_impl
+            .items
+            .iter()
+            .find_map(|i| if let syn::ImplItem::Fn(f) = i { Some(f) } else { None })
+            .expect("impl has a method")
+    }
+
+    #[test]
+    fn test_analyze_impl_method_bindgen_on_method() {
+        // wasm_bindgen on the method itself → Some, is_wasm_bindgen=true.
+        let item_impl = parse_impl(quote! {
+            impl Widget {
+                #[wasm_bindgen]
+                pub fn new() -> Self { Widget }
+            }
+        });
+        let method = first_method(&item_impl);
+        let out = analyze_impl_method(method, &item_impl.attrs).expect("bindgen method is a boundary");
+        assert!(out.is_wasm_bindgen);
+        assert!(!out.is_extern_c);
+        assert!(!out.is_no_mangle);
+        assert_eq!(out.name, "new");
+    }
+
+    #[test]
+    fn test_analyze_impl_method_bindgen_on_impl_block() {
+        // wasm_bindgen on the impl block (not the method) must still mark the method as a boundary
+        // via the RHS of `has_attribute(&method.attrs, "wasm_bindgen") || has_attribute(impl_attrs, "wasm_bindgen")`.
+        let item_impl = parse_impl(quote! {
+            #[wasm_bindgen]
+            impl Widget {
+                pub fn bare_method(&self) -> i32 { 0 }
+            }
+        });
+        let method = first_method(&item_impl);
+        let out =
+            analyze_impl_method(method, &item_impl.attrs).expect("inherited impl-block attr must mark boundary");
+        assert!(out.is_wasm_bindgen, "impl-block attr must be inherited");
+        assert!(!out.is_no_mangle);
+        assert!(!out.is_extern_c);
+        assert_eq!(out.name, "bare_method");
+    }
+
+    #[test]
+    fn test_analyze_impl_method_non_boundary_returns_none() {
+        // No wasm_bindgen, no no_mangle, no extern "C" → early return None.
+        // Kills the `&&` → `||` mutation at line 124 (would otherwise return Some(..)).
+        let item_impl = parse_impl(quote! {
+            impl Widget {
+                pub fn plain(&self) {}
+            }
+        });
+        let method = first_method(&item_impl);
+        assert!(analyze_impl_method(method, &item_impl.attrs).is_none());
+    }
+
+    #[test]
+    fn test_analyze_impl_method_extern_c_abi() {
+        // `extern "C"` on the method's sig.abi alone is enough to make it a boundary.
+        let item_impl = parse_impl(quote! {
+            impl Widget {
+                pub extern "C" fn ffi_call(x: i32) -> i32 { x }
+            }
+        });
+        let method = first_method(&item_impl);
+        let out = analyze_impl_method(method, &item_impl.attrs).expect("extern C is a boundary");
+        assert!(out.is_extern_c);
+        assert!(!out.is_wasm_bindgen);
+        assert!(!out.is_no_mangle);
+    }
+
+    #[test]
+    fn test_analyze_impl_method_no_mangle_only() {
+        // #[no_mangle] alone (without extern "C") also flags the method as a boundary.
+        let item_impl = parse_impl(quote! {
+            impl Widget {
+                #[no_mangle]
+                pub fn exported(&self) {}
+            }
+        });
+        let method = first_method(&item_impl);
+        let out = analyze_impl_method(method, &item_impl.attrs).expect("no_mangle method is a boundary");
+        assert!(out.is_no_mangle);
+        assert!(!out.is_wasm_bindgen);
+        assert!(!out.is_extern_c);
+    }
+
+    #[test]
+    fn test_full_file_analysis_picks_up_impl_methods() {
+        // analyze_wasm_constructs dispatcher at lines 72-80 must collect impl-method boundaries.
+        let file: syn::File = syn::parse2(quote! {
+            #[wasm_bindgen]
+            impl Api {
+                pub fn greet() {}
+                pub fn farewell() {}
+            }
+
+            impl Plain {
+                pub fn unrelated(&self) {}
+            }
+        })
+        .unwrap();
+        let analysis = analyze_wasm_constructs(&file);
+        assert_eq!(
+            analysis.boundary_functions.len(),
+            2,
+            "both methods on #[wasm_bindgen] impl are boundaries; method on plain impl is not"
+        );
+        let names: Vec<&str> = analysis
+            .boundary_functions
+            .iter()
+            .map(|f| f.name.as_str())
+            .collect();
+        assert!(names.contains(&"greet"));
+        assert!(names.contains(&"farewell"));
+        assert!(!names.contains(&"unrelated"));
+    }
 }


### PR DESCRIPTION
## Summary

- Covers `analyze_impl_method` at `src/services/rust_wasm_analyzer.rs:114`: previously the `method_attr || impl_attr` disjunction (line 120) and the `!is_wasm_bindgen && !is_no_mangle && !is_extern_c` early-return guard (line 124) had no tests. Module is feature-gated behind `deep-wasm`, which is on for `make coverage` / `make coverage-broad` via `--features all-languages`.
- Adds 6 tests + 2 parsing helpers: bindgen on method, bindgen on impl-block (inherited), non-boundary returns `None` (kills `&&`→`||` mutant), `extern \"C\"` ABI alone, `#[no_mangle]` alone, and the full-file `analyze_wasm_constructs` dispatcher picking up impl methods.
- Marks PMAT-625/626/627/628 completed (their target code was already covered by #394/#396/#398/#415/#420 but tickets were stuck inprogress).
- Appends a Phase-1 drip-feed progress log to `docs/specifications/improve-coverage-80-95.md` so the 95% plan stays load-bearing across sessions.

## Test plan

- [x] `cargo test --lib --features deep-wasm -- services::rust_wasm_analyzer` — 13 passed, 0 failed
- [ ] CI `ci / gate` + `workspace-test` green
- [ ] Post-merge: `pmat query --coverage-gaps --rank-by impact --exclude-tests` no longer surfaces `analyze_impl_method`

🤖 Generated with [Claude Code](https://claude.com/claude-code)