### PR TITLE
test(coverage): ast_formatting.rs pure formatter surface (PMAT-644)

### DIFF
--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -3213,3 +3213,20 @@ roadmap:
   estimated_effort: null
   labels: []
   notes: null
+- id: PMAT-644
+  github_issue: null
+  item_type: task
+  title: 'Phase 1 pivot: services/deep_context/analyzer_formatting/ast_formatting.rs coverage'
+  status: inprogress
+  priority: medium
+  assigned_to: null
+  created: 2026-04-24T08:25:02Z
+  updated: 2026-04-24T08:25:02Z
+  spec: null
+  acceptance_criteria:
+  - 'Phase 1 CLI/services pivot — ast_formatting.rs is 484 lines, 0/282 broad-covered, 100% sync. Cover format_import_path all 3 branches, categorize_single_ast_item all 8 AstItem variants (including Import with/without items/alias), each write_*_section empty/populated/truncation branches (functions >10, structs/enums/traits/impls/modules >5, imports ≤8 vs count-only), full format_enhanced_ast_section integration test.'
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels: []
+  notes: null

--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -3217,7 +3217,7 @@ roadmap:
   github_issue: null
   item_type: task
   title: 'Phase 1 pivot: services/deep_context/analyzer_formatting/ast_formatting.rs coverage'
-  status: inprogress
+  status: review
   priority: medium
   assigned_to: null
   created: 2026-04-24T08:25:02Z

--- a/examples/mcp_agent_context_demo.rs
+++ b/examples/mcp_agent_context_demo.rs
@@ -54,68 +54,132 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     thread::sleep(Duration::from_secs(10));
 
     // 1. initialize handshake
-    let resp = rpc(&mut writer, &mut reader, 1, "initialize", json!({
-        "protocolVersion": "2024-11-05",
-        "capabilities": {},
-        "clientInfo": { "name": "mcp_agent_context_demo", "version": "1.0" }
-    }))?;
-    let server_info = resp.pointer("/result/serverInfo/name").cloned().unwrap_or(json!("?"));
+    let resp = rpc(
+        &mut writer,
+        &mut reader,
+        1,
+        "initialize",
+        json!({
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": { "name": "mcp_agent_context_demo", "version": "1.0" }
+        }),
+    )?;
+    let server_info = resp
+        .pointer("/result/serverInfo/name")
+        .cloned()
+        .unwrap_or(json!("?"));
     println!("[initialize] server={}", server_info);
 
     // 2. tools/list — sanity check that the 4 pmat_* tools are registered
     let resp = rpc(&mut writer, &mut reader, 2, "tools/list", json!({}))?;
-    let tools = resp.pointer("/result/tools").and_then(|v| v.as_array()).cloned().unwrap_or_default();
-    let pmat_tools: Vec<&str> = tools.iter()
+    let tools = resp
+        .pointer("/result/tools")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+    let pmat_tools: Vec<&str> = tools
+        .iter()
         .filter_map(|t| t.get("name").and_then(|n| n.as_str()))
         .filter(|n| n.starts_with("pmat_"))
         .collect();
-    println!("[tools/list] total={} pmat_*={} ({:?})", tools.len(), pmat_tools.len(), pmat_tools);
+    println!(
+        "[tools/list] total={} pmat_*={} ({:?})",
+        tools.len(),
+        pmat_tools.len(),
+        pmat_tools
+    );
 
     // 3. pmat_index_stats — pick up a real function_id we can reuse below
-    let resp = call_tool(&mut writer, &mut reader, 3, "pmat_index_stats",
-        json!({ "rebuild": false }))?;
+    let resp = call_tool(
+        &mut writer,
+        &mut reader,
+        3,
+        "pmat_index_stats",
+        json!({ "rebuild": false }),
+    )?;
     let index_result = extract_tool_result(&resp);
-    let fn_count = index_result.pointer("/manifest/function_count").cloned().unwrap_or(json!(0));
-    let file_count = index_result.pointer("/manifest/file_count").cloned().unwrap_or(json!(0));
-    println!("[pmat_index_stats] ok: functions={} files={}", fn_count, file_count);
+    let fn_count = index_result
+        .pointer("/manifest/function_count")
+        .cloned()
+        .unwrap_or(json!(0));
+    let file_count = index_result
+        .pointer("/manifest/file_count")
+        .cloned()
+        .unwrap_or(json!(0));
+    println!(
+        "[pmat_index_stats] ok: functions={} files={}",
+        fn_count, file_count
+    );
 
     // 4. pmat_query_code — realistic semantic query
-    let resp = call_tool(&mut writer, &mut reader, 4, "pmat_query_code",
-        json!({ "query": "error handling", "limit": 3 }))?;
+    let resp = call_tool(
+        &mut writer,
+        &mut reader,
+        4,
+        "pmat_query_code",
+        json!({ "query": "error handling", "limit": 3 }),
+    )?;
     let query_result = extract_tool_result(&resp);
-    let result_count = query_result.get("results")
+    let result_count = query_result
+        .get("results")
         .or_else(|| query_result.get("functions"))
         .and_then(|v| v.as_array())
         .map(|a| a.len())
         .unwrap_or(0);
-    let first_id = query_result.pointer("/results/0/id")
+    let first_id = query_result
+        .pointer("/results/0/id")
         .or_else(|| query_result.pointer("/functions/0/id"))
         .and_then(|v| v.as_str())
         .map(|s| s.to_string());
-    println!("[pmat_query_code] ok: {} results; first_id={:?}", result_count, first_id);
+    println!(
+        "[pmat_query_code] ok: {} results; first_id={:?}",
+        result_count, first_id
+    );
 
     // 5. pmat_get_function — use the first id from query_code, or fall back to "main"
