### PR TITLE
test(coverage): profdata.rs pure-compute surface (PMAT-643, Phase-1 CLI pivot)

### DIFF
--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -3217,7 +3217,7 @@ roadmap:
   github_issue: null
   item_type: task
   title: 'Phase 1 pivot: services/agent_context/query/coverage/profdata.rs coverage'
-  status: inprogress
+  status: review
   priority: medium
   assigned_to: null
   created: 2026-04-24T08:18:40Z

--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -3213,3 +3213,20 @@ roadmap:
   estimated_effort: null
   labels: []
   notes: null
+- id: PMAT-643
+  github_issue: null
+  item_type: task
+  title: 'Phase 1 pivot: services/agent_context/query/coverage/profdata.rs coverage'
+  status: inprogress
+  priority: medium
+  assigned_to: null
+  created: 2026-04-24T08:18:40Z
+  updated: 2026-04-24T08:18:40Z
+  spec: null
+  acceptance_criteria:
+  - 'Phase 1 CLI/services pivot — profdata.rs is 0/340 broad-covered. Cover pure-compute helpers: dir_mtime, target_dir_from_cargo_config (parses TOML target-dir, relative + absolute + missing), mnt_target_candidates (scans /mnt, handles missing dir), collect_fast_candidates (stored_path + CARGO_TARGET_DIR + cargo config + mnt + default target), extract_target_directory (JSON parse), write_coverage_cache + write_negative_coverage_cache (JSON round-trip), load_coverage_from_cache (valid mtime / invalid mtime / fallback git-hash / corrupt JSON). Skip subprocess paths (run_llvm_cov_subprocess, wait_with_timeout, cargo_metadata_target_dir) — they spawn cargo.'
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels: []
+  notes: null

--- a/examples/mcp_agent_context_demo.rs
+++ b/examples/mcp_agent_context_demo.rs
@@ -54,68 +54,132 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     thread::sleep(Duration::from_secs(10));
 
     // 1. initialize handshake
-    let resp = rpc(&mut writer, &mut reader, 1, "initialize", json!({
-        "protocolVersion": "2024-11-05",
-        "capabilities": {},
-        "clientInfo": { "name": "mcp_agent_context_demo", "version": "1.0" }
-    }))?;
-    let server_info = resp.pointer("/result/serverInfo/name").cloned().unwrap_or(json!("?"));
+    let resp = rpc(
+        &mut writer,
+        &mut reader,
+        1,
+        "initialize",
+        json!({
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": { "name": "mcp_agent_context_demo", "version": "1.0" }
+        }),
+    )?;
+    let server_info = resp
+        .pointer("/result/serverInfo/name")
+        .cloned()
+        .unwrap_or(json!("?"));
     println!("[initialize] server={}", server_info);
 
     // 2. tools/list — sanity check that the 4 pmat_* tools are registered
     let resp = rpc(&mut writer, &mut reader, 2, "tools/list", json!({}))?;
-    let tools = resp.pointer("/result/tools").and_then(|v| v.as_array()).cloned().unwrap_or_default();
-    let pmat_tools: Vec<&str> = tools.iter()
+    let tools = resp
+        .pointer("/result/tools")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+    let pmat_tools: Vec<&str> = tools
+        .iter()
         .filter_map(|t| t.get("name").and_then(|n| n.as_str()))
         .filter(|n| n.starts_with("pmat_"))
         .collect();
-    println!("[tools/list] total={} pmat_*={} ({:?})", tools.len(), pmat_tools.len(), pmat_tools);
+    println!(
+        "[tools/list] total={} pmat_*={} ({:?})",
+        tools.len(),
+        pmat_tools.len(),
+        pmat_tools
+    );
 
     // 3. pmat_index_stats — pick up a real function_id we can reuse below
-    let resp = call_tool(&mut writer, &mut reader, 3, "pmat_index_stats",
-        json!({ "rebuild": false }))?;
+    let resp = call_tool(
+        &mut writer,
+        &mut reader,
+        3,
+        "pmat_index_stats",
+        json!({ "rebuild": false }),
+    )?;
     let index_result = extract_tool_result(&resp);
-    let fn_count = index_result.pointer("/manifest/function_count").cloned().unwrap_or(json!(0));
-    let file_count = index_result.pointer("/manifest/file_count").cloned().unwrap_or(json!(0));
-    println!("[pmat_index_stats] ok: functions={} files={}", fn_count, file_count);
+    let fn_count = index_result
+        .pointer("/manifest/function_count")
+        .cloned()
+        .unwrap_or(json!(0));
+    let file_count = index_result
+        .pointer("/manifest/file_count")
+        .cloned()
+        .unwrap_or(json!(0));
+    println!(
+        "[pmat_index_stats] ok: functions={} files={}",
+        fn_count, file_count
+    );
 
     // 4. pmat_query_code — realistic semantic query
-    let resp = call_tool(&mut writer, &mut reader, 4, "pmat_query_code",
-        json!({ "query": "error handling", "limit": 3 }))?;
+    let resp = call_tool(
+        &mut writer,
+        &mut reader,
+        4,
+        "pmat_query_code",
+        json!({ "query": "error handling", "limit": 3 }),
+    )?;
     let query_result = extract_tool_result(&resp);
-    let result_count = query_result.get("results")
+    let result_count = query_result
+        .get("results")
         .or_else(|| query_result.get("functions"))
         .and_then(|v| v.as_array())
         .map(|a| a.len())
         .unwrap_or(0);
-    let first_id = query_result.pointer("/results/0/id")
+    let first_id = query_result
+        .pointer("/results/0/id")
         .or_else(|| query_result.pointer("/functions/0/id"))
         .and_then(|v| v.as_str())
         .map(|s| s.to_string());
-    println!("[pmat_query_code] ok: {} results; first_id={:?}", result_count, first_id);
+    println!(
+        "[pmat_query_code] ok: {} results; first_id={:?}",
+        result_count, first_id
+    );
 
     // 5. pmat_get_function — use the first id from query_code, or fall back to "main"
