### PR TITLE
test(coverage): tdg_formatting.rs pure output formatters (PMAT-649)

### DIFF
--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -3213,3 +3213,20 @@ roadmap:
   estimated_effort: null
   labels: []
   notes: null
+- id: PMAT-649
+  github_issue: null
+  item_type: task
+  title: 'Phase 1 pivot: cli/analysis_utilities/tdg_formatting.rs coverage'
+  status: inprogress
+  priority: medium
+  assigned_to: null
+  created: 2026-04-24T08:55:52Z
+  updated: 2026-04-24T08:55:52Z
+  spec: null
+  acceptance_criteria:
+  - 'Phase 1 CLI pivot — tdg_formatting.rs is 294 lines, 232/232 missed on master broad, 0 async, pure output formatting. Cover format_output_from_summary (4 format arms), format_empty_results (4 arms), format_tdg_single_file_output (severity mapping to critical/warning counts), format_table_output (with/without hotspots + components+verbose), format_json_output (with/without components), format_markdown_output (full pipeline + add_markdown_components toggle), format_sarif_output (empty + populated + error-vs-warning level).'
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels: []
+  notes: null

--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -3217,7 +3217,7 @@ roadmap:
   github_issue: null
   item_type: task
   title: 'Phase 1 pivot: cli/analysis_utilities/tdg_formatting.rs coverage'
-  status: inprogress
+  status: review
   priority: medium
   assigned_to: null
   created: 2026-04-24T08:55:52Z

--- a/examples/mcp_agent_context_demo.rs
+++ b/examples/mcp_agent_context_demo.rs
@@ -54,68 +54,132 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     thread::sleep(Duration::from_secs(10));
 
     // 1. initialize handshake
-    let resp = rpc(&mut writer, &mut reader, 1, "initialize", json!({
-        "protocolVersion": "2024-11-05",
-        "capabilities": {},
-        "clientInfo": { "name": "mcp_agent_context_demo", "version": "1.0" }
-    }))?;
-    let server_info = resp.pointer("/result/serverInfo/name").cloned().unwrap_or(json!("?"));
+    let resp = rpc(
+        &mut writer,
+        &mut reader,
+        1,
+        "initialize",
+        json!({
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": { "name": "mcp_agent_context_demo", "version": "1.0" }
+        }),
+    )?;
+    let server_info = resp
+        .pointer("/result/serverInfo/name")
+        .cloned()
+        .unwrap_or(json!("?"));
     println!("[initialize] server={}", server_info);
 
     // 2. tools/list — sanity check that the 4 pmat_* tools are registered
     let resp = rpc(&mut writer, &mut reader, 2, "tools/list", json!({}))?;
-    let tools = resp.pointer("/result/tools").and_then(|v| v.as_array()).cloned().unwrap_or_default();
-    let pmat_tools: Vec<&str> = tools.iter()
+    let tools = resp
+        .pointer("/result/tools")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+    let pmat_tools: Vec<&str> = tools
+        .iter()
         .filter_map(|t| t.get("name").and_then(|n| n.as_str()))
         .filter(|n| n.starts_with("pmat_"))
         .collect();
-    println!("[tools/list] total={} pmat_*={} ({:?})", tools.len(), pmat_tools.len(), pmat_tools);
+    println!(
+        "[tools/list] total={} pmat_*={} ({:?})",
+        tools.len(),
+        pmat_tools.len(),
+        pmat_tools
+    );
 
     // 3. pmat_index_stats — pick up a real function_id we can reuse below
-    let resp = call_tool(&mut writer, &mut reader, 3, "pmat_index_stats",
-        json!({ "rebuild": false }))?;
+    let resp = call_tool(
+        &mut writer,
+        &mut reader,
+        3,
+        "pmat_index_stats",
+        json!({ "rebuild": false }),
+    )?;
     let index_result = extract_tool_result(&resp);
-    let fn_count = index_result.pointer("/manifest/function_count").cloned().unwrap_or(json!(0));
-    let file_count = index_result.pointer("/manifest/file_count").cloned().unwrap_or(json!(0));
-    println!("[pmat_index_stats] ok: functions={} files={}", fn_count, file_count);
+    let fn_count = index_result
+        .pointer("/manifest/function_count")
+        .cloned()
+        .unwrap_or(json!(0));
+    let file_count = index_result
+        .pointer("/manifest/file_count")
+        .cloned()
+        .unwrap_or(json!(0));
+    println!(
+        "[pmat_index_stats] ok: functions={} files={}",
+        fn_count, file_count
+    );
 
     // 4. pmat_query_code — realistic semantic query
-    let resp = call_tool(&mut writer, &mut reader, 4, "pmat_query_code",
-        json!({ "query": "error handling", "limit": 3 }))?;
+    let resp = call_tool(
+        &mut writer,
+        &mut reader,
+        4,
+        "pmat_query_code",
+        json!({ "query": "error handling", "limit": 3 }),
+    )?;
     let query_result = extract_tool_result(&resp);
-    let result_count = query_result.get("results")
+    let result_count = query_result
+        .get("results")
         .or_else(|| query_result.get("functions"))
         .and_then(|v| v.as_array())
         .map(|a| a.len())
         .unwrap_or(0);
-    let first_id = query_result.pointer("/results/0/id")
+    let first_id = query_result
+        .pointer("/results/0/id")
         .or_else(|| query_result.pointer("/functions/0/id"))
         .and_then(|v| v.as_str())
         .map(|s| s.to_string());
-    println!("[pmat_query_code] ok: {} results; first_id={:?}", result_count, first_id);
+    println!(
+        "[pmat_query_code] ok: {} results; first_id={:?}",
+        result_count, first_id
+    );
 
     // 5. pmat_get_function — use the first id from query_code, or fall back to "main"
