### PR TITLE
test(coverage): dynamic_lua.rs pure-compute surface (PMAT-646, Phase-1 CLI pivot)

### DIFF
--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -3213,3 +3213,20 @@ roadmap:
   estimated_effort: null
   labels: []
   notes: null
+- id: PMAT-646
+  github_issue: null
+  item_type: task
+  title: 'Phase 1 pivot: cli/language_analyzer/dynamic_lua.rs coverage'
+  status: inprogress
+  priority: medium
+  assigned_to: null
+  created: 2026-04-24T08:37:57Z
+  updated: 2026-04-24T08:37:57Z
+  spec: null
+  acceptance_criteria:
+  - 'Phase 1 CLI pivot — dynamic_lua.rs is 300 lines, 250/250 broad-covered, 0 async. Both tree-sitter (lua-ast feature, default-on) and heuristic fallback paths testable. Cover is_function_declaration, extract_function_name (local + function + empty), find_function_end (normal end, nested blocks, repeat/until, EOF fallback), extract_functions_heuristic, estimate_complexity_heuristic (if/for/while/repeat/and/or branches + nesting + elseif), LanguageAnalyzer trait impls (extract_functions + estimate_complexity) which go through tree-sitter path first.'
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels: []
+  notes: null

--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -3217,7 +3217,7 @@ roadmap:
   github_issue: null
   item_type: task
   title: 'Phase 1 pivot: cli/language_analyzer/dynamic_lua.rs coverage'
-  status: inprogress
+  status: review
   priority: medium
   assigned_to: null
   created: 2026-04-24T08:37:57Z

--- a/examples/mcp_agent_context_demo.rs
+++ b/examples/mcp_agent_context_demo.rs
@@ -54,68 +54,132 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     thread::sleep(Duration::from_secs(10));
 
     // 1. initialize handshake
-    let resp = rpc(&mut writer, &mut reader, 1, "initialize", json!({
-        "protocolVersion": "2024-11-05",
-        "capabilities": {},
-        "clientInfo": { "name": "mcp_agent_context_demo", "version": "1.0" }
-    }))?;
-    let server_info = resp.pointer("/result/serverInfo/name").cloned().unwrap_or(json!("?"));
+    let resp = rpc(
+        &mut writer,
+        &mut reader,
+        1,
+        "initialize",
+        json!({
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": { "name": "mcp_agent_context_demo", "version": "1.0" }
+        }),
+    )?;
+    let server_info = resp
+        .pointer("/result/serverInfo/name")
+        .cloned()
+        .unwrap_or(json!("?"));
     println!("[initialize] server={}", server_info);
 
     // 2. tools/list — sanity check that the 4 pmat_* tools are registered
     let resp = rpc(&mut writer, &mut reader, 2, "tools/list", json!({}))?;
-    let tools = resp.pointer("/result/tools").and_then(|v| v.as_array()).cloned().unwrap_or_default();
-    let pmat_tools: Vec<&str> = tools.iter()
+    let tools = resp
+        .pointer("/result/tools")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+    let pmat_tools: Vec<&str> = tools
+        .iter()
         .filter_map(|t| t.get("name").and_then(|n| n.as_str()))
         .filter(|n| n.starts_with("pmat_"))
         .collect();
-    println!("[tools/list] total={} pmat_*={} ({:?})", tools.len(), pmat_tools.len(), pmat_tools);
+    println!(
+        "[tools/list] total={} pmat_*={} ({:?})",
+        tools.len(),
+        pmat_tools.len(),
+        pmat_tools
+    );
 
     // 3. pmat_index_stats — pick up a real function_id we can reuse below
-    let resp = call_tool(&mut writer, &mut reader, 3, "pmat_index_stats",
-        json!({ "rebuild": false }))?;
+    let resp = call_tool(
+        &mut writer,
+        &mut reader,
+        3,
+        "pmat_index_stats",
+        json!({ "rebuild": false }),
+    )?;
     let index_result = extract_tool_result(&resp);
-    let fn_count = index_result.pointer("/manifest/function_count").cloned().unwrap_or(json!(0));
-    let file_count = index_result.pointer("/manifest/file_count").cloned().unwrap_or(json!(0));
-    println!("[pmat_index_stats] ok: functions={} files={}", fn_count, file_count);
+    let fn_count = index_result
+        .pointer("/manifest/function_count")
+        .cloned()
+        .unwrap_or(json!(0));
+    let file_count = index_result
+        .pointer("/manifest/file_count")
+        .cloned()
+        .unwrap_or(json!(0));
+    println!(
+        "[pmat_index_stats] ok: functions={} files={}",
+        fn_count, file_count
+    );
 
     // 4. pmat_query_code — realistic semantic query
-    let resp = call_tool(&mut writer, &mut reader, 4, "pmat_query_code",
-        json!({ "query": "error handling", "limit": 3 }))?;
+    let resp = call_tool(
+        &mut writer,
+        &mut reader,
+        4,
+        "pmat_query_code",
+        json!({ "query": "error handling", "limit": 3 }),
+    )?;
     let query_result = extract_tool_result(&resp);
-    let result_count = query_result.get("results")
+    let result_count = query_result
+        .get("results")
         .or_else(|| query_result.get("functions"))
         .and_then(|v| v.as_array())
         .map(|a| a.len())
         .unwrap_or(0);
-    let first_id = query_result.pointer("/results/0/id")
+    let first_id = query_result
+        .pointer("/results/0/id")
         .or_else(|| query_result.pointer("/functions/0/id"))
         .and_then(|v| v.as_str())
         .map(|s| s.to_string());
-    println!("[pmat_query_code] ok: {} results; first_id={:?}", result_count, first_id);
+    println!(
+        "[pmat_query_code] ok: {} results; first_id={:?}",
+        result_count, first_id
+    );
 
     // 5. pmat_get_function — use the first id from query_code, or fall back to "main"