-    let function_id = first_id.clone().unwrap_or_else(|| "src/bin/pmat.rs::main".to_string());
-    let resp = call_tool(&mut writer, &mut reader, 5, "pmat_get_function",
-        json!({ "function_id": function_id, "include_source": false }))?;
+    let function_id = first_id
+        .clone()
+        .unwrap_or_else(|| "src/bin/pmat.rs::main".to_string());
+    let resp = call_tool(
+        &mut writer,
+        &mut reader,
+        5,
+        "pmat_get_function",
+        json!({ "function_id": function_id, "include_source": false }),
+    )?;
     match resp.get("error") {
-        Some(err) => println!("[pmat_get_function] graceful miss for {:?}: {}", function_id,
-            err.get("message").and_then(|m| m.as_str()).unwrap_or("?")),
+        Some(err) => println!(
+            "[pmat_get_function] graceful miss for {:?}: {}",
+            function_id,
+            err.get("message").and_then(|m| m.as_str()).unwrap_or("?")
+        ),
         None => {
             let gf = extract_tool_result(&resp);
-            println!("[pmat_get_function] ok: name={} grade={}",
+            println!(
+                "[pmat_get_function] ok: name={} grade={}",
                 gf.get("name").and_then(|v| v.as_str()).unwrap_or("?"),
-                gf.pointer("/quality/grade").and_then(|v| v.as_str()).unwrap_or("?"));
+                gf.pointer("/quality/grade")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("?")
+            );
         }
     }
 
     // 6. pmat_find_similar — only meaningful if we got a real id from the query
     if let Some(id) = first_id {
-        let resp = call_tool(&mut writer, &mut reader, 6, "pmat_find_similar",
-            json!({ "function_id": id, "limit": 3, "min_similarity": 0.3 }))?;
+        let resp = call_tool(
+            &mut writer,
+            &mut reader,
+            6,
+            "pmat_find_similar",
+            json!({ "function_id": id, "limit": 3, "min_similarity": 0.3 }),
+        )?;
         match resp.get("error") {
-            Some(err) => println!("[pmat_find_similar] error: {}",
-                err.get("message").and_then(|m| m.as_str()).unwrap_or("?")),
+            Some(err) => println!(
+                "[pmat_find_similar] error: {}",
+                err.get("message").and_then(|m| m.as_str()).unwrap_or("?")
+            ),
             None => {
                 let sim = extract_tool_result(&resp);
                 let total = sim.get("total").and_then(|v| v.as_u64()).unwrap_or(0);
@@ -162,7 +226,13 @@ fn call_tool(
     name: &str,
     args: Value,
 ) -> Result<Value, Box<dyn std::error::Error>> {
-    rpc(writer, reader, id, "tools/call", json!({ "name": name, "arguments": args }))
+    rpc(
+        writer,
+        reader,
+        id,
+        "tools/call",
+        json!({ "name": name, "arguments": args }),
+    )
 }
 
 /// MCP `tools/call` wraps results in `result.content[0].text` (JSON string) or
@@ -171,7 +241,10 @@ fn extract_tool_result(resp: &Value) -> Value {
     if let Some(sc) = resp.pointer("/result/structuredContent") {
         return sc.clone();
     }
-    if let Some(text) = resp.pointer("/result/content/0/text").and_then(|v| v.as_str()) {
+    if let Some(text) = resp
+        .pointer("/result/content/0/text")
+        .and_then(|v| v.as_str())
+    {
         if let Ok(parsed) = serde_json::from_str::<Value>(text) {
             return parsed;
         }

--- a/src/bin/pmat.rs
+++ b/src/bin/pmat.rs
@@ -16,301 +16,301 @@ fn main() {
 
 #[cfg(feature = "standard-deps")]
 mod full {
-use anyhow::Result;
-use pmat::{cli, stateless_server::StatelessTemplateServer};
-use std::io::IsTerminal;
-use std::process;
-use std::sync::Arc;
-use tracing::{debug, error, info, trace};
-use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
+    use anyhow::Result;
+    use pmat::{cli, stateless_server::StatelessTemplateServer};
+    use std::io::IsTerminal;
+    use std::process;
+    use std::sync::Arc;
+    use tracing::{debug, error, info, trace};
+    use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 
-enum ExecutionMode {
-    Mcp,
-    Cli,
-    /// No subcommand given and stdin is piped (not a TTY) without an explicit
-    /// MCP opt-in. Print help and exit non-zero instead of blocking on stdin
-    /// (see GH-285).
-    HelpAndExit,
-}
-
-/// POSIX-compliant exit codes for CLI interface
-/// Per SPECIFICATION.md Section 23: CLI Interface
-#[derive(Debug, Clone, Copy)]
-pub enum ExitCode {
-    /// Success
-    Success = 0,
-    /// General error
-    GeneralError = 1,
-    /// Misuse of shell command
-    MisuseError = 2,
-    /// Permission denied
-    PermissionDenied = 126,
-    /// Command not found
-    CommandNotFound = 127,
-    /// Invalid argument to exit
-    InvalidExitArg = 128,
-    /// Quality gate failure (custom)
-    QualityGateFailure = 3,
-    /// Configuration error (custom)
-    ConfigurationError = 4,
-    /// Analysis error (custom)
-    AnalysisError = 5,
-}
-
-impl From<ExitCode> for i32 {
-    fn from(code: ExitCode) -> Self {
-        code as i32
-    }
-}
-
-fn detect_execution_mode() -> ExecutionMode {
-    classify_execution_mode(
-        std::env::var("MCP_VERSION").is_ok(),
-        std::env::args().len() == 1,
-        !std::io::stdin().is_terminal(),
-    )
-}
-
-/// Pure decision function for execution mode so it can be unit-tested
-/// without touching real stdin / env vars (see GH-285 regression test).
-fn classify_execution_mode(
-    mcp_version_env: bool,
-    no_args: bool,
-    stdin_is_pipe: bool,
-) -> ExecutionMode {
-    // Explicit MCP opt-in via env var always wins (e.g. Claude Desktop sets this).
-    if mcp_version_env {
-        return ExecutionMode::Mcp;
+    enum ExecutionMode {
+        Mcp,
+        Cli,
+        /// No subcommand given and stdin is piped (not a TTY) without an explicit
+        /// MCP opt-in. Print help and exit non-zero instead of blocking on stdin
+        /// (see GH-285).
+        HelpAndExit,
     }
 
-    // GH-285: If the user ran bare `pmat` with stdin piped (e.g. `echo "" | pmat`)
-    // without opting into MCP via `MCP_VERSION`, previous behavior entered the MCP
-    // server and blocked forever on stdin. Treat that case the same as bare `pmat`
-    // on a terminal: print help and exit non-zero.
-    if no_args && stdin_is_pipe {
-        return ExecutionMode::HelpAndExit;
+    /// POSIX-compliant exit codes for CLI interface
+    /// Per SPECIFICATION.md Section 23: CLI Interface
+    #[derive(Debug, Clone, Copy)]
+    pub enum ExitCode {
+        /// Success
+        Success = 0,
+        /// General error
+        GeneralError = 1,
+        /// Misuse of shell command
+        MisuseError = 2,
+        /// Permission denied
+        PermissionDenied = 126,
+        /// Command not found
+        CommandNotFound = 127,
+        /// Invalid argument to exit
+        InvalidExitArg = 128,
+        /// Quality gate failure (custom)
+        QualityGateFailure = 3,
+        /// Configuration error (custom)
+        ConfigurationError = 4,
+        /// Analysis error (custom)
+        AnalysisError = 5,
     }
 
-    ExecutionMode::Cli
-}
+    impl From<ExitCode> for i32 {
+        fn from(code: ExitCode) -> Self {
+            code as i32
+        }
+    }
 
-/// Initialize the enhanced tracing system based on CLI flags
-fn init_tracing(cli: &cli::EarlyCliArgs) -> Result<()> {
-    let filter = create_env_filter(cli)?;
-
-    tracing_subscriber::registry()
-        .with(filter)
-        .with(
-            tracing_subscriber::fmt::layer()
-                .with_target(cli.debug || cli.trace)
-                .with_thread_ids(cli.trace)
-                .with_file(cli.trace)
-                .with_line_number(cli.trace)
-                .compact()
-                .with_writer(std::io::stderr),
+    fn detect_execution_mode() -> ExecutionMode {
+        classify_execution_mode(
+            std::env::var("MCP_VERSION").is_ok(),
+            std::env::args().len() == 1,
+            !std::io::stdin().is_terminal(),
         )
-        .init();
-
-    Ok(())
-}
-
-/// Create environment filter based on CLI flags
-fn create_env_filter(cli: &cli::EarlyCliArgs) -> Result<EnvFilter> {
-    if cli.is_mcp_server {
-        Ok(create_mcp_filter(cli.debug))
-    } else {
-        create_cli_filter(cli)
-    }
-}
-
-/// Create filter for MCP server mode
-fn create_mcp_filter(debug: bool) -> EnvFilter {
-    if debug {
-        EnvFilter::new("warn,pmat=debug")
-    } else {
-        EnvFilter::new("off")
-    }
-}
-
-/// Create filter for CLI mode
-fn create_cli_filter(cli: &cli::EarlyCliArgs) -> Result<EnvFilter> {
-    if let Some(ref custom) = cli.trace_filter {
-        return Ok(EnvFilter::try_new(custom)?);
     }
 
-    let filter_str = match (cli.trace, cli.debug, cli.verbose) {
-        (true, _, _) => "debug,pmat=trace",
-        (_, true, _) => "warn,pmat=debug",
-        (_, _, true) => "warn,pmat=info",
-        _ => return Ok(get_default_filter()),
-    };
-
-    Ok(EnvFilter::new(filter_str))
-}
-
-/// Get default production filter
-fn get_default_filter() -> EnvFilter {
-    EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("warn"))
-}
-
-#[tokio::main]
-#[allow(unreachable_pub)]
-pub async fn real_main() {
-    let exit_code = match run_main().await {
-        Ok(()) => ExitCode::Success,
-        Err(e) => {
-            error!("Error: {:#}", e);
-            categorize_error(&e)
+    /// Pure decision function for execution mode so it can be unit-tested
+    /// without touching real stdin / env vars (see GH-285 regression test).
+    fn classify_execution_mode(
+        mcp_version_env: bool,
+        no_args: bool,
+        stdin_is_pipe: bool,
+    ) -> ExecutionMode {
+        // Explicit MCP opt-in via env var always wins (e.g. Claude Desktop sets this).
+        if mcp_version_env {
+            return ExecutionMode::Mcp;
         }
-    };
 
-    if exit_code as i32 != 0 {
-        process::exit(exit_code.into());
-    }
-}
+        // GH-285: If the user ran bare `pmat` with stdin piped (e.g. `echo "" | pmat`)
+        // without opting into MCP via `MCP_VERSION`, previous behavior entered the MCP
+        // server and blocked forever on stdin. Treat that case the same as bare `pmat`
+        // on a terminal: print help and exit non-zero.
+        if no_args && stdin_is_pipe {
+            return ExecutionMode::HelpAndExit;
+        }
 
-fn categorize_error(error: &anyhow::Error) -> ExitCode {
-    let error_str = error.to_string().to_lowercase();
-
-    match () {
-        _ if is_quality_gate_error(&error_str) => ExitCode::QualityGateFailure,
-        _ if is_configuration_error(&error_str) => ExitCode::ConfigurationError,
-        _ if is_analysis_error(&error_str) => ExitCode::AnalysisError,
-        _ if is_permission_error(&error_str) => ExitCode::PermissionDenied,
-        _ => ExitCode::GeneralError,
-    }
-}
-
-fn is_quality_gate_error(error_str: &str) -> bool {
-    error_str.contains("quality gate") || error_str.contains("violation")
-}
-
-fn is_configuration_error(error_str: &str) -> bool {
-    error_str.contains("config") || error_str.contains("parse")
-}
-
-fn is_analysis_error(error_str: &str) -> bool {
-    error_str.contains("analysis") || error_str.contains("complexity")
-}
-
-fn is_permission_error(error_str: &str) -> bool {
-    error_str.contains("permission") || error_str.contains("access")
-}
-
-async fn run_main() -> Result<()> {
-    // Parse CLI to get tracing configuration early
-    let cli = cli::parse_early_for_tracing();
-
-    // Initialize enhanced tracing system
-    init_tracing(&cli)?;
-
-    // Only log to stdout if not running MCP server mode
-    if !cli.is_mcp_server {
-        info!(
-            "Starting PAIML MCP Agent Toolkit v{}",
-            env!("CARGO_PKG_VERSION")
-        );
-        debug!("Debug logging enabled");
-        trace!("Trace logging enabled");
+        ExecutionMode::Cli
     }
 
-    // Create shared template server
-    let server = Arc::new(StatelessTemplateServer::new()?);
+    /// Initialize the enhanced tracing system based on CLI flags
+    fn init_tracing(cli: &cli::EarlyCliArgs) -> Result<()> {
+        let filter = create_env_filter(cli)?;
 
-    if !cli.is_mcp_server {
-        debug!("Template server initialized");
+        tracing_subscriber::registry()
+            .with(filter)
+            .with(
+                tracing_subscriber::fmt::layer()
+                    .with_target(cli.debug || cli.trace)
+                    .with_thread_ids(cli.trace)
+                    .with_file(cli.trace)
+                    .with_line_number(cli.trace)
+                    .compact()
+                    .with_writer(std::io::stderr),
+            )
+            .init();
+
+        Ok(())
     }
 
-    match detect_execution_mode() {
-        ExecutionMode::Mcp => {
-            if !cli.is_mcp_server {
-                info!("Running unified MCP server (pmcp SDK)");
+    /// Create environment filter based on CLI flags
+    fn create_env_filter(cli: &cli::EarlyCliArgs) -> Result<EnvFilter> {
+        if cli.is_mcp_server {
+            Ok(create_mcp_filter(cli.debug))
+        } else {
+            create_cli_filter(cli)
+        }
+    }
+
+    /// Create filter for MCP server mode
+    fn create_mcp_filter(debug: bool) -> EnvFilter {
+        if debug {
+            EnvFilter::new("warn,pmat=debug")
+        } else {
+            EnvFilter::new("off")
+        }
+    }
+
+    /// Create filter for CLI mode
+    fn create_cli_filter(cli: &cli::EarlyCliArgs) -> Result<EnvFilter> {
+        if let Some(ref custom) = cli.trace_filter {
+            return Ok(EnvFilter::try_new(custom)?);
+        }
+
+        let filter_str = match (cli.trace, cli.debug, cli.verbose) {
+            (true, _, _) => "debug,pmat=trace",
+            (_, true, _) => "warn,pmat=debug",
+            (_, _, true) => "warn,pmat=info",
+            _ => return Ok(get_default_filter()),
+        };
+
+        Ok(EnvFilter::new(filter_str))
+    }
+
+    /// Get default production filter
+    fn get_default_filter() -> EnvFilter {
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("warn"))
+    }
+
+    #[tokio::main]
+    #[allow(unreachable_pub)]
+    pub async fn real_main() {
+        let exit_code = match run_main().await {
+            Ok(()) => ExitCode::Success,
+            Err(e) => {
+                error!("Error: {:#}", e);
+                categorize_error(&e)
             }
-            let unified_server = pmat::mcp_pmcp::UnifiedServer::new()
-                .map_err(|e| anyhow::anyhow!("Failed to create unified server: {}", e))?;
-            unified_server
-                .run()
-                .await
-                .map_err(|e| anyhow::anyhow!("{}", e))
+        };
+
+        if exit_code as i32 != 0 {
+            process::exit(exit_code.into());
         }
-        ExecutionMode::Cli => {
-            if !cli.is_mcp_server {
-                info!("Running in CLI mode");
-            }
-            cli::run(server).await
+    }
+
+    fn categorize_error(error: &anyhow::Error) -> ExitCode {
+        let error_str = error.to_string().to_lowercase();
+
+        match () {
+            _ if is_quality_gate_error(&error_str) => ExitCode::QualityGateFailure,
+            _ if is_configuration_error(&error_str) => ExitCode::ConfigurationError,
+            _ if is_analysis_error(&error_str) => ExitCode::AnalysisError,
+            _ if is_permission_error(&error_str) => ExitCode::PermissionDenied,
+            _ => ExitCode::GeneralError,
         }
-        ExecutionMode::HelpAndExit => {
-            // GH-285: No subcommand + piped stdin + no MCP_VERSION. Print help on
-            // stderr and exit with code 2 (misuse), matching the convention for
-            // "no command supplied" on a terminal.
-            let mut cmd = <pmat::cli::Cli as clap::CommandFactory>::command();
-            let _ = cmd.print_help();
-            eprintln!(
-                "\nerror: no subcommand given and stdin is not a terminal. \
-                 Set MCP_VERSION=1 (or run `pmat agent mcp-server`) to start the MCP server."
+    }
+
+    fn is_quality_gate_error(error_str: &str) -> bool {
+        error_str.contains("quality gate") || error_str.contains("violation")
+    }
+
+    fn is_configuration_error(error_str: &str) -> bool {
+        error_str.contains("config") || error_str.contains("parse")
+    }
+
+    fn is_analysis_error(error_str: &str) -> bool {
+        error_str.contains("analysis") || error_str.contains("complexity")
+    }
+
+    fn is_permission_error(error_str: &str) -> bool {
+        error_str.contains("permission") || error_str.contains("access")
+    }
+
+    async fn run_main() -> Result<()> {
+        // Parse CLI to get tracing configuration early
+        let cli = cli::parse_early_for_tracing();
+
+        // Initialize enhanced tracing system
+        init_tracing(&cli)?;
+
+        // Only log to stdout if not running MCP server mode
+        if !cli.is_mcp_server {
+            info!(
+                "Starting PAIML MCP Agent Toolkit v{}",
+                env!("CARGO_PKG_VERSION")
             );
-            process::exit(ExitCode::MisuseError as i32);
+            debug!("Debug logging enabled");
+            trace!("Trace logging enabled");
+        }
+
+        // Create shared template server
+        let server = Arc::new(StatelessTemplateServer::new()?);
+
+        if !cli.is_mcp_server {
+            debug!("Template server initialized");
+        }
+
+        match detect_execution_mode() {
+            ExecutionMode::Mcp => {
+                if !cli.is_mcp_server {
+                    info!("Running unified MCP server (pmcp SDK)");
+                }
+                let unified_server = pmat::mcp_pmcp::UnifiedServer::new()
+                    .map_err(|e| anyhow::anyhow!("Failed to create unified server: {}", e))?;
+                unified_server
+                    .run()
+                    .await
+                    .map_err(|e| anyhow::anyhow!("{}", e))
+            }
+            ExecutionMode::Cli => {
+                if !cli.is_mcp_server {
+                    info!("Running in CLI mode");
+                }
+                cli::run(server).await
+            }
+            ExecutionMode::HelpAndExit => {
+                // GH-285: No subcommand + piped stdin + no MCP_VERSION. Print help on
+                // stderr and exit with code 2 (misuse), matching the convention for
+                // "no command supplied" on a terminal.
+                let mut cmd = <pmat::cli::Cli as clap::CommandFactory>::command();
+                let _ = cmd.print_help();
+                eprintln!(
+                    "\nerror: no subcommand given and stdin is not a terminal. \
+                 Set MCP_VERSION=1 (or run `pmat agent mcp-server`) to start the MCP server."
+                );
+                process::exit(ExitCode::MisuseError as i32);
+            }
         }
     }
-}
 
-#[cfg_attr(coverage_nightly, coverage(off))]
-#[cfg(test)]
-mod gh285_tests {
-    //! Regression tests for GH-285: `pmat` hangs when invoked with no args
-    //! and stdin is a pipe. See `classify_execution_mode`.
-    //!
-    //! Manual end-to-end repro (should NOT hang or exit 124):
-    //! ```text
-    //! echo "" | timeout 3 target/debug/pmat 2>&1; echo exit=$?
-    //! timeout 3 target/debug/pmat < /dev/null; echo exit=$?
-    //! ```
-    //! Both should print help and exit with code 2.
-    use super::{classify_execution_mode, ExecutionMode};
+    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg(test)]
+    mod gh285_tests {
+        //! Regression tests for GH-285: `pmat` hangs when invoked with no args
+        //! and stdin is a pipe. See `classify_execution_mode`.
+        //!
+        //! Manual end-to-end repro (should NOT hang or exit 124):
+        //! ```text
+        //! echo "" | timeout 3 target/debug/pmat 2>&1; echo exit=$?
+        //! timeout 3 target/debug/pmat < /dev/null; echo exit=$?
+        //! ```
+        //! Both should print help and exit with code 2.
+        use super::{classify_execution_mode, ExecutionMode};
 
-    #[test]
-    fn bare_invocation_on_tty_is_cli() {
-        // `pmat` typed into a terminal with no pipe -> normal CLI (clap
-        // will then print help on missing subcommand).
-        assert!(matches!(
-            classify_execution_mode(false, true, false),
-            ExecutionMode::Cli
-        ));
+        #[test]
+        fn bare_invocation_on_tty_is_cli() {
+            // `pmat` typed into a terminal with no pipe -> normal CLI (clap
+            // will then print help on missing subcommand).
+            assert!(matches!(
+                classify_execution_mode(false, true, false),
+                ExecutionMode::Cli
+            ));
+        }
+
+        #[test]
+        fn piped_stdin_with_no_args_prints_help_instead_of_hanging() {
+            // GH-285: This used to enter MCP mode and block on stdin forever.
+            assert!(matches!(
+                classify_execution_mode(false, true, true),
+                ExecutionMode::HelpAndExit
+            ));
+        }
+
+        #[test]
+        fn explicit_mcp_version_env_still_enters_mcp_mode() {
+            // Claude Desktop and similar hosts set MCP_VERSION; they must still
+            // get the MCP server regardless of TTY state.
+            assert!(matches!(
+                classify_execution_mode(true, true, true),
+                ExecutionMode::Mcp
+            ));
+            assert!(matches!(
+                classify_execution_mode(true, false, false),
+                ExecutionMode::Mcp
+            ));
+        }
+
+        #[test]
+        fn subcommand_with_piped_stdin_is_still_cli() {
+            // `echo foo | pmat analyze ...` must dispatch to the CLI subcommand,
+            // not to help-and-exit.
+            assert!(matches!(
+                classify_execution_mode(false, false, true),
+                ExecutionMode::Cli
+            ));
+        }
     }
-
-    #[test]
-    fn piped_stdin_with_no_args_prints_help_instead_of_hanging() {
-        // GH-285: This used to enter MCP mode and block on stdin forever.
-        assert!(matches!(
-            classify_execution_mode(false, true, true),
-            ExecutionMode::HelpAndExit
-        ));
-    }
-
-    #[test]
-    fn explicit_mcp_version_env_still_enters_mcp_mode() {
-        // Claude Desktop and similar hosts set MCP_VERSION; they must still
-        // get the MCP server regardless of TTY state.
-        assert!(matches!(
-            classify_execution_mode(true, true, true),
-            ExecutionMode::Mcp
-        ));
-        assert!(matches!(
-            classify_execution_mode(true, false, false),
-            ExecutionMode::Mcp
-        ));
-    }
-
-    #[test]
-    fn subcommand_with_piped_stdin_is_still_cli() {
-        // `echo foo | pmat analyze ...` must dispatch to the CLI subcommand,
-        // not to help-and-exit.
-        assert!(matches!(
-            classify_execution_mode(false, false, true),
-            ExecutionMode::Cli
-        ));
-    }
-}
 } // end of mod full
 
 #[cfg(feature = "standard-deps")]

--- a/src/entropy/pattern_extractor_tests.rs
+++ b/src/entropy/pattern_extractor_tests.rs
@@ -845,7 +845,10 @@ fn test_calculate_pattern_match_variation_score_short_circuits_single_match() {
 
     let score =
         extractor.calculate_pattern_match_variation_score(&enums, &matches, &arrows, content);
-    assert_eq!(score, 0.0, "fewer than 2 match blocks must short-circuit to 0.0");
+    assert_eq!(
+        score, 0.0,
+        "fewer than 2 match blocks must short-circuit to 0.0"
+    );
 }
 
 /// pattern_extractor_ruchy.rs:405 — enum_matches.len() <= 1 low-variation arm (0.3).

--- a/src/maintenance/updater.rs
+++ b/src/maintenance/updater.rs
@@ -375,9 +375,13 @@ mod tests {
             files: vec!["src/lib.rs".into()], // no ticket file
         };
 
-        let result =
-            process_ticket_update(&mut roadmap, &commit, "TICKET-PMAT-5013", tickets_dir.path())
-                .unwrap();
+        let result = process_ticket_update(
+            &mut roadmap,
+            &commit,
+            "TICKET-PMAT-5013",
+            tickets_dir.path(),
+        )
+        .unwrap();
         assert!(!result, "must short-circuit when ticket file not in commit");
         assert!(!roadmap.sprints[0].tickets[0].completed);
     }
@@ -394,10 +398,17 @@ mod tests {
             files: vec!["docs/tickets/TICKET-PMAT-5013.md".into()],
         };
 
-        let result =
-            process_ticket_update(&mut roadmap, &commit, "TICKET-PMAT-5013", tickets_dir.path())
-                .unwrap();
-        assert!(!result, "missing ticket file must return Ok(false), not error");
+        let result = process_ticket_update(
+            &mut roadmap,
+            &commit,
+            "TICKET-PMAT-5013",
+            tickets_dir.path(),
+        )
+        .unwrap();
+        assert!(
+            !result,
+            "missing ticket file must return Ok(false), not error"
+        );
         assert!(!roadmap.sprints[0].tickets[0].completed);
     }
 
@@ -417,11 +428,7 @@ mod tests {
              Still failing.\n\n\
              ## Success Criteria\n\n\
              - [ ] One\n";
-        std::fs::write(
-            tickets_dir.path().join("TICKET-PMAT-5013.md"),
-            red_content,
-        )
-        .unwrap();
+        std::fs::write(tickets_dir.path().join("TICKET-PMAT-5013.md"), red_content).unwrap();
         let mut roadmap = create_test_roadmap();
         let commit = CommitInfo {
             hash: "deadbee".into(),
@@ -429,9 +436,13 @@ mod tests {
             files: vec!["docs/tickets/TICKET-PMAT-5013.md".into()],
         };
 
-        let result =
-            process_ticket_update(&mut roadmap, &commit, "TICKET-PMAT-5013", tickets_dir.path())
-                .unwrap();
+        let result = process_ticket_update(
+            &mut roadmap,
+            &commit,
+            "TICKET-PMAT-5013",
+            tickets_dir.path(),
+        )
+        .unwrap();
         assert!(!result, "RED ticket must not mark roadmap completed");
         assert!(!roadmap.sprints[0].tickets[0].completed);
     }
@@ -450,9 +461,13 @@ mod tests {
             files: vec!["docs/tickets/TICKET-PMAT-5013.md".into()],
         };
 
-        let result =
-            process_ticket_update(&mut roadmap, &commit, "TICKET-PMAT-5013", tickets_dir.path())
-                .unwrap();
+        let result = process_ticket_update(
+            &mut roadmap,
+            &commit,
+            "TICKET-PMAT-5013",
+            tickets_dir.path(),
+        )
+        .unwrap();
         assert!(result, "GREEN ticket must flip roadmap entry");
         assert!(roadmap.sprints[0].tickets[0].completed);
         assert_eq!(

--- a/src/mcp_pmcp/agent_context_handlers.rs
+++ b/src/mcp_pmcp/agent_context_handlers.rs
@@ -37,11 +37,7 @@ macro_rules! impl_pmat_handler {
 
         #[async_trait]
         impl ToolHandler for $wrapper {
-            async fn handle(
-                &self,
-                args: Value,
-                _extra: RequestHandlerExtra,
-            ) -> PmcpResult<Value> {
+            async fn handle(&self, args: Value, _extra: RequestHandlerExtra) -> PmcpResult<Value> {
                 self.inner.execute(args).await.map_err(PmcpError::internal)
             }
 

--- a/src/mcp_pmcp/analyze_handlers.rs
+++ b/src/mcp_pmcp/analyze_handlers.rs
@@ -32,7 +32,8 @@ use tracing::debug;
 // MCP tools (see R15 #3 bench matrix).
 pub use self::{
     ComplexityTool as AnalyzeComplexityTool, DeadCodeTool as AnalyzeDeadCodeTool,
-    SatdTool as AnalyzeSatdTool, TdgCompareTool as AnalyzeTdgCompareTool, TdgTool as AnalyzeTdgTool,
+    SatdTool as AnalyzeSatdTool, TdgCompareTool as AnalyzeTdgCompareTool,
+    TdgTool as AnalyzeTdgTool,
 };
 
 // Complexity analysis tool handler

--- a/src/mcp_pmcp/mod.rs
+++ b/src/mcp_pmcp/mod.rs
@@ -103,12 +103,12 @@ pub mod quality_handlers;
 pub mod quality_proxy_handler;
 pub mod server;
 pub mod simple_unified_server;
-pub mod tool_schemas;
 #[cfg_attr(coverage_nightly, coverage(off))]
 #[cfg(test)]
 pub mod tdg_git_context_tests;
 pub mod tdg_handlers;
 pub mod tool_functions;
+pub mod tool_schemas;
 pub mod tool_schemas_generated; // KAIZEN-0178: build.rs-generated tool schema registry
 pub mod tools; // Sprint 65 Phase 2B: MCP git-context integration
 

--- a/src/mcp_pmcp/tool_schemas.rs
+++ b/src/mcp_pmcp/tool_schemas.rs
@@ -45,7 +45,10 @@ pub fn paths_object_schema(extra_properties: Value, required: Vec<&str>) -> Valu
             base.insert(k.clone(), v.clone());
         }
     }
-    let req: Vec<Value> = required.into_iter().map(|s| Value::String(s.into())).collect();
+    let req: Vec<Value> = required
+        .into_iter()
+        .map(|s| Value::String(s.into()))
+        .collect();
     json!({
         "type": "object",
         "properties": base_props,

--- a/src/services/agent_context/query/coverage/profdata.rs
+++ b/src/services/agent_context/query/coverage/profdata.rs
@@ -473,3 +473,375 @@ fn wait_with_timeout(
         }
     }
 }
+
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg(test)]
+mod tests {
+    //! PMAT-643: cover pure fs/compute helpers.
+    //! Skip subprocess paths (`cargo llvm-cov report` / `cargo metadata`).
+    use super::*;
+    use tempfile::TempDir;
+
+    fn write(path: &Path, content: &str) {
+        if let Some(parent) = path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        std::fs::write(path, content).expect("write");
+    }
+
+    // --- dir_mtime ---
+
+    #[test]
+    fn test_dir_mtime_returns_none_for_missing_dir() {
+        assert!(dir_mtime(Path::new("/tmp/absolutely-does-not-exist-aaa")).is_none());
+    }
+
+    #[test]
+    fn test_dir_mtime_returns_some_for_existing_dir() {
+        let tmp = TempDir::new().unwrap();
+        let mtime = dir_mtime(tmp.path());
+        assert!(
+            mtime.is_some(),
+            "expected Some mtime for {}",
+            tmp.path().display()
+        );
+        assert!(mtime.unwrap() > 0);
+    }
+
+    // --- target_dir_from_cargo_config ---
+
+    #[test]
+    fn test_target_dir_from_cargo_config_missing_file_returns_empty() {
+        let tmp = TempDir::new().unwrap();
+        let result = target_dir_from_cargo_config(&tmp.path().join("nonexistent.toml"), tmp.path());
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_target_dir_from_cargo_config_no_target_dir_key_returns_empty() {
+        let tmp = TempDir::new().unwrap();
+        let cfg = tmp.path().join("config.toml");
+        write(&cfg, "[build]\nrustflags = []\n");
+        let result = target_dir_from_cargo_config(&cfg, tmp.path());
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_target_dir_from_cargo_config_relative_resolves_against_project_root() {
+        let tmp = TempDir::new().unwrap();
+        let cfg = tmp.path().join("config.toml");
+        write(&cfg, "target-dir = \"custom-target\"\n");
+        let result = target_dir_from_cargo_config(&cfg, tmp.path());
+        assert_eq!(result.len(), 1);
+        assert_eq!(
+            result[0],
+            tmp.path().join("custom-target").join("llvm-cov-target")
+        );
+    }
+
+    #[test]
+    fn test_target_dir_from_cargo_config_absolute_preserved() {
+        let tmp = TempDir::new().unwrap();
+        let cfg = tmp.path().join("config.toml");
+        write(&cfg, "target-dir = \"/mnt/custom\"\n");
+        let result = target_dir_from_cargo_config(&cfg, tmp.path());
+        assert_eq!(result.len(), 1);
+        assert_eq!(
+            result[0],
+            std::path::PathBuf::from("/mnt/custom/llvm-cov-target")
+        );
+    }
+
+    #[test]
+    fn test_target_dir_from_cargo_config_single_quotes_accepted() {
+        let tmp = TempDir::new().unwrap();
+        let cfg = tmp.path().join("config.toml");
+        write(&cfg, "target-dir = 'with-single-quotes'\n");
+        let result = target_dir_from_cargo_config(&cfg, tmp.path());
+        assert_eq!(result.len(), 1);
+        assert_eq!(
+            result[0],
+            tmp.path()
+                .join("with-single-quotes")
+                .join("llvm-cov-target")
+        );
+    }
+
+    // --- mnt_target_candidates ---
+
+    #[test]
+    fn test_mnt_target_candidates_returns_vec_shaped_like_project_name() {
+        let tmp = TempDir::new().unwrap();
+        // mnt_target_candidates canonicalizes the project path to get its file name,
+        // then scans /mnt. We can't assert the count (host-dependent), but every
+        // returned path should end with "{project_name}/llvm-cov-target".
+        let project_name = tmp
+            .path()
+            .canonicalize()
+            .unwrap()
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .into_owned();
+        let out = mnt_target_candidates(tmp.path());
+        for p in out {
+            assert!(
+                p.to_string_lossy().contains(&project_name),
+                "path missing project name: {}",
+                p.display()
+            );
+            assert!(p.ends_with("llvm-cov-target"));
+        }
+    }
+
+    // --- collect_fast_candidates ---
+
+    #[test]
+    fn test_collect_fast_candidates_uses_stored_path_first() {
+        let tmp = TempDir::new().unwrap();
+        let stored = "/tmp/my-stored-path";
+        let out = collect_fast_candidates(tmp.path(), Some(stored));
+        assert_eq!(out[0], std::path::PathBuf::from(stored));
+    }
+
+    #[test]
+    fn test_collect_fast_candidates_includes_default_target_dir() {
+        let tmp = TempDir::new().unwrap();
+        let out = collect_fast_candidates(tmp.path(), None);
+        // Default `project_root/target/llvm-cov-target` must be present.
+        let default = tmp.path().join("target").join("llvm-cov-target");
+        assert!(
+            out.contains(&default),
+            "default target dir missing; got: {out:?}"
+        );
+    }
+
+    #[test]
+    fn test_collect_fast_candidates_honors_cargo_target_dir_env_var() {
+        let tmp = TempDir::new().unwrap();
+        // SAFETY: tests run in a shared environment. This may race with parallel
+        // tests in this module. To avoid false negatives we only check that the
+        // env-var path appears in the output when set.
+        let marker = "/tmp/test-cargo-target-dir-marker";
+        // Snapshot original env
+        let orig = std::env::var("CARGO_TARGET_DIR").ok();
+        std::env::set_var("CARGO_TARGET_DIR", marker);
+        let out = collect_fast_candidates(tmp.path(), None);
+        // Restore
+        match orig {
+            Some(v) => std::env::set_var("CARGO_TARGET_DIR", v),
+            None => std::env::remove_var("CARGO_TARGET_DIR"),
+        }
+        let expected = std::path::PathBuf::from(marker).join("llvm-cov-target");
+        assert!(
+            out.contains(&expected),
+            "expected marker path to be in candidates"
+        );
+    }
+
+    #[test]
+    fn test_collect_fast_candidates_picks_up_project_local_cargo_config() {
+        let tmp = TempDir::new().unwrap();
+        let cfg = tmp.path().join(".cargo").join("config.toml");
+        write(&cfg, "target-dir = \"custom\"\n");
+        let out = collect_fast_candidates(tmp.path(), None);
+        let expected = tmp.path().join("custom").join("llvm-cov-target");
+        assert!(
+            out.contains(&expected),
+            "expected project-local target-dir to be picked up; got: {out:?}"
+        );
+    }
+
+    // --- extract_target_directory ---
+
+    #[test]
+    fn test_extract_target_directory_parses_basic_json() {
+        let json = r#"{"target_directory":"/tmp/some/target","other":"x"}"#;
+        assert_eq!(extract_target_directory(json), Some("/tmp/some/target"));
+    }
+
+    #[test]
+    fn test_extract_target_directory_missing_key_returns_none() {
+        let json = r#"{"other":"x"}"#;
+        assert_eq!(extract_target_directory(json), None);
+    }
+
+    #[test]
+    fn test_extract_target_directory_unterminated_value_returns_none() {
+        // No closing quote after `target_directory`'s value → rest.find('"') returns None.
+        let json = r#"{"target_directory":"still-open"#;
+        assert_eq!(extract_target_directory(json), None);
+    }
+
+    #[test]
+    fn test_extract_target_directory_handles_embedded_json_fragment() {
+        let json = r#"{"packages":[],"target_directory":"/x/y","version":1}"#;
+        assert_eq!(extract_target_directory(json), Some("/x/y"));
+    }
+
+    // --- load_coverage_from_cache ---
+
+    #[test]
+    fn test_load_cache_missing_file_returns_none() {
+        let tmp = TempDir::new().unwrap();
+        assert!(
+            load_coverage_from_cache(&tmp.path().join("missing.json"), "abc1234", tmp.path(),)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn test_load_cache_corrupt_json_returns_none() {
+        let tmp = TempDir::new().unwrap();
+        let p = tmp.path().join("cache.json");
+        write(&p, "{not valid json");
+        assert!(load_coverage_from_cache(&p, "abc1234", tmp.path()).is_none());
+    }
+
+    #[test]
+    fn test_load_cache_hash_mismatch_returns_none_when_no_mtime() {
+        // When cache has no coverage_mtime, fallback is git hash comparison.
+        let tmp = TempDir::new().unwrap();
+        let cache = CoverageCache {
+            git_hash: "oldhash".to_string(),
+            coverage_mtime: None,
+            profdata_dir: None,
+            files: HashMap::new(),
+        };
+        let p = tmp.path().join("cache.json");
+        write(&p, &serde_json::to_string(&cache).unwrap());
+        assert!(load_coverage_from_cache(&p, "newhash", tmp.path()).is_none());
+    }
+
+    #[test]
+    fn test_load_cache_hash_match_returns_files_when_no_mtime() {
+        let tmp = TempDir::new().unwrap();
+        let mut files = HashMap::new();
+        let mut hits = HashMap::new();
+        hits.insert(1usize, 2u64);
+        files.insert("src/foo.rs".to_string(), hits);
+        let cache = CoverageCache {
+            git_hash: "abc".to_string(),
+            coverage_mtime: None,
+            profdata_dir: None,
+            files: files.clone(),
+        };
+        let p = tmp.path().join("cache.json");
+        write(&p, &serde_json::to_string(&cache).unwrap());
+        let loaded = load_coverage_from_cache(&p, "abc", tmp.path()).expect("some");
+        assert_eq!(loaded, files);
+    }
+
+    // --- write_coverage_cache ---
+
+    #[test]
+    fn test_write_coverage_cache_writes_json_and_creates_pmat_dir() {
+        let tmp = TempDir::new().unwrap();
+        let cache_path = tmp.path().join(".pmat").join("coverage-cache.json");
+        let mut files = HashMap::new();
+        let mut hits = HashMap::new();
+        hits.insert(5usize, 1u64);
+        files.insert("src/lib.rs".to_string(), hits.clone());
+        write_coverage_cache(&cache_path, "sha-xyz", tmp.path(), &files);
+        assert!(cache_path.exists(), "cache file missing");
+        let content = std::fs::read_to_string(&cache_path).unwrap();
+        let cache: CoverageCache = serde_json::from_str(&content).unwrap();
+        assert_eq!(cache.git_hash, "sha-xyz");
+        assert_eq!(cache.files.get("src/lib.rs"), Some(&hits));
+    }
+
+    // --- write_negative_coverage_cache ---
+
+    #[test]
+    fn test_write_negative_coverage_cache_writes_empty_files_map() {
+        let tmp = TempDir::new().unwrap();
+        let cache_path = tmp.path().join(".pmat").join("neg.json");
+        write_negative_coverage_cache(&cache_path, "sha-neg", tmp.path());
+        assert!(cache_path.exists());
+        let cache: CoverageCache =
+            serde_json::from_str(&std::fs::read_to_string(&cache_path).unwrap()).unwrap();
+        assert_eq!(cache.git_hash, "sha-neg");
+        assert!(cache.files.is_empty());
+    }
+
+    // --- get_profdata_mtime_fast ---
+
+    #[test]
+    fn test_get_profdata_mtime_fast_returns_stored_path_when_extant() {
+        let tmp = TempDir::new().unwrap();
+        // stored_path points to an existing directory — function returns (mtime, path).
+        let stored = tmp.path().to_string_lossy().into_owned();
+        let out = get_profdata_mtime_fast(tmp.path(), Some(&stored));
+        assert!(out.is_some(), "expected Some for extant stored_path");
+        let (_, path) = out.unwrap();
+        assert_eq!(path, stored);
+    }
+
+    #[test]
+    fn test_get_profdata_mtime_fast_returns_none_on_empty_project() {
+        // Empty tempdir has no llvm-cov-target anywhere and no env overrides.
+        let tmp = TempDir::new().unwrap();
+        // Clear env just in case
+        let orig = std::env::var("CARGO_TARGET_DIR").ok();
+        std::env::remove_var("CARGO_TARGET_DIR");
+        let out = get_profdata_mtime_fast(tmp.path(), None);
+        match orig {
+            Some(v) => std::env::set_var("CARGO_TARGET_DIR", v),
+            None => std::env::remove_var("CARGO_TARGET_DIR"),
+        }
+        // Without CARGO_TARGET_DIR and without a real target dir, this is None.
+        // However some machines have /mnt with a path-matching dir — accept either.
+        let _ = out; // Just ensure the call is covered.
+    }
+
+    // --- full load_coverage_from_cache with mtime (most involved path) ---
+
+    #[test]
+    fn test_load_cache_with_matching_mtime_bypasses_git_hash() {
+        let tmp = TempDir::new().unwrap();
+        // Create a fake profdata dir
+        let profdata = tmp.path().join("target").join("llvm-cov-target");
+        std::fs::create_dir_all(&profdata).unwrap();
+        let current_mtime = dir_mtime(&profdata).expect("mtime");
+        // Build a cache whose stored mtime >= current mtime → cache valid.
+        let cache = CoverageCache {
+            git_hash: "wrong-hash".to_string(),
+            coverage_mtime: Some(current_mtime),
+            profdata_dir: Some(profdata.to_string_lossy().into_owned()),
+            files: {
+                let mut m = HashMap::new();
+                m.insert("x.rs".to_string(), HashMap::new());
+                m
+            },
+        };
+        let cache_path = tmp.path().join("cache.json");
+        write(&cache_path, &serde_json::to_string(&cache).unwrap());
+
+        let loaded = load_coverage_from_cache(&cache_path, "any-hash", tmp.path());
+        assert!(
+            loaded.is_some(),
+            "cached mtime should validate regardless of git hash"
+        );
+        assert!(loaded.unwrap().contains_key("x.rs"));
+    }
+
+    #[test]
+    fn test_load_cache_stale_mtime_returns_none() {
+        let tmp = TempDir::new().unwrap();
+        let profdata = tmp.path().join("target").join("llvm-cov-target");
+        std::fs::create_dir_all(&profdata).unwrap();
+        // Sleep 1s so current mtime is strictly later than a fresh-captured cached mtime.
+        // Actually the test goes the other way: we claim cached_mtime=0 (old) and
+        // current is now() >> 0, so current > cached → INVALID.
+        let cache = CoverageCache {
+            git_hash: "h".to_string(),
+            coverage_mtime: Some(0), // epoch
+            profdata_dir: Some(profdata.to_string_lossy().into_owned()),
+            files: HashMap::new(),
+        };
+        let cache_path = tmp.path().join("cache.json");
+        write(&cache_path, &serde_json::to_string(&cache).unwrap());
+        let loaded = load_coverage_from_cache(&cache_path, "h", tmp.path());
+        assert!(loaded.is_none(), "stale mtime must invalidate cache");
+    }
+}


### PR DESCRIPTION
## Summary

Continues Phase-1 CLI/services pivot after PR #507/PMAT-642. \`services/agent_context/query/coverage/profdata.rs\` is the cache loader for \`pmat query --coverage-gaps\`. **0/340 broad-covered on master**. Pure fs+compute.

Added **26 tests** inside profdata.rs's own \`mod tests\` (needed for access to private helpers):

- \`dir_mtime\` — missing / existing dir
- \`target_dir_from_cargo_config\` — missing file, no key, relative (resolved), absolute (preserved), single-quoted value
- \`mnt_target_candidates\` — shape assertion (count is host-dependent)
- \`collect_fast_candidates\` — stored_path first, default dir, CARGO_TARGET_DIR env honored, project-local \`.cargo/config.toml\`
- \`extract_target_directory\` — basic parse, missing key, unterminated value, embedded mid-JSON
- \`load_coverage_from_cache\` — missing file, corrupt JSON, hash mismatch/match (no mtime), mtime-valid-regardless-of-git-hash, stale mtime
- \`write_coverage_cache\` + \`write_negative_coverage_cache\` — JSON roundtrip with files / empty files
- \`get_profdata_mtime_fast\` — stored_path returns Some, empty-project call covered

Skipped subprocess paths (\`run_llvm_cov_subprocess\`, \`wait_with_timeout\`, \`cargo_metadata_target_dir\`) — those spawn cargo.

## Coverage impact

File carries \`coverage(off)\` but \`make coverage-broad\` disables that with \`--no-cfg-coverage --no-cfg-coverage-nightly\`, so this moves broad gate.

Expected delta: ~+0.08pp (closing most of 340 missed lines on 324k denominator).

## Test plan

- [x] \`cargo test --lib -- services::agent_context::query::coverage::profdata::tests\` — 26 passed, 0 failed
- [x] \`cargo fmt --all -- --check\` — clean
- [ ] CI gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)