-    let function_id = first_id.clone().unwrap_or_else(|| "src/bin/pmat.rs::main".to_string());
-    let resp = call_tool(&mut writer, &mut reader, 5, "pmat_get_function",
-        json!({ "function_id": function_id, "include_source": false }))?;
+    let function_id = first_id
+        .clone()
+        .unwrap_or_else(|| "src/bin/pmat.rs::main".to_string());
+    let resp = call_tool(
+        &mut writer,
+        &mut reader,
+        5,
+        "pmat_get_function",
+        json!({ "function_id": function_id, "include_source": false }),
+    )?;
     match resp.get("error") {
-        Some(err) => println!("[pmat_get_function] graceful miss for {:?}: {}", function_id,
-            err.get("message").and_then(|m| m.as_str()).unwrap_or("?")),
+        Some(err) => println!(
+            "[pmat_get_function] graceful miss for {:?}: {}",
+            function_id,
+            err.get("message").and_then(|m| m.as_str()).unwrap_or("?")
+        ),
         None => {
             let gf = extract_tool_result(&resp);
-            println!("[pmat_get_function] ok: name={} grade={}",
+            println!(
+                "[pmat_get_function] ok: name={} grade={}",
                 gf.get("name").and_then(|v| v.as_str()).unwrap_or("?"),
-                gf.pointer("/quality/grade").and_then(|v| v.as_str()).unwrap_or("?"));
+                gf.pointer("/quality/grade")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("?")
+            );
         }
     }
 
     // 6. pmat_find_similar — only meaningful if we got a real id from the query
     if let Some(id) = first_id {
-        let resp = call_tool(&mut writer, &mut reader, 6, "pmat_find_similar",
-            json!({ "function_id": id, "limit": 3, "min_similarity": 0.3 }))?;
+        let resp = call_tool(
+            &mut writer,
+            &mut reader,
+            6,
+            "pmat_find_similar",
+            json!({ "function_id": id, "limit": 3, "min_similarity": 0.3 }),
+        )?;
         match resp.get("error") {
-            Some(err) => println!("[pmat_find_similar] error: {}",
-                err.get("message").and_then(|m| m.as_str()).unwrap_or("?")),
+            Some(err) => println!(
+                "[pmat_find_similar] error: {}",
+                err.get("message").and_then(|m| m.as_str()).unwrap_or("?")
+            ),
             None => {
                 let sim = extract_tool_result(&resp);
                 let total = sim.get("total").and_then(|v| v.as_u64()).unwrap_or(0);
@@ -162,7 +226,13 @@ fn call_tool(
     name: &str,
     args: Value,
 ) -> Result<Value, Box<dyn std::error::Error>> {
-    rpc(writer, reader, id, "tools/call", json!({ "name": name, "arguments": args }))
+    rpc(
+        writer,
+        reader,
+        id,
+        "tools/call",
+        json!({ "name": name, "arguments": args }),
+    )
 }
 
 /// MCP `tools/call` wraps results in `result.content[0].text` (JSON string) or
@@ -171,7 +241,10 @@ fn extract_tool_result(resp: &Value) -> Value {
     if let Some(sc) = resp.pointer("/result/structuredContent") {
         return sc.clone();
     }
-    if let Some(text) = resp.pointer("/result/content/0/text").and_then(|v| v.as_str()) {
+    if let Some(text) = resp
+        .pointer("/result/content/0/text")
+        .and_then(|v| v.as_str())
+    {
         if let Ok(parsed) = serde_json::from_str::<Value>(text) {
             return parsed;
         }

--- a/src/bin/pmat.rs
+++ b/src/bin/pmat.rs
@@ -16,301 +16,301 @@ fn main() {
 
 #[cfg(feature = "standard-deps")]
 mod full {
-use anyhow::Result;
-use pmat::{cli, stateless_server::StatelessTemplateServer};
-use std::io::IsTerminal;
-use std::process;
-use std::sync::Arc;
-use tracing::{debug, error, info, trace};
-use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
+    use anyhow::Result;
+    use pmat::{cli, stateless_server::StatelessTemplateServer};
+    use std::io::IsTerminal;
+    use std::process;
+    use std::sync::Arc;
+    use tracing::{debug, error, info, trace};
+    use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 
-enum ExecutionMode {
-    Mcp,
-    Cli,
-    /// No subcommand given and stdin is piped (not a TTY) without an explicit
-    /// MCP opt-in. Print help and exit non-zero instead of blocking on stdin
-    /// (see GH-285).
-    HelpAndExit,
-}
-
-/// POSIX-compliant exit codes for CLI interface
-/// Per SPECIFICATION.md Section 23: CLI Interface
-#[derive(Debug, Clone, Copy)]
-pub enum ExitCode {
-    /// Success
-    Success = 0,
-    /// General error
-    GeneralError = 1,
-    /// Misuse of shell command
-    MisuseError = 2,
-    /// Permission denied
-    PermissionDenied = 126,
-    /// Command not found
-    CommandNotFound = 127,
-    /// Invalid argument to exit
-    InvalidExitArg = 128,
-    /// Quality gate failure (custom)
-    QualityGateFailure = 3,
-    /// Configuration error (custom)
-    ConfigurationError = 4,
-    /// Analysis error (custom)
-    AnalysisError = 5,
-}
-
-impl From<ExitCode> for i32 {
-    fn from(code: ExitCode) -> Self {
-        code as i32
-    }
-}
-
-fn detect_execution_mode() -> ExecutionMode {
-    classify_execution_mode(
-        std::env::var("MCP_VERSION").is_ok(),
-        std::env::args().len() == 1,
-        !std::io::stdin().is_terminal(),
-    )
-}
-
-/// Pure decision function for execution mode so it can be unit-tested
-/// without touching real stdin / env vars (see GH-285 regression test).
-fn classify_execution_mode(
-    mcp_version_env: bool,
-    no_args: bool,
-    stdin_is_pipe: bool,
-) -> ExecutionMode {
-    // Explicit MCP opt-in via env var always wins (e.g. Claude Desktop sets this).
-    if mcp_version_env {
-        return ExecutionMode::Mcp;
+    enum ExecutionMode {
+        Mcp,
+        Cli,
+        /// No subcommand given and stdin is piped (not a TTY) without an explicit
+        /// MCP opt-in. Print help and exit non-zero instead of blocking on stdin
+        /// (see GH-285).
+        HelpAndExit,
     }
 
-    // GH-285: If the user ran bare `pmat` with stdin piped (e.g. `echo "" | pmat`)
-    // without opting into MCP via `MCP_VERSION`, previous behavior entered the MCP
-    // server and blocked forever on stdin. Treat that case the same as bare `pmat`
-    // on a terminal: print help and exit non-zero.
-    if no_args && stdin_is_pipe {
-        return ExecutionMode::HelpAndExit;
+    /// POSIX-compliant exit codes for CLI interface
+    /// Per SPECIFICATION.md Section 23: CLI Interface
+    #[derive(Debug, Clone, Copy)]
+    pub enum ExitCode {
+        /// Success
+        Success = 0,
+        /// General error
+        GeneralError = 1,
+        /// Misuse of shell command
+        MisuseError = 2,
+        /// Permission denied
+        PermissionDenied = 126,
+        /// Command not found
+        CommandNotFound = 127,
+        /// Invalid argument to exit
+        InvalidExitArg = 128,
+        /// Quality gate failure (custom)
+        QualityGateFailure = 3,
+        /// Configuration error (custom)
+        ConfigurationError = 4,
+        /// Analysis error (custom)
+        AnalysisError = 5,
     }
 
-    ExecutionMode::Cli
-}
+    impl From<ExitCode> for i32 {
+        fn from(code: ExitCode) -> Self {
+            code as i32
+        }
+    }
 
-/// Initialize the enhanced tracing system based on CLI flags
-fn init_tracing(cli: &cli::EarlyCliArgs) -> Result<()> {
-    let filter = create_env_filter(cli)?;
-
-    tracing_subscriber::registry()
-        .with(filter)
-        .with(
-            tracing_subscriber::fmt::layer()
-                .with_target(cli.debug || cli.trace)
-                .with_thread_ids(cli.trace)
-                .with_file(cli.trace)
-                .with_line_number(cli.trace)
-                .compact()
-                .with_writer(std::io::stderr),
+    fn detect_execution_mode() -> ExecutionMode {
+        classify_execution_mode(
+            std::env::var("MCP_VERSION").is_ok(),
+            std::env::args().len() == 1,
+            !std::io::stdin().is_terminal(),
         )
-        .init();
-
-    Ok(())
-}
-
-/// Create environment filter based on CLI flags
-fn create_env_filter(cli: &cli::EarlyCliArgs) -> Result<EnvFilter> {
-    if cli.is_mcp_server {
-        Ok(create_mcp_filter(cli.debug))
-    } else {
-        create_cli_filter(cli)
-    }
-}
-
-/// Create filter for MCP server mode
-fn create_mcp_filter(debug: bool) -> EnvFilter {
-    if debug {
-        EnvFilter::new("warn,pmat=debug")
-    } else {
-        EnvFilter::new("off")
-    }
-}
-
-/// Create filter for CLI mode
-fn create_cli_filter(cli: &cli::EarlyCliArgs) -> Result<EnvFilter> {
-    if let Some(ref custom) = cli.trace_filter {
-        return Ok(EnvFilter::try_new(custom)?);
     }
 
-    let filter_str = match (cli.trace, cli.debug, cli.verbose) {
-        (true, _, _) => "debug,pmat=trace",
-        (_, true, _) => "warn,pmat=debug",
-        (_, _, true) => "warn,pmat=info",
-        _ => return Ok(get_default_filter()),
-    };
-
-    Ok(EnvFilter::new(filter_str))
-}
-
-/// Get default production filter
-fn get_default_filter() -> EnvFilter {
-    EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("warn"))
-}
-
-#[tokio::main]
-#[allow(unreachable_pub)]
-pub async fn real_main() {
-    let exit_code = match run_main().await {
-        Ok(()) => ExitCode::Success,
-        Err(e) => {
-            error!("Error: {:#}", e);
-            categorize_error(&e)
+    /// Pure decision function for execution mode so it can be unit-tested
+    /// without touching real stdin / env vars (see GH-285 regression test).
+    fn classify_execution_mode(
+        mcp_version_env: bool,
+        no_args: bool,
+        stdin_is_pipe: bool,
+    ) -> ExecutionMode {
+        // Explicit MCP opt-in via env var always wins (e.g. Claude Desktop sets this).
+        if mcp_version_env {
+            return ExecutionMode::Mcp;
         }
-    };
 
-    if exit_code as i32 != 0 {
-        process::exit(exit_code.into());
-    }
-}
+        // GH-285: If the user ran bare `pmat` with stdin piped (e.g. `echo "" | pmat`)
+        // without opting into MCP via `MCP_VERSION`, previous behavior entered the MCP
+        // server and blocked forever on stdin. Treat that case the same as bare `pmat`
+        // on a terminal: print help and exit non-zero.
+        if no_args && stdin_is_pipe {
+            return ExecutionMode::HelpAndExit;
+        }
 
-fn categorize_error(error: &anyhow::Error) -> ExitCode {
-    let error_str = error.to_string().to_lowercase();
-
-    match () {
-        _ if is_quality_gate_error(&error_str) => ExitCode::QualityGateFailure,
-        _ if is_configuration_error(&error_str) => ExitCode::ConfigurationError,
-        _ if is_analysis_error(&error_str) => ExitCode::AnalysisError,
-        _ if is_permission_error(&error_str) => ExitCode::PermissionDenied,
-        _ => ExitCode::GeneralError,
-    }
-}
-
-fn is_quality_gate_error(error_str: &str) -> bool {
-    error_str.contains("quality gate") || error_str.contains("violation")
-}
-
-fn is_configuration_error(error_str: &str) -> bool {
-    error_str.contains("config") || error_str.contains("parse")
-}
-
-fn is_analysis_error(error_str: &str) -> bool {
-    error_str.contains("analysis") || error_str.contains("complexity")
-}
-
-fn is_permission_error(error_str: &str) -> bool {
-    error_str.contains("permission") || error_str.contains("access")
-}
-
-async fn run_main() -> Result<()> {
-    // Parse CLI to get tracing configuration early
-    let cli = cli::parse_early_for_tracing();
-
-    // Initialize enhanced tracing system
-    init_tracing(&cli)?;
-
-    // Only log to stdout if not running MCP server mode
-    if !cli.is_mcp_server {
-        info!(
-            "Starting PAIML MCP Agent Toolkit v{}",
-            env!("CARGO_PKG_VERSION")
-        );
-        debug!("Debug logging enabled");
-        trace!("Trace logging enabled");
+        ExecutionMode::Cli
     }
 
-    // Create shared template server
-    let server = Arc::new(StatelessTemplateServer::new()?);
+    /// Initialize the enhanced tracing system based on CLI flags
+    fn init_tracing(cli: &cli::EarlyCliArgs) -> Result<()> {
+        let filter = create_env_filter(cli)?;
 
-    if !cli.is_mcp_server {
-        debug!("Template server initialized");
+        tracing_subscriber::registry()
+            .with(filter)
+            .with(
+                tracing_subscriber::fmt::layer()
+                    .with_target(cli.debug || cli.trace)
+                    .with_thread_ids(cli.trace)
+                    .with_file(cli.trace)
+                    .with_line_number(cli.trace)
+                    .compact()
+                    .with_writer(std::io::stderr),
+            )
+            .init();
+
+        Ok(())
     }
 
-    match detect_execution_mode() {
-        ExecutionMode::Mcp => {
-            if !cli.is_mcp_server {
-                info!("Running unified MCP server (pmcp SDK)");
+    /// Create environment filter based on CLI flags
+    fn create_env_filter(cli: &cli::EarlyCliArgs) -> Result<EnvFilter> {
+        if cli.is_mcp_server {
+            Ok(create_mcp_filter(cli.debug))
+        } else {
+            create_cli_filter(cli)
+        }
+    }
+
+    /// Create filter for MCP server mode
+    fn create_mcp_filter(debug: bool) -> EnvFilter {
+        if debug {
+            EnvFilter::new("warn,pmat=debug")
+        } else {
+            EnvFilter::new("off")
+        }
+    }
+
+    /// Create filter for CLI mode
+    fn create_cli_filter(cli: &cli::EarlyCliArgs) -> Result<EnvFilter> {
+        if let Some(ref custom) = cli.trace_filter {
+            return Ok(EnvFilter::try_new(custom)?);
+        }
+
+        let filter_str = match (cli.trace, cli.debug, cli.verbose) {
+            (true, _, _) => "debug,pmat=trace",
+            (_, true, _) => "warn,pmat=debug",
+            (_, _, true) => "warn,pmat=info",
+            _ => return Ok(get_default_filter()),
+        };
+
+        Ok(EnvFilter::new(filter_str))
+    }
+
+    /// Get default production filter
+    fn get_default_filter() -> EnvFilter {
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("warn"))
+    }
+
+    #[tokio::main]
+    #[allow(unreachable_pub)]
+    pub async fn real_main() {
+        let exit_code = match run_main().await {
+            Ok(()) => ExitCode::Success,
+            Err(e) => {
+                error!("Error: {:#}", e);
+                categorize_error(&e)
             }
-            let unified_server = pmat::mcp_pmcp::UnifiedServer::new()
-                .map_err(|e| anyhow::anyhow!("Failed to create unified server: {}", e))?;
-            unified_server
-                .run()
-                .await
-                .map_err(|e| anyhow::anyhow!("{}", e))
+        };
+
+        if exit_code as i32 != 0 {
+            process::exit(exit_code.into());
         }
-        ExecutionMode::Cli => {
-            if !cli.is_mcp_server {
-                info!("Running in CLI mode");
-            }
-            cli::run(server).await
+    }
+
+    fn categorize_error(error: &anyhow::Error) -> ExitCode {
+        let error_str = error.to_string().to_lowercase();
+
+        match () {
+            _ if is_quality_gate_error(&error_str) => ExitCode::QualityGateFailure,
+            _ if is_configuration_error(&error_str) => ExitCode::ConfigurationError,
+            _ if is_analysis_error(&error_str) => ExitCode::AnalysisError,
+            _ if is_permission_error(&error_str) => ExitCode::PermissionDenied,
+            _ => ExitCode::GeneralError,
         }
-        ExecutionMode::HelpAndExit => {
-            // GH-285: No subcommand + piped stdin + no MCP_VERSION. Print help on
-            // stderr and exit with code 2 (misuse), matching the convention for
-            // "no command supplied" on a terminal.
-            let mut cmd = <pmat::cli::Cli as clap::CommandFactory>::command();
-            let _ = cmd.print_help();
-            eprintln!(
-                "\nerror: no subcommand given and stdin is not a terminal. \
-                 Set MCP_VERSION=1 (or run `pmat agent mcp-server`) to start the MCP server."
+    }
+
+    fn is_quality_gate_error(error_str: &str) -> bool {
+        error_str.contains("quality gate") || error_str.contains("violation")
+    }
+
+    fn is_configuration_error(error_str: &str) -> bool {
+        error_str.contains("config") || error_str.contains("parse")
+    }
+
+    fn is_analysis_error(error_str: &str) -> bool {
+        error_str.contains("analysis") || error_str.contains("complexity")
+    }
+
+    fn is_permission_error(error_str: &str) -> bool {
+        error_str.contains("permission") || error_str.contains("access")
+    }
+
+    async fn run_main() -> Result<()> {
+        // Parse CLI to get tracing configuration early
+        let cli = cli::parse_early_for_tracing();
+
+        // Initialize enhanced tracing system
+        init_tracing(&cli)?;
+
+        // Only log to stdout if not running MCP server mode
+        if !cli.is_mcp_server {
+            info!(
+                "Starting PAIML MCP Agent Toolkit v{}",
+                env!("CARGO_PKG_VERSION")
             );
-            process::exit(ExitCode::MisuseError as i32);
+            debug!("Debug logging enabled");
+            trace!("Trace logging enabled");
+        }
+
+        // Create shared template server
+        let server = Arc::new(StatelessTemplateServer::new()?);
+
+        if !cli.is_mcp_server {
+            debug!("Template server initialized");
+        }
+
+        match detect_execution_mode() {
+            ExecutionMode::Mcp => {
+                if !cli.is_mcp_server {
+                    info!("Running unified MCP server (pmcp SDK)");
+                }
+                let unified_server = pmat::mcp_pmcp::UnifiedServer::new()
+                    .map_err(|e| anyhow::anyhow!("Failed to create unified server: {}", e))?;
+                unified_server
+                    .run()
+                    .await
+                    .map_err(|e| anyhow::anyhow!("{}", e))
+            }
+            ExecutionMode::Cli => {
+                if !cli.is_mcp_server {
+                    info!("Running in CLI mode");
+                }
+                cli::run(server).await
+            }
+            ExecutionMode::HelpAndExit => {
+                // GH-285: No subcommand + piped stdin + no MCP_VERSION. Print help on
+                // stderr and exit with code 2 (misuse), matching the convention for
+                // "no command supplied" on a terminal.
+                let mut cmd = <pmat::cli::Cli as clap::CommandFactory>::command();
+                let _ = cmd.print_help();
+                eprintln!(
+                    "\nerror: no subcommand given and stdin is not a terminal. \
+                 Set MCP_VERSION=1 (or run `pmat agent mcp-server`) to start the MCP server."
+                );
+                process::exit(ExitCode::MisuseError as i32);
+            }
         }
     }
-}
 
-#[cfg_attr(coverage_nightly, coverage(off))]
-#[cfg(test)]
-mod gh285_tests {
-    //! Regression tests for GH-285: `pmat` hangs when invoked with no args
-    //! and stdin is a pipe. See `classify_execution_mode`.
-    //!
-    //! Manual end-to-end repro (should NOT hang or exit 124):
-    //! ```text
-    //! echo "" | timeout 3 target/debug/pmat 2>&1; echo exit=$?
-    //! timeout 3 target/debug/pmat < /dev/null; echo exit=$?
-    //! ```
-    //! Both should print help and exit with code 2.
-    use super::{classify_execution_mode, ExecutionMode};
+    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg(test)]
+    mod gh285_tests {
+        //! Regression tests for GH-285: `pmat` hangs when invoked with no args
+        //! and stdin is a pipe. See `classify_execution_mode`.
+        //!
+        //! Manual end-to-end repro (should NOT hang or exit 124):
+        //! ```text
+        //! echo "" | timeout 3 target/debug/pmat 2>&1; echo exit=$?
+        //! timeout 3 target/debug/pmat < /dev/null; echo exit=$?
+        //! ```
+        //! Both should print help and exit with code 2.
+        use super::{classify_execution_mode, ExecutionMode};
 
-    #[test]
-    fn bare_invocation_on_tty_is_cli() {
-        // `pmat` typed into a terminal with no pipe -> normal CLI (clap
-        // will then print help on missing subcommand).
-        assert!(matches!(
-            classify_execution_mode(false, true, false),
-            ExecutionMode::Cli
-        ));
+        #[test]
+        fn bare_invocation_on_tty_is_cli() {
+            // `pmat` typed into a terminal with no pipe -> normal CLI (clap
+            // will then print help on missing subcommand).
+            assert!(matches!(
+                classify_execution_mode(false, true, false),
+                ExecutionMode::Cli
+            ));
+        }
+
+        #[test]
+        fn piped_stdin_with_no_args_prints_help_instead_of_hanging() {
+            // GH-285: This used to enter MCP mode and block on stdin forever.
+            assert!(matches!(
+                classify_execution_mode(false, true, true),
+                ExecutionMode::HelpAndExit
+            ));
+        }
+
+        #[test]
+        fn explicit_mcp_version_env_still_enters_mcp_mode() {
+            // Claude Desktop and similar hosts set MCP_VERSION; they must still
+            // get the MCP server regardless of TTY state.
+            assert!(matches!(
+                classify_execution_mode(true, true, true),
+                ExecutionMode::Mcp
+            ));
+            assert!(matches!(
+                classify_execution_mode(true, false, false),
+                ExecutionMode::Mcp
+            ));
+        }
+
+        #[test]
+        fn subcommand_with_piped_stdin_is_still_cli() {
+            // `echo foo | pmat analyze ...` must dispatch to the CLI subcommand,
+            // not to help-and-exit.
+            assert!(matches!(
+                classify_execution_mode(false, false, true),
+                ExecutionMode::Cli
+            ));
+        }
     }
-
-    #[test]
-    fn piped_stdin_with_no_args_prints_help_instead_of_hanging() {
-        // GH-285: This used to enter MCP mode and block on stdin forever.
-        assert!(matches!(
-            classify_execution_mode(false, true, true),
-            ExecutionMode::HelpAndExit
-        ));
-    }
-
-    #[test]
-    fn explicit_mcp_version_env_still_enters_mcp_mode() {
-        // Claude Desktop and similar hosts set MCP_VERSION; they must still
-        // get the MCP server regardless of TTY state.
-        assert!(matches!(
-            classify_execution_mode(true, true, true),
-            ExecutionMode::Mcp
-        ));
-        assert!(matches!(
-            classify_execution_mode(true, false, false),
-            ExecutionMode::Mcp
-        ));
-    }
-
-    #[test]
-    fn subcommand_with_piped_stdin_is_still_cli() {
-        // `echo foo | pmat analyze ...` must dispatch to the CLI subcommand,
-        // not to help-and-exit.
-        assert!(matches!(
-            classify_execution_mode(false, false, true),
-            ExecutionMode::Cli
-        ));
-    }
-}
 } // end of mod full
 
 #[cfg(feature = "standard-deps")]

--- a/src/cli/analysis_utilities/tdg.rs
+++ b/src/cli/analysis_utilities/tdg.rs
@@ -15,3 +15,292 @@ include!("tdg_watch.rs");
 
 // Main entry point and orchestration
 include!("tdg_handler.rs");
+
+#[cfg(test)]
+mod tdg_formatting_tests {
+    //! PMAT-649: cover tdg_formatting.rs pure helpers.
+    use super::*;
+    use crate::cli::TdgOutputFormat;
+    use crate::models::tdg::{TDGComponents, TDGHotspot, TDGScore, TDGSeverity, TDGSummary};
+
+    fn summary_zero() -> TDGSummary {
+        TDGSummary {
+            total_files: 0,
+            critical_files: 0,
+            warning_files: 0,
+            average_tdg: 0.0,
+            p95_tdg: 0.0,
+            p99_tdg: 0.0,
+            estimated_debt_hours: 0.0,
+            hotspots: Vec::new(),
+        }
+    }
+
+    fn summary_with(total: usize, critical: usize, warning: usize, avg: f64) -> TDGSummary {
+        TDGSummary {
+            total_files: total,
+            critical_files: critical,
+            warning_files: warning,
+            average_tdg: avg,
+            p95_tdg: avg * 1.2,
+            p99_tdg: avg * 1.5,
+            estimated_debt_hours: 100.0,
+            hotspots: Vec::new(),
+        }
+    }
+
+    fn hotspot(path: &str, tdg: f64) -> TDGHotspot {
+        TDGHotspot {
+            path: path.to_string(),
+            tdg_score: tdg,
+            primary_factor: "Complexity".to_string(),
+            estimated_hours: 5.0,
+        }
+    }
+
+    // --- format_empty_results: all 4 format arms ---
+
+    #[test]
+    fn test_format_empty_results_table() {
+        let out = format_empty_results(TdgOutputFormat::Table);
+        assert!(out.contains("No files found"));
+    }
+
+    #[test]
+    fn test_format_empty_results_json_is_valid_json() {
+        let out = format_empty_results(TdgOutputFormat::Json);
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["summary"]["total_files"], 0);
+    }
+
+    #[test]
+    fn test_format_empty_results_markdown_has_header() {
+        let out = format_empty_results(TdgOutputFormat::Markdown);
+        assert!(out.starts_with("# Technical Debt Gradient Analysis"));
+        assert!(out.contains("No files found"));
+    }
+
+    #[test]
+    fn test_format_empty_results_sarif_is_valid_json() {
+        let out = format_empty_results(TdgOutputFormat::Sarif);
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["version"], "2.1.0");
+    }
+
+    // --- format_output_from_summary dispatches to each format ---
+
+    #[test]
+    fn test_format_output_from_summary_table_dispatch() {
+        let s = summary_zero();
+        let out = format_output_from_summary(&s, TdgOutputFormat::Table, false, false).unwrap();
+        assert!(out.contains("# Technical Debt Gradient"));
+    }
+
+    #[test]
+    fn test_format_output_from_summary_json_dispatch() {
+        let s = summary_zero();
+        let out = format_output_from_summary(&s, TdgOutputFormat::Json, false, false).unwrap();
+        let _: serde_json::Value = serde_json::from_str(&out).unwrap();
+    }
+
+    #[test]
+    fn test_format_output_from_summary_markdown_dispatch() {
+        let s = summary_zero();
+        let out = format_output_from_summary(&s, TdgOutputFormat::Markdown, false, false).unwrap();
+        assert!(out.contains("# Technical Debt Gradient Analysis"));
+    }
+
+    #[test]
+    fn test_format_output_from_summary_sarif_dispatch() {
+        let s = summary_zero();
+        let out = format_output_from_summary(&s, TdgOutputFormat::Sarif, false, false).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert!(v["runs"][0]["tool"]["driver"]["name"].as_str() == Some("pmat-tdg"));
+    }
+
+    // --- format_table_output ---
+
+    #[test]
+    fn test_format_table_output_no_files_skips_percentage_lines() {
+        let s = summary_zero();
+        let out = format_table_output(&s, false, false);
+        assert!(out.contains("Total Files Analyzed"));
+        // When total_files==0, percentage lines are omitted.
+        assert!(!out.contains("Critical Files"));
+    }
+
+    #[test]
+    fn test_format_table_output_with_files_emits_percentages() {
+        let s = summary_with(10, 1, 2, 1.5);
+        let out = format_table_output(&s, false, false);
+        assert!(out.contains("Critical Files**: 1 (10.0%)"));
+        assert!(out.contains("Warning Files**: 2 (20.0%)"));
+        assert!(out.contains("Average TDG**: 1.50"));
+    }
+
+    #[test]
+    fn test_format_table_output_hotspots_emitted_when_present() {
+        let mut s = summary_with(5, 1, 0, 1.0);
+        s.hotspots = vec![hotspot("src/a.rs", 2.5)];
+        let out = format_table_output(&s, false, false);
+        assert!(out.contains("## Top Hotspots"));
+        assert!(out.contains("src/a.rs"));
+        assert!(out.contains("2.50"));
+    }
+
+    #[test]
+    fn test_format_table_output_components_only_when_include_and_verbose() {
+        let s = summary_with(5, 0, 0, 1.0);
+        let with = format_table_output(&s, true, true);
+        assert!(with.contains("## Component Weights"));
+        let without_verbose = format_table_output(&s, true, false);
+        assert!(!without_verbose.contains("## Component Weights"));
+        let without_include = format_table_output(&s, false, true);
+        assert!(!without_include.contains("## Component Weights"));
+    }
+
+    // --- format_json_output ---
+
+    #[test]
+    fn test_format_json_output_without_components_has_null_components_field() {
+        let s = summary_with(3, 0, 0, 1.0);
+        let out = format_json_output(&s, false);
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["summary"]["total_files"], 3);
+        assert!(v["components"].is_null());
+    }
+
+    #[test]
+    fn test_format_json_output_with_components_has_weights() {
+        let s = summary_with(3, 0, 0, 1.0);
+        let out = format_json_output(&s, true);
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["components"]["complexity_weight"], 0.30);
+        assert_eq!(v["components"]["churn_weight"], 0.35);
+    }
+
+    // --- format_markdown_output ---
+
+    #[test]
+    fn test_format_markdown_output_without_components() {
+        let s = summary_with(5, 1, 2, 1.2);
+        let out = format_markdown_output(&s, false);
+        assert!(out.contains("# Technical Debt Gradient Analysis"));
+        assert!(out.contains("## Summary"));
+        assert!(out.contains("Total Files**: 5"));
+        assert!(!out.contains("## TDG Components"));
+    }
+
+    #[test]
+    fn test_format_markdown_output_with_components_includes_section() {
+        let s = summary_with(5, 0, 0, 1.0);
+        let out = format_markdown_output(&s, true);
+        assert!(out.contains("## TDG Components"));
+        assert!(out.contains("Complexity** (30%)"));
+    }
+
+    #[test]
+    fn test_format_markdown_output_zero_total_skips_file_stats() {
+        let s = summary_zero();
+        let out = format_markdown_output(&s, false);
+        assert!(!out.contains("Critical Files"));
+        // But still has TDG stats and header.
+        assert!(out.contains("Average TDG"));
+    }
+
+    #[test]
+    fn test_format_markdown_output_hotspots_enumerated() {
+        let mut s = summary_with(5, 1, 0, 1.0);
+        s.hotspots = vec![hotspot("src/a.rs", 3.0), hotspot("src/b.rs", 2.0)];
+        let out = format_markdown_output(&s, false);
+        assert!(out.contains("## Hotspots"));
+        assert!(out.contains("### 1. src/a.rs"));
+        assert!(out.contains("### 2. src/b.rs"));
+    }
+
+    // --- format_sarif_output ---
+
+    #[test]
+    fn test_format_sarif_output_empty_hotspots_has_zero_results() {
+        let s = summary_zero();
+        let out = format_sarif_output(&s);
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["runs"][0]["results"].as_array().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn test_format_sarif_output_high_tdg_is_error_level() {
+        let mut s = summary_with(2, 1, 0, 3.0);
+        s.hotspots = vec![hotspot("src/critical.rs", 3.5)];
+        let out = format_sarif_output(&s);
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        let level = v["runs"][0]["results"][0]["level"].as_str().unwrap();
+        assert_eq!(level, "error");
+    }
+
+    #[test]
+    fn test_format_sarif_output_low_tdg_is_warning_level() {
+        let mut s = summary_with(2, 0, 1, 2.0);
+        s.hotspots = vec![hotspot("src/warn.rs", 2.0)];
+        let out = format_sarif_output(&s);
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        let level = v["runs"][0]["results"][0]["level"].as_str().unwrap();
+        assert_eq!(level, "warning");
+    }
+
+    #[test]
+    fn test_format_sarif_output_contains_rule_metadata() {
+        let s = summary_zero();
+        let out = format_sarif_output(&s);
+        assert!(out.contains("TDG001"));
+        assert!(out.contains("HighTechnicalDebtGradient"));
+    }
+
+    // --- format_tdg_single_file_output ---
+
+    fn score_with(value: f64, severity: TDGSeverity) -> TDGScore {
+        TDGScore {
+            value,
+            components: TDGComponents::default(),
+            severity,
+            percentile: 50.0,
+            confidence: 0.8,
+        }
+    }
+
+    #[test]
+    fn test_format_tdg_single_file_output_critical_flags_critical_count() {
+        let score = score_with(3.0, TDGSeverity::Critical);
+        let path = std::path::Path::new("src/x.rs");
+        let out =
+            format_tdg_single_file_output(&score, path, TdgOutputFormat::Json, false, false)
+                .unwrap();
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["summary"]["critical_files"], 1);
+        assert_eq!(v["summary"]["warning_files"], 0);
+    }
+
+    #[test]
+    fn test_format_tdg_single_file_output_warning_flags_warning_count() {
+        let score = score_with(2.0, TDGSeverity::Warning);
+        let path = std::path::Path::new("src/y.rs");
+        let out =
+            format_tdg_single_file_output(&score, path, TdgOutputFormat::Json, false, false)
+                .unwrap();
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["summary"]["critical_files"], 0);
+        assert_eq!(v["summary"]["warning_files"], 1);
+    }
+
+    #[test]
+    fn test_format_tdg_single_file_output_normal_flags_neither() {
+        let score = score_with(1.0, TDGSeverity::Normal);
+        let path = std::path::Path::new("src/z.rs");
+        let out =
+            format_tdg_single_file_output(&score, path, TdgOutputFormat::Json, false, false)
+                .unwrap();
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["summary"]["critical_files"], 0);
+        assert_eq!(v["summary"]["warning_files"], 0);
+    }
+}

--- a/src/entropy/pattern_extractor_tests.rs
+++ b/src/entropy/pattern_extractor_tests.rs
@@ -845,7 +845,10 @@ fn test_calculate_pattern_match_variation_score_short_circuits_single_match() {
 
     let score =
         extractor.calculate_pattern_match_variation_score(&enums, &matches, &arrows, content);
-    assert_eq!(score, 0.0, "fewer than 2 match blocks must short-circuit to 0.0");
+    assert_eq!(
+        score, 0.0,
+        "fewer than 2 match blocks must short-circuit to 0.0"
+    );
 }
 
 /// pattern_extractor_ruchy.rs:405 — enum_matches.len() <= 1 low-variation arm (0.3).

--- a/src/maintenance/updater.rs
+++ b/src/maintenance/updater.rs
@@ -375,9 +375,13 @@ mod tests {
             files: vec!["src/lib.rs".into()], // no ticket file
         };
 
-        let result =
-            process_ticket_update(&mut roadmap, &commit, "TICKET-PMAT-5013", tickets_dir.path())
-                .unwrap();
+        let result = process_ticket_update(
+            &mut roadmap,
+            &commit,
+            "TICKET-PMAT-5013",
+            tickets_dir.path(),
+        )
+        .unwrap();
         assert!(!result, "must short-circuit when ticket file not in commit");
         assert!(!roadmap.sprints[0].tickets[0].completed);
     }
@@ -394,10 +398,17 @@ mod tests {
             files: vec!["docs/tickets/TICKET-PMAT-5013.md".into()],
         };
 
-        let result =
-            process_ticket_update(&mut roadmap, &commit, "TICKET-PMAT-5013", tickets_dir.path())
-                .unwrap();
-        assert!(!result, "missing ticket file must return Ok(false), not error");
+        let result = process_ticket_update(
+            &mut roadmap,
+            &commit,
+            "TICKET-PMAT-5013",
+            tickets_dir.path(),
+        )
+        .unwrap();
+        assert!(
+            !result,
+            "missing ticket file must return Ok(false), not error"
+        );
         assert!(!roadmap.sprints[0].tickets[0].completed);
     }
 
@@ -417,11 +428,7 @@ mod tests {
              Still failing.\n\n\
              ## Success Criteria\n\n\
              - [ ] One\n";
-        std::fs::write(
-            tickets_dir.path().join("TICKET-PMAT-5013.md"),
-            red_content,
-        )
-        .unwrap();
+        std::fs::write(tickets_dir.path().join("TICKET-PMAT-5013.md"), red_content).unwrap();
         let mut roadmap = create_test_roadmap();
         let commit = CommitInfo {
             hash: "deadbee".into(),
@@ -429,9 +436,13 @@ mod tests {
             files: vec!["docs/tickets/TICKET-PMAT-5013.md".into()],
         };
 
-        let result =
-            process_ticket_update(&mut roadmap, &commit, "TICKET-PMAT-5013", tickets_dir.path())
-                .unwrap();
+        let result = process_ticket_update(
+            &mut roadmap,
+            &commit,
+            "TICKET-PMAT-5013",
+            tickets_dir.path(),
+        )
+        .unwrap();
         assert!(!result, "RED ticket must not mark roadmap completed");
         assert!(!roadmap.sprints[0].tickets[0].completed);
     }
@@ -450,9 +461,13 @@ mod tests {
             files: vec!["docs/tickets/TICKET-PMAT-5013.md".into()],
         };
 
-        let result =
-            process_ticket_update(&mut roadmap, &commit, "TICKET-PMAT-5013", tickets_dir.path())
-                .unwrap();
+        let result = process_ticket_update(
+            &mut roadmap,
+            &commit,
+            "TICKET-PMAT-5013",
+            tickets_dir.path(),
+        )
+        .unwrap();
         assert!(result, "GREEN ticket must flip roadmap entry");
         assert!(roadmap.sprints[0].tickets[0].completed);
         assert_eq!(

--- a/src/mcp_pmcp/agent_context_handlers.rs
+++ b/src/mcp_pmcp/agent_context_handlers.rs
@@ -37,11 +37,7 @@ macro_rules! impl_pmat_handler {
 
         #[async_trait]
         impl ToolHandler for $wrapper {
-            async fn handle(
-                &self,
-                args: Value,
-                _extra: RequestHandlerExtra,
-            ) -> PmcpResult<Value> {
+            async fn handle(&self, args: Value, _extra: RequestHandlerExtra) -> PmcpResult<Value> {
                 self.inner.execute(args).await.map_err(PmcpError::internal)
             }
 

--- a/src/mcp_pmcp/analyze_handlers.rs
+++ b/src/mcp_pmcp/analyze_handlers.rs
@@ -32,7 +32,8 @@ use tracing::debug;
 // MCP tools (see R15 #3 bench matrix).
 pub use self::{
     ComplexityTool as AnalyzeComplexityTool, DeadCodeTool as AnalyzeDeadCodeTool,
-    SatdTool as AnalyzeSatdTool, TdgCompareTool as AnalyzeTdgCompareTool, TdgTool as AnalyzeTdgTool,
+    SatdTool as AnalyzeSatdTool, TdgCompareTool as AnalyzeTdgCompareTool,
+    TdgTool as AnalyzeTdgTool,
 };
 
 // Complexity analysis tool handler

--- a/src/mcp_pmcp/mod.rs
+++ b/src/mcp_pmcp/mod.rs
@@ -103,12 +103,12 @@ pub mod quality_handlers;
 pub mod quality_proxy_handler;
 pub mod server;
 pub mod simple_unified_server;
-pub mod tool_schemas;
 #[cfg_attr(coverage_nightly, coverage(off))]
 #[cfg(test)]
 pub mod tdg_git_context_tests;
 pub mod tdg_handlers;
 pub mod tool_functions;
+pub mod tool_schemas;
 pub mod tool_schemas_generated; // KAIZEN-0178: build.rs-generated tool schema registry
 pub mod tools; // Sprint 65 Phase 2B: MCP git-context integration
 

--- a/src/mcp_pmcp/tool_schemas.rs
+++ b/src/mcp_pmcp/tool_schemas.rs
@@ -45,7 +45,10 @@ pub fn paths_object_schema(extra_properties: Value, required: Vec<&str>) -> Valu
             base.insert(k.clone(), v.clone());
         }
     }
-    let req: Vec<Value> = required.into_iter().map(|s| Value::String(s.into())).collect();
+    let req: Vec<Value> = required
+        .into_iter()
+        .map(|s| Value::String(s.into()))
+        .collect();
     json!({
         "type": "object",
         "properties": base_props,


### PR DESCRIPTION
## Summary

Continues Phase-1 CLI pivot after PR #513/PMAT-648. \`tdg_formatting.rs\` is 294 lines, **232/232 missed** on master broad. Pure output formatting — 0 async.

**25 new tests** covering:

- \`format_empty_results\` all 4 formats (table/json/markdown/sarif)
- \`format_output_from_summary\` dispatches each TdgOutputFormat variant
- \`format_table_output\`: zero-total skips %, with-files emits %, hotspots conditional, component weights only when include+verbose truth-table
- \`format_json_output\`: components null vs populated
- \`format_markdown_output\`: header, summary section, zero-total file-stats skip, hotspots enumerated
- \`format_sarif_output\`: 0 results when empty, error vs warning level by TDG threshold, rule metadata
- \`format_tdg_single_file_output\`: Critical/Warning/Normal severity mapping

## Coverage impact

Expected delta: **~+0.07pp** on broad.

## Test plan

- [x] \`cargo test --lib -- tdg_formatting_tests\` — 25 passed, 0 failed
- [x] \`cargo fmt --all -- --check\` — clean
- [ ] CI gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)