### PR TITLE
test(coverage): tools_advanced_part2.rs pure helpers (PMAT-648)

### DIFF
--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -3217,7 +3217,7 @@ roadmap:
   github_issue: null
   item_type: task
   title: 'Phase 1 pivot: handlers/tools_advanced_part2.rs coverage'
-  status: inprogress
+  status: review
   priority: medium
   assigned_to: null
   created: 2026-04-24T08:49:46Z

--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -3213,3 +3213,20 @@ roadmap:
   estimated_effort: null
   labels: []
   notes: null
+- id: PMAT-648
+  github_issue: null
+  item_type: task
+  title: 'Phase 1 pivot: handlers/tools_advanced_part2.rs coverage'
+  status: inprogress
+  priority: medium
+  assigned_to: null
+  created: 2026-04-24T08:49:46Z
+  updated: 2026-04-24T08:49:46Z
+  spec: null
+  acceptance_criteria:
+  - 'Phase 1 CLI pivot — tools_advanced_part2.rs is 464 lines, 297/303 missed on master broad, 2 async (handlers only; all helpers pure). Cover get_confidence_level_text (3 variants), format_confidence_emoji (3 variants), calculate_dead_files_percentage (zero-guard + ratio), calculate_percentage (zero-guard + ratio), write_dead_code_* helpers (header, summary, metrics, table), format_dead_code_as_sarif_mcp, format_dead_code_as_markdown_mcp, write_single_dead_code_row, parse_tdg_args (valid + err), extract_tdg_project_path (None/empty Err), format_tdg_summary full pipeline, append_tdg_hotspots_section empty+populated.'
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels: []
+  notes: null

--- a/examples/mcp_agent_context_demo.rs
+++ b/examples/mcp_agent_context_demo.rs
@@ -54,68 +54,132 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     thread::sleep(Duration::from_secs(10));
 
     // 1. initialize handshake
-    let resp = rpc(&mut writer, &mut reader, 1, "initialize", json!({
-        "protocolVersion": "2024-11-05",
-        "capabilities": {},
-        "clientInfo": { "name": "mcp_agent_context_demo", "version": "1.0" }
-    }))?;
-    let server_info = resp.pointer("/result/serverInfo/name").cloned().unwrap_or(json!("?"));
+    let resp = rpc(
+        &mut writer,
+        &mut reader,
+        1,
+        "initialize",
+        json!({
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": { "name": "mcp_agent_context_demo", "version": "1.0" }
+        }),
+    )?;
+    let server_info = resp
+        .pointer("/result/serverInfo/name")
+        .cloned()
+        .unwrap_or(json!("?"));
     println!("[initialize] server={}", server_info);
 
     // 2. tools/list — sanity check that the 4 pmat_* tools are registered
     let resp = rpc(&mut writer, &mut reader, 2, "tools/list", json!({}))?;
-    let tools = resp.pointer("/result/tools").and_then(|v| v.as_array()).cloned().unwrap_or_default();
-    let pmat_tools: Vec<&str> = tools.iter()
+    let tools = resp
+        .pointer("/result/tools")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+    let pmat_tools: Vec<&str> = tools
+        .iter()
         .filter_map(|t| t.get("name").and_then(|n| n.as_str()))
         .filter(|n| n.starts_with("pmat_"))
         .collect();
-    println!("[tools/list] total={} pmat_*={} ({:?})", tools.len(), pmat_tools.len(), pmat_tools);
+    println!(
+        "[tools/list] total={} pmat_*={} ({:?})",
+        tools.len(),
+        pmat_tools.len(),
+        pmat_tools
+    );
 
     // 3. pmat_index_stats — pick up a real function_id we can reuse below
-    let resp = call_tool(&mut writer, &mut reader, 3, "pmat_index_stats",
-        json!({ "rebuild": false }))?;
+    let resp = call_tool(
+        &mut writer,
+        &mut reader,
+        3,
+        "pmat_index_stats",
+        json!({ "rebuild": false }),
+    )?;
     let index_result = extract_tool_result(&resp);
-    let fn_count = index_result.pointer("/manifest/function_count").cloned().unwrap_or(json!(0));
-    let file_count = index_result.pointer("/manifest/file_count").cloned().unwrap_or(json!(0));
-    println!("[pmat_index_stats] ok: functions={} files={}", fn_count, file_count);
+    let fn_count = index_result
+        .pointer("/manifest/function_count")
+        .cloned()
+        .unwrap_or(json!(0));
+    let file_count = index_result
+        .pointer("/manifest/file_count")
+        .cloned()
+        .unwrap_or(json!(0));
+    println!(
+        "[pmat_index_stats] ok: functions={} files={}",
+        fn_count, file_count
+    );
 
     // 4. pmat_query_code — realistic semantic query
-    let resp = call_tool(&mut writer, &mut reader, 4, "pmat_query_code",
-        json!({ "query": "error handling", "limit": 3 }))?;
+    let resp = call_tool(
+        &mut writer,
+        &mut reader,
+        4,
+        "pmat_query_code",
+        json!({ "query": "error handling", "limit": 3 }),
+    )?;
     let query_result = extract_tool_result(&resp);
-    let result_count = query_result.get("results")
+    let result_count = query_result
+        .get("results")
         .or_else(|| query_result.get("functions"))
         .and_then(|v| v.as_array())
         .map(|a| a.len())
         .unwrap_or(0);
-    let first_id = query_result.pointer("/results/0/id")
+    let first_id = query_result
+        .pointer("/results/0/id")
         .or_else(|| query_result.pointer("/functions/0/id"))
         .and_then(|v| v.as_str())
         .map(|s| s.to_string());
-    println!("[pmat_query_code] ok: {} results; first_id={:?}", result_count, first_id);
+    println!(
+        "[pmat_query_code] ok: {} results; first_id={:?}",
+        result_count, first_id
+    );
 
     // 5. pmat_get_function — use the first id from query_code, or fall back to "main"
