### PR TITLE
test(coverage): extended_tools_complexity.rs pure helpers (PMAT-647)

### DIFF
--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -3217,7 +3217,7 @@ roadmap:
   github_issue: null
   item_type: task
   title: 'Phase 1 pivot: handlers/tools/extended_tools_complexity.rs coverage'
-  status: inprogress
+  status: review
   priority: medium
   assigned_to: null
   created: 2026-04-24T08:45:12Z

--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -3213,3 +3213,20 @@ roadmap:
   estimated_effort: null
   labels: []
   notes: null
+- id: PMAT-647
+  github_issue: null
+  item_type: task
+  title: 'Phase 1 pivot: handlers/tools/extended_tools_complexity.rs coverage'
+  status: inprogress
+  priority: medium
+  assigned_to: null
+  created: 2026-04-24T08:45:12Z
+  updated: 2026-04-24T08:45:12Z
+  spec: null
+  acceptance_criteria:
+  - 'Phase 1 CLI pivot — extended_tools_complexity.rs is 393 lines, 244/266 broad-covered, 4 async (async only in public handler; pure helpers are sync). Cover parse_complexity_args (valid + serde err), detect_toolchain (5 branches: explicit, Cargo.toml, package.json, deno.json, pyproject.toml, requirements.txt, default), build_complexity_thresholds (none / max_cyclomatic only / max_cognitive only / both), should_analyze_file (rust/deno/python/unknown), matches_include_filters (None, empty Vec, no match, match), matches_pattern (** glob, *.ext, substring, non-match), format_complexity_output (full/json/sarif/summary), generate_complexity_content (top_files=0 → summary, top_files=N → rankings), format_complexity_rankings (json + table).'
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels: []
+  notes: null

--- a/examples/mcp_agent_context_demo.rs
+++ b/examples/mcp_agent_context_demo.rs
@@ -54,68 +54,132 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     thread::sleep(Duration::from_secs(10));
 
     // 1. initialize handshake
-    let resp = rpc(&mut writer, &mut reader, 1, "initialize", json!({
-        "protocolVersion": "2024-11-05",
-        "capabilities": {},
-        "clientInfo": { "name": "mcp_agent_context_demo", "version": "1.0" }
-    }))?;
-    let server_info = resp.pointer("/result/serverInfo/name").cloned().unwrap_or(json!("?"));
+    let resp = rpc(
+        &mut writer,
+        &mut reader,
+        1,
+        "initialize",
+        json!({
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": { "name": "mcp_agent_context_demo", "version": "1.0" }
+        }),
+    )?;
+    let server_info = resp
+        .pointer("/result/serverInfo/name")
+        .cloned()
+        .unwrap_or(json!("?"));
     println!("[initialize] server={}", server_info);
 
     // 2. tools/list — sanity check that the 4 pmat_* tools are registered
     let resp = rpc(&mut writer, &mut reader, 2, "tools/list", json!({}))?;
-    let tools = resp.pointer("/result/tools").and_then(|v| v.as_array()).cloned().unwrap_or_default();
-    let pmat_tools: Vec<&str> = tools.iter()
+    let tools = resp
+        .pointer("/result/tools")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+    let pmat_tools: Vec<&str> = tools
+        .iter()
         .filter_map(|t| t.get("name").and_then(|n| n.as_str()))
         .filter(|n| n.starts_with("pmat_"))
         .collect();
-    println!("[tools/list] total={} pmat_*={} ({:?})", tools.len(), pmat_tools.len(), pmat_tools);
+    println!(
+        "[tools/list] total={} pmat_*={} ({:?})",
+        tools.len(),
+        pmat_tools.len(),
+        pmat_tools
+    );
 
     // 3. pmat_index_stats — pick up a real function_id we can reuse below
-    let resp = call_tool(&mut writer, &mut reader, 3, "pmat_index_stats",
-        json!({ "rebuild": false }))?;
+    let resp = call_tool(
+        &mut writer,
+        &mut reader,
+        3,
+        "pmat_index_stats",
+        json!({ "rebuild": false }),
+    )?;
     let index_result = extract_tool_result(&resp);
-    let fn_count = index_result.pointer("/manifest/function_count").cloned().unwrap_or(json!(0));
-    let file_count = index_result.pointer("/manifest/file_count").cloned().unwrap_or(json!(0));
-    println!("[pmat_index_stats] ok: functions={} files={}", fn_count, file_count);
+    let fn_count = index_result
+        .pointer("/manifest/function_count")
+        .cloned()
+        .unwrap_or(json!(0));
+    let file_count = index_result
+        .pointer("/manifest/file_count")
+        .cloned()
+        .unwrap_or(json!(0));
+    println!(
+        "[pmat_index_stats] ok: functions={} files={}",
+        fn_count, file_count
+    );
 
     // 4. pmat_query_code — realistic semantic query
-    let resp = call_tool(&mut writer, &mut reader, 4, "pmat_query_code",
-        json!({ "query": "error handling", "limit": 3 }))?;
+    let resp = call_tool(
+        &mut writer,
+        &mut reader,
+        4,
+        "pmat_query_code",
+        json!({ "query": "error handling", "limit": 3 }),
+    )?;
     let query_result = extract_tool_result(&resp);
-    let result_count = query_result.get("results")
+    let result_count = query_result
+        .get("results")
         .or_else(|| query_result.get("functions"))
         .and_then(|v| v.as_array())
         .map(|a| a.len())
         .unwrap_or(0);
-    let first_id = query_result.pointer("/results/0/id")
+    let first_id = query_result
+        .pointer("/results/0/id")
         .or_else(|| query_result.pointer("/functions/0/id"))
         .and_then(|v| v.as_str())
         .map(|s| s.to_string());
-    println!("[pmat_query_code] ok: {} results; first_id={:?}", result_count, first_id);
+    println!(
+        "[pmat_query_code] ok: {} results; first_id={:?}",
+        result_count, first_id
+    );
 
     // 5. pmat_get_function — use the first id from query_code, or fall back to "main"