-    let function_id = first_id.clone().unwrap_or_else(|| "src/bin/pmat.rs::main".to_string());
-    let resp = call_tool(&mut writer, &mut reader, 5, "pmat_get_function",
-        json!({ "function_id": function_id, "include_source": false }))?;
+    let function_id = first_id
+        .clone()
+        .unwrap_or_else(|| "src/bin/pmat.rs::main".to_string());
+    let resp = call_tool(
+        &mut writer,
+        &mut reader,
+        5,
+        "pmat_get_function",
+        json!({ "function_id": function_id, "include_source": false }),
+    )?;
     match resp.get("error") {
-        Some(err) => println!("[pmat_get_function] graceful miss for {:?}: {}", function_id,
-            err.get("message").and_then(|m| m.as_str()).unwrap_or("?")),
+        Some(err) => println!(
+            "[pmat_get_function] graceful miss for {:?}: {}",
+            function_id,
+            err.get("message").and_then(|m| m.as_str()).unwrap_or("?")
+        ),
         None => {
             let gf = extract_tool_result(&resp);
-            println!("[pmat_get_function] ok: name={} grade={}",
+            println!(
+                "[pmat_get_function] ok: name={} grade={}",
                 gf.get("name").and_then(|v| v.as_str()).unwrap_or("?"),
-                gf.pointer("/quality/grade").and_then(|v| v.as_str()).unwrap_or("?"));
+                gf.pointer("/quality/grade")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("?")
+            );
         }
     }
 
     // 6. pmat_find_similar — only meaningful if we got a real id from the query
     if let Some(id) = first_id {
-        let resp = call_tool(&mut writer, &mut reader, 6, "pmat_find_similar",
-            json!({ "function_id": id, "limit": 3, "min_similarity": 0.3 }))?;
+        let resp = call_tool(
+            &mut writer,
+            &mut reader,
+            6,
+            "pmat_find_similar",
+            json!({ "function_id": id, "limit": 3, "min_similarity": 0.3 }),
+        )?;
         match resp.get("error") {
-            Some(err) => println!("[pmat_find_similar] error: {}",
-                err.get("message").and_then(|m| m.as_str()).unwrap_or("?")),
+            Some(err) => println!(
+                "[pmat_find_similar] error: {}",
+                err.get("message").and_then(|m| m.as_str()).unwrap_or("?")
+            ),
             None => {
                 let sim = extract_tool_result(&resp);
                 let total = sim.get("total").and_then(|v| v.as_u64()).unwrap_or(0);
@@ -162,7 +226,13 @@ fn call_tool(
     name: &str,
     args: Value,
 ) -> Result<Value, Box<dyn std::error::Error>> {
-    rpc(writer, reader, id, "tools/call", json!({ "name": name, "arguments": args }))
+    rpc(
+        writer,
+        reader,
+        id,
+        "tools/call",
+        json!({ "name": name, "arguments": args }),
+    )
 }
 
 /// MCP `tools/call` wraps results in `result.content[0].text` (JSON string) or
@@ -171,7 +241,10 @@ fn extract_tool_result(resp: &Value) -> Value {
     if let Some(sc) = resp.pointer("/result/structuredContent") {
         return sc.clone();
     }
-    if let Some(text) = resp.pointer("/result/content/0/text").and_then(|v| v.as_str()) {
+    if let Some(text) = resp
+        .pointer("/result/content/0/text")
+        .and_then(|v| v.as_str())
+    {
         if let Ok(parsed) = serde_json::from_str::<Value>(text) {
             return parsed;
         }

--- a/src/bin/pmat.rs
+++ b/src/bin/pmat.rs
@@ -16,301 +16,301 @@ fn main() {
 
 #[cfg(feature = "standard-deps")]
 mod full {
-use anyhow::Result;
-use pmat::{cli, stateless_server::StatelessTemplateServer};
-use std::io::IsTerminal;
-use std::process;
-use std::sync::Arc;
-use tracing::{debug, error, info, trace};
-use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
+    use anyhow::Result;
+    use pmat::{cli, stateless_server::StatelessTemplateServer};
+    use std::io::IsTerminal;
+    use std::process;
+    use std::sync::Arc;
+    use tracing::{debug, error, info, trace};
+    use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 
-enum ExecutionMode {
-    Mcp,
-    Cli,
-    /// No subcommand given and stdin is piped (not a TTY) without an explicit
-    /// MCP opt-in. Print help and exit non-zero instead of blocking on stdin
-    /// (see GH-285).
-    HelpAndExit,
-}
-
-/// POSIX-compliant exit codes for CLI interface
-/// Per SPECIFICATION.md Section 23: CLI Interface
-#[derive(Debug, Clone, Copy)]
-pub enum ExitCode {
-    /// Success
-    Success = 0,
-    /// General error
-    GeneralError = 1,
-    /// Misuse of shell command
-    MisuseError = 2,
-    /// Permission denied
-    PermissionDenied = 126,
-    /// Command not found
-    CommandNotFound = 127,
-    /// Invalid argument to exit
-    InvalidExitArg = 128,
-    /// Quality gate failure (custom)
-    QualityGateFailure = 3,
-    /// Configuration error (custom)
-    ConfigurationError = 4,
-    /// Analysis error (custom)
-    AnalysisError = 5,
-}
-
-impl From<ExitCode> for i32 {
-    fn from(code: ExitCode) -> Self {
-        code as i32
-    }
-}
-
-fn detect_execution_mode() -> ExecutionMode {
-    classify_execution_mode(
-        std::env::var("MCP_VERSION").is_ok(),
-        std::env::args().len() == 1,
-        !std::io::stdin().is_terminal(),
-    )
-}
-
-/// Pure decision function for execution mode so it can be unit-tested
-/// without touching real stdin / env vars (see GH-285 regression test).
-fn classify_execution_mode(
-    mcp_version_env: bool,
-    no_args: bool,
-    stdin_is_pipe: bool,
-) -> ExecutionMode {
-    // Explicit MCP opt-in via env var always wins (e.g. Claude Desktop sets this).
-    if mcp_version_env {
-        return ExecutionMode::Mcp;
+    enum ExecutionMode {
+        Mcp,
+        Cli,
+        /// No subcommand given and stdin is piped (not a TTY) without an explicit
+        /// MCP opt-in. Print help and exit non-zero instead of blocking on stdin
+        /// (see GH-285).
+        HelpAndExit,
     }
 
-    // GH-285: If the user ran bare `pmat` with stdin piped (e.g. `echo "" | pmat`)
-    // without opting into MCP via `MCP_VERSION`, previous behavior entered the MCP
-    // server and blocked forever on stdin. Treat that case the same as bare `pmat`
-    // on a terminal: print help and exit non-zero.
-    if no_args && stdin_is_pipe {
-        return ExecutionMode::HelpAndExit;
+    /// POSIX-compliant exit codes for CLI interface
+    /// Per SPECIFICATION.md Section 23: CLI Interface
+    #[derive(Debug, Clone, Copy)]
+    pub enum ExitCode {
+        /// Success
+        Success = 0,
+        /// General error
+        GeneralError = 1,
+        /// Misuse of shell command
+        MisuseError = 2,
+        /// Permission denied
+        PermissionDenied = 126,
+        /// Command not found
+        CommandNotFound = 127,
+        /// Invalid argument to exit
+        InvalidExitArg = 128,
+        /// Quality gate failure (custom)
+        QualityGateFailure = 3,
+        /// Configuration error (custom)
+        ConfigurationError = 4,
+        /// Analysis error (custom)
+        AnalysisError = 5,
     }
 
-    ExecutionMode::Cli
-}
+    impl From<ExitCode> for i32 {
+        fn from(code: ExitCode) -> Self {
+            code as i32
+        }
+    }
 
-/// Initialize the enhanced tracing system based on CLI flags
-fn init_tracing(cli: &cli::EarlyCliArgs) -> Result<()> {
-    let filter = create_env_filter(cli)?;
-
-    tracing_subscriber::registry()
-        .with(filter)
-        .with(
-            tracing_subscriber::fmt::layer()
-                .with_target(cli.debug || cli.trace)
-                .with_thread_ids(cli.trace)
-                .with_file(cli.trace)
-                .with_line_number(cli.trace)
-                .compact()
-                .with_writer(std::io::stderr),
+    fn detect_execution_mode() -> ExecutionMode {
+        classify_execution_mode(
+            std::env::var("MCP_VERSION").is_ok(),
+            std::env::args().len() == 1,
+            !std::io::stdin().is_terminal(),
         )
-        .init();
-
-    Ok(())
-}
-
-/// Create environment filter based on CLI flags
-fn create_env_filter(cli: &cli::EarlyCliArgs) -> Result<EnvFilter> {
-    if cli.is_mcp_server {
-        Ok(create_mcp_filter(cli.debug))
-    } else {
-        create_cli_filter(cli)
-    }
-}
-
-/// Create filter for MCP server mode
-fn create_mcp_filter(debug: bool) -> EnvFilter {
-    if debug {
-        EnvFilter::new("warn,pmat=debug")
-    } else {
-        EnvFilter::new("off")
-    }
-}
-
-/// Create filter for CLI mode
-fn create_cli_filter(cli: &cli::EarlyCliArgs) -> Result<EnvFilter> {
-    if let Some(ref custom) = cli.trace_filter {
-        return Ok(EnvFilter::try_new(custom)?);
     }
 
-    let filter_str = match (cli.trace, cli.debug, cli.verbose) {
-        (true, _, _) => "debug,pmat=trace",
-        (_, true, _) => "warn,pmat=debug",
-        (_, _, true) => "warn,pmat=info",
-        _ => return Ok(get_default_filter()),
-    };
-
-    Ok(EnvFilter::new(filter_str))
-}
-
-/// Get default production filter
-fn get_default_filter() -> EnvFilter {
-    EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("warn"))
-}
-
-#[tokio::main]
-#[allow(unreachable_pub)]
-pub async fn real_main() {
-    let exit_code = match run_main().await {
-        Ok(()) => ExitCode::Success,
-        Err(e) => {
-            error!("Error: {:#}", e);
-            categorize_error(&e)
+    /// Pure decision function for execution mode so it can be unit-tested
+    /// without touching real stdin / env vars (see GH-285 regression test).
+    fn classify_execution_mode(
+        mcp_version_env: bool,
+        no_args: bool,
+        stdin_is_pipe: bool,
+    ) -> ExecutionMode {
+        // Explicit MCP opt-in via env var always wins (e.g. Claude Desktop sets this).
+        if mcp_version_env {
+            return ExecutionMode::Mcp;
         }
-    };
 
-    if exit_code as i32 != 0 {
-        process::exit(exit_code.into());
-    }
-}
+        // GH-285: If the user ran bare `pmat` with stdin piped (e.g. `echo "" | pmat`)
+        // without opting into MCP via `MCP_VERSION`, previous behavior entered the MCP
+        // server and blocked forever on stdin. Treat that case the same as bare `pmat`
+        // on a terminal: print help and exit non-zero.
+        if no_args && stdin_is_pipe {
+            return ExecutionMode::HelpAndExit;
+        }
 
-fn categorize_error(error: &anyhow::Error) -> ExitCode {
-    let error_str = error.to_string().to_lowercase();
-
-    match () {
-        _ if is_quality_gate_error(&error_str) => ExitCode::QualityGateFailure,
-        _ if is_configuration_error(&error_str) => ExitCode::ConfigurationError,
-        _ if is_analysis_error(&error_str) => ExitCode::AnalysisError,
-        _ if is_permission_error(&error_str) => ExitCode::PermissionDenied,
-        _ => ExitCode::GeneralError,
-    }
-}
-
-fn is_quality_gate_error(error_str: &str) -> bool {
-    error_str.contains("quality gate") || error_str.contains("violation")
-}
-
-fn is_configuration_error(error_str: &str) -> bool {
-    error_str.contains("config") || error_str.contains("parse")
-}
-
-fn is_analysis_error(error_str: &str) -> bool {
-    error_str.contains("analysis") || error_str.contains("complexity")
-}
-
-fn is_permission_error(error_str: &str) -> bool {
-    error_str.contains("permission") || error_str.contains("access")
-}
-
-async fn run_main() -> Result<()> {
-    // Parse CLI to get tracing configuration early
-    let cli = cli::parse_early_for_tracing();
-
-    // Initialize enhanced tracing system
-    init_tracing(&cli)?;
-
-    // Only log to stdout if not running MCP server mode
-    if !cli.is_mcp_server {
-        info!(
-            "Starting PAIML MCP Agent Toolkit v{}",
-            env!("CARGO_PKG_VERSION")
-        );
-        debug!("Debug logging enabled");
-        trace!("Trace logging enabled");
+        ExecutionMode::Cli
     }
 
-    // Create shared template server
-    let server = Arc::new(StatelessTemplateServer::new()?);
+    /// Initialize the enhanced tracing system based on CLI flags
+    fn init_tracing(cli: &cli::EarlyCliArgs) -> Result<()> {
+        let filter = create_env_filter(cli)?;
 
-    if !cli.is_mcp_server {
-        debug!("Template server initialized");
+        tracing_subscriber::registry()
+            .with(filter)
+            .with(
+                tracing_subscriber::fmt::layer()
+                    .with_target(cli.debug || cli.trace)
+                    .with_thread_ids(cli.trace)
+                    .with_file(cli.trace)
+                    .with_line_number(cli.trace)
+                    .compact()
+                    .with_writer(std::io::stderr),
+            )
+            .init();
+
+        Ok(())
     }
 
-    match detect_execution_mode() {
-        ExecutionMode::Mcp => {
-            if !cli.is_mcp_server {
-                info!("Running unified MCP server (pmcp SDK)");
+    /// Create environment filter based on CLI flags
+    fn create_env_filter(cli: &cli::EarlyCliArgs) -> Result<EnvFilter> {
+        if cli.is_mcp_server {
+            Ok(create_mcp_filter(cli.debug))
+        } else {
+            create_cli_filter(cli)
+        }
+    }
+
+    /// Create filter for MCP server mode
+    fn create_mcp_filter(debug: bool) -> EnvFilter {
+        if debug {
+            EnvFilter::new("warn,pmat=debug")
+        } else {
+            EnvFilter::new("off")
+        }
+    }
+
+    /// Create filter for CLI mode
+    fn create_cli_filter(cli: &cli::EarlyCliArgs) -> Result<EnvFilter> {
+        if let Some(ref custom) = cli.trace_filter {
+            return Ok(EnvFilter::try_new(custom)?);
+        }
+
+        let filter_str = match (cli.trace, cli.debug, cli.verbose) {
+            (true, _, _) => "debug,pmat=trace",
+            (_, true, _) => "warn,pmat=debug",
+            (_, _, true) => "warn,pmat=info",
+            _ => return Ok(get_default_filter()),
+        };
+
+        Ok(EnvFilter::new(filter_str))
+    }
+
+    /// Get default production filter
+    fn get_default_filter() -> EnvFilter {
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("warn"))
+    }
+
+    #[tokio::main]
+    #[allow(unreachable_pub)]
+    pub async fn real_main() {
+        let exit_code = match run_main().await {
+            Ok(()) => ExitCode::Success,
+            Err(e) => {
+                error!("Error: {:#}", e);
+                categorize_error(&e)
             }
-            let unified_server = pmat::mcp_pmcp::UnifiedServer::new()
-                .map_err(|e| anyhow::anyhow!("Failed to create unified server: {}", e))?;
-            unified_server
-                .run()
-                .await
-                .map_err(|e| anyhow::anyhow!("{}", e))
+        };
+
+        if exit_code as i32 != 0 {
+            process::exit(exit_code.into());
         }
-        ExecutionMode::Cli => {
-            if !cli.is_mcp_server {
-                info!("Running in CLI mode");
-            }
-            cli::run(server).await
+    }
+
+    fn categorize_error(error: &anyhow::Error) -> ExitCode {
+        let error_str = error.to_string().to_lowercase();
+
+        match () {
+            _ if is_quality_gate_error(&error_str) => ExitCode::QualityGateFailure,
+            _ if is_configuration_error(&error_str) => ExitCode::ConfigurationError,
+            _ if is_analysis_error(&error_str) => ExitCode::AnalysisError,
+            _ if is_permission_error(&error_str) => ExitCode::PermissionDenied,
+            _ => ExitCode::GeneralError,
         }
-        ExecutionMode::HelpAndExit => {
-            // GH-285: No subcommand + piped stdin + no MCP_VERSION. Print help on
-            // stderr and exit with code 2 (misuse), matching the convention for
-            // "no command supplied" on a terminal.
-            let mut cmd = <pmat::cli::Cli as clap::CommandFactory>::command();
-            let _ = cmd.print_help();
-            eprintln!(
-                "\nerror: no subcommand given and stdin is not a terminal. \
-                 Set MCP_VERSION=1 (or run `pmat agent mcp-server`) to start the MCP server."
+    }
+
+    fn is_quality_gate_error(error_str: &str) -> bool {
+        error_str.contains("quality gate") || error_str.contains("violation")
+    }
+
+    fn is_configuration_error(error_str: &str) -> bool {
+        error_str.contains("config") || error_str.contains("parse")
+    }
+
+    fn is_analysis_error(error_str: &str) -> bool {
+        error_str.contains("analysis") || error_str.contains("complexity")
+    }
+
+    fn is_permission_error(error_str: &str) -> bool {
+        error_str.contains("permission") || error_str.contains("access")
+    }
+
+    async fn run_main() -> Result<()> {
+        // Parse CLI to get tracing configuration early
+        let cli = cli::parse_early_for_tracing();
+
+        // Initialize enhanced tracing system
+        init_tracing(&cli)?;
+
+        // Only log to stdout if not running MCP server mode
+        if !cli.is_mcp_server {
+            info!(
+                "Starting PAIML MCP Agent Toolkit v{}",
+                env!("CARGO_PKG_VERSION")
             );
-            process::exit(ExitCode::MisuseError as i32);
+            debug!("Debug logging enabled");
+            trace!("Trace logging enabled");
+        }
+
+        // Create shared template server
+        let server = Arc::new(StatelessTemplateServer::new()?);
+
+        if !cli.is_mcp_server {
+            debug!("Template server initialized");
+        }
+
+        match detect_execution_mode() {
+            ExecutionMode::Mcp => {
+                if !cli.is_mcp_server {
+                    info!("Running unified MCP server (pmcp SDK)");
+                }
+                let unified_server = pmat::mcp_pmcp::UnifiedServer::new()
+                    .map_err(|e| anyhow::anyhow!("Failed to create unified server: {}", e))?;
+                unified_server
+                    .run()
+                    .await
+                    .map_err(|e| anyhow::anyhow!("{}", e))
+            }
+            ExecutionMode::Cli => {
+                if !cli.is_mcp_server {
+                    info!("Running in CLI mode");
+                }
+                cli::run(server).await
+            }
+            ExecutionMode::HelpAndExit => {
+                // GH-285: No subcommand + piped stdin + no MCP_VERSION. Print help on
+                // stderr and exit with code 2 (misuse), matching the convention for
+                // "no command supplied" on a terminal.
+                let mut cmd = <pmat::cli::Cli as clap::CommandFactory>::command();
+                let _ = cmd.print_help();
+                eprintln!(
+                    "\nerror: no subcommand given and stdin is not a terminal. \
+                 Set MCP_VERSION=1 (or run `pmat agent mcp-server`) to start the MCP server."
+                );
+                process::exit(ExitCode::MisuseError as i32);
+            }
         }
     }
-}
 
-#[cfg_attr(coverage_nightly, coverage(off))]
-#[cfg(test)]
-mod gh285_tests {
-    //! Regression tests for GH-285: `pmat` hangs when invoked with no args
-    //! and stdin is a pipe. See `classify_execution_mode`.
-    //!
-    //! Manual end-to-end repro (should NOT hang or exit 124):
-    //! ```text
-    //! echo "" | timeout 3 target/debug/pmat 2>&1; echo exit=$?
-    //! timeout 3 target/debug/pmat < /dev/null; echo exit=$?
-    //! ```
-    //! Both should print help and exit with code 2.
-    use super::{classify_execution_mode, ExecutionMode};
+    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg(test)]
+    mod gh285_tests {
+        //! Regression tests for GH-285: `pmat` hangs when invoked with no args
+        //! and stdin is a pipe. See `classify_execution_mode`.
+        //!
+        //! Manual end-to-end repro (should NOT hang or exit 124):
+        //! ```text
+        //! echo "" | timeout 3 target/debug/pmat 2>&1; echo exit=$?
+        //! timeout 3 target/debug/pmat < /dev/null; echo exit=$?
+        //! ```
+        //! Both should print help and exit with code 2.
+        use super::{classify_execution_mode, ExecutionMode};
 
-    #[test]
-    fn bare_invocation_on_tty_is_cli() {
-        // `pmat` typed into a terminal with no pipe -> normal CLI (clap
-        // will then print help on missing subcommand).
-        assert!(matches!(
-            classify_execution_mode(false, true, false),
-            ExecutionMode::Cli
-        ));
+        #[test]
+        fn bare_invocation_on_tty_is_cli() {
+            // `pmat` typed into a terminal with no pipe -> normal CLI (clap
+            // will then print help on missing subcommand).
+            assert!(matches!(
+                classify_execution_mode(false, true, false),
+                ExecutionMode::Cli
+            ));
+        }
+
+        #[test]
+        fn piped_stdin_with_no_args_prints_help_instead_of_hanging() {
+            // GH-285: This used to enter MCP mode and block on stdin forever.
+            assert!(matches!(
+                classify_execution_mode(false, true, true),
+                ExecutionMode::HelpAndExit
+            ));
+        }
+
+        #[test]
+        fn explicit_mcp_version_env_still_enters_mcp_mode() {
+            // Claude Desktop and similar hosts set MCP_VERSION; they must still
+            // get the MCP server regardless of TTY state.
+            assert!(matches!(
+                classify_execution_mode(true, true, true),
+                ExecutionMode::Mcp
+            ));
+            assert!(matches!(
+                classify_execution_mode(true, false, false),
+                ExecutionMode::Mcp
+            ));
+        }
+
+        #[test]
+        fn subcommand_with_piped_stdin_is_still_cli() {
+            // `echo foo | pmat analyze ...` must dispatch to the CLI subcommand,
+            // not to help-and-exit.
+            assert!(matches!(
+                classify_execution_mode(false, false, true),
+                ExecutionMode::Cli
+            ));
+        }
     }
-
-    #[test]
-    fn piped_stdin_with_no_args_prints_help_instead_of_hanging() {
-        // GH-285: This used to enter MCP mode and block on stdin forever.
-        assert!(matches!(
-            classify_execution_mode(false, true, true),
-            ExecutionMode::HelpAndExit
-        ));
-    }
-
-    #[test]
-    fn explicit_mcp_version_env_still_enters_mcp_mode() {
-        // Claude Desktop and similar hosts set MCP_VERSION; they must still
-        // get the MCP server regardless of TTY state.
-        assert!(matches!(
-            classify_execution_mode(true, true, true),
-            ExecutionMode::Mcp
-        ));
-        assert!(matches!(
-            classify_execution_mode(true, false, false),
-            ExecutionMode::Mcp
-        ));
-    }
-
-    #[test]
-    fn subcommand_with_piped_stdin_is_still_cli() {
-        // `echo foo | pmat analyze ...` must dispatch to the CLI subcommand,
-        // not to help-and-exit.
-        assert!(matches!(
-            classify_execution_mode(false, false, true),
-            ExecutionMode::Cli
-        ));
-    }
-}
 } // end of mod full
 
 #[cfg(feature = "standard-deps")]

--- a/src/entropy/pattern_extractor_tests.rs
+++ b/src/entropy/pattern_extractor_tests.rs
@@ -845,7 +845,10 @@ fn test_calculate_pattern_match_variation_score_short_circuits_single_match() {
 
     let score =
         extractor.calculate_pattern_match_variation_score(&enums, &matches, &arrows, content);
-    assert_eq!(score, 0.0, "fewer than 2 match blocks must short-circuit to 0.0");
+    assert_eq!(
+        score, 0.0,
+        "fewer than 2 match blocks must short-circuit to 0.0"
+    );
 }
 
 /// pattern_extractor_ruchy.rs:405 — enum_matches.len() <= 1 low-variation arm (0.3).

--- a/src/maintenance/updater.rs
+++ b/src/maintenance/updater.rs
@@ -375,9 +375,13 @@ mod tests {
             files: vec!["src/lib.rs".into()], // no ticket file
         };
 
-        let result =
-            process_ticket_update(&mut roadmap, &commit, "TICKET-PMAT-5013", tickets_dir.path())
-                .unwrap();
+        let result = process_ticket_update(
+            &mut roadmap,
+            &commit,
+            "TICKET-PMAT-5013",
+            tickets_dir.path(),
+        )
+        .unwrap();
         assert!(!result, "must short-circuit when ticket file not in commit");
         assert!(!roadmap.sprints[0].tickets[0].completed);
     }
@@ -394,10 +398,17 @@ mod tests {
             files: vec!["docs/tickets/TICKET-PMAT-5013.md".into()],
         };
 
-        let result =
-            process_ticket_update(&mut roadmap, &commit, "TICKET-PMAT-5013", tickets_dir.path())
-                .unwrap();
-        assert!(!result, "missing ticket file must return Ok(false), not error");
+        let result = process_ticket_update(
+            &mut roadmap,
+            &commit,
+            "TICKET-PMAT-5013",
+            tickets_dir.path(),
+        )
+        .unwrap();
+        assert!(
+            !result,
+            "missing ticket file must return Ok(false), not error"
+        );
         assert!(!roadmap.sprints[0].tickets[0].completed);
     }
 
@@ -417,11 +428,7 @@ mod tests {
              Still failing.\n\n\
              ## Success Criteria\n\n\
              - [ ] One\n";
-        std::fs::write(
-            tickets_dir.path().join("TICKET-PMAT-5013.md"),
-            red_content,
-        )
-        .unwrap();
+        std::fs::write(tickets_dir.path().join("TICKET-PMAT-5013.md"), red_content).unwrap();
         let mut roadmap = create_test_roadmap();
         let commit = CommitInfo {
             hash: "deadbee".into(),
@@ -429,9 +436,13 @@ mod tests {
             files: vec!["docs/tickets/TICKET-PMAT-5013.md".into()],
         };
 
-        let result =
-            process_ticket_update(&mut roadmap, &commit, "TICKET-PMAT-5013", tickets_dir.path())
-                .unwrap();
+        let result = process_ticket_update(
+            &mut roadmap,
+            &commit,
+            "TICKET-PMAT-5013",
+            tickets_dir.path(),
+        )
+        .unwrap();
         assert!(!result, "RED ticket must not mark roadmap completed");
         assert!(!roadmap.sprints[0].tickets[0].completed);
     }
@@ -450,9 +461,13 @@ mod tests {
             files: vec!["docs/tickets/TICKET-PMAT-5013.md".into()],
         };
 
-        let result =
-            process_ticket_update(&mut roadmap, &commit, "TICKET-PMAT-5013", tickets_dir.path())
-                .unwrap();
+        let result = process_ticket_update(
+            &mut roadmap,
+            &commit,
+            "TICKET-PMAT-5013",
+            tickets_dir.path(),
+        )
+        .unwrap();
         assert!(result, "GREEN ticket must flip roadmap entry");
         assert!(roadmap.sprints[0].tickets[0].completed);
         assert_eq!(

--- a/src/mcp_pmcp/agent_context_handlers.rs
+++ b/src/mcp_pmcp/agent_context_handlers.rs
@@ -37,11 +37,7 @@ macro_rules! impl_pmat_handler {
 
         #[async_trait]
         impl ToolHandler for $wrapper {
-            async fn handle(
-                &self,
-                args: Value,
-                _extra: RequestHandlerExtra,
-            ) -> PmcpResult<Value> {
+            async fn handle(&self, args: Value, _extra: RequestHandlerExtra) -> PmcpResult<Value> {
                 self.inner.execute(args).await.map_err(PmcpError::internal)
             }
 

--- a/src/mcp_pmcp/analyze_handlers.rs
+++ b/src/mcp_pmcp/analyze_handlers.rs
@@ -32,7 +32,8 @@ use tracing::debug;
 // MCP tools (see R15 #3 bench matrix).
 pub use self::{
     ComplexityTool as AnalyzeComplexityTool, DeadCodeTool as AnalyzeDeadCodeTool,
-    SatdTool as AnalyzeSatdTool, TdgCompareTool as AnalyzeTdgCompareTool, TdgTool as AnalyzeTdgTool,
+    SatdTool as AnalyzeSatdTool, TdgCompareTool as AnalyzeTdgCompareTool,
+    TdgTool as AnalyzeTdgTool,
 };
 
 // Complexity analysis tool handler

--- a/src/mcp_pmcp/mod.rs
+++ b/src/mcp_pmcp/mod.rs
@@ -103,12 +103,12 @@ pub mod quality_handlers;
 pub mod quality_proxy_handler;
 pub mod server;
 pub mod simple_unified_server;
-pub mod tool_schemas;
 #[cfg_attr(coverage_nightly, coverage(off))]
 #[cfg(test)]
 pub mod tdg_git_context_tests;
 pub mod tdg_handlers;
 pub mod tool_functions;
+pub mod tool_schemas;
 pub mod tool_schemas_generated; // KAIZEN-0178: build.rs-generated tool schema registry
 pub mod tools; // Sprint 65 Phase 2B: MCP git-context integration
 

--- a/src/mcp_pmcp/tool_schemas.rs
+++ b/src/mcp_pmcp/tool_schemas.rs
@@ -45,7 +45,10 @@ pub fn paths_object_schema(extra_properties: Value, required: Vec<&str>) -> Valu
             base.insert(k.clone(), v.clone());
         }
     }
-    let req: Vec<Value> = required.into_iter().map(|s| Value::String(s.into())).collect();
+    let req: Vec<Value> = required
+        .into_iter()
+        .map(|s| Value::String(s.into()))
+        .collect();
     json!({
         "type": "object",
         "properties": base_props,

--- a/src/services/deep_context/analyzer_formatting/ast_formatting.rs
+++ b/src/services/deep_context/analyzer_formatting/ast_formatting.rs
@@ -482,3 +482,459 @@ impl DeepContextAnalyzer {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    //! PMAT-644: cover ast_formatting.rs surface.
+    use super::super::super::{
+        DeepContextAnalyzer, DeepContextConfig, DefectAnnotations, EnhancedFileContext,
+    };
+    use super::*;
+    use crate::services::context::{AstItem, FileContext};
+
+    fn analyzer() -> DeepContextAnalyzer {
+        DeepContextAnalyzer::new(DeepContextConfig::default())
+    }
+
+    fn ctx_with_items(items: Vec<AstItem>) -> EnhancedFileContext {
+        EnhancedFileContext {
+            base: FileContext {
+                path: "test.rs".to_string(),
+                language: "rust".to_string(),
+                items,
+                complexity_metrics: None,
+            },
+            complexity_metrics: None,
+            churn_metrics: None,
+            defects: DefectAnnotations {
+                dead_code: None,
+                technical_debt: Vec::new(),
+                complexity_violations: Vec::new(),
+                tdg_score: None,
+            },
+            symbol_id: String::new(),
+        }
+    }
+
+    fn func(name: &str, is_async: bool) -> AstItem {
+        AstItem::Function {
+            name: name.to_string(),
+            visibility: "pub".to_string(),
+            is_async,
+            line: 10,
+        }
+    }
+
+    fn struct_item(name: &str, fields: usize, derives: Vec<&str>) -> AstItem {
+        AstItem::Struct {
+            name: name.to_string(),
+            visibility: "pub".to_string(),
+            fields_count: fields,
+            derives: derives.into_iter().map(String::from).collect(),
+            line: 20,
+        }
+    }
+
+    // --- format_import_path (3 branches) ---
+
+    #[test]
+    fn test_format_import_path_with_alias() {
+        let a = analyzer();
+        let s = a.format_import_path("numpy", &[], &Some("np".to_string()));
+        assert_eq!(s, "numpy as np");
+    }
+
+    #[test]
+    fn test_format_import_path_with_items_no_alias() {
+        let a = analyzer();
+        let s = a.format_import_path("os", &["path".to_string(), "sep".to_string()], &None);
+        assert_eq!(s, "os (path, sep)");
+    }
+
+    #[test]
+    fn test_format_import_path_bare_module() {
+        let a = analyzer();
+        let s = a.format_import_path("json", &[], &None);
+        assert_eq!(s, "json");
+    }
+
+    // --- categorize_ast_items: cover every AstItem variant ---
+
+    #[test]
+    fn test_categorize_all_variants_distributes_counts() {
+        let a = analyzer();
+        let items = vec![
+            func("f1", false),
+            func("f2", true),
+            struct_item("S", 2, vec!["Debug", "Clone"]),
+            AstItem::Enum {
+                name: "E".into(),
+                visibility: "pub".into(),
+                variants_count: 3,
+                line: 1,
+            },
+            AstItem::Trait {
+                name: "T".into(),
+                visibility: "pub".into(),
+                line: 1,
+            },
+            AstItem::Impl {
+                type_name: "S".into(),
+                trait_name: Some("Debug".into()),
+                line: 1,
+            },
+            AstItem::Module {
+                name: "m".into(),
+                visibility: "pub".into(),
+                line: 1,
+            },
+            AstItem::Use {
+                path: "std::fs".into(),
+                line: 1,
+            },
+            AstItem::Import {
+                module: "numpy".into(),
+                items: vec![],
+                alias: Some("np".into()),
+                line: 1,
+            },
+        ];
+        let cat = a.categorize_ast_items(&items);
+        assert_eq!(cat.functions.len(), 2);
+        assert_eq!(cat.structs.len(), 1);
+        assert_eq!(cat.enums.len(), 1);
+        assert_eq!(cat.traits.len(), 1);
+        assert_eq!(cat.impls.len(), 1);
+        assert_eq!(cat.modules.len(), 1);
+        // Use + Import both land in `uses`.
+        assert_eq!(cat.uses.len(), 2);
+    }
+
+    // --- write_*_section early-return (empty collection) ---
+
+    #[test]
+    fn test_write_sections_empty_are_no_ops() {
+        let a = analyzer();
+        let mut out = String::new();
+        a.write_functions_section(&mut out, &[]).unwrap();
+        a.write_structs_section(&mut out, &[]).unwrap();
+        a.write_enums_section(&mut out, &[]).unwrap();
+        a.write_traits_section(&mut out, &[]).unwrap();
+        a.write_impls_section(&mut out, &[]).unwrap();
+        a.write_modules_section(&mut out, &[]).unwrap();
+        a.write_imports_section(&mut out, &[]).unwrap();
+        assert!(out.is_empty(), "empty sections must produce no output");
+    }
+
+    // --- write_functions_section: async marker + truncation ---
+
+    #[test]
+    fn test_write_functions_marks_async_and_lists_up_to_10() {
+        let a = analyzer();
+        let funcs = vec![
+            AstFunction {
+                name: "plain".into(),
+                visibility: "pub".into(),
+                is_async: false,
+                line: 1,
+            },
+            AstFunction {
+                name: "awaits".into(),
+                visibility: "pub".into(),
+                is_async: true,
+                line: 2,
+            },
+        ];
+        let mut out = String::new();
+        a.write_functions_section(&mut out, &funcs).unwrap();
+        assert!(out.contains("`plain` (pub)"));
+        assert!(out.contains("`awaits (async)` (pub)"));
+        assert!(!out.contains("and"));
+    }
+
+    #[test]
+    fn test_write_functions_truncates_over_10_and_emits_more_line() {
+        let a = analyzer();
+        let funcs: Vec<AstFunction> = (0..13)
+            .map(|i| AstFunction {
+                name: format!("f{i}"),
+                visibility: "pub".into(),
+                is_async: false,
+                line: i,
+            })
+            .collect();
+        let mut out = String::new();
+        a.write_functions_section(&mut out, &funcs).unwrap();
+        assert!(out.contains("and 3 more functions"));
+    }
+
+    // --- write_structs_section ---
+
+    #[test]
+    fn test_write_structs_derives_and_field_singular_plural() {
+        let a = analyzer();
+        let structs = vec![
+            AstStruct {
+                name: "One".into(),
+                visibility: "pub".into(),
+                fields_count: 1,
+                derives: vec![],
+                line: 1,
+            },
+            AstStruct {
+                name: "Many".into(),
+                visibility: "pub".into(),
+                fields_count: 3,
+                derives: vec!["Debug".into(), "Clone".into()],
+                line: 2,
+            },
+        ];
+        let mut out = String::new();
+        a.write_structs_section(&mut out, &structs).unwrap();
+        // Singular field for fields_count=1, no derives list.
+        assert!(out.contains("with 1 field "));
+        // Plural form with derives string.
+        assert!(out.contains("with 3 fields"));
+        assert!(out.contains("derives: Debug, Clone"));
+    }
+
+    #[test]
+    fn test_write_structs_truncates_over_5() {
+        let a = analyzer();
+        let structs: Vec<AstStruct> = (0..7)
+            .map(|i| AstStruct {
+                name: format!("S{i}"),
+                visibility: "pub".into(),
+                fields_count: 1,
+                derives: vec![],
+                line: i,
+            })
+            .collect();
+        let mut out = String::new();
+        a.write_structs_section(&mut out, &structs).unwrap();
+        assert!(out.contains("and 2 more structs"));
+    }
+
+    // --- write_enums_section ---
+
+    #[test]
+    fn test_write_enums_singular_and_plural_variant_count() {
+        let a = analyzer();
+        let enums = vec![
+            AstEnum {
+                name: "One".into(),
+                visibility: "pub".into(),
+                variants_count: 1,
+                line: 1,
+            },
+            AstEnum {
+                name: "Many".into(),
+                visibility: "pub".into(),
+                variants_count: 4,
+                line: 2,
+            },
+        ];
+        let mut out = String::new();
+        a.write_enums_section(&mut out, &enums).unwrap();
+        assert!(out.contains("with 1 variant "));
+        assert!(out.contains("with 4 variants"));
+    }
+
+    #[test]
+    fn test_write_enums_truncates_over_5() {
+        let a = analyzer();
+        let enums: Vec<AstEnum> = (0..9)
+            .map(|i| AstEnum {
+                name: format!("E{i}"),
+                visibility: "pub".into(),
+                variants_count: 1,
+                line: i,
+            })
+            .collect();
+        let mut out = String::new();
+        a.write_enums_section(&mut out, &enums).unwrap();
+        assert!(out.contains("and 4 more enums"));
+    }
+
+    // --- write_traits_section ---
+
+    #[test]
+    fn test_write_traits_truncates_over_5() {
+        let a = analyzer();
+        let traits: Vec<AstTrait> = (0..6)
+            .map(|i| AstTrait {
+                name: format!("T{i}"),
+                visibility: "pub".into(),
+                line: i,
+            })
+            .collect();
+        let mut out = String::new();
+        a.write_traits_section(&mut out, &traits).unwrap();
+        assert!(out.contains("and 1 more traits"));
+    }
+
+    // --- write_impls_section: inherent vs trait impl ---
+
+    #[test]
+    fn test_write_impls_both_trait_and_inherent_forms() {
+        let a = analyzer();
+        let impls = vec![
+            AstImpl {
+                type_name: "S".into(),
+                trait_name: None,
+                line: 1,
+            },
+            AstImpl {
+                type_name: "S".into(),
+                trait_name: Some("Debug".into()),
+                line: 2,
+            },
+        ];
+        let mut out = String::new();
+        a.write_impls_section(&mut out, &impls).unwrap();
+        assert!(out.contains("`impl S` at line 1"));
+        assert!(out.contains("`Debug for S` at line 2"));
+    }
+
+    #[test]
+    fn test_write_impls_truncates_over_5() {
+        let a = analyzer();
+        let impls: Vec<AstImpl> = (0..7)
+            .map(|i| AstImpl {
+                type_name: format!("T{i}"),
+                trait_name: None,
+                line: i,
+            })
+            .collect();
+        let mut out = String::new();
+        a.write_impls_section(&mut out, &impls).unwrap();
+        assert!(out.contains("and 2 more implementations"));
+    }
+
+    // --- write_modules_section ---
+
+    #[test]
+    fn test_write_modules_truncates_over_5() {
+        let a = analyzer();
+        let mods: Vec<AstModule> = (0..10)
+            .map(|i| AstModule {
+                name: format!("m{i}"),
+                visibility: "pub".into(),
+                line: i,
+            })
+            .collect();
+        let mut out = String::new();
+        a.write_modules_section(&mut out, &mods).unwrap();
+        assert!(out.contains("and 5 more modules"));
+    }
+
+    // --- write_imports_section: ≤8 shows paths, >8 shows count ---
+
+    #[test]
+    fn test_write_imports_lists_paths_when_small() {
+        let a = analyzer();
+        let uses: Vec<AstUse> = (0..5)
+            .map(|i| AstUse {
+                path: format!("mod::item{i}"),
+                line: i,
+            })
+            .collect();
+        let mut out = String::new();
+        a.write_imports_section(&mut out, &uses).unwrap();
+        assert!(out.contains("Key Imports"));
+        assert!(out.contains("mod::item0"));
+        assert!(out.contains("mod::item4"));
+    }
+
+    #[test]
+    fn test_write_imports_shows_count_only_when_over_8() {
+        let a = analyzer();
+        let uses: Vec<AstUse> = (0..12)
+            .map(|i| AstUse {
+                path: format!("x{i}"),
+                line: i,
+            })
+            .collect();
+        let mut out = String::new();
+        a.write_imports_section(&mut out, &uses).unwrap();
+        assert!(out.contains("12 import statements"));
+        assert!(!out.contains("Key Imports"));
+    }
+
+    // --- Integration: format_enhanced_ast_section end-to-end ---
+
+    #[test]
+    fn test_format_enhanced_ast_section_integration() {
+        let a = analyzer();
+        let items = vec![
+            func("parse", false),
+            func("load", true),
+            struct_item("Config", 3, vec!["Debug"]),
+            AstItem::Enum {
+                name: "Status".into(),
+                visibility: "pub".into(),
+                variants_count: 2,
+                line: 30,
+            },
+            AstItem::Trait {
+                name: "Validate".into(),
+                visibility: "pub".into(),
+                line: 40,
+            },
+            AstItem::Impl {
+                type_name: "Config".into(),
+                trait_name: Some("Default".into()),
+                line: 50,
+            },
+            AstItem::Module {
+                name: "helpers".into(),
+                visibility: "pub".into(),
+                line: 60,
+            },
+            AstItem::Use {
+                path: "std::path::Path".into(),
+                line: 1,
+            },
+            AstItem::Import {
+                module: "os".into(),
+                items: vec!["path".into()],
+                alias: None,
+                line: 2,
+            },
+        ];
+        let ctxs = vec![ctx_with_items(items)];
+        let mut out = String::new();
+        a.format_enhanced_ast_section(&mut out, &ctxs).unwrap();
+
+        // Header
+        assert!(out.contains("## Enhanced AST Analysis"));
+        assert!(out.contains("### test.rs"));
+        assert!(out.contains("**Language:** rust"));
+        // Summary line
+        assert!(out.contains("Functions:** 2"));
+        assert!(out.contains("Structs:** 1"));
+        assert!(out.contains("Enums:** 1"));
+        assert!(out.contains("Traits:** 1"));
+        assert!(out.contains("Impls:** 1"));
+        assert!(out.contains("Modules:** 1"));
+        // Both Use + Import items went into `uses`; expect count 2.
+        assert!(out.contains("Imports:** 2"));
+        // Detail sections
+        assert!(out.contains("parse"));
+        assert!(out.contains("load (async)"));
+        assert!(out.contains("Config"));
+        assert!(out.contains("Default for Config"));
+    }
+
+    #[test]
+    fn test_format_enhanced_ast_section_empty_items_list() {
+        let a = analyzer();
+        let ctxs = vec![ctx_with_items(vec![])];
+        let mut out = String::new();
+        a.format_enhanced_ast_section(&mut out, &ctxs).unwrap();
+        // Summary line with all zeros + no detail sections.
+        assert!(out.contains("Functions:** 0"));
+        assert!(!out.contains("Implementations:"));
+        assert!(!out.contains("Key Imports"));
+    }
+}


### PR DESCRIPTION
## Summary

Continues Phase-1 CLI/services pivot after PR #508/PMAT-643. \`ast_formatting.rs\` is a DeepContextAnalyzer formatter — 484 lines, 0/282 broad-covered, 100% sync.

**19 new tests** covering:

- \`format_import_path\` all 3 branches (alias / items / bare)
- \`categorize_ast_items\` — all 8 AstItem variants distribute to correct categories
- All 7 \`write_*_section\` empty-collection early-return
- \`write_functions_section\` async-marker + over-10 truncation
- \`write_structs_section\` singular/plural "field"/"fields" + derives + over-5 truncation
- \`write_enums_section\` variant count pluralization + over-5 truncation
- \`write_traits_section\` / \`write_modules_section\` over-5 truncation
- \`write_impls_section\` both inherent (\`impl S\`) and trait-impl (\`Trait for S\`) forms + truncation
- \`write_imports_section\` ≤8 key-imports vs >8 count-only
- \`format_enhanced_ast_section\` integration — full pipeline + empty items

**Imports note**: DefectAnnotations / EnhancedFileContext aren't separate modules — they're include!'d directly into deep_context/mod.rs, so \`super::super::super::\` resolves.

## Coverage impact

File has \`coverage(off)\` but \`make coverage-broad\` disables that with \`--no-cfg-coverage --no-cfg-coverage-nightly\`. Expected delta: **~+0.07pp**.

## Test plan

- [x] \`cargo test --lib -- services::deep_context::analyzer_formatting::ast_formatting::tests\` — 19 passed, 0 failed
- [x] \`cargo fmt --all -- --check\` — clean
- [ ] CI gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)