-    let function_id = first_id.clone().unwrap_or_else(|| "src/bin/pmat.rs::main".to_string());
-    let resp = call_tool(&mut writer, &mut reader, 5, "pmat_get_function",
-        json!({ "function_id": function_id, "include_source": false }))?;
+    let function_id = first_id
+        .clone()
+        .unwrap_or_else(|| "src/bin/pmat.rs::main".to_string());
+    let resp = call_tool(
+        &mut writer,
+        &mut reader,
+        5,
+        "pmat_get_function",
+        json!({ "function_id": function_id, "include_source": false }),
+    )?;
     match resp.get("error") {
-        Some(err) => println!("[pmat_get_function] graceful miss for {:?}: {}", function_id,
-            err.get("message").and_then(|m| m.as_str()).unwrap_or("?")),
+        Some(err) => println!(
+            "[pmat_get_function] graceful miss for {:?}: {}",
+            function_id,
+            err.get("message").and_then(|m| m.as_str()).unwrap_or("?")
+        ),
         None => {
             let gf = extract_tool_result(&resp);
-            println!("[pmat_get_function] ok: name={} grade={}",
+            println!(
+                "[pmat_get_function] ok: name={} grade={}",
                 gf.get("name").and_then(|v| v.as_str()).unwrap_or("?"),
-                gf.pointer("/quality/grade").and_then(|v| v.as_str()).unwrap_or("?"));
+                gf.pointer("/quality/grade")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("?")
+            );
         }
     }
 
     // 6. pmat_find_similar — only meaningful if we got a real id from the query
     if let Some(id) = first_id {
-        let resp = call_tool(&mut writer, &mut reader, 6, "pmat_find_similar",
-            json!({ "function_id": id, "limit": 3, "min_similarity": 0.3 }))?;
+        let resp = call_tool(
+            &mut writer,
+            &mut reader,
+            6,
+            "pmat_find_similar",
+            json!({ "function_id": id, "limit": 3, "min_similarity": 0.3 }),
+        )?;
         match resp.get("error") {
-            Some(err) => println!("[pmat_find_similar] error: {}",
-                err.get("message").and_then(|m| m.as_str()).unwrap_or("?")),
+            Some(err) => println!(
+                "[pmat_find_similar] error: {}",
+                err.get("message").and_then(|m| m.as_str()).unwrap_or("?")
+            ),
             None => {
                 let sim = extract_tool_result(&resp);
                 let total = sim.get("total").and_then(|v| v.as_u64()).unwrap_or(0);
@@ -162,7 +226,13 @@ fn call_tool(
     name: &str,
     args: Value,
 ) -> Result<Value, Box<dyn std::error::Error>> {
-    rpc(writer, reader, id, "tools/call", json!({ "name": name, "arguments": args }))
+    rpc(
+        writer,
+        reader,
+        id,
+        "tools/call",
+        json!({ "name": name, "arguments": args }),
+    )
 }
 
 /// MCP `tools/call` wraps results in `result.content[0].text` (JSON string) or
@@ -171,7 +241,10 @@ fn extract_tool_result(resp: &Value) -> Value {
     if let Some(sc) = resp.pointer("/result/structuredContent") {
         return sc.clone();
     }
-    if let Some(text) = resp.pointer("/result/content/0/text").and_then(|v| v.as_str()) {
+    if let Some(text) = resp
+        .pointer("/result/content/0/text")
+        .and_then(|v| v.as_str())
+    {
         if let Ok(parsed) = serde_json::from_str::<Value>(text) {
             return parsed;
         }

--- a/src/bin/pmat.rs
+++ b/src/bin/pmat.rs
@@ -16,301 +16,301 @@ fn main() {
 
 #[cfg(feature = "standard-deps")]
 mod full {
-use anyhow::Result;
-use pmat::{cli, stateless_server::StatelessTemplateServer};
-use std::io::IsTerminal;
-use std::process;
-use std::sync::Arc;
-use tracing::{debug, error, info, trace};
-use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
+    use anyhow::Result;
+    use pmat::{cli, stateless_server::StatelessTemplateServer};
+    use std::io::IsTerminal;
+    use std::process;
+    use std::sync::Arc;
+    use tracing::{debug, error, info, trace};
+    use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 
-enum ExecutionMode {
-    Mcp,
-    Cli,
-    /// No subcommand given and stdin is piped (not a TTY) without an explicit
-    /// MCP opt-in. Print help and exit non-zero instead of blocking on stdin
-    /// (see GH-285).
-    HelpAndExit,
-}
-
-/// POSIX-compliant exit codes for CLI interface
-/// Per SPECIFICATION.md Section 23: CLI Interface
-#[derive(Debug, Clone, Copy)]
-pub enum ExitCode {
-    /// Success
-    Success = 0,
-    /// General error
-    GeneralError = 1,
-    /// Misuse of shell command
-    MisuseError = 2,
-    /// Permission denied
-    PermissionDenied = 126,
-    /// Command not found
-    CommandNotFound = 127,
-    /// Invalid argument to exit
-    InvalidExitArg = 128,
-    /// Quality gate failure (custom)
-    QualityGateFailure = 3,
-    /// Configuration error (custom)
-    ConfigurationError = 4,
-    /// Analysis error (custom)
-    AnalysisError = 5,
-}
-
-impl From<ExitCode> for i32 {
-    fn from(code: ExitCode) -> Self {
-        code as i32
-    }
-}
-
-fn detect_execution_mode() -> ExecutionMode {
-    classify_execution_mode(
-        std::env::var("MCP_VERSION").is_ok(),
-        std::env::args().len() == 1,
-        !std::io::stdin().is_terminal(),
-    )
-}
-
-/// Pure decision function for execution mode so it can be unit-tested
-/// without touching real stdin / env vars (see GH-285 regression test).
-fn classify_execution_mode(
-    mcp_version_env: bool,
-    no_args: bool,
-    stdin_is_pipe: bool,
-) -> ExecutionMode {
-    // Explicit MCP opt-in via env var always wins (e.g. Claude Desktop sets this).
-    if mcp_version_env {
-        return ExecutionMode::Mcp;
+    enum ExecutionMode {
+        Mcp,
+        Cli,
+        /// No subcommand given and stdin is piped (not a TTY) without an explicit
+        /// MCP opt-in. Print help and exit non-zero instead of blocking on stdin
+        /// (see GH-285).
+        HelpAndExit,
     }
 
-    // GH-285: If the user ran bare `pmat` with stdin piped (e.g. `echo "" | pmat`)
-    // without opting into MCP via `MCP_VERSION`, previous behavior entered the MCP
-    // server and blocked forever on stdin. Treat that case the same as bare `pmat`
-    // on a terminal: print help and exit non-zero.
-    if no_args && stdin_is_pipe {
-        return ExecutionMode::HelpAndExit;
+    /// POSIX-compliant exit codes for CLI interface
+    /// Per SPECIFICATION.md Section 23: CLI Interface
+    #[derive(Debug, Clone, Copy)]
+    pub enum ExitCode {
+        /// Success
+        Success = 0,
+        /// General error
+        GeneralError = 1,
+        /// Misuse of shell command
+        MisuseError = 2,
+        /// Permission denied
+        PermissionDenied = 126,
+        /// Command not found
+        CommandNotFound = 127,
+        /// Invalid argument to exit
+        InvalidExitArg = 128,
+        /// Quality gate failure (custom)
+        QualityGateFailure = 3,
+        /// Configuration error (custom)
+        ConfigurationError = 4,
+        /// Analysis error (custom)
+        AnalysisError = 5,
     }
 
-    ExecutionMode::Cli
-}
+    impl From<ExitCode> for i32 {
+        fn from(code: ExitCode) -> Self {
+            code as i32
+        }
+    }
 
-/// Initialize the enhanced tracing system based on CLI flags
-fn init_tracing(cli: &cli::EarlyCliArgs) -> Result<()> {
-    let filter = create_env_filter(cli)?;
-
-    tracing_subscriber::registry()
-        .with(filter)
-        .with(
-            tracing_subscriber::fmt::layer()
-                .with_target(cli.debug || cli.trace)
-                .with_thread_ids(cli.trace)
-                .with_file(cli.trace)
-                .with_line_number(cli.trace)
-                .compact()
-                .with_writer(std::io::stderr),
+    fn detect_execution_mode() -> ExecutionMode {
+        classify_execution_mode(
+            std::env::var("MCP_VERSION").is_ok(),
+            std::env::args().len() == 1,
+            !std::io::stdin().is_terminal(),
         )
-        .init();
-
-    Ok(())
-}
-
-/// Create environment filter based on CLI flags
-fn create_env_filter(cli: &cli::EarlyCliArgs) -> Result<EnvFilter> {
-    if cli.is_mcp_server {
-        Ok(create_mcp_filter(cli.debug))
-    } else {
-        create_cli_filter(cli)
-    }
-}
-
-/// Create filter for MCP server mode
-fn create_mcp_filter(debug: bool) -> EnvFilter {
-    if debug {
-        EnvFilter::new("warn,pmat=debug")
-    } else {
-        EnvFilter::new("off")
-    }
-}
-
-/// Create filter for CLI mode
-fn create_cli_filter(cli: &cli::EarlyCliArgs) -> Result<EnvFilter> {
-    if let Some(ref custom) = cli.trace_filter {
-        return Ok(EnvFilter::try_new(custom)?);
     }
 
-    let filter_str = match (cli.trace, cli.debug, cli.verbose) {
-        (true, _, _) => "debug,pmat=trace",
-        (_, true, _) => "warn,pmat=debug",
-        (_, _, true) => "warn,pmat=info",
-        _ => return Ok(get_default_filter()),
-    };
-
-    Ok(EnvFilter::new(filter_str))
-}
-
-/// Get default production filter
-fn get_default_filter() -> EnvFilter {
-    EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("warn"))
-}
-
-#[tokio::main]
-#[allow(unreachable_pub)]
-pub async fn real_main() {
-    let exit_code = match run_main().await {
-        Ok(()) => ExitCode::Success,
-        Err(e) => {
-            error!("Error: {:#}", e);
-            categorize_error(&e)
+    /// Pure decision function for execution mode so it can be unit-tested
+    /// without touching real stdin / env vars (see GH-285 regression test).
+    fn classify_execution_mode(
+        mcp_version_env: bool,
+        no_args: bool,
+        stdin_is_pipe: bool,
+    ) -> ExecutionMode {
+        // Explicit MCP opt-in via env var always wins (e.g. Claude Desktop sets this).
+        if mcp_version_env {
+            return ExecutionMode::Mcp;
         }
-    };
 
-    if exit_code as i32 != 0 {
-        process::exit(exit_code.into());
-    }
-}
+        // GH-285: If the user ran bare `pmat` with stdin piped (e.g. `echo "" | pmat`)
+        // without opting into MCP via `MCP_VERSION`, previous behavior entered the MCP
+        // server and blocked forever on stdin. Treat that case the same as bare `pmat`
+        // on a terminal: print help and exit non-zero.
+        if no_args && stdin_is_pipe {
+            return ExecutionMode::HelpAndExit;
+        }
 
-fn categorize_error(error: &anyhow::Error) -> ExitCode {
-    let error_str = error.to_string().to_lowercase();
-
-    match () {
-        _ if is_quality_gate_error(&error_str) => ExitCode::QualityGateFailure,
-        _ if is_configuration_error(&error_str) => ExitCode::ConfigurationError,
-        _ if is_analysis_error(&error_str) => ExitCode::AnalysisError,
-        _ if is_permission_error(&error_str) => ExitCode::PermissionDenied,
-        _ => ExitCode::GeneralError,
-    }
-}
-
-fn is_quality_gate_error(error_str: &str) -> bool {
-    error_str.contains("quality gate") || error_str.contains("violation")
-}
-
-fn is_configuration_error(error_str: &str) -> bool {
-    error_str.contains("config") || error_str.contains("parse")
-}
-
-fn is_analysis_error(error_str: &str) -> bool {
-    error_str.contains("analysis") || error_str.contains("complexity")
-}
-
-fn is_permission_error(error_str: &str) -> bool {
-    error_str.contains("permission") || error_str.contains("access")
-}
-
-async fn run_main() -> Result<()> {
-    // Parse CLI to get tracing configuration early
-    let cli = cli::parse_early_for_tracing();
-
-    // Initialize enhanced tracing system
-    init_tracing(&cli)?;
-
-    // Only log to stdout if not running MCP server mode
-    if !cli.is_mcp_server {
-        info!(
-            "Starting PAIML MCP Agent Toolkit v{}",
-            env!("CARGO_PKG_VERSION")
-        );
-        debug!("Debug logging enabled");
-        trace!("Trace logging enabled");
+        ExecutionMode::Cli
     }
 
-    // Create shared template server
-    let server = Arc::new(StatelessTemplateServer::new()?);
+    /// Initialize the enhanced tracing system based on CLI flags
+    fn init_tracing(cli: &cli::EarlyCliArgs) -> Result<()> {
+        let filter = create_env_filter(cli)?;
 
-    if !cli.is_mcp_server {
-        debug!("Template server initialized");
+        tracing_subscriber::registry()
+            .with(filter)
+            .with(
+                tracing_subscriber::fmt::layer()
+                    .with_target(cli.debug || cli.trace)
+                    .with_thread_ids(cli.trace)
+                    .with_file(cli.trace)
+                    .with_line_number(cli.trace)
+                    .compact()
+                    .with_writer(std::io::stderr),
+            )
+            .init();
+
+        Ok(())
     }
 
-    match detect_execution_mode() {
-        ExecutionMode::Mcp => {
-            if !cli.is_mcp_server {
-                info!("Running unified MCP server (pmcp SDK)");
+    /// Create environment filter based on CLI flags
+    fn create_env_filter(cli: &cli::EarlyCliArgs) -> Result<EnvFilter> {
+        if cli.is_mcp_server {
+            Ok(create_mcp_filter(cli.debug))
+        } else {
+            create_cli_filter(cli)
+        }
+    }
+
+    /// Create filter for MCP server mode
+    fn create_mcp_filter(debug: bool) -> EnvFilter {
+        if debug {
+            EnvFilter::new("warn,pmat=debug")
+        } else {
+            EnvFilter::new("off")
+        }
+    }
+
+    /// Create filter for CLI mode
+    fn create_cli_filter(cli: &cli::EarlyCliArgs) -> Result<EnvFilter> {
+        if let Some(ref custom) = cli.trace_filter {
+            return Ok(EnvFilter::try_new(custom)?);
+        }
+
+        let filter_str = match (cli.trace, cli.debug, cli.verbose) {
+            (true, _, _) => "debug,pmat=trace",
+            (_, true, _) => "warn,pmat=debug",
+            (_, _, true) => "warn,pmat=info",
+            _ => return Ok(get_default_filter()),
+        };
+
+        Ok(EnvFilter::new(filter_str))
+    }
+
+    /// Get default production filter
+    fn get_default_filter() -> EnvFilter {
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("warn"))
+    }
+
+    #[tokio::main]
+    #[allow(unreachable_pub)]
+    pub async fn real_main() {
+        let exit_code = match run_main().await {
+            Ok(()) => ExitCode::Success,
+            Err(e) => {
+                error!("Error: {:#}", e);
+                categorize_error(&e)
             }
-            let unified_server = pmat::mcp_pmcp::UnifiedServer::new()
-                .map_err(|e| anyhow::anyhow!("Failed to create unified server: {}", e))?;
-            unified_server
-                .run()
-                .await
-                .map_err(|e| anyhow::anyhow!("{}", e))
+        };
+
+        if exit_code as i32 != 0 {
+            process::exit(exit_code.into());
         }
-        ExecutionMode::Cli => {
-            if !cli.is_mcp_server {
-                info!("Running in CLI mode");
-            }
-            cli::run(server).await
+    }
+
+    fn categorize_error(error: &anyhow::Error) -> ExitCode {
+        let error_str = error.to_string().to_lowercase();
+
+        match () {
+            _ if is_quality_gate_error(&error_str) => ExitCode::QualityGateFailure,
+            _ if is_configuration_error(&error_str) => ExitCode::ConfigurationError,
+            _ if is_analysis_error(&error_str) => ExitCode::AnalysisError,
+            _ if is_permission_error(&error_str) => ExitCode::PermissionDenied,
+            _ => ExitCode::GeneralError,
         }
-        ExecutionMode::HelpAndExit => {
-            // GH-285: No subcommand + piped stdin + no MCP_VERSION. Print help on
-            // stderr and exit with code 2 (misuse), matching the convention for
-            // "no command supplied" on a terminal.
-            let mut cmd = <pmat::cli::Cli as clap::CommandFactory>::command();
-            let _ = cmd.print_help();
-            eprintln!(
-                "\nerror: no subcommand given and stdin is not a terminal. \
-                 Set MCP_VERSION=1 (or run `pmat agent mcp-server`) to start the MCP server."
+    }
+
+    fn is_quality_gate_error(error_str: &str) -> bool {
+        error_str.contains("quality gate") || error_str.contains("violation")
+    }
+
+    fn is_configuration_error(error_str: &str) -> bool {
+        error_str.contains("config") || error_str.contains("parse")
+    }
+
+    fn is_analysis_error(error_str: &str) -> bool {
+        error_str.contains("analysis") || error_str.contains("complexity")
+    }
+
+    fn is_permission_error(error_str: &str) -> bool {
+        error_str.contains("permission") || error_str.contains("access")
+    }
+
+    async fn run_main() -> Result<()> {
+        // Parse CLI to get tracing configuration early
+        let cli = cli::parse_early_for_tracing();
+
+        // Initialize enhanced tracing system
+        init_tracing(&cli)?;
+
+        // Only log to stdout if not running MCP server mode
+        if !cli.is_mcp_server {
+            info!(
+                "Starting PAIML MCP Agent Toolkit v{}",
+                env!("CARGO_PKG_VERSION")
             );
-            process::exit(ExitCode::MisuseError as i32);
+            debug!("Debug logging enabled");
+            trace!("Trace logging enabled");
+        }
+
+        // Create shared template server
+        let server = Arc::new(StatelessTemplateServer::new()?);
+
+        if !cli.is_mcp_server {
+            debug!("Template server initialized");
+        }
+
+        match detect_execution_mode() {
+            ExecutionMode::Mcp => {
+                if !cli.is_mcp_server {
+                    info!("Running unified MCP server (pmcp SDK)");
+                }
+                let unified_server = pmat::mcp_pmcp::UnifiedServer::new()
+                    .map_err(|e| anyhow::anyhow!("Failed to create unified server: {}", e))?;
+                unified_server
+                    .run()
+                    .await
+                    .map_err(|e| anyhow::anyhow!("{}", e))
+            }
+            ExecutionMode::Cli => {
+                if !cli.is_mcp_server {
+                    info!("Running in CLI mode");
+                }
+                cli::run(server).await
+            }
+            ExecutionMode::HelpAndExit => {
+                // GH-285: No subcommand + piped stdin + no MCP_VERSION. Print help on
+                // stderr and exit with code 2 (misuse), matching the convention for
+                // "no command supplied" on a terminal.
+                let mut cmd = <pmat::cli::Cli as clap::CommandFactory>::command();
+                let _ = cmd.print_help();
+                eprintln!(
+                    "\nerror: no subcommand given and stdin is not a terminal. \
+                 Set MCP_VERSION=1 (or run `pmat agent mcp-server`) to start the MCP server."
+                );
+                process::exit(ExitCode::MisuseError as i32);
+            }
         }
     }
-}
 
-#[cfg_attr(coverage_nightly, coverage(off))]
-#[cfg(test)]
-mod gh285_tests {
-    //! Regression tests for GH-285: `pmat` hangs when invoked with no args
-    //! and stdin is a pipe. See `classify_execution_mode`.
-    //!
-    //! Manual end-to-end repro (should NOT hang or exit 124):
-    //! ```text
-    //! echo "" | timeout 3 target/debug/pmat 2>&1; echo exit=$?
-    //! timeout 3 target/debug/pmat < /dev/null; echo exit=$?
-    //! ```
-    //! Both should print help and exit with code 2.
-    use super::{classify_execution_mode, ExecutionMode};
+    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg(test)]
+    mod gh285_tests {
+        //! Regression tests for GH-285: `pmat` hangs when invoked with no args
+        //! and stdin is a pipe. See `classify_execution_mode`.
+        //!
+        //! Manual end-to-end repro (should NOT hang or exit 124):
+        //! ```text
+        //! echo "" | timeout 3 target/debug/pmat 2>&1; echo exit=$?
+        //! timeout 3 target/debug/pmat < /dev/null; echo exit=$?
+        //! ```
+        //! Both should print help and exit with code 2.
+        use super::{classify_execution_mode, ExecutionMode};
 
-    #[test]
-    fn bare_invocation_on_tty_is_cli() {
-        // `pmat` typed into a terminal with no pipe -> normal CLI (clap
-        // will then print help on missing subcommand).
-        assert!(matches!(
-            classify_execution_mode(false, true, false),
-            ExecutionMode::Cli
-        ));
+        #[test]
+        fn bare_invocation_on_tty_is_cli() {
+            // `pmat` typed into a terminal with no pipe -> normal CLI (clap
+            // will then print help on missing subcommand).
+            assert!(matches!(
+                classify_execution_mode(false, true, false),
+                ExecutionMode::Cli
+            ));
+        }
+
+        #[test]
+        fn piped_stdin_with_no_args_prints_help_instead_of_hanging() {
+            // GH-285: This used to enter MCP mode and block on stdin forever.
+            assert!(matches!(
+                classify_execution_mode(false, true, true),
+                ExecutionMode::HelpAndExit
+            ));
+        }
+
+        #[test]
+        fn explicit_mcp_version_env_still_enters_mcp_mode() {
+            // Claude Desktop and similar hosts set MCP_VERSION; they must still
+            // get the MCP server regardless of TTY state.
+            assert!(matches!(
+                classify_execution_mode(true, true, true),
+                ExecutionMode::Mcp
+            ));
+            assert!(matches!(
+                classify_execution_mode(true, false, false),
+                ExecutionMode::Mcp
+            ));
+        }
+
+        #[test]
+        fn subcommand_with_piped_stdin_is_still_cli() {
+            // `echo foo | pmat analyze ...` must dispatch to the CLI subcommand,
+            // not to help-and-exit.
+            assert!(matches!(
+                classify_execution_mode(false, false, true),
+                ExecutionMode::Cli
+            ));
+        }
     }
-
-    #[test]
-    fn piped_stdin_with_no_args_prints_help_instead_of_hanging() {
-        // GH-285: This used to enter MCP mode and block on stdin forever.
-        assert!(matches!(
-            classify_execution_mode(false, true, true),
-            ExecutionMode::HelpAndExit
-        ));
-    }
-
-    #[test]
-    fn explicit_mcp_version_env_still_enters_mcp_mode() {
-        // Claude Desktop and similar hosts set MCP_VERSION; they must still
-        // get the MCP server regardless of TTY state.
-        assert!(matches!(
-            classify_execution_mode(true, true, true),
-            ExecutionMode::Mcp
-        ));
-        assert!(matches!(
-            classify_execution_mode(true, false, false),
-            ExecutionMode::Mcp
-        ));
-    }
-
-    #[test]
-    fn subcommand_with_piped_stdin_is_still_cli() {
-        // `echo foo | pmat analyze ...` must dispatch to the CLI subcommand,
-        // not to help-and-exit.
-        assert!(matches!(
-            classify_execution_mode(false, false, true),
-            ExecutionMode::Cli
-        ));
-    }
-}
 } // end of mod full
 
 #[cfg(feature = "standard-deps")]

--- a/src/entropy/pattern_extractor_tests.rs
+++ b/src/entropy/pattern_extractor_tests.rs
@@ -845,7 +845,10 @@ fn test_calculate_pattern_match_variation_score_short_circuits_single_match() {
 
     let score =
         extractor.calculate_pattern_match_variation_score(&enums, &matches, &arrows, content);
-    assert_eq!(score, 0.0, "fewer than 2 match blocks must short-circuit to 0.0");
+    assert_eq!(
+        score, 0.0,
+        "fewer than 2 match blocks must short-circuit to 0.0"
+    );
 }
 
 /// pattern_extractor_ruchy.rs:405 — enum_matches.len() <= 1 low-variation arm (0.3).

--- a/src/handlers/tools_advanced.rs
+++ b/src/handlers/tools_advanced.rs
@@ -352,7 +352,7 @@ mod part2_tests {
         s.hotspots = vec![
             TDGHotspot {
                 path: "src/a.rs".to_string(),
-                tdg_score: 3.14,
+                tdg_score: 3.15,
                 primary_factor: "Complexity".to_string(),
                 estimated_hours: 4.5,
             },
@@ -367,7 +367,7 @@ mod part2_tests {
         append_tdg_hotspots_section(&mut out, &s);
         assert!(out.contains("## Top Hotspots"));
         assert!(out.contains("src/a.rs"));
-        assert!(out.contains("3.14"));
+        assert!(out.contains("3.15"));
         assert!(out.contains("Complexity"));
         assert!(out.contains("src/b.rs"));
         assert!(out.contains("Duplication"));

--- a/src/handlers/tools_advanced.rs
+++ b/src/handlers/tools_advanced.rs
@@ -12,3 +12,397 @@ include!("tools_advanced_part1.rs");
 include!("tools_advanced_part2.rs");
 include!("tools_advanced_part3.rs");
 include!("tools_advanced_part4.rs");
+
+#[cfg(test)]
+mod part2_tests {
+    //! PMAT-648: cover tools_advanced_part2.rs pure helpers.
+    use super::*;
+    use crate::models::dead_code::{
+        ConfidenceLevel, DeadCodeAnalysisConfig, DeadCodeItem, DeadCodeRankingResult,
+        DeadCodeSummary, DeadCodeType, FileDeadCodeMetrics,
+    };
+    use crate::models::tdg::{TDGHotspot, TDGSummary};
+    use chrono::Utc;
+    use serde_json::json;
+
+    fn empty_dc_summary() -> DeadCodeSummary {
+        DeadCodeSummary {
+            total_files_analyzed: 0,
+            files_with_dead_code: 0,
+            total_dead_lines: 0,
+            dead_percentage: 0.0,
+            dead_functions: 0,
+            dead_classes: 0,
+            dead_modules: 0,
+            unreachable_blocks: 0,
+        }
+    }
+
+    fn tdg_summary(total: usize, critical: usize, warning: usize) -> TDGSummary {
+        TDGSummary {
+            total_files: total,
+            critical_files: critical,
+            warning_files: warning,
+            average_tdg: 1.5,
+            p95_tdg: 2.5,
+            p99_tdg: 3.0,
+            estimated_debt_hours: 42.0,
+            hotspots: Vec::new(),
+        }
+    }
+
+    // --- get_confidence_level_text / format_confidence_emoji ---
+
+    #[test]
+    fn test_get_confidence_level_text_all_variants() {
+        assert_eq!(get_confidence_level_text(ConfidenceLevel::High), "HIGH ");
+        assert_eq!(
+            get_confidence_level_text(ConfidenceLevel::Medium),
+            "MEDIUM "
+        );
+        assert_eq!(get_confidence_level_text(ConfidenceLevel::Low), "LOW ");
+    }
+
+    #[test]
+    fn test_format_confidence_emoji_all_variants() {
+        assert_eq!(format_confidence_emoji(ConfidenceLevel::High), "🔴 High");
+        assert_eq!(
+            format_confidence_emoji(ConfidenceLevel::Medium),
+            "🟡 Medium"
+        );
+        assert_eq!(format_confidence_emoji(ConfidenceLevel::Low), "🟢 Low");
+    }
+
+    // --- calculate_percentage / calculate_dead_files_percentage ---
+
+    #[test]
+    fn test_calculate_percentage_zero_total_returns_zero() {
+        assert_eq!(calculate_percentage(5, 0), 0.0);
+    }
+
+    #[test]
+    fn test_calculate_percentage_basic_ratio() {
+        assert!((calculate_percentage(1, 4) - 25.0).abs() < 1e-10);
+        assert!((calculate_percentage(7, 10) - 70.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_calculate_dead_files_percentage_zero_total() {
+        let s = empty_dc_summary();
+        assert_eq!(calculate_dead_files_percentage(&s), 0.0);
+    }
+
+    #[test]
+    fn test_calculate_dead_files_percentage_ratio() {
+        let mut s = empty_dc_summary();
+        s.total_files_analyzed = 10;
+        s.files_with_dead_code = 3;
+        assert!((calculate_dead_files_percentage(&s) - 30.0).abs() < 1e-3);
+    }
+
+    // --- write_dead_code_header ---
+
+    #[test]
+    fn test_write_dead_code_header_includes_title_and_date() {
+        let mut out = String::new();
+        let ts = Utc::now();
+        write_dead_code_header(&mut out, &ts);
+        assert!(out.contains("# Dead Code Analysis Report"));
+        assert!(out.contains("**Analysis Date:**"));
+    }
+
+    // --- write_dead_code_metrics ---
+
+    #[test]
+    fn test_write_dead_code_metrics_has_all_fields() {
+        let mut s = empty_dc_summary();
+        s.total_dead_lines = 100;
+        s.dead_percentage = 12.5;
+        s.dead_functions = 7;
+        s.dead_classes = 2;
+        s.dead_modules = 1;
+        s.unreachable_blocks = 3;
+        let mut out = String::new();
+        write_dead_code_metrics(&mut out, &s);
+        for key in [
+            "Total dead lines",
+            "100",
+            "12.5%",
+            "Dead functions:** 7",
+            "Dead classes:** 2",
+            "Dead modules:** 1",
+            "Unreachable blocks:** 3",
+        ] {
+            assert!(out.contains(key), "missing {key} in: {out}");
+        }
+    }
+
+    // --- write_dead_code_summary_section ---
+
+    #[test]
+    fn test_write_dead_code_summary_section_integration() {
+        let mut s = empty_dc_summary();
+        s.total_files_analyzed = 100;
+        s.files_with_dead_code = 25;
+        let mut out = String::new();
+        write_dead_code_summary_section(&mut out, &s);
+        assert!(out.contains("## Summary"));
+        assert!(out.contains("Total files analyzed:** 100"));
+        assert!(out.contains("Files with dead code:** 25 (25.0%)"));
+    }
+
+    // --- write_dead_code_top_files_section ---
+
+    #[test]
+    fn test_write_dead_code_top_files_section_empty_is_no_op() {
+        let mut out = String::new();
+        write_dead_code_top_files_section(&mut out, &[]);
+        assert!(out.is_empty());
+    }
+
+    fn dc_metric(path: &str, lines: usize, conf: ConfidenceLevel) -> FileDeadCodeMetrics {
+        FileDeadCodeMetrics {
+            path: path.to_string(),
+            dead_lines: lines,
+            total_lines: 100,
+            dead_percentage: lines as f32,
+            dead_functions: 1,
+            dead_classes: 0,
+            dead_modules: 0,
+            unreachable_blocks: 0,
+            dead_score: 50.0,
+            confidence: conf,
+            items: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn test_write_dead_code_top_files_section_populated_has_table() {
+        let files = vec![
+            dc_metric("src/a.rs", 10, ConfidenceLevel::High),
+            dc_metric("src/b.rs", 5, ConfidenceLevel::Medium),
+        ];
+        let mut out = String::new();
+        write_dead_code_top_files_section(&mut out, &files);
+        assert!(out.contains("## Top Files with Dead Code"));
+        assert!(out.contains("| Rank |"));
+        assert!(out.contains("src/a.rs"));
+        assert!(out.contains("src/b.rs"));
+        assert!(out.contains("🔴 High"));
+        assert!(out.contains("🟡 Medium"));
+    }
+
+    // --- format_dead_code_as_sarif_mcp ---
+
+    #[test]
+    fn test_format_dead_code_as_sarif_mcp_basic_shape() {
+        let file = FileDeadCodeMetrics {
+            path: "src/x.rs".to_string(),
+            dead_lines: 5,
+            total_lines: 50,
+            dead_percentage: 10.0,
+            dead_functions: 1,
+            dead_classes: 0,
+            dead_modules: 0,
+            unreachable_blocks: 0,
+            dead_score: 30.0,
+            confidence: ConfidenceLevel::High,
+            items: vec![DeadCodeItem {
+                item_type: DeadCodeType::Function,
+                name: "unused_fn".to_string(),
+                line: 42,
+                reason: "No call sites".to_string(),
+            }],
+        };
+        let result = DeadCodeRankingResult {
+            summary: empty_dc_summary(),
+            ranked_files: vec![file],
+            analysis_timestamp: Utc::now(),
+            config: DeadCodeAnalysisConfig {
+                include_unreachable: false,
+                include_tests: false,
+                min_dead_lines: 0,
+            },
+        };
+        let sarif = format_dead_code_as_sarif_mcp(&result).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&sarif).unwrap();
+        assert_eq!(
+            v.get("$schema").and_then(|s| s.as_str()),
+            Some("https://json.schemastore.org/sarif-2.1.0.json")
+        );
+        assert!(v.get("runs").is_some());
+        assert!(sarif.contains("dead-code-function"));
+        assert!(sarif.contains("unused_fn"));
+    }
+
+    #[test]
+    fn test_format_dead_code_as_sarif_mcp_empty_has_zero_results() {
+        let result = DeadCodeRankingResult {
+            summary: empty_dc_summary(),
+            ranked_files: Vec::new(),
+            analysis_timestamp: Utc::now(),
+            config: DeadCodeAnalysisConfig {
+                include_unreachable: false,
+                include_tests: false,
+                min_dead_lines: 0,
+            },
+        };
+        let sarif = format_dead_code_as_sarif_mcp(&result).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&sarif).unwrap();
+        let results_len = v["runs"][0]["results"].as_array().unwrap().len();
+        assert_eq!(results_len, 0);
+    }
+
+    // --- format_dead_code_as_markdown_mcp ---
+
+    #[test]
+    fn test_format_dead_code_as_markdown_mcp_integration() {
+        let result = DeadCodeRankingResult {
+            summary: empty_dc_summary(),
+            ranked_files: Vec::new(),
+            analysis_timestamp: Utc::now(),
+            config: DeadCodeAnalysisConfig {
+                include_unreachable: false,
+                include_tests: false,
+                min_dead_lines: 0,
+            },
+        };
+        let out = format_dead_code_as_markdown_mcp(&result).unwrap();
+        assert!(out.contains("# Dead Code Analysis Report"));
+        assert!(out.contains("## Summary"));
+    }
+
+    // --- parse_tdg_args ---
+
+    #[test]
+    fn test_parse_tdg_args_valid() {
+        let args = parse_tdg_args(json!({
+            "project_path": "/tmp",
+            "format": "json",
+            "threshold": 1.5,
+        }))
+        .unwrap();
+        assert_eq!(args.project_path.as_deref(), Some("/tmp"));
+        assert_eq!(args.format.as_deref(), Some("json"));
+        assert_eq!(args.threshold, Some(1.5));
+    }
+
+    #[test]
+    fn test_parse_tdg_args_invalid_type_returns_err() {
+        let result = parse_tdg_args(json!({"threshold": "not-a-number"}));
+        assert!(result.is_err());
+    }
+
+    // --- extract_tdg_project_path ---
+
+    #[test]
+    fn test_extract_tdg_project_path_none_is_err() {
+        let args = AnalyzeTdgArgs {
+            project_path: None,
+            format: None,
+            threshold: None,
+            include_components: None,
+            max_results: None,
+        };
+        assert!(extract_tdg_project_path(&args).is_err());
+    }
+
+    #[test]
+    fn test_extract_tdg_project_path_empty_is_err() {
+        let args = AnalyzeTdgArgs {
+            project_path: Some(String::new()),
+            format: None,
+            threshold: None,
+            include_components: None,
+            max_results: None,
+        };
+        assert!(extract_tdg_project_path(&args).is_err());
+    }
+
+    // --- format_tdg_summary / append_tdg_* helpers ---
+
+    #[test]
+    fn test_format_tdg_summary_integration_empty_hotspots() {
+        let s = tdg_summary(10, 1, 2);
+        let out = format_tdg_summary(&s);
+        assert!(out.contains("# Technical Debt Gradient Analysis"));
+        assert!(out.contains("## Summary"));
+        assert!(out.contains("Total files:** 10"));
+        assert!(out.contains("Critical files:** 1 (10.0%)"));
+        assert!(out.contains("Warning files:** 2 (20.0%)"));
+        assert!(out.contains("## Severity Distribution"));
+        assert!(out.contains("🔴 Critical"));
+        assert!(out.contains("🟡 Warning"));
+        assert!(out.contains("🟢 Normal"));
+        // No Top Hotspots section when empty.
+        assert!(!out.contains("## Top Hotspots"));
+    }
+
+    #[test]
+    fn test_append_tdg_hotspots_section_empty_no_op() {
+        let mut out = String::new();
+        let s = tdg_summary(5, 0, 0);
+        append_tdg_hotspots_section(&mut out, &s);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn test_append_tdg_hotspots_section_populated_has_rows() {
+        let mut s = tdg_summary(10, 1, 0);
+        s.hotspots = vec![
+            TDGHotspot {
+                path: "src/a.rs".to_string(),
+                tdg_score: 3.14,
+                primary_factor: "Complexity".to_string(),
+                estimated_hours: 4.5,
+            },
+            TDGHotspot {
+                path: "src/b.rs".to_string(),
+                tdg_score: 2.5,
+                primary_factor: "Duplication".to_string(),
+                estimated_hours: 2.0,
+            },
+        ];
+        let mut out = String::new();
+        append_tdg_hotspots_section(&mut out, &s);
+        assert!(out.contains("## Top Hotspots"));
+        assert!(out.contains("src/a.rs"));
+        assert!(out.contains("3.14"));
+        assert!(out.contains("Complexity"));
+        assert!(out.contains("src/b.rs"));
+        assert!(out.contains("Duplication"));
+    }
+
+    #[test]
+    fn test_append_tdg_severity_section_computes_normal_via_saturating_sub() {
+        let mut out = String::new();
+        // critical + warning > total → saturating sub produces 0.
+        let s = tdg_summary(3, 5, 10);
+        append_tdg_severity_section(&mut out, &s);
+        assert!(out.contains("🟢 Normal (<1.5): 0 files"));
+    }
+
+    // --- format_and_respond_tdg ---
+
+    #[test]
+    fn test_format_and_respond_tdg_json_format_emits_json_content() {
+        let s = tdg_summary(5, 1, 1);
+        let resp = format_and_respond_tdg(json!(42), s, Some("json".to_string()));
+        assert!(resp.error.is_none());
+        let result = resp.result.as_ref().unwrap();
+        // Content text should be valid JSON (TDGSummary serialized).
+        let content = result["content"][0]["text"].as_str().unwrap();
+        let _: serde_json::Value = serde_json::from_str(content).unwrap();
+        assert_eq!(result["format"], "json");
+    }
+
+    #[test]
+    fn test_format_and_respond_tdg_default_format_is_summary() {
+        let s = tdg_summary(5, 0, 1);
+        let resp = format_and_respond_tdg(json!(99), s, None);
+        let result = resp.result.as_ref().unwrap();
+        assert_eq!(result["format"], "summary");
+        let content = result["content"][0]["text"].as_str().unwrap();
+        assert!(content.contains("# Technical Debt Gradient Analysis"));
+    }
+}

--- a/src/maintenance/updater.rs
+++ b/src/maintenance/updater.rs
@@ -375,9 +375,13 @@ mod tests {
             files: vec!["src/lib.rs".into()], // no ticket file
         };
 
-        let result =
-            process_ticket_update(&mut roadmap, &commit, "TICKET-PMAT-5013", tickets_dir.path())
-                .unwrap();
+        let result = process_ticket_update(
+            &mut roadmap,
+            &commit,
+            "TICKET-PMAT-5013",
+            tickets_dir.path(),
+        )
+        .unwrap();
         assert!(!result, "must short-circuit when ticket file not in commit");
         assert!(!roadmap.sprints[0].tickets[0].completed);
     }
@@ -394,10 +398,17 @@ mod tests {
             files: vec!["docs/tickets/TICKET-PMAT-5013.md".into()],
         };
 
-        let result =
-            process_ticket_update(&mut roadmap, &commit, "TICKET-PMAT-5013", tickets_dir.path())
-                .unwrap();
-        assert!(!result, "missing ticket file must return Ok(false), not error");
+        let result = process_ticket_update(
+            &mut roadmap,
+            &commit,
+            "TICKET-PMAT-5013",
+            tickets_dir.path(),
+        )
+        .unwrap();
+        assert!(
+            !result,
+            "missing ticket file must return Ok(false), not error"
+        );
         assert!(!roadmap.sprints[0].tickets[0].completed);
     }
 
@@ -417,11 +428,7 @@ mod tests {
              Still failing.\n\n\
              ## Success Criteria\n\n\
              - [ ] One\n";
-        std::fs::write(
-            tickets_dir.path().join("TICKET-PMAT-5013.md"),
-            red_content,
-        )
-        .unwrap();
+        std::fs::write(tickets_dir.path().join("TICKET-PMAT-5013.md"), red_content).unwrap();
         let mut roadmap = create_test_roadmap();
         let commit = CommitInfo {
             hash: "deadbee".into(),
@@ -429,9 +436,13 @@ mod tests {
             files: vec!["docs/tickets/TICKET-PMAT-5013.md".into()],
         };
 
-        let result =
-            process_ticket_update(&mut roadmap, &commit, "TICKET-PMAT-5013", tickets_dir.path())
-                .unwrap();
+        let result = process_ticket_update(
+            &mut roadmap,
+            &commit,
+            "TICKET-PMAT-5013",
+            tickets_dir.path(),
+        )
+        .unwrap();
         assert!(!result, "RED ticket must not mark roadmap completed");
         assert!(!roadmap.sprints[0].tickets[0].completed);
     }
@@ -450,9 +461,13 @@ mod tests {
             files: vec!["docs/tickets/TICKET-PMAT-5013.md".into()],
         };
 
-        let result =
-            process_ticket_update(&mut roadmap, &commit, "TICKET-PMAT-5013", tickets_dir.path())
-                .unwrap();
+        let result = process_ticket_update(
+            &mut roadmap,
+            &commit,
+            "TICKET-PMAT-5013",
+            tickets_dir.path(),
+        )
+        .unwrap();
         assert!(result, "GREEN ticket must flip roadmap entry");
         assert!(roadmap.sprints[0].tickets[0].completed);
         assert_eq!(

--- a/src/mcp_pmcp/agent_context_handlers.rs
+++ b/src/mcp_pmcp/agent_context_handlers.rs
@@ -37,11 +37,7 @@ macro_rules! impl_pmat_handler {
 
         #[async_trait]
         impl ToolHandler for $wrapper {
-            async fn handle(
-                &self,
-                args: Value,
-                _extra: RequestHandlerExtra,
-            ) -> PmcpResult<Value> {
+            async fn handle(&self, args: Value, _extra: RequestHandlerExtra) -> PmcpResult<Value> {
                 self.inner.execute(args).await.map_err(PmcpError::internal)
             }
 

--- a/src/mcp_pmcp/analyze_handlers.rs
+++ b/src/mcp_pmcp/analyze_handlers.rs
@@ -32,7 +32,8 @@ use tracing::debug;
 // MCP tools (see R15 #3 bench matrix).
 pub use self::{
     ComplexityTool as AnalyzeComplexityTool, DeadCodeTool as AnalyzeDeadCodeTool,
-    SatdTool as AnalyzeSatdTool, TdgCompareTool as AnalyzeTdgCompareTool, TdgTool as AnalyzeTdgTool,
+    SatdTool as AnalyzeSatdTool, TdgCompareTool as AnalyzeTdgCompareTool,
+    TdgTool as AnalyzeTdgTool,
 };
 
 // Complexity analysis tool handler

--- a/src/mcp_pmcp/mod.rs
+++ b/src/mcp_pmcp/mod.rs
@@ -103,12 +103,12 @@ pub mod quality_handlers;
 pub mod quality_proxy_handler;
 pub mod server;
 pub mod simple_unified_server;
-pub mod tool_schemas;
 #[cfg_attr(coverage_nightly, coverage(off))]
 #[cfg(test)]
 pub mod tdg_git_context_tests;
 pub mod tdg_handlers;
 pub mod tool_functions;
+pub mod tool_schemas;
 pub mod tool_schemas_generated; // KAIZEN-0178: build.rs-generated tool schema registry
 pub mod tools; // Sprint 65 Phase 2B: MCP git-context integration
 

--- a/src/mcp_pmcp/tool_schemas.rs
+++ b/src/mcp_pmcp/tool_schemas.rs
@@ -45,7 +45,10 @@ pub fn paths_object_schema(extra_properties: Value, required: Vec<&str>) -> Valu
             base.insert(k.clone(), v.clone());
         }
     }
-    let req: Vec<Value> = required.into_iter().map(|s| Value::String(s.into())).collect();
+    let req: Vec<Value> = required
+        .into_iter()
+        .map(|s| Value::String(s.into()))
+        .collect();
     json!({
         "type": "object",
         "properties": base_props,


### PR DESCRIPTION
## Summary

Continues Phase-1 CLI pivot after PR #512/PMAT-647. \`tools_advanced_part2.rs\` is 464 lines, **297/303 missed** on master broad. Async in public handler only; every helper is pure sync.

**24 new tests** covering:

**Dead code formatting**
- get_confidence_level_text / format_confidence_emoji all 3 variants
- calculate_dead_files_percentage / calculate_percentage zero-total guard + ratio
- write_dead_code_header title + date
- write_dead_code_metrics emits all fields
- write_dead_code_summary_section integration
- write_dead_code_top_files_section: empty + populated
- format_dead_code_as_sarif_mcp: full shape (schema URL, rule IDs) + empty
- format_dead_code_as_markdown_mcp integration

**TDG formatting**
- parse_tdg_args valid / invalid-type
- extract_tdg_project_path None/empty Err (D101)
- format_tdg_summary full pipeline
- append_tdg_hotspots_section empty + populated
- append_tdg_severity_section saturating_sub edge case
- format_and_respond_tdg json + default summary

## Coverage impact

Expected delta: **~+0.09pp** on broad.

## Test plan

- [x] \`cargo test --lib -- handlers::tools_advanced::part2_tests\` — 24 passed, 0 failed
- [x] \`cargo fmt --all -- --check\` — clean
- [ ] CI gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)