-    let function_id = first_id.clone().unwrap_or_else(|| "src/bin/pmat.rs::main".to_string());
-    let resp = call_tool(&mut writer, &mut reader, 5, "pmat_get_function",
-        json!({ "function_id": function_id, "include_source": false }))?;
+    let function_id = first_id
+        .clone()
+        .unwrap_or_else(|| "src/bin/pmat.rs::main".to_string());
+    let resp = call_tool(
+        &mut writer,
+        &mut reader,
+        5,
+        "pmat_get_function",
+        json!({ "function_id": function_id, "include_source": false }),
+    )?;
     match resp.get("error") {
-        Some(err) => println!("[pmat_get_function] graceful miss for {:?}: {}", function_id,
-            err.get("message").and_then(|m| m.as_str()).unwrap_or("?")),
+        Some(err) => println!(
+            "[pmat_get_function] graceful miss for {:?}: {}",
+            function_id,
+            err.get("message").and_then(|m| m.as_str()).unwrap_or("?")
+        ),
         None => {
             let gf = extract_tool_result(&resp);
-            println!("[pmat_get_function] ok: name={} grade={}",
+            println!(
+                "[pmat_get_function] ok: name={} grade={}",
                 gf.get("name").and_then(|v| v.as_str()).unwrap_or("?"),
-                gf.pointer("/quality/grade").and_then(|v| v.as_str()).unwrap_or("?"));
+                gf.pointer("/quality/grade")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("?")
+            );
         }
     }
 
     // 6. pmat_find_similar — only meaningful if we got a real id from the query
     if let Some(id) = first_id {
-        let resp = call_tool(&mut writer, &mut reader, 6, "pmat_find_similar",
-            json!({ "function_id": id, "limit": 3, "min_similarity": 0.3 }))?;
+        let resp = call_tool(
+            &mut writer,
+            &mut reader,
+            6,
+            "pmat_find_similar",
+            json!({ "function_id": id, "limit": 3, "min_similarity": 0.3 }),
+        )?;
         match resp.get("error") {
-            Some(err) => println!("[pmat_find_similar] error: {}",
-                err.get("message").and_then(|m| m.as_str()).unwrap_or("?")),
+            Some(err) => println!(
+                "[pmat_find_similar] error: {}",
+                err.get("message").and_then(|m| m.as_str()).unwrap_or("?")
+            ),
             None => {
                 let sim = extract_tool_result(&resp);
                 let total = sim.get("total").and_then(|v| v.as_u64()).unwrap_or(0);
@@ -162,7 +226,13 @@ fn call_tool(
     name: &str,
     args: Value,
 ) -> Result<Value, Box<dyn std::error::Error>> {
-    rpc(writer, reader, id, "tools/call", json!({ "name": name, "arguments": args }))
+    rpc(
+        writer,
+        reader,
+        id,
+        "tools/call",
+        json!({ "name": name, "arguments": args }),
+    )
 }
 
 /// MCP `tools/call` wraps results in `result.content[0].text` (JSON string) or
@@ -171,7 +241,10 @@ fn extract_tool_result(resp: &Value) -> Value {
     if let Some(sc) = resp.pointer("/result/structuredContent") {
         return sc.clone();
     }
-    if let Some(text) = resp.pointer("/result/content/0/text").and_then(|v| v.as_str()) {
+    if let Some(text) = resp
+        .pointer("/result/content/0/text")
+        .and_then(|v| v.as_str())
+    {
         if let Ok(parsed) = serde_json::from_str::<Value>(text) {
             return parsed;
         }

--- a/src/bin/pmat.rs
+++ b/src/bin/pmat.rs
@@ -16,301 +16,301 @@ fn main() {
 
 #[cfg(feature = "standard-deps")]
 mod full {
-use anyhow::Result;
-use pmat::{cli, stateless_server::StatelessTemplateServer};
-use std::io::IsTerminal;
-use std::process;
-use std::sync::Arc;
-use tracing::{debug, error, info, trace};
-use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
+    use anyhow::Result;
+    use pmat::{cli, stateless_server::StatelessTemplateServer};
+    use std::io::IsTerminal;
+    use std::process;
+    use std::sync::Arc;
+    use tracing::{debug, error, info, trace};
+    use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 
-enum ExecutionMode {
-    Mcp,
-    Cli,
-    /// No subcommand given and stdin is piped (not a TTY) without an explicit
-    /// MCP opt-in. Print help and exit non-zero instead of blocking on stdin
-    /// (see GH-285).
-    HelpAndExit,
-}
-
-/// POSIX-compliant exit codes for CLI interface
-/// Per SPECIFICATION.md Section 23: CLI Interface
-#[derive(Debug, Clone, Copy)]
-pub enum ExitCode {
-    /// Success
-    Success = 0,
-    /// General error
-    GeneralError = 1,
-    /// Misuse of shell command
-    MisuseError = 2,
-    /// Permission denied
-    PermissionDenied = 126,
-    /// Command not found
-    CommandNotFound = 127,
-    /// Invalid argument to exit
-    InvalidExitArg = 128,
-    /// Quality gate failure (custom)
-    QualityGateFailure = 3,
-    /// Configuration error (custom)
-    ConfigurationError = 4,
-    /// Analysis error (custom)
-    AnalysisError = 5,
-}
-
-impl From<ExitCode> for i32 {
-    fn from(code: ExitCode) -> Self {
-        code as i32
-    }
-}
-
-fn detect_execution_mode() -> ExecutionMode {
-    classify_execution_mode(
-        std::env::var("MCP_VERSION").is_ok(),
-        std::env::args().len() == 1,
-        !std::io::stdin().is_terminal(),
-    )
-}
-
-/// Pure decision function for execution mode so it can be unit-tested
-/// without touching real stdin / env vars (see GH-285 regression test).
-fn classify_execution_mode(
-    mcp_version_env: bool,
-    no_args: bool,
-    stdin_is_pipe: bool,
-) -> ExecutionMode {
-    // Explicit MCP opt-in via env var always wins (e.g. Claude Desktop sets this).
-    if mcp_version_env {
-        return ExecutionMode::Mcp;
+    enum ExecutionMode {
+        Mcp,
+        Cli,
+        /// No subcommand given and stdin is piped (not a TTY) without an explicit
+        /// MCP opt-in. Print help and exit non-zero instead of blocking on stdin
+        /// (see GH-285).
+        HelpAndExit,
     }
 
-    // GH-285: If the user ran bare `pmat` with stdin piped (e.g. `echo "" | pmat`)
-    // without opting into MCP via `MCP_VERSION`, previous behavior entered the MCP
-    // server and blocked forever on stdin. Treat that case the same as bare `pmat`
-    // on a terminal: print help and exit non-zero.
-    if no_args && stdin_is_pipe {
-        return ExecutionMode::HelpAndExit;
+    /// POSIX-compliant exit codes for CLI interface
+    /// Per SPECIFICATION.md Section 23: CLI Interface
+    #[derive(Debug, Clone, Copy)]
+    pub enum ExitCode {
+        /// Success
+        Success = 0,
+        /// General error
+        GeneralError = 1,
+        /// Misuse of shell command
+        MisuseError = 2,
+        /// Permission denied
+        PermissionDenied = 126,
+        /// Command not found
+        CommandNotFound = 127,
+        /// Invalid argument to exit
+        InvalidExitArg = 128,
+        /// Quality gate failure (custom)
+        QualityGateFailure = 3,
+        /// Configuration error (custom)
+        ConfigurationError = 4,
+        /// Analysis error (custom)
+        AnalysisError = 5,
     }
 
-    ExecutionMode::Cli
-}
+    impl From<ExitCode> for i32 {
+        fn from(code: ExitCode) -> Self {
+            code as i32
+        }
+    }
 
-/// Initialize the enhanced tracing system based on CLI flags
-fn init_tracing(cli: &cli::EarlyCliArgs) -> Result<()> {
-    let filter = create_env_filter(cli)?;
-
-    tracing_subscriber::registry()
-        .with(filter)
-        .with(
-            tracing_subscriber::fmt::layer()
-                .with_target(cli.debug || cli.trace)
-                .with_thread_ids(cli.trace)
-                .with_file(cli.trace)
-                .with_line_number(cli.trace)
-                .compact()
-                .with_writer(std::io::stderr),
+    fn detect_execution_mode() -> ExecutionMode {
+        classify_execution_mode(
+            std::env::var("MCP_VERSION").is_ok(),
+            std::env::args().len() == 1,
+            !std::io::stdin().is_terminal(),
         )
-        .init();
-
-    Ok(())
-}
-
-/// Create environment filter based on CLI flags
-fn create_env_filter(cli: &cli::EarlyCliArgs) -> Result<EnvFilter> {
-    if cli.is_mcp_server {
-        Ok(create_mcp_filter(cli.debug))
-    } else {
-        create_cli_filter(cli)
-    }
-}
-
-/// Create filter for MCP server mode
-fn create_mcp_filter(debug: bool) -> EnvFilter {
-    if debug {
-        EnvFilter::new("warn,pmat=debug")
-    } else {
-        EnvFilter::new("off")
-    }
-}
-
-/// Create filter for CLI mode
-fn create_cli_filter(cli: &cli::EarlyCliArgs) -> Result<EnvFilter> {
-    if let Some(ref custom) = cli.trace_filter {
-        return Ok(EnvFilter::try_new(custom)?);
     }
 
-    let filter_str = match (cli.trace, cli.debug, cli.verbose) {
-        (true, _, _) => "debug,pmat=trace",
-        (_, true, _) => "warn,pmat=debug",
-        (_, _, true) => "warn,pmat=info",
-        _ => return Ok(get_default_filter()),
-    };
-
-    Ok(EnvFilter::new(filter_str))
-}
-
-/// Get default production filter
-fn get_default_filter() -> EnvFilter {
-    EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("warn"))
-}
-
-#[tokio::main]
-#[allow(unreachable_pub)]
-pub async fn real_main() {
-    let exit_code = match run_main().await {
-        Ok(()) => ExitCode::Success,
-        Err(e) => {
-            error!("Error: {:#}", e);
-            categorize_error(&e)
+    /// Pure decision function for execution mode so it can be unit-tested
+    /// without touching real stdin / env vars (see GH-285 regression test).
+    fn classify_execution_mode(
+        mcp_version_env: bool,
+        no_args: bool,
+        stdin_is_pipe: bool,
+    ) -> ExecutionMode {
+        // Explicit MCP opt-in via env var always wins (e.g. Claude Desktop sets this).
+        if mcp_version_env {
+            return ExecutionMode::Mcp;
         }
-    };
 
-    if exit_code as i32 != 0 {
-        process::exit(exit_code.into());
-    }
-}
+        // GH-285: If the user ran bare `pmat` with stdin piped (e.g. `echo "" | pmat`)
+        // without opting into MCP via `MCP_VERSION`, previous behavior entered the MCP
+        // server and blocked forever on stdin. Treat that case the same as bare `pmat`
+        // on a terminal: print help and exit non-zero.
+        if no_args && stdin_is_pipe {
+            return ExecutionMode::HelpAndExit;
+        }
 
-fn categorize_error(error: &anyhow::Error) -> ExitCode {
-    let error_str = error.to_string().to_lowercase();
-
-    match () {
-        _ if is_quality_gate_error(&error_str) => ExitCode::QualityGateFailure,
-        _ if is_configuration_error(&error_str) => ExitCode::ConfigurationError,
-        _ if is_analysis_error(&error_str) => ExitCode::AnalysisError,
-        _ if is_permission_error(&error_str) => ExitCode::PermissionDenied,
-        _ => ExitCode::GeneralError,
-    }
-}
-
-fn is_quality_gate_error(error_str: &str) -> bool {
-    error_str.contains("quality gate") || error_str.contains("violation")
-}
-
-fn is_configuration_error(error_str: &str) -> bool {
-    error_str.contains("config") || error_str.contains("parse")
-}
-
-fn is_analysis_error(error_str: &str) -> bool {
-    error_str.contains("analysis") || error_str.contains("complexity")
-}
-
-fn is_permission_error(error_str: &str) -> bool {
-    error_str.contains("permission") || error_str.contains("access")
-}
-
-async fn run_main() -> Result<()> {
-    // Parse CLI to get tracing configuration early
-    let cli = cli::parse_early_for_tracing();
-
-    // Initialize enhanced tracing system
-    init_tracing(&cli)?;
-
-    // Only log to stdout if not running MCP server mode
-    if !cli.is_mcp_server {
-        info!(
-            "Starting PAIML MCP Agent Toolkit v{}",
-            env!("CARGO_PKG_VERSION")
-        );
-        debug!("Debug logging enabled");
-        trace!("Trace logging enabled");
+        ExecutionMode::Cli
     }
 
-    // Create shared template server
-    let server = Arc::new(StatelessTemplateServer::new()?);
+    /// Initialize the enhanced tracing system based on CLI flags
+    fn init_tracing(cli: &cli::EarlyCliArgs) -> Result<()> {
+        let filter = create_env_filter(cli)?;
 
-    if !cli.is_mcp_server {
-        debug!("Template server initialized");
+        tracing_subscriber::registry()
+            .with(filter)
+            .with(
+                tracing_subscriber::fmt::layer()
+                    .with_target(cli.debug || cli.trace)
+                    .with_thread_ids(cli.trace)
+                    .with_file(cli.trace)
+                    .with_line_number(cli.trace)
+                    .compact()
+                    .with_writer(std::io::stderr),
+            )
+            .init();
+
+        Ok(())
     }
 
-    match detect_execution_mode() {
-        ExecutionMode::Mcp => {
-            if !cli.is_mcp_server {
-                info!("Running unified MCP server (pmcp SDK)");
+    /// Create environment filter based on CLI flags
+    fn create_env_filter(cli: &cli::EarlyCliArgs) -> Result<EnvFilter> {
+        if cli.is_mcp_server {
+            Ok(create_mcp_filter(cli.debug))
+        } else {
+            create_cli_filter(cli)
+        }
+    }
+
+    /// Create filter for MCP server mode
+    fn create_mcp_filter(debug: bool) -> EnvFilter {
+        if debug {
+            EnvFilter::new("warn,pmat=debug")
+        } else {
+            EnvFilter::new("off")
+        }
+    }
+
+    /// Create filter for CLI mode
+    fn create_cli_filter(cli: &cli::EarlyCliArgs) -> Result<EnvFilter> {
+        if let Some(ref custom) = cli.trace_filter {
+            return Ok(EnvFilter::try_new(custom)?);
+        }
+
+        let filter_str = match (cli.trace, cli.debug, cli.verbose) {
+            (true, _, _) => "debug,pmat=trace",
+            (_, true, _) => "warn,pmat=debug",
+            (_, _, true) => "warn,pmat=info",
+            _ => return Ok(get_default_filter()),
+        };
+
+        Ok(EnvFilter::new(filter_str))
+    }
+
+    /// Get default production filter
+    fn get_default_filter() -> EnvFilter {
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("warn"))
+    }
+
+    #[tokio::main]
+    #[allow(unreachable_pub)]
+    pub async fn real_main() {
+        let exit_code = match run_main().await {
+            Ok(()) => ExitCode::Success,
+            Err(e) => {
+                error!("Error: {:#}", e);
+                categorize_error(&e)
             }
-            let unified_server = pmat::mcp_pmcp::UnifiedServer::new()
-                .map_err(|e| anyhow::anyhow!("Failed to create unified server: {}", e))?;
-            unified_server
-                .run()
-                .await
-                .map_err(|e| anyhow::anyhow!("{}", e))
+        };
+
+        if exit_code as i32 != 0 {
+            process::exit(exit_code.into());
         }
-        ExecutionMode::Cli => {
-            if !cli.is_mcp_server {
-                info!("Running in CLI mode");
-            }
-            cli::run(server).await
+    }
+
+    fn categorize_error(error: &anyhow::Error) -> ExitCode {
+        let error_str = error.to_string().to_lowercase();
+
+        match () {
+            _ if is_quality_gate_error(&error_str) => ExitCode::QualityGateFailure,
+            _ if is_configuration_error(&error_str) => ExitCode::ConfigurationError,
+            _ if is_analysis_error(&error_str) => ExitCode::AnalysisError,
+            _ if is_permission_error(&error_str) => ExitCode::PermissionDenied,
+            _ => ExitCode::GeneralError,
         }
-        ExecutionMode::HelpAndExit => {
-            // GH-285: No subcommand + piped stdin + no MCP_VERSION. Print help on
-            // stderr and exit with code 2 (misuse), matching the convention for
-            // "no command supplied" on a terminal.
-            let mut cmd = <pmat::cli::Cli as clap::CommandFactory>::command();
-            let _ = cmd.print_help();
-            eprintln!(
-                "\nerror: no subcommand given and stdin is not a terminal. \
-                 Set MCP_VERSION=1 (or run `pmat agent mcp-server`) to start the MCP server."
+    }
+
+    fn is_quality_gate_error(error_str: &str) -> bool {
+        error_str.contains("quality gate") || error_str.contains("violation")
+    }
+
+    fn is_configuration_error(error_str: &str) -> bool {
+        error_str.contains("config") || error_str.contains("parse")
+    }
+
+    fn is_analysis_error(error_str: &str) -> bool {
+        error_str.contains("analysis") || error_str.contains("complexity")
+    }
+
+    fn is_permission_error(error_str: &str) -> bool {
+        error_str.contains("permission") || error_str.contains("access")
+    }
+
+    async fn run_main() -> Result<()> {
+        // Parse CLI to get tracing configuration early
+        let cli = cli::parse_early_for_tracing();
+
+        // Initialize enhanced tracing system
+        init_tracing(&cli)?;
+
+        // Only log to stdout if not running MCP server mode
+        if !cli.is_mcp_server {
+            info!(
+                "Starting PAIML MCP Agent Toolkit v{}",
+                env!("CARGO_PKG_VERSION")
             );
-            process::exit(ExitCode::MisuseError as i32);
+            debug!("Debug logging enabled");
+            trace!("Trace logging enabled");
+        }
+
+        // Create shared template server
+        let server = Arc::new(StatelessTemplateServer::new()?);
+
+        if !cli.is_mcp_server {
+            debug!("Template server initialized");
+        }
+
+        match detect_execution_mode() {
+            ExecutionMode::Mcp => {
+                if !cli.is_mcp_server {
+                    info!("Running unified MCP server (pmcp SDK)");
+                }
+                let unified_server = pmat::mcp_pmcp::UnifiedServer::new()
+                    .map_err(|e| anyhow::anyhow!("Failed to create unified server: {}", e))?;
+                unified_server
+                    .run()
+                    .await
+                    .map_err(|e| anyhow::anyhow!("{}", e))
+            }
+            ExecutionMode::Cli => {
+                if !cli.is_mcp_server {
+                    info!("Running in CLI mode");
+                }
+                cli::run(server).await
+            }
+            ExecutionMode::HelpAndExit => {
+                // GH-285: No subcommand + piped stdin + no MCP_VERSION. Print help on
+                // stderr and exit with code 2 (misuse), matching the convention for
+                // "no command supplied" on a terminal.
+                let mut cmd = <pmat::cli::Cli as clap::CommandFactory>::command();
+                let _ = cmd.print_help();
+                eprintln!(
+                    "\nerror: no subcommand given and stdin is not a terminal. \
+                 Set MCP_VERSION=1 (or run `pmat agent mcp-server`) to start the MCP server."
+                );
+                process::exit(ExitCode::MisuseError as i32);
+            }
         }
     }
-}
 
-#[cfg_attr(coverage_nightly, coverage(off))]
-#[cfg(test)]
-mod gh285_tests {
-    //! Regression tests for GH-285: `pmat` hangs when invoked with no args
-    //! and stdin is a pipe. See `classify_execution_mode`.
-    //!
-    //! Manual end-to-end repro (should NOT hang or exit 124):
-    //! ```text
-    //! echo "" | timeout 3 target/debug/pmat 2>&1; echo exit=$?
-    //! timeout 3 target/debug/pmat < /dev/null; echo exit=$?
-    //! ```
-    //! Both should print help and exit with code 2.
-    use super::{classify_execution_mode, ExecutionMode};
+    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg(test)]
+    mod gh285_tests {
+        //! Regression tests for GH-285: `pmat` hangs when invoked with no args
+        //! and stdin is a pipe. See `classify_execution_mode`.
+        //!
+        //! Manual end-to-end repro (should NOT hang or exit 124):
+        //! ```text
+        //! echo "" | timeout 3 target/debug/pmat 2>&1; echo exit=$?
+        //! timeout 3 target/debug/pmat < /dev/null; echo exit=$?
+        //! ```
+        //! Both should print help and exit with code 2.
+        use super::{classify_execution_mode, ExecutionMode};
 
-    #[test]
-    fn bare_invocation_on_tty_is_cli() {
-        // `pmat` typed into a terminal with no pipe -> normal CLI (clap
-        // will then print help on missing subcommand).
-        assert!(matches!(
-            classify_execution_mode(false, true, false),
-            ExecutionMode::Cli
-        ));
+        #[test]
+        fn bare_invocation_on_tty_is_cli() {
+            // `pmat` typed into a terminal with no pipe -> normal CLI (clap
+            // will then print help on missing subcommand).
+            assert!(matches!(
+                classify_execution_mode(false, true, false),
+                ExecutionMode::Cli
+            ));
+        }
+
+        #[test]
+        fn piped_stdin_with_no_args_prints_help_instead_of_hanging() {
+            // GH-285: This used to enter MCP mode and block on stdin forever.
+            assert!(matches!(
+                classify_execution_mode(false, true, true),
+                ExecutionMode::HelpAndExit
+            ));
+        }
+
+        #[test]
+        fn explicit_mcp_version_env_still_enters_mcp_mode() {
+            // Claude Desktop and similar hosts set MCP_VERSION; they must still
+            // get the MCP server regardless of TTY state.
+            assert!(matches!(
+                classify_execution_mode(true, true, true),
+                ExecutionMode::Mcp
+            ));
+            assert!(matches!(
+                classify_execution_mode(true, false, false),
+                ExecutionMode::Mcp
+            ));
+        }
+
+        #[test]
+        fn subcommand_with_piped_stdin_is_still_cli() {
+            // `echo foo | pmat analyze ...` must dispatch to the CLI subcommand,
+            // not to help-and-exit.
+            assert!(matches!(
+                classify_execution_mode(false, false, true),
+                ExecutionMode::Cli
+            ));
+        }
     }
-
-    #[test]
-    fn piped_stdin_with_no_args_prints_help_instead_of_hanging() {
-        // GH-285: This used to enter MCP mode and block on stdin forever.
-        assert!(matches!(
-            classify_execution_mode(false, true, true),
-            ExecutionMode::HelpAndExit
-        ));
-    }
-
-    #[test]
-    fn explicit_mcp_version_env_still_enters_mcp_mode() {
-        // Claude Desktop and similar hosts set MCP_VERSION; they must still
-        // get the MCP server regardless of TTY state.
-        assert!(matches!(
-            classify_execution_mode(true, true, true),
-            ExecutionMode::Mcp
-        ));
-        assert!(matches!(
-            classify_execution_mode(true, false, false),
-            ExecutionMode::Mcp
-        ));
-    }
-
-    #[test]
-    fn subcommand_with_piped_stdin_is_still_cli() {
-        // `echo foo | pmat analyze ...` must dispatch to the CLI subcommand,
-        // not to help-and-exit.
-        assert!(matches!(
-            classify_execution_mode(false, false, true),
-            ExecutionMode::Cli
-        ));
-    }
-}
 } // end of mod full
 
 #[cfg(feature = "standard-deps")]

--- a/src/cli/language_analyzer/dynamic.rs
+++ b/src/cli/language_analyzer/dynamic.rs
@@ -54,3 +54,232 @@ impl LanguageAnalyzer for LuaAnalyzer {
 include!("dynamic_lua.rs");
 include!("dynamic_sql.rs");
 include!("dynamic_scala.rs");
+
+#[cfg(test)]
+mod lua_tests {
+    //! PMAT-646: cover dynamic_lua.rs pure fn + trait-dispatch paths.
+    use super::*;
+
+    // --- is_function_declaration / extract_function_name (heuristic helpers) ---
+
+    #[test]
+    fn test_is_function_declaration_plain() {
+        let a = LuaAnalyzer;
+        assert!(a.is_function_declaration("function foo()"));
+        assert!(a.is_function_declaration("local function bar(x)"));
+        assert!(!a.is_function_declaration("-- a comment"));
+        assert!(!a.is_function_declaration("x = 1"));
+        // Missing parenthesis → false.
+        assert!(!a.is_function_declaration("function no_paren"));
+    }
+
+    #[test]
+    fn test_extract_function_name_local_function() {
+        let a = LuaAnalyzer;
+        assert_eq!(
+            a.extract_function_name("local function my_fn(a, b)"),
+            Some("my_fn".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_function_name_plain_function() {
+        let a = LuaAnalyzer;
+        assert_eq!(
+            a.extract_function_name("function top_level()"),
+            Some("top_level".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_function_name_returns_none_for_non_function_line() {
+        let a = LuaAnalyzer;
+        assert_eq!(a.extract_function_name("return 42"), None);
+    }
+
+    #[test]
+    fn test_extract_function_name_returns_none_for_empty_name() {
+        let a = LuaAnalyzer;
+        // "function ()" would be an anonymous function; the helper returns None
+        // when the name between `function ` and `(` is empty.
+        assert_eq!(a.extract_function_name("function ()"), None);
+    }
+
+    // --- find_function_end (heuristic) ---
+
+    #[test]
+    fn test_find_function_end_simple_flat_function() {
+        let a = LuaAnalyzer;
+        let src = "function foo()\n  return 1\nend\n";
+        let lines: Vec<&str> = src.lines().collect();
+        // "function foo()" is at line 0; matching `end` is at line 2.
+        assert_eq!(a.find_function_end(&lines, 0), 2);
+    }
+
+    #[test]
+    fn test_find_function_end_with_nested_if() {
+        let a = LuaAnalyzer;
+        let src = "function foo()\n  if x then\n    return 1\n  end\nend\n";
+        let lines: Vec<&str> = src.lines().collect();
+        // Last `end` (outer) at line 4 matches.
+        assert_eq!(a.find_function_end(&lines, 0), 4);
+    }
+
+    #[test]
+    fn test_find_function_end_repeat_until_closes() {
+        let a = LuaAnalyzer;
+        let src = "function f()\n  repeat\n    x = x + 1\n  until x > 5\nend\n";
+        let lines: Vec<&str> = src.lines().collect();
+        // `until x > 5` closes the repeat depth, final `end` closes function.
+        let end = a.find_function_end(&lines, 0);
+        // End is last `end` at line 4.
+        assert_eq!(end, 4);
+    }
+
+    #[test]
+    fn test_find_function_end_skips_comment_only_lines() {
+        let a = LuaAnalyzer;
+        let src = "function f()\n  -- comment\n  return 1\nend\n";
+        let lines: Vec<&str> = src.lines().collect();
+        assert_eq!(a.find_function_end(&lines, 0), 3);
+    }
+
+    #[test]
+    fn test_find_function_end_missing_end_falls_back_to_last_line() {
+        let a = LuaAnalyzer;
+        // Function with no matching `end` (source truncated).
+        let src = "function f()\n  return 1\n";
+        let lines: Vec<&str> = src.lines().collect();
+        // Fallback: lines.len() - 1 == 1.
+        assert_eq!(a.find_function_end(&lines, 0), lines.len() - 1);
+    }
+
+    // --- extract_functions_heuristic ---
+
+    #[test]
+    fn test_extract_functions_heuristic_empty_source() {
+        let a = LuaAnalyzer;
+        assert!(a.extract_functions_heuristic("").is_empty());
+    }
+
+    #[test]
+    fn test_extract_functions_heuristic_single_function() {
+        let a = LuaAnalyzer;
+        let src = "function lonely()\n  return 0\nend\n";
+        let fns = a.extract_functions_heuristic(src);
+        assert_eq!(fns.len(), 1);
+        assert_eq!(fns[0].name, "lonely");
+        assert_eq!(fns[0].line_start, 0);
+    }
+
+    #[test]
+    fn test_extract_functions_heuristic_multiple_functions_mixed_styles() {
+        let a = LuaAnalyzer;
+        let src = "local function helper(x)\n  return x * 2\nend\n\nfunction top()\n  return helper(3)\nend\n";
+        let fns = a.extract_functions_heuristic(src);
+        assert_eq!(fns.len(), 2);
+        assert!(fns.iter().any(|f| f.name == "helper"));
+        assert!(fns.iter().any(|f| f.name == "top"));
+    }
+
+    // --- estimate_complexity_heuristic ---
+
+    #[test]
+    fn test_estimate_complexity_heuristic_flat_function_is_1() {
+        let a = LuaAnalyzer;
+        let src = "function flat()\n  return 1\nend\n";
+        let fns = a.extract_functions_heuristic(src);
+        let m = a.estimate_complexity_heuristic(src, &fns[0]);
+        assert_eq!(m.cyclomatic, 1);
+        assert_eq!(m.cognitive, 0);
+        // nesting_max: the "function" line itself increments nesting, so max is 1.
+        assert!(m.nesting_max >= 1);
+    }
+
+    #[test]
+    fn test_estimate_complexity_heuristic_if_branch_raises_cyclomatic() {
+        let a = LuaAnalyzer;
+        let src = "function with_if(x)\n  if x > 0 then\n    return 1\n  end\nend\n";
+        let fns = a.extract_functions_heuristic(src);
+        let m = a.estimate_complexity_heuristic(src, &fns[0]);
+        // +1 for `if`, baseline 1 → cyclomatic ≥ 2
+        assert!(m.cyclomatic >= 2, "got {}", m.cyclomatic);
+    }
+
+    #[test]
+    fn test_estimate_complexity_heuristic_and_or_add_to_cyclomatic() {
+        let a = LuaAnalyzer;
+        let src = "function combined(x, y)\n  if x and y then\n    return 1\n  end\nend\n";
+        let fns = a.extract_functions_heuristic(src);
+        let m = a.estimate_complexity_heuristic(src, &fns[0]);
+        // `if` +1 and `and` +1 → cyclomatic ≥ 3
+        assert!(m.cyclomatic >= 3, "got {}", m.cyclomatic);
+    }
+
+    #[test]
+    fn test_estimate_complexity_heuristic_nested_for_raises_nesting() {
+        let a = LuaAnalyzer;
+        let src = "function nested()\n  for i = 1, 10 do\n    for j = 1, 10 do\n      x = i + j\n    end\n  end\nend\n";
+        let fns = a.extract_functions_heuristic(src);
+        let m = a.estimate_complexity_heuristic(src, &fns[0]);
+        // Nesting: function (1), outer for (2), inner for (3)
+        assert!(m.nesting_max >= 3, "got {}", m.nesting_max);
+    }
+
+    // --- LanguageAnalyzer trait dispatch ---
+
+    #[test]
+    fn test_lua_trait_extract_functions_finds_functions() {
+        let a = LuaAnalyzer;
+        let src = "function foo()\n  return 1\nend\n\nlocal function bar()\n  return 2\nend\n";
+        let fns = a.extract_functions(src);
+        assert!(fns.iter().any(|f| f.name == "foo"));
+        assert!(fns.iter().any(|f| f.name == "bar"));
+    }
+
+    #[test]
+    fn test_lua_trait_estimate_complexity_returns_nonzero() {
+        let a = LuaAnalyzer;
+        let src = "function complex(x)\n  if x > 0 then\n    return x\n  else\n    return -x\n  end\nend\n";
+        let fns = a.extract_functions(src);
+        assert!(!fns.is_empty());
+        let m = a.estimate_complexity(src, &fns[0]);
+        // `if` + `else` may or may not count depending on path — cyclomatic should be >= 2.
+        assert!(m.cyclomatic >= 2, "got {}", m.cyclomatic);
+        assert!(m.lines > 0);
+    }
+
+    #[test]
+    fn test_lua_trait_handles_empty_input_gracefully() {
+        let a = LuaAnalyzer;
+        assert!(a.extract_functions("").is_empty());
+    }
+
+    #[test]
+    fn test_lua_trait_handles_non_function_input() {
+        let a = LuaAnalyzer;
+        // Valid Lua with no function definitions.
+        let src = "x = 1\ny = 2\nprint(x + y)\n";
+        assert!(a.extract_functions(src).is_empty());
+    }
+
+    #[test]
+    fn test_estimate_complexity_heuristic_while_and_repeat_increase_cyclomatic() {
+        let a = LuaAnalyzer;
+        let src = "function loops()\n  while x > 0 do\n    x = x - 1\n  end\n  repeat\n    y = y + 1\n  until y > 10\nend\n";
+        let fns = a.extract_functions_heuristic(src);
+        let m = a.estimate_complexity_heuristic(src, &fns[0]);
+        // baseline 1 + while +1 + repeat +1 = 3
+        assert!(m.cyclomatic >= 3, "got {}", m.cyclomatic);
+    }
+
+    #[test]
+    fn test_estimate_complexity_heuristic_elseif_bumps_cyclomatic() {
+        let a = LuaAnalyzer;
+        let src = "function ladder(x)\n  if x == 1 then\n    return 1\n  elseif x == 2 then\n    return 2\n  end\nend\n";
+        let fns = a.extract_functions_heuristic(src);
+        let m = a.estimate_complexity_heuristic(src, &fns[0]);
+        // if +1, elseif +1 → cyclomatic ≥ 3.
+        assert!(m.cyclomatic >= 3, "got {}", m.cyclomatic);
+    }
+}

--- a/src/entropy/pattern_extractor_tests.rs
+++ b/src/entropy/pattern_extractor_tests.rs
@@ -845,7 +845,10 @@ fn test_calculate_pattern_match_variation_score_short_circuits_single_match() {
 
     let score =
         extractor.calculate_pattern_match_variation_score(&enums, &matches, &arrows, content);
-    assert_eq!(score, 0.0, "fewer than 2 match blocks must short-circuit to 0.0");
+    assert_eq!(
+        score, 0.0,
+        "fewer than 2 match blocks must short-circuit to 0.0"
+    );
 }
 
 /// pattern_extractor_ruchy.rs:405 — enum_matches.len() <= 1 low-variation arm (0.3).

--- a/src/maintenance/updater.rs
+++ b/src/maintenance/updater.rs
@@ -375,9 +375,13 @@ mod tests {
             files: vec!["src/lib.rs".into()], // no ticket file
         };
 
-        let result =
-            process_ticket_update(&mut roadmap, &commit, "TICKET-PMAT-5013", tickets_dir.path())
-                .unwrap();
+        let result = process_ticket_update(
+            &mut roadmap,
+            &commit,
+            "TICKET-PMAT-5013",
+            tickets_dir.path(),
+        )
+        .unwrap();
         assert!(!result, "must short-circuit when ticket file not in commit");
         assert!(!roadmap.sprints[0].tickets[0].completed);
     }
@@ -394,10 +398,17 @@ mod tests {
             files: vec!["docs/tickets/TICKET-PMAT-5013.md".into()],
         };
 
-        let result =
-            process_ticket_update(&mut roadmap, &commit, "TICKET-PMAT-5013", tickets_dir.path())
-                .unwrap();
-        assert!(!result, "missing ticket file must return Ok(false), not error");
+        let result = process_ticket_update(
+            &mut roadmap,
+            &commit,
+            "TICKET-PMAT-5013",
+            tickets_dir.path(),
+        )
+        .unwrap();
+        assert!(
+            !result,
+            "missing ticket file must return Ok(false), not error"
+        );
         assert!(!roadmap.sprints[0].tickets[0].completed);
     }
 
@@ -417,11 +428,7 @@ mod tests {
              Still failing.\n\n\
              ## Success Criteria\n\n\
              - [ ] One\n";
-        std::fs::write(
-            tickets_dir.path().join("TICKET-PMAT-5013.md"),
-            red_content,
-        )
-        .unwrap();
+        std::fs::write(tickets_dir.path().join("TICKET-PMAT-5013.md"), red_content).unwrap();
         let mut roadmap = create_test_roadmap();
         let commit = CommitInfo {
             hash: "deadbee".into(),
@@ -429,9 +436,13 @@ mod tests {
             files: vec!["docs/tickets/TICKET-PMAT-5013.md".into()],
         };
 
-        let result =
-            process_ticket_update(&mut roadmap, &commit, "TICKET-PMAT-5013", tickets_dir.path())
-                .unwrap();
+        let result = process_ticket_update(
+            &mut roadmap,
+            &commit,
+            "TICKET-PMAT-5013",
+            tickets_dir.path(),
+        )
+        .unwrap();
         assert!(!result, "RED ticket must not mark roadmap completed");
         assert!(!roadmap.sprints[0].tickets[0].completed);
     }
@@ -450,9 +461,13 @@ mod tests {
             files: vec!["docs/tickets/TICKET-PMAT-5013.md".into()],
         };
 
-        let result =
-            process_ticket_update(&mut roadmap, &commit, "TICKET-PMAT-5013", tickets_dir.path())
-                .unwrap();
+        let result = process_ticket_update(
+            &mut roadmap,
+            &commit,
+            "TICKET-PMAT-5013",
+            tickets_dir.path(),
+        )
+        .unwrap();
         assert!(result, "GREEN ticket must flip roadmap entry");
         assert!(roadmap.sprints[0].tickets[0].completed);
         assert_eq!(

--- a/src/mcp_pmcp/agent_context_handlers.rs
+++ b/src/mcp_pmcp/agent_context_handlers.rs
@@ -37,11 +37,7 @@ macro_rules! impl_pmat_handler {
 
         #[async_trait]
         impl ToolHandler for $wrapper {
-            async fn handle(
-                &self,
-                args: Value,
-                _extra: RequestHandlerExtra,
-            ) -> PmcpResult<Value> {
+            async fn handle(&self, args: Value, _extra: RequestHandlerExtra) -> PmcpResult<Value> {
                 self.inner.execute(args).await.map_err(PmcpError::internal)
             }
 

--- a/src/mcp_pmcp/analyze_handlers.rs
+++ b/src/mcp_pmcp/analyze_handlers.rs
@@ -32,7 +32,8 @@ use tracing::debug;
 // MCP tools (see R15 #3 bench matrix).
 pub use self::{
     ComplexityTool as AnalyzeComplexityTool, DeadCodeTool as AnalyzeDeadCodeTool,
-    SatdTool as AnalyzeSatdTool, TdgCompareTool as AnalyzeTdgCompareTool, TdgTool as AnalyzeTdgTool,
+    SatdTool as AnalyzeSatdTool, TdgCompareTool as AnalyzeTdgCompareTool,
+    TdgTool as AnalyzeTdgTool,
 };
 
 // Complexity analysis tool handler

--- a/src/mcp_pmcp/mod.rs
+++ b/src/mcp_pmcp/mod.rs
@@ -103,12 +103,12 @@ pub mod quality_handlers;
 pub mod quality_proxy_handler;
 pub mod server;
 pub mod simple_unified_server;
-pub mod tool_schemas;
 #[cfg_attr(coverage_nightly, coverage(off))]
 #[cfg(test)]
 pub mod tdg_git_context_tests;
 pub mod tdg_handlers;
 pub mod tool_functions;
+pub mod tool_schemas;
 pub mod tool_schemas_generated; // KAIZEN-0178: build.rs-generated tool schema registry
 pub mod tools; // Sprint 65 Phase 2B: MCP git-context integration
 

--- a/src/mcp_pmcp/tool_schemas.rs
+++ b/src/mcp_pmcp/tool_schemas.rs
@@ -45,7 +45,10 @@ pub fn paths_object_schema(extra_properties: Value, required: Vec<&str>) -> Valu
             base.insert(k.clone(), v.clone());
         }
     }
-    let req: Vec<Value> = required.into_iter().map(|s| Value::String(s.into())).collect();
+    let req: Vec<Value> = required
+        .into_iter()
+        .map(|s| Value::String(s.into()))
+        .collect();
     json!({
         "type": "object",
         "properties": base_props,


### PR DESCRIPTION
## Summary

Continues Phase-1 CLI pivot after PR #510/PMAT-645. \`dynamic_lua.rs\` is 300 lines, **0/250 broad-covered** on master, 0 async. Both tree-sitter (\`lua-ast\` feature, default-on) and heuristic fallback paths testable via the \`LanguageAnalyzer\` trait impl.

**23 new tests** in \`dynamic.rs\`'s \`mod lua_tests\`:

- Heuristic helpers: is_function_declaration (5 cases), extract_function_name (4 cases), find_function_end (5 cases: simple, nested if, repeat/until, comment-skip, missing-end EOF), extract_functions_heuristic (empty/single/mixed styles), estimate_complexity_heuristic (flat=1, if, and/or, nested for, while+repeat, elseif)
- Trait dispatch: extract_functions + estimate_complexity + empty + no-functions

File has no \`coverage(off)\` and is **not** in \`COVERAGE_EXCLUDE\`, so this moves both narrow AND broad gates. Expected delta: **~+0.07pp** on broad.

## Cumulative measurement from Phase-1 pivot

**Measured on PMAT-642 branch**: broad 73.42% → **73.59% (+0.17pp)** from just PMAT-642. \`score_handler_compute.rs\` jumped 0% → **75.99%** (307 lines covered of 404).

If all 5 Phase-1 pivot PRs (#507, #508, #509, #510, this one) merge, broad is estimated to move ~**+0.5pp total** on the 324k denominator — still drip-feed territory but 15× the scaffold sweep rate.

## Test plan

- [x] \`cargo test --lib -- cli::language_analyzer::dynamic::lua_tests\` — 23 passed, 0 failed
- [x] \`cargo fmt --all -- --check\` — clean
- [ ] CI gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)