-    let function_id = first_id.clone().unwrap_or_else(|| "src/bin/pmat.rs::main".to_string());
-    let resp = call_tool(&mut writer, &mut reader, 5, "pmat_get_function",
-        json!({ "function_id": function_id, "include_source": false }))?;
+    let function_id = first_id
+        .clone()
+        .unwrap_or_else(|| "src/bin/pmat.rs::main".to_string());
+    let resp = call_tool(
+        &mut writer,
+        &mut reader,
+        5,
+        "pmat_get_function",
+        json!({ "function_id": function_id, "include_source": false }),
+    )?;
     match resp.get("error") {
-        Some(err) => println!("[pmat_get_function] graceful miss for {:?}: {}", function_id,
-            err.get("message").and_then(|m| m.as_str()).unwrap_or("?")),
+        Some(err) => println!(
+            "[pmat_get_function] graceful miss for {:?}: {}",
+            function_id,
+            err.get("message").and_then(|m| m.as_str()).unwrap_or("?")
+        ),
         None => {
             let gf = extract_tool_result(&resp);
-            println!("[pmat_get_function] ok: name={} grade={}",
+            println!(
+                "[pmat_get_function] ok: name={} grade={}",
                 gf.get("name").and_then(|v| v.as_str()).unwrap_or("?"),
-                gf.pointer("/quality/grade").and_then(|v| v.as_str()).unwrap_or("?"));
+                gf.pointer("/quality/grade")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("?")
+            );
         }
     }
 
     // 6. pmat_find_similar — only meaningful if we got a real id from the query
     if let Some(id) = first_id {
-        let resp = call_tool(&mut writer, &mut reader, 6, "pmat_find_similar",
-            json!({ "function_id": id, "limit": 3, "min_similarity": 0.3 }))?;
+        let resp = call_tool(
+            &mut writer,
+            &mut reader,
+            6,
+            "pmat_find_similar",
+            json!({ "function_id": id, "limit": 3, "min_similarity": 0.3 }),
+        )?;
         match resp.get("error") {
-            Some(err) => println!("[pmat_find_similar] error: {}",
-                err.get("message").and_then(|m| m.as_str()).unwrap_or("?")),
+            Some(err) => println!(
+                "[pmat_find_similar] error: {}",
+                err.get("message").and_then(|m| m.as_str()).unwrap_or("?")
+            ),
             None => {
                 let sim = extract_tool_result(&resp);
                 let total = sim.get("total").and_then(|v| v.as_u64()).unwrap_or(0);
@@ -162,7 +226,13 @@ fn call_tool(
     name: &str,
     args: Value,
 ) -> Result<Value, Box<dyn std::error::Error>> {
-    rpc(writer, reader, id, "tools/call", json!({ "name": name, "arguments": args }))
+    rpc(
+        writer,
+        reader,
+        id,
+        "tools/call",
+        json!({ "name": name, "arguments": args }),
+    )
 }
 
 /// MCP `tools/call` wraps results in `result.content[0].text` (JSON string) or
@@ -171,7 +241,10 @@ fn extract_tool_result(resp: &Value) -> Value {
     if let Some(sc) = resp.pointer("/result/structuredContent") {
         return sc.clone();
     }
-    if let Some(text) = resp.pointer("/result/content/0/text").and_then(|v| v.as_str()) {
+    if let Some(text) = resp
+        .pointer("/result/content/0/text")
+        .and_then(|v| v.as_str())
+    {
         if let Ok(parsed) = serde_json::from_str::<Value>(text) {
             return parsed;
         }

--- a/src/bin/pmat.rs
+++ b/src/bin/pmat.rs
@@ -16,301 +16,301 @@ fn main() {
 
 #[cfg(feature = "standard-deps")]
 mod full {
-use anyhow::Result;
-use pmat::{cli, stateless_server::StatelessTemplateServer};
-use std::io::IsTerminal;
-use std::process;
-use std::sync::Arc;
-use tracing::{debug, error, info, trace};
-use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
+    use anyhow::Result;
+    use pmat::{cli, stateless_server::StatelessTemplateServer};
+    use std::io::IsTerminal;
+    use std::process;
+    use std::sync::Arc;
+    use tracing::{debug, error, info, trace};
+    use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 
-enum ExecutionMode {
-    Mcp,
-    Cli,
-    /// No subcommand given and stdin is piped (not a TTY) without an explicit
-    /// MCP opt-in. Print help and exit non-zero instead of blocking on stdin
-    /// (see GH-285).
-    HelpAndExit,
-}
-
-/// POSIX-compliant exit codes for CLI interface
-/// Per SPECIFICATION.md Section 23: CLI Interface
-#[derive(Debug, Clone, Copy)]
-pub enum ExitCode {
-    /// Success
-    Success = 0,
-    /// General error
-    GeneralError = 1,
-    /// Misuse of shell command
-    MisuseError = 2,
-    /// Permission denied
-    PermissionDenied = 126,
-    /// Command not found
-    CommandNotFound = 127,
-    /// Invalid argument to exit
-    InvalidExitArg = 128,
-    /// Quality gate failure (custom)
-    QualityGateFailure = 3,
-    /// Configuration error (custom)
-    ConfigurationError = 4,
-    /// Analysis error (custom)
-    AnalysisError = 5,
-}
-
-impl From<ExitCode> for i32 {
-    fn from(code: ExitCode) -> Self {
-        code as i32
-    }
-}
-
-fn detect_execution_mode() -> ExecutionMode {
-    classify_execution_mode(
-        std::env::var("MCP_VERSION").is_ok(),
-        std::env::args().len() == 1,
-        !std::io::stdin().is_terminal(),
-    )
-}
-
-/// Pure decision function for execution mode so it can be unit-tested
-/// without touching real stdin / env vars (see GH-285 regression test).
-fn classify_execution_mode(
-    mcp_version_env: bool,
-    no_args: bool,
-    stdin_is_pipe: bool,
-) -> ExecutionMode {
-    // Explicit MCP opt-in via env var always wins (e.g. Claude Desktop sets this).
-    if mcp_version_env {
-        return ExecutionMode::Mcp;
+    enum ExecutionMode {
+        Mcp,
+        Cli,
+        /// No subcommand given and stdin is piped (not a TTY) without an explicit
+        /// MCP opt-in. Print help and exit non-zero instead of blocking on stdin
+        /// (see GH-285).
+        HelpAndExit,
     }
 
-    // GH-285: If the user ran bare `pmat` with stdin piped (e.g. `echo "" | pmat`)
-    // without opting into MCP via `MCP_VERSION`, previous behavior entered the MCP
-    // server and blocked forever on stdin. Treat that case the same as bare `pmat`
-    // on a terminal: print help and exit non-zero.
-    if no_args && stdin_is_pipe {
-        return ExecutionMode::HelpAndExit;
+    /// POSIX-compliant exit codes for CLI interface
+    /// Per SPECIFICATION.md Section 23: CLI Interface
+    #[derive(Debug, Clone, Copy)]
+    pub enum ExitCode {
+        /// Success
+        Success = 0,
+        /// General error
+        GeneralError = 1,
+        /// Misuse of shell command
+        MisuseError = 2,
+        /// Permission denied
+        PermissionDenied = 126,
+        /// Command not found
+        CommandNotFound = 127,
+        /// Invalid argument to exit
+        InvalidExitArg = 128,
+        /// Quality gate failure (custom)
+        QualityGateFailure = 3,
+        /// Configuration error (custom)
+        ConfigurationError = 4,
+        /// Analysis error (custom)
+        AnalysisError = 5,
     }
 
-    ExecutionMode::Cli
-}
+    impl From<ExitCode> for i32 {
+        fn from(code: ExitCode) -> Self {
+            code as i32
+        }
+    }
 
-/// Initialize the enhanced tracing system based on CLI flags
-fn init_tracing(cli: &cli::EarlyCliArgs) -> Result<()> {
-    let filter = create_env_filter(cli)?;
-
-    tracing_subscriber::registry()
-        .with(filter)
-        .with(
-            tracing_subscriber::fmt::layer()
-                .with_target(cli.debug || cli.trace)
-                .with_thread_ids(cli.trace)
-                .with_file(cli.trace)
-                .with_line_number(cli.trace)
-                .compact()
-                .with_writer(std::io::stderr),
+    fn detect_execution_mode() -> ExecutionMode {
+        classify_execution_mode(
+            std::env::var("MCP_VERSION").is_ok(),
+            std::env::args().len() == 1,
+            !std::io::stdin().is_terminal(),
         )
-        .init();
-
-    Ok(())
-}
-
-/// Create environment filter based on CLI flags
-fn create_env_filter(cli: &cli::EarlyCliArgs) -> Result<EnvFilter> {
-    if cli.is_mcp_server {
-        Ok(create_mcp_filter(cli.debug))
-    } else {
-        create_cli_filter(cli)
-    }
-}
-
-/// Create filter for MCP server mode
-fn create_mcp_filter(debug: bool) -> EnvFilter {
-    if debug {
-        EnvFilter::new("warn,pmat=debug")
-    } else {
-        EnvFilter::new("off")
-    }
-}
-
-/// Create filter for CLI mode
-fn create_cli_filter(cli: &cli::EarlyCliArgs) -> Result<EnvFilter> {
-    if let Some(ref custom) = cli.trace_filter {
-        return Ok(EnvFilter::try_new(custom)?);
     }
 
-    let filter_str = match (cli.trace, cli.debug, cli.verbose) {
-        (true, _, _) => "debug,pmat=trace",
-        (_, true, _) => "warn,pmat=debug",
-        (_, _, true) => "warn,pmat=info",
-        _ => return Ok(get_default_filter()),
-    };
-
-    Ok(EnvFilter::new(filter_str))
-}
-
-/// Get default production filter
-fn get_default_filter() -> EnvFilter {
-    EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("warn"))
-}
-
-#[tokio::main]
-#[allow(unreachable_pub)]
-pub async fn real_main() {
-    let exit_code = match run_main().await {
-        Ok(()) => ExitCode::Success,
-        Err(e) => {
-            error!("Error: {:#}", e);
-            categorize_error(&e)
+    /// Pure decision function for execution mode so it can be unit-tested
+    /// without touching real stdin / env vars (see GH-285 regression test).
+    fn classify_execution_mode(
+        mcp_version_env: bool,
+        no_args: bool,
+        stdin_is_pipe: bool,
+    ) -> ExecutionMode {
+        // Explicit MCP opt-in via env var always wins (e.g. Claude Desktop sets this).
+        if mcp_version_env {
+            return ExecutionMode::Mcp;
         }
-    };
 
-    if exit_code as i32 != 0 {
-        process::exit(exit_code.into());
-    }
-}
+        // GH-285: If the user ran bare `pmat` with stdin piped (e.g. `echo "" | pmat`)
+        // without opting into MCP via `MCP_VERSION`, previous behavior entered the MCP
+        // server and blocked forever on stdin. Treat that case the same as bare `pmat`
+        // on a terminal: print help and exit non-zero.
+        if no_args && stdin_is_pipe {
+            return ExecutionMode::HelpAndExit;
+        }
 
-fn categorize_error(error: &anyhow::Error) -> ExitCode {
-    let error_str = error.to_string().to_lowercase();
-
-    match () {
-        _ if is_quality_gate_error(&error_str) => ExitCode::QualityGateFailure,
-        _ if is_configuration_error(&error_str) => ExitCode::ConfigurationError,
-        _ if is_analysis_error(&error_str) => ExitCode::AnalysisError,
-        _ if is_permission_error(&error_str) => ExitCode::PermissionDenied,
-        _ => ExitCode::GeneralError,
-    }
-}
-
-fn is_quality_gate_error(error_str: &str) -> bool {
-    error_str.contains("quality gate") || error_str.contains("violation")
-}
-
-fn is_configuration_error(error_str: &str) -> bool {
-    error_str.contains("config") || error_str.contains("parse")
-}
-
-fn is_analysis_error(error_str: &str) -> bool {
-    error_str.contains("analysis") || error_str.contains("complexity")
-}
-
-fn is_permission_error(error_str: &str) -> bool {
-    error_str.contains("permission") || error_str.contains("access")
-}
-
-async fn run_main() -> Result<()> {
-    // Parse CLI to get tracing configuration early
-    let cli = cli::parse_early_for_tracing();
-
-    // Initialize enhanced tracing system
-    init_tracing(&cli)?;
-
-    // Only log to stdout if not running MCP server mode
-    if !cli.is_mcp_server {
-        info!(
-            "Starting PAIML MCP Agent Toolkit v{}",
-            env!("CARGO_PKG_VERSION")
-        );
-        debug!("Debug logging enabled");
-        trace!("Trace logging enabled");
+        ExecutionMode::Cli
     }
 
-    // Create shared template server
-    let server = Arc::new(StatelessTemplateServer::new()?);
+    /// Initialize the enhanced tracing system based on CLI flags
+    fn init_tracing(cli: &cli::EarlyCliArgs) -> Result<()> {
+        let filter = create_env_filter(cli)?;
 
-    if !cli.is_mcp_server {
-        debug!("Template server initialized");
+        tracing_subscriber::registry()
+            .with(filter)
+            .with(
+                tracing_subscriber::fmt::layer()
+                    .with_target(cli.debug || cli.trace)
+                    .with_thread_ids(cli.trace)
+                    .with_file(cli.trace)
+                    .with_line_number(cli.trace)
+                    .compact()
+                    .with_writer(std::io::stderr),
+            )
+            .init();
+
+        Ok(())
     }
 
-    match detect_execution_mode() {
-        ExecutionMode::Mcp => {
-            if !cli.is_mcp_server {
-                info!("Running unified MCP server (pmcp SDK)");
+    /// Create environment filter based on CLI flags
+    fn create_env_filter(cli: &cli::EarlyCliArgs) -> Result<EnvFilter> {
+        if cli.is_mcp_server {
+            Ok(create_mcp_filter(cli.debug))
+        } else {
+            create_cli_filter(cli)
+        }
+    }
+
+    /// Create filter for MCP server mode
+    fn create_mcp_filter(debug: bool) -> EnvFilter {
+        if debug {
+            EnvFilter::new("warn,pmat=debug")
+        } else {
+            EnvFilter::new("off")
+        }
+    }
+
+    /// Create filter for CLI mode
+    fn create_cli_filter(cli: &cli::EarlyCliArgs) -> Result<EnvFilter> {
+        if let Some(ref custom) = cli.trace_filter {
+            return Ok(EnvFilter::try_new(custom)?);
+        }
+
+        let filter_str = match (cli.trace, cli.debug, cli.verbose) {
+            (true, _, _) => "debug,pmat=trace",
+            (_, true, _) => "warn,pmat=debug",
+            (_, _, true) => "warn,pmat=info",
+            _ => return Ok(get_default_filter()),
+        };
+
+        Ok(EnvFilter::new(filter_str))
+    }
+
+    /// Get default production filter
+    fn get_default_filter() -> EnvFilter {
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("warn"))
+    }
+
+    #[tokio::main]
+    #[allow(unreachable_pub)]
+    pub async fn real_main() {
+        let exit_code = match run_main().await {
+            Ok(()) => ExitCode::Success,
+            Err(e) => {
+                error!("Error: {:#}", e);
+                categorize_error(&e)
             }
-            let unified_server = pmat::mcp_pmcp::UnifiedServer::new()
-                .map_err(|e| anyhow::anyhow!("Failed to create unified server: {}", e))?;
-            unified_server
-                .run()
-                .await
-                .map_err(|e| anyhow::anyhow!("{}", e))
+        };
+
+        if exit_code as i32 != 0 {
+            process::exit(exit_code.into());
         }
-        ExecutionMode::Cli => {
-            if !cli.is_mcp_server {
-                info!("Running in CLI mode");
-            }
-            cli::run(server).await
+    }
+
+    fn categorize_error(error: &anyhow::Error) -> ExitCode {
+        let error_str = error.to_string().to_lowercase();
+
+        match () {
+            _ if is_quality_gate_error(&error_str) => ExitCode::QualityGateFailure,
+            _ if is_configuration_error(&error_str) => ExitCode::ConfigurationError,
+            _ if is_analysis_error(&error_str) => ExitCode::AnalysisError,
+            _ if is_permission_error(&error_str) => ExitCode::PermissionDenied,
+            _ => ExitCode::GeneralError,
         }
-        ExecutionMode::HelpAndExit => {
-            // GH-285: No subcommand + piped stdin + no MCP_VERSION. Print help on
-            // stderr and exit with code 2 (misuse), matching the convention for
-            // "no command supplied" on a terminal.
-            let mut cmd = <pmat::cli::Cli as clap::CommandFactory>::command();
-            let _ = cmd.print_help();
-            eprintln!(
-                "\nerror: no subcommand given and stdin is not a terminal. \
-                 Set MCP_VERSION=1 (or run `pmat agent mcp-server`) to start the MCP server."
+    }
+
+    fn is_quality_gate_error(error_str: &str) -> bool {
+        error_str.contains("quality gate") || error_str.contains("violation")
+    }
+
+    fn is_configuration_error(error_str: &str) -> bool {
+        error_str.contains("config") || error_str.contains("parse")
+    }
+
+    fn is_analysis_error(error_str: &str) -> bool {
+        error_str.contains("analysis") || error_str.contains("complexity")
+    }
+
+    fn is_permission_error(error_str: &str) -> bool {
+        error_str.contains("permission") || error_str.contains("access")
+    }
+
+    async fn run_main() -> Result<()> {
+        // Parse CLI to get tracing configuration early
+        let cli = cli::parse_early_for_tracing();
+
+        // Initialize enhanced tracing system
+        init_tracing(&cli)?;
+
+        // Only log to stdout if not running MCP server mode
+        if !cli.is_mcp_server {
+            info!(
+                "Starting PAIML MCP Agent Toolkit v{}",
+                env!("CARGO_PKG_VERSION")
             );
-            process::exit(ExitCode::MisuseError as i32);
+            debug!("Debug logging enabled");
+            trace!("Trace logging enabled");
+        }
+
+        // Create shared template server
+        let server = Arc::new(StatelessTemplateServer::new()?);
+
+        if !cli.is_mcp_server {
+            debug!("Template server initialized");
+        }
+
+        match detect_execution_mode() {
+            ExecutionMode::Mcp => {
+                if !cli.is_mcp_server {
+                    info!("Running unified MCP server (pmcp SDK)");
+                }
+                let unified_server = pmat::mcp_pmcp::UnifiedServer::new()
+                    .map_err(|e| anyhow::anyhow!("Failed to create unified server: {}", e))?;
+                unified_server
+                    .run()
+                    .await
+                    .map_err(|e| anyhow::anyhow!("{}", e))
+            }
+            ExecutionMode::Cli => {
+                if !cli.is_mcp_server {
+                    info!("Running in CLI mode");
+                }
+                cli::run(server).await
+            }
+            ExecutionMode::HelpAndExit => {
+                // GH-285: No subcommand + piped stdin + no MCP_VERSION. Print help on
+                // stderr and exit with code 2 (misuse), matching the convention for
+                // "no command supplied" on a terminal.
+                let mut cmd = <pmat::cli::Cli as clap::CommandFactory>::command();
+                let _ = cmd.print_help();
+                eprintln!(
+                    "\nerror: no subcommand given and stdin is not a terminal. \
+                 Set MCP_VERSION=1 (or run `pmat agent mcp-server`) to start the MCP server."
+                );
+                process::exit(ExitCode::MisuseError as i32);
+            }
         }
     }
-}
 
-#[cfg_attr(coverage_nightly, coverage(off))]
-#[cfg(test)]
-mod gh285_tests {
-    //! Regression tests for GH-285: `pmat` hangs when invoked with no args
-    //! and stdin is a pipe. See `classify_execution_mode`.
-    //!
-    //! Manual end-to-end repro (should NOT hang or exit 124):
-    //! ```text
-    //! echo "" | timeout 3 target/debug/pmat 2>&1; echo exit=$?
-    //! timeout 3 target/debug/pmat < /dev/null; echo exit=$?
-    //! ```
-    //! Both should print help and exit with code 2.
-    use super::{classify_execution_mode, ExecutionMode};
+    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg(test)]
+    mod gh285_tests {
+        //! Regression tests for GH-285: `pmat` hangs when invoked with no args
+        //! and stdin is a pipe. See `classify_execution_mode`.
+        //!
+        //! Manual end-to-end repro (should NOT hang or exit 124):
+        //! ```text
+        //! echo "" | timeout 3 target/debug/pmat 2>&1; echo exit=$?
+        //! timeout 3 target/debug/pmat < /dev/null; echo exit=$?
+        //! ```
+        //! Both should print help and exit with code 2.
+        use super::{classify_execution_mode, ExecutionMode};
 
-    #[test]
-    fn bare_invocation_on_tty_is_cli() {
-        // `pmat` typed into a terminal with no pipe -> normal CLI (clap
-        // will then print help on missing subcommand).
-        assert!(matches!(
-            classify_execution_mode(false, true, false),
-            ExecutionMode::Cli
-        ));
+        #[test]
+        fn bare_invocation_on_tty_is_cli() {
+            // `pmat` typed into a terminal with no pipe -> normal CLI (clap
+            // will then print help on missing subcommand).
+            assert!(matches!(
+                classify_execution_mode(false, true, false),
+                ExecutionMode::Cli
+            ));
+        }
+
+        #[test]
+        fn piped_stdin_with_no_args_prints_help_instead_of_hanging() {
+            // GH-285: This used to enter MCP mode and block on stdin forever.
+            assert!(matches!(
+                classify_execution_mode(false, true, true),
+                ExecutionMode::HelpAndExit
+            ));
+        }
+
+        #[test]
+        fn explicit_mcp_version_env_still_enters_mcp_mode() {
+            // Claude Desktop and similar hosts set MCP_VERSION; they must still
+            // get the MCP server regardless of TTY state.
+            assert!(matches!(
+                classify_execution_mode(true, true, true),
+                ExecutionMode::Mcp
+            ));
+            assert!(matches!(
+                classify_execution_mode(true, false, false),
+                ExecutionMode::Mcp
+            ));
+        }
+
+        #[test]
+        fn subcommand_with_piped_stdin_is_still_cli() {
+            // `echo foo | pmat analyze ...` must dispatch to the CLI subcommand,
+            // not to help-and-exit.
+            assert!(matches!(
+                classify_execution_mode(false, false, true),
+                ExecutionMode::Cli
+            ));
+        }
     }
-
-    #[test]
-    fn piped_stdin_with_no_args_prints_help_instead_of_hanging() {
-        // GH-285: This used to enter MCP mode and block on stdin forever.
-        assert!(matches!(
-            classify_execution_mode(false, true, true),
-            ExecutionMode::HelpAndExit
-        ));
-    }
-
-    #[test]
-    fn explicit_mcp_version_env_still_enters_mcp_mode() {
-        // Claude Desktop and similar hosts set MCP_VERSION; they must still
-        // get the MCP server regardless of TTY state.
-        assert!(matches!(
-            classify_execution_mode(true, true, true),
-            ExecutionMode::Mcp
-        ));
-        assert!(matches!(
-            classify_execution_mode(true, false, false),
-            ExecutionMode::Mcp
-        ));
-    }
-
-    #[test]
-    fn subcommand_with_piped_stdin_is_still_cli() {
-        // `echo foo | pmat analyze ...` must dispatch to the CLI subcommand,
-        // not to help-and-exit.
-        assert!(matches!(
-            classify_execution_mode(false, false, true),
-            ExecutionMode::Cli
-        ));
-    }
-}
 } // end of mod full
 
 #[cfg(feature = "standard-deps")]

--- a/src/entropy/pattern_extractor_tests.rs
+++ b/src/entropy/pattern_extractor_tests.rs
@@ -845,7 +845,10 @@ fn test_calculate_pattern_match_variation_score_short_circuits_single_match() {
 
     let score =
         extractor.calculate_pattern_match_variation_score(&enums, &matches, &arrows, content);
-    assert_eq!(score, 0.0, "fewer than 2 match blocks must short-circuit to 0.0");
+    assert_eq!(
+        score, 0.0,
+        "fewer than 2 match blocks must short-circuit to 0.0"
+    );
 }
 
 /// pattern_extractor_ruchy.rs:405 — enum_matches.len() <= 1 low-variation arm (0.3).

--- a/src/handlers/tools/mod.rs
+++ b/src/handlers/tools/mod.rs
@@ -5,7 +5,394 @@ include!("extended_tools.rs");
 
 #[cfg(test)]
 mod tests {
-    // Tests from original file
+    //! PMAT-647: cover extended_tools_complexity.rs pure helpers.
+    use super::*;
+    use serde_json::json;
+    use std::path::Path;
+
+    fn mkdir(p: &Path) {
+        std::fs::create_dir_all(p).expect("mkdir");
+    }
+    fn touch(p: &Path) {
+        if let Some(parent) = p.parent() {
+            mkdir(parent);
+        }
+        std::fs::write(p, "").expect("touch");
+    }
+
+    // --- parse_complexity_args ---
+
+    #[test]
+    fn test_parse_complexity_args_valid() {
+        let args = parse_complexity_args(json!({
+            "project_path": "/tmp",
+            "toolchain": "rust",
+            "max_cyclomatic": 10,
+        }))
+        .expect("valid parse");
+        assert_eq!(args.project_path.as_deref(), Some("/tmp"));
+        assert_eq!(args.toolchain.as_deref(), Some("rust"));
+        assert_eq!(args.max_cyclomatic, Some(10));
+    }
+
+    #[test]
+    fn test_parse_complexity_args_empty_object_all_none() {
+        let args = parse_complexity_args(json!({})).expect("empty object is valid");
+        assert!(args.project_path.is_none());
+        assert!(args.toolchain.is_none());
+        assert!(args.max_cyclomatic.is_none());
+    }
+
+    #[test]
+    fn test_parse_complexity_args_wrong_types_return_err() {
+        let result = parse_complexity_args(json!({"max_cyclomatic": "not-a-number"}));
+        let err = result.unwrap_err();
+        assert!(err.contains("Invalid analyze_complexity arguments"));
+    }
+
+    // --- detect_toolchain ---
+
+    #[test]
+    fn test_detect_toolchain_explicit_arg_wins() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        // Create Cargo.toml, but explicit arg should win.
+        touch(&tmp.path().join("Cargo.toml"));
+        let t = detect_toolchain(&Some("deno".to_string()), tmp.path());
+        assert_eq!(t, "deno");
+    }
+
+    #[test]
+    fn test_detect_toolchain_detects_rust_from_cargo_toml() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        touch(&tmp.path().join("Cargo.toml"));
+        assert_eq!(detect_toolchain(&None, tmp.path()), "rust");
+    }
+
+    #[test]
+    fn test_detect_toolchain_detects_deno_from_package_json() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        touch(&tmp.path().join("package.json"));
+        assert_eq!(detect_toolchain(&None, tmp.path()), "deno");
+    }
+
+    #[test]
+    fn test_detect_toolchain_detects_deno_from_deno_json() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        touch(&tmp.path().join("deno.json"));
+        assert_eq!(detect_toolchain(&None, tmp.path()), "deno");
+    }
+
+    #[test]
+    fn test_detect_toolchain_detects_python_uv_from_pyproject() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        touch(&tmp.path().join("pyproject.toml"));
+        assert_eq!(detect_toolchain(&None, tmp.path()), "python-uv");
+    }
+
+    #[test]
+    fn test_detect_toolchain_detects_python_uv_from_requirements_txt() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        touch(&tmp.path().join("requirements.txt"));
+        assert_eq!(detect_toolchain(&None, tmp.path()), "python-uv");
+    }
+
+    #[test]
+    fn test_detect_toolchain_defaults_to_rust() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        // Empty project, no manifests.
+        assert_eq!(detect_toolchain(&None, tmp.path()), "rust");
+    }
+
+    // --- build_complexity_thresholds ---
+
+    #[test]
+    fn test_build_complexity_thresholds_defaults_when_none() {
+        let args = AnalyzeComplexityArgs {
+            project_path: None,
+            toolchain: None,
+            format: None,
+            max_cyclomatic: None,
+            max_cognitive: None,
+            include: None,
+            top_files: None,
+        };
+        let t = build_complexity_thresholds(&args);
+        // Defaults come from ComplexityThresholds::default(); just verify they're non-zero.
+        assert!(t.cyclomatic_error > 0);
+        assert!(t.cognitive_error > 0);
+    }
+
+    #[test]
+    fn test_build_complexity_thresholds_sets_cyclomatic() {
+        let args = AnalyzeComplexityArgs {
+            project_path: None,
+            toolchain: None,
+            format: None,
+            max_cyclomatic: Some(20),
+            max_cognitive: None,
+            include: None,
+            top_files: None,
+        };
+        let t = build_complexity_thresholds(&args);
+        assert_eq!(t.cyclomatic_error, 20);
+        assert_eq!(t.cyclomatic_warn, 15); // 20 * 3 / 4
+    }
+
+    #[test]
+    fn test_build_complexity_thresholds_sets_cognitive() {
+        let args = AnalyzeComplexityArgs {
+            project_path: None,
+            toolchain: None,
+            format: None,
+            max_cyclomatic: None,
+            max_cognitive: Some(12),
+            include: None,
+            top_files: None,
+        };
+        let t = build_complexity_thresholds(&args);
+        assert_eq!(t.cognitive_error, 12);
+        assert_eq!(t.cognitive_warn, 9); // 12 * 3 / 4
+    }
+
+    #[test]
+    fn test_build_complexity_thresholds_min_warn_is_one() {
+        // `max * 3 / 4` floors to 0 for small values; .max(1) clamps to 1.
+        let args = AnalyzeComplexityArgs {
+            project_path: None,
+            toolchain: None,
+            format: None,
+            max_cyclomatic: Some(1),
+            max_cognitive: Some(1),
+            include: None,
+            top_files: None,
+        };
+        let t = build_complexity_thresholds(&args);
+        assert_eq!(t.cyclomatic_warn, 1);
+        assert_eq!(t.cognitive_warn, 1);
+    }
+
+    // --- should_analyze_file ---
+
+    #[test]
+    fn test_should_analyze_file_rust_only_rs() {
+        assert!(should_analyze_file(Path::new("main.rs"), "rust"));
+        assert!(!should_analyze_file(Path::new("main.ts"), "rust"));
+        assert!(!should_analyze_file(Path::new("main"), "rust"));
+    }
+
+    #[test]
+    fn test_should_analyze_file_deno_accepts_ts_tsx_js_jsx() {
+        for ext in ["ts", "tsx", "js", "jsx"] {
+            let path = format!("file.{ext}");
+            assert!(
+                should_analyze_file(Path::new(&path), "deno"),
+                "failed for {ext}"
+            );
+        }
+        assert!(!should_analyze_file(Path::new("file.py"), "deno"));
+    }
+
+    #[test]
+    fn test_should_analyze_file_python_uv_only_py() {
+        assert!(should_analyze_file(Path::new("x.py"), "python-uv"));
+        assert!(!should_analyze_file(Path::new("x.rs"), "python-uv"));
+    }
+
+    #[test]
+    fn test_should_analyze_file_unknown_toolchain_rejects_all() {
+        assert!(!should_analyze_file(Path::new("x.rs"), "unknown-toolchain"));
+        assert!(!should_analyze_file(Path::new("x.py"), ""));
+    }
+
+    // --- matches_include_filters ---
+
+    #[test]
+    fn test_matches_include_filters_none_returns_true() {
+        assert!(matches_include_filters(Path::new("src/main.rs"), &None));
+    }
+
+    #[test]
+    fn test_matches_include_filters_empty_vec_returns_true() {
+        assert!(matches_include_filters(
+            Path::new("src/main.rs"),
+            &Some(vec![])
+        ));
+    }
+
+    #[test]
+    fn test_matches_include_filters_any_pattern_matches() {
+        let patterns = Some(vec!["*.rs".to_string(), "lib".to_string()]);
+        assert!(matches_include_filters(Path::new("src/main.rs"), &patterns));
+    }
+
+    #[test]
+    fn test_matches_include_filters_no_pattern_matches_is_false() {
+        let patterns = Some(vec!["*.py".to_string(), "*.ts".to_string()]);
+        assert!(!matches_include_filters(
+            Path::new("src/main.rs"),
+            &patterns
+        ));
+    }
+
+    // --- matches_pattern ---
+
+    #[test]
+    fn test_matches_pattern_double_star_matches_trailing_suffix() {
+        assert!(matches_pattern("src/a/b/c.rs", "src/**/c.rs"));
+    }
+
+    #[test]
+    fn test_matches_pattern_double_star_with_three_parts_returns_false() {
+        // "**" splits → 3 parts → fallback to false.
+        assert!(!matches_pattern("a/b/c", "a/**/b/**"));
+    }
+
+    #[test]
+    fn test_matches_pattern_extension_wildcard() {
+        assert!(matches_pattern("src/main.rs", "*.rs"));
+        assert!(!matches_pattern("src/main.ts", "*.rs"));
+    }
+
+    #[test]
+    fn test_matches_pattern_substring_fallback() {
+        assert!(matches_pattern("path/to/my-handler.rs", "my-handler"));
+        assert!(!matches_pattern("path/to/other.rs", "my-handler"));
+    }
+
+    // --- format_complexity_output ---
+
+    fn empty_report() -> crate::services::complexity::ComplexityReport {
+        crate::services::complexity::aggregate_results(Vec::new())
+    }
+
+    fn args_with_format(fmt: &str) -> AnalyzeComplexityArgs {
+        AnalyzeComplexityArgs {
+            project_path: None,
+            toolchain: None,
+            format: Some(fmt.to_string()),
+            max_cyclomatic: None,
+            max_cognitive: None,
+            include: None,
+            top_files: None,
+        }
+    }
+
+    #[test]
+    fn test_format_complexity_output_json_returns_valid_json() {
+        let rpt = empty_report();
+        let out = format_complexity_output(&rpt, &args_with_format("json"));
+        let _: serde_json::Value = serde_json::from_str(&out).expect("valid JSON");
+    }
+
+    #[test]
+    fn test_format_complexity_output_sarif_contains_recognizable_content() {
+        let rpt = empty_report();
+        let out = format_complexity_output(&rpt, &args_with_format("sarif"));
+        // Valid SARIF is JSON with a schema URL, or on fallback an error string.
+        assert!(!out.is_empty());
+    }
+
+    #[test]
+    fn test_format_complexity_output_full_returns_non_empty() {
+        let rpt = empty_report();
+        let out = format_complexity_output(&rpt, &args_with_format("full"));
+        assert!(!out.is_empty());
+    }
+
+    #[test]
+    fn test_format_complexity_output_default_summary_when_no_format() {
+        let rpt = empty_report();
+        let args = AnalyzeComplexityArgs {
+            project_path: None,
+            toolchain: None,
+            format: None,
+            max_cyclomatic: None,
+            max_cognitive: None,
+            include: None,
+            top_files: None,
+        };
+        let out = format_complexity_output(&rpt, &args);
+        assert!(!out.is_empty());
+    }
+
+    // --- generate_complexity_content ---
+
+    #[test]
+    fn test_generate_complexity_content_top_files_zero_falls_back_to_summary() {
+        let rpt = empty_report();
+        let args = AnalyzeComplexityArgs {
+            project_path: None,
+            toolchain: None,
+            format: Some("summary".into()),
+            max_cyclomatic: None,
+            max_cognitive: None,
+            include: None,
+            top_files: Some(0),
+        };
+        let out = generate_complexity_content(&rpt, &[], &args);
+        assert!(!out.is_empty());
+    }
+
+    #[test]
+    fn test_generate_complexity_content_no_top_files_uses_summary() {
+        let rpt = empty_report();
+        let args = args_with_format("summary");
+        let out = generate_complexity_content(&rpt, &[], &args);
+        assert!(!out.is_empty());
+    }
+
+    #[test]
+    fn test_generate_complexity_content_top_files_nonzero_uses_rankings() {
+        let rpt = empty_report();
+        let args = AnalyzeComplexityArgs {
+            project_path: None,
+            toolchain: None,
+            format: Some("summary".into()),
+            max_cyclomatic: None,
+            max_cognitive: None,
+            include: None,
+            top_files: Some(5),
+        };
+        let out = generate_complexity_content(&rpt, &[], &args);
+        // With empty file_metrics, rankings produce an empty table header.
+        assert!(out.contains("Top 0") || out.contains("Top"));
+    }
+
+    // --- format_complexity_rankings json path ---
+
+    #[test]
+    fn test_format_complexity_rankings_json_output_has_rankings_key() {
+        let args = args_with_format("json");
+        let rankings: Vec<(String, crate::services::ranking::CompositeComplexityScore)> = vec![];
+        let out = format_complexity_rankings(&rankings, &args);
+        let v: serde_json::Value = serde_json::from_str(&out).expect("valid JSON");
+        assert!(v.get("rankings").is_some());
+        assert!(v.get("analysis_type").is_some());
+    }
+
+    #[test]
+    fn test_format_complexity_rankings_table_output_has_header() {
+        let args = args_with_format("summary");
+        let rankings: Vec<(String, crate::services::ranking::CompositeComplexityScore)> = vec![];
+        let out = format_complexity_rankings(&rankings, &args);
+        assert!(out.contains("Top 0 Complexity Files"));
+        assert!(out.contains("| Rank |"));
+    }
+
+    // --- resolve_project_path_complexity error path ---
+
+    #[test]
+    fn test_resolve_project_path_complexity_none_is_err() {
+        let err = resolve_project_path_complexity(None).unwrap_err();
+        // Must fail — the D101 rule rejects None/missing values.
+        assert!(!err.is_empty());
+    }
+
+    #[test]
+    fn test_resolve_project_path_complexity_empty_string_is_err() {
+        let err = resolve_project_path_complexity(Some(String::new())).unwrap_err();
+        assert!(!err.is_empty());
+    }
 }
 
 // ============================================================================

--- a/src/maintenance/updater.rs
+++ b/src/maintenance/updater.rs
@@ -375,9 +375,13 @@ mod tests {
             files: vec!["src/lib.rs".into()], // no ticket file
         };
 
-        let result =
-            process_ticket_update(&mut roadmap, &commit, "TICKET-PMAT-5013", tickets_dir.path())
-                .unwrap();
+        let result = process_ticket_update(
+            &mut roadmap,
+            &commit,
+            "TICKET-PMAT-5013",
+            tickets_dir.path(),
+        )
+        .unwrap();
         assert!(!result, "must short-circuit when ticket file not in commit");
         assert!(!roadmap.sprints[0].tickets[0].completed);
     }
@@ -394,10 +398,17 @@ mod tests {
             files: vec!["docs/tickets/TICKET-PMAT-5013.md".into()],
         };
 
-        let result =
-            process_ticket_update(&mut roadmap, &commit, "TICKET-PMAT-5013", tickets_dir.path())
-                .unwrap();
-        assert!(!result, "missing ticket file must return Ok(false), not error");
+        let result = process_ticket_update(
+            &mut roadmap,
+            &commit,
+            "TICKET-PMAT-5013",
+            tickets_dir.path(),
+        )
+        .unwrap();
+        assert!(
+            !result,
+            "missing ticket file must return Ok(false), not error"
+        );
         assert!(!roadmap.sprints[0].tickets[0].completed);
     }
 
@@ -417,11 +428,7 @@ mod tests {
              Still failing.\n\n\
              ## Success Criteria\n\n\
              - [ ] One\n";
-        std::fs::write(
-            tickets_dir.path().join("TICKET-PMAT-5013.md"),
-            red_content,
-        )
-        .unwrap();
+        std::fs::write(tickets_dir.path().join("TICKET-PMAT-5013.md"), red_content).unwrap();
         let mut roadmap = create_test_roadmap();
         let commit = CommitInfo {
             hash: "deadbee".into(),
@@ -429,9 +436,13 @@ mod tests {
             files: vec!["docs/tickets/TICKET-PMAT-5013.md".into()],
         };
 
-        let result =
-            process_ticket_update(&mut roadmap, &commit, "TICKET-PMAT-5013", tickets_dir.path())
-                .unwrap();
+        let result = process_ticket_update(
+            &mut roadmap,
+            &commit,
+            "TICKET-PMAT-5013",
+            tickets_dir.path(),
+        )
+        .unwrap();
         assert!(!result, "RED ticket must not mark roadmap completed");
         assert!(!roadmap.sprints[0].tickets[0].completed);
     }
@@ -450,9 +461,13 @@ mod tests {
             files: vec!["docs/tickets/TICKET-PMAT-5013.md".into()],
         };
 
-        let result =
-            process_ticket_update(&mut roadmap, &commit, "TICKET-PMAT-5013", tickets_dir.path())
-                .unwrap();
+        let result = process_ticket_update(
+            &mut roadmap,
+            &commit,
+            "TICKET-PMAT-5013",
+            tickets_dir.path(),
+        )
+        .unwrap();
         assert!(result, "GREEN ticket must flip roadmap entry");
         assert!(roadmap.sprints[0].tickets[0].completed);
         assert_eq!(

--- a/src/mcp_pmcp/agent_context_handlers.rs
+++ b/src/mcp_pmcp/agent_context_handlers.rs
@@ -37,11 +37,7 @@ macro_rules! impl_pmat_handler {
 
         #[async_trait]
         impl ToolHandler for $wrapper {
-            async fn handle(
-                &self,
-                args: Value,
-                _extra: RequestHandlerExtra,
-            ) -> PmcpResult<Value> {
+            async fn handle(&self, args: Value, _extra: RequestHandlerExtra) -> PmcpResult<Value> {
                 self.inner.execute(args).await.map_err(PmcpError::internal)
             }
 

--- a/src/mcp_pmcp/analyze_handlers.rs
+++ b/src/mcp_pmcp/analyze_handlers.rs
@@ -32,7 +32,8 @@ use tracing::debug;
 // MCP tools (see R15 #3 bench matrix).
 pub use self::{
     ComplexityTool as AnalyzeComplexityTool, DeadCodeTool as AnalyzeDeadCodeTool,
-    SatdTool as AnalyzeSatdTool, TdgCompareTool as AnalyzeTdgCompareTool, TdgTool as AnalyzeTdgTool,
+    SatdTool as AnalyzeSatdTool, TdgCompareTool as AnalyzeTdgCompareTool,
+    TdgTool as AnalyzeTdgTool,
 };
 
 // Complexity analysis tool handler

--- a/src/mcp_pmcp/mod.rs
+++ b/src/mcp_pmcp/mod.rs
@@ -103,12 +103,12 @@ pub mod quality_handlers;
 pub mod quality_proxy_handler;
 pub mod server;
 pub mod simple_unified_server;
-pub mod tool_schemas;
 #[cfg_attr(coverage_nightly, coverage(off))]
 #[cfg(test)]
 pub mod tdg_git_context_tests;
 pub mod tdg_handlers;
 pub mod tool_functions;
+pub mod tool_schemas;
 pub mod tool_schemas_generated; // KAIZEN-0178: build.rs-generated tool schema registry
 pub mod tools; // Sprint 65 Phase 2B: MCP git-context integration
 

--- a/src/mcp_pmcp/tool_schemas.rs
+++ b/src/mcp_pmcp/tool_schemas.rs
@@ -45,7 +45,10 @@ pub fn paths_object_schema(extra_properties: Value, required: Vec<&str>) -> Valu
             base.insert(k.clone(), v.clone());
         }
     }
-    let req: Vec<Value> = required.into_iter().map(|s| Value::String(s.into())).collect();
+    let req: Vec<Value> = required
+        .into_iter()
+        .map(|s| Value::String(s.into()))
+        .collect();
     json!({
         "type": "object",
         "properties": base_props,


### PR DESCRIPTION
## Summary

Continues Phase-1 CLI pivot after PR #511/PMAT-646. \`extended_tools_complexity.rs\` is 393 lines, **244/266 missed** on master broad. Public handler is async (spawns subprocesses, skipped), but all internal helpers are pure sync.

**37 new tests** covering:

- \`parse_complexity_args\` (3): valid, empty, wrong-types Err
- \`detect_toolchain\` (7): explicit arg wins + Cargo.toml/package.json/deno.json/pyproject.toml/requirements.txt detection + default
- \`build_complexity_thresholds\` (4): defaults, cyclomatic, cognitive, min-warn clamp
- \`should_analyze_file\` (4): rust=.rs, deno=.ts/.tsx/.js/.jsx, python-uv=.py, unknown→false
- \`matches_include_filters\` (4): None, empty Vec, match, no-match
- \`matches_pattern\` (4): ** glob, 3-part ** false, *.ext, substring
- \`format_complexity_output\` (4): json/sarif/full/summary
- \`generate_complexity_content\` (3): top_files=0, None, top_files=N
- \`format_complexity_rankings\` (2): json + table
- \`resolve_project_path_complexity\` (2): None/empty → Err (D101 rule)

## Coverage impact

Expected delta: **~+0.06pp** on broad.

## Test plan

- [x] \`cargo test --lib -- handlers::tools::tests\` — 37 passed, 0 failed
- [x] \`cargo fmt --all -- --check\` — clean
- [ ] CI gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)