### PR TITLE
test(coverage): churn.rs pure formatting helpers (PMAT-650)

### DIFF
--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -3217,7 +3217,7 @@ roadmap:
   github_issue: null
   item_type: task
   title: 'Phase 1 pivot: cli/analysis_utilities/churn.rs coverage'
-  status: inprogress
+  status: review
   priority: medium
   assigned_to: null
   created: 2026-04-24T09:09:02Z

--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -3213,3 +3213,20 @@ roadmap:
   estimated_effort: null
   labels: []
   notes: null
+- id: PMAT-650
+  github_issue: null
+  item_type: task
+  title: 'Phase 1 pivot: cli/analysis_utilities/churn.rs coverage'
+  status: inprogress
+  priority: medium
+  assigned_to: null
+  created: 2026-04-24T09:09:02Z
+  updated: 2026-04-24T09:09:02Z
+  spec: null
+  acceptance_criteria:
+  - 'Phase 1 CLI pivot — churn.rs is 498 lines, 230/230 missed on master broad. Pure formatting fns only (handle_analyze_churn + write_churn_output are async but everything else is sync). Cover format_churn_as_{json,summary,markdown,csv} integration, format_churn_content dispatch (4 ChurnOutputFormat arms), apply_churn_file_filtering (top_files=0 keeps all, top_files>=len no-op, top_files<len truncates with sort), write_summary_{top_files,hotspot_files,stable_files,top_contributors} empty-vs-populated, write_markdown_recommendations static content, write_*_row helpers (commits/files_changed/hotspot/stable/authors).'
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels: []
+  notes: null

--- a/examples/mcp_agent_context_demo.rs
+++ b/examples/mcp_agent_context_demo.rs
@@ -54,68 +54,132 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     thread::sleep(Duration::from_secs(10));
 
     // 1. initialize handshake
-    let resp = rpc(&mut writer, &mut reader, 1, "initialize", json!({
-        "protocolVersion": "2024-11-05",
-        "capabilities": {},
-        "clientInfo": { "name": "mcp_agent_context_demo", "version": "1.0" }
-    }))?;
-    let server_info = resp.pointer("/result/serverInfo/name").cloned().unwrap_or(json!("?"));
+    let resp = rpc(
+        &mut writer,
+        &mut reader,
+        1,
+        "initialize",
+        json!({
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": { "name": "mcp_agent_context_demo", "version": "1.0" }
+        }),
+    )?;
+    let server_info = resp
+        .pointer("/result/serverInfo/name")
+        .cloned()
+        .unwrap_or(json!("?"));
     println!("[initialize] server={}", server_info);
 
     // 2. tools/list — sanity check that the 4 pmat_* tools are registered
     let resp = rpc(&mut writer, &mut reader, 2, "tools/list", json!({}))?;
-    let tools = resp.pointer("/result/tools").and_then(|v| v.as_array()).cloned().unwrap_or_default();
-    let pmat_tools: Vec<&str> = tools.iter()
+    let tools = resp
+        .pointer("/result/tools")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+    let pmat_tools: Vec<&str> = tools
+        .iter()
         .filter_map(|t| t.get("name").and_then(|n| n.as_str()))
         .filter(|n| n.starts_with("pmat_"))
         .collect();
-    println!("[tools/list] total={} pmat_*={} ({:?})", tools.len(), pmat_tools.len(), pmat_tools);
+    println!(
+        "[tools/list] total={} pmat_*={} ({:?})",
+        tools.len(),
+        pmat_tools.len(),
+        pmat_tools
+    );
 
     // 3. pmat_index_stats — pick up a real function_id we can reuse below
-    let resp = call_tool(&mut writer, &mut reader, 3, "pmat_index_stats",
-        json!({ "rebuild": false }))?;
+    let resp = call_tool(
+        &mut writer,
+        &mut reader,
+        3,
+        "pmat_index_stats",
+        json!({ "rebuild": false }),
+    )?;
     let index_result = extract_tool_result(&resp);
-    let fn_count = index_result.pointer("/manifest/function_count").cloned().unwrap_or(json!(0));
-    let file_count = index_result.pointer("/manifest/file_count").cloned().unwrap_or(json!(0));
-    println!("[pmat_index_stats] ok: functions={} files={}", fn_count, file_count);
+    let fn_count = index_result
+        .pointer("/manifest/function_count")
+        .cloned()
+        .unwrap_or(json!(0));
+    let file_count = index_result
+        .pointer("/manifest/file_count")
+        .cloned()
+        .unwrap_or(json!(0));
+    println!(
+        "[pmat_index_stats] ok: functions={} files={}",
+        fn_count, file_count
+    );
 
     // 4. pmat_query_code — realistic semantic query
-    let resp = call_tool(&mut writer, &mut reader, 4, "pmat_query_code",
-        json!({ "query": "error handling", "limit": 3 }))?;
+    let resp = call_tool(
+        &mut writer,
+        &mut reader,
+        4,
+        "pmat_query_code",
+        json!({ "query": "error handling", "limit": 3 }),
+    )?;
     let query_result = extract_tool_result(&resp);
-    let result_count = query_result.get("results")
+    let result_count = query_result
+        .get("results")
         .or_else(|| query_result.get("functions"))
         .and_then(|v| v.as_array())
         .map(|a| a.len())
         .unwrap_or(0);
-    let first_id = query_result.pointer("/results/0/id")
+    let first_id = query_result
+        .pointer("/results/0/id")
         .or_else(|| query_result.pointer("/functions/0/id"))
         .and_then(|v| v.as_str())
         .map(|s| s.to_string());
-    println!("[pmat_query_code] ok: {} results; first_id={:?}", result_count, first_id);
+    println!(
+        "[pmat_query_code] ok: {} results; first_id={:?}",
+        result_count, first_id
+    );
 
     // 5. pmat_get_function — use the first id from query_code, or fall back to "main"
-    let function_id = first_id.clone().unwrap_or_else(|| "src/bin/pmat.rs::main".to_string());
-    let resp = call_tool(&mut writer, &mut reader, 5, "pmat_get_function",
-        json!({ "function_id": function_id, "include_source": false }))?;
+    let function_id = first_id
+        .clone()
+        .unwrap_or_else(|| "src/bin/pmat.rs::main".to_string());
+    let resp = call_tool(
+        &mut writer,
+        &mut reader,
+        5,
+        "pmat_get_function",
+        json!({ "function_id": function_id, "include_source": false }),
+    )?;
     match resp.get("error") {
-        Some(err) => println!("[pmat_get_function] graceful miss for {:?}: {}", function_id,
-            err.get("message").and_then(|m| m.as_str()).unwrap_or("?")),
+        Some(err) => println!(
+            "[pmat_get_function] graceful miss for {:?}: {}",
+            function_id,
+            err.get("message").and_then(|m| m.as_str()).unwrap_or("?")
+        ),
         None => {
             let gf = extract_tool_result(&resp);
-            println!("[pmat_get_function] ok: name={} grade={}",
+            println!(
+                "[pmat_get_function] ok: name={} grade={}",
                 gf.get("name").and_then(|v| v.as_str()).unwrap_or("?"),
-                gf.pointer("/quality/grade").and_then(|v| v.as_str()).unwrap_or("?"));
+                gf.pointer("/quality/grade")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("?")
+            );
         }
     }
 
     // 6. pmat_find_similar — only meaningful if we got a real id from the query
     if let Some(id) = first_id {
-        let resp = call_tool(&mut writer, &mut reader, 6, "pmat_find_similar",
-            json!({ "function_id": id, "limit": 3, "min_similarity": 0.3 }))?;
+        let resp = call_tool(
+            &mut writer,
+            &mut reader,
+            6,
+            "pmat_find_similar",
+            json!({ "function_id": id, "limit": 3, "min_similarity": 0.3 }),
+        )?;
         match resp.get("error") {
-            Some(err) => println!("[pmat_find_similar] error: {}",
-                err.get("message").and_then(|m| m.as_str()).unwrap_or("?")),
+            Some(err) => println!(
+                "[pmat_find_similar] error: {}",
+                err.get("message").and_then(|m| m.as_str()).unwrap_or("?")
+            ),
             None => {
                 let sim = extract_tool_result(&resp);
                 let total = sim.get("total").and_then(|v| v.as_u64()).unwrap_or(0);
@@ -162,7 +226,13 @@ fn call_tool(
     name: &str,
     args: Value,
 ) -> Result<Value, Box<dyn std::error::Error>> {
-    rpc(writer, reader, id, "tools/call", json!({ "name": name, "arguments": args }))
+    rpc(
+        writer,
+        reader,
+        id,
+        "tools/call",
+        json!({ "name": name, "arguments": args }),
+    )
 }
 
 /// MCP `tools/call` wraps results in `result.content[0].text` (JSON string) or
@@ -171,7 +241,10 @@ fn extract_tool_result(resp: &Value) -> Value {
     if let Some(sc) = resp.pointer("/result/structuredContent") {
         return sc.clone();
     }
-    if let Some(text) = resp.pointer("/result/content/0/text").and_then(|v| v.as_str()) {
+    if let Some(text) = resp
+        .pointer("/result/content/0/text")
+        .and_then(|v| v.as_str())
+    {
         if let Ok(parsed) = serde_json::from_str::<Value>(text) {
             return parsed;
         }

--- a/src/bin/pmat.rs
+++ b/src/bin/pmat.rs
@@ -16,301 +16,301 @@ fn main() {
 
 #[cfg(feature = "standard-deps")]
 mod full {
-use anyhow::Result;
-use pmat::{cli, stateless_server::StatelessTemplateServer};
-use std::io::IsTerminal;
-use std::process;
-use std::sync::Arc;
-use tracing::{debug, error, info, trace};
-use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
+    use anyhow::Result;
+    use pmat::{cli, stateless_server::StatelessTemplateServer};
+    use std::io::IsTerminal;
+    use std::process;
+    use std::sync::Arc;
+    use tracing::{debug, error, info, trace};
+    use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 
-enum ExecutionMode {
-    Mcp,
-    Cli,
-    /// No subcommand given and stdin is piped (not a TTY) without an explicit
-    /// MCP opt-in. Print help and exit non-zero instead of blocking on stdin
-    /// (see GH-285).
-    HelpAndExit,
-}
-
-/// POSIX-compliant exit codes for CLI interface
-/// Per SPECIFICATION.md Section 23: CLI Interface
-#[derive(Debug, Clone, Copy)]
-pub enum ExitCode {
-    /// Success
-    Success = 0,
-    /// General error
-    GeneralError = 1,
-    /// Misuse of shell command
-    MisuseError = 2,
-    /// Permission denied
-    PermissionDenied = 126,
-    /// Command not found
-    CommandNotFound = 127,
-    /// Invalid argument to exit
-    InvalidExitArg = 128,
-    /// Quality gate failure (custom)
-    QualityGateFailure = 3,
-    /// Configuration error (custom)
-    ConfigurationError = 4,
-    /// Analysis error (custom)
-    AnalysisError = 5,
-}
-
-impl From<ExitCode> for i32 {
-    fn from(code: ExitCode) -> Self {
-        code as i32
-    }
-}
-
-fn detect_execution_mode() -> ExecutionMode {
-    classify_execution_mode(
-        std::env::var("MCP_VERSION").is_ok(),
-        std::env::args().len() == 1,
-        !std::io::stdin().is_terminal(),
-    )
-}
-
-/// Pure decision function for execution mode so it can be unit-tested
-/// without touching real stdin / env vars (see GH-285 regression test).
-fn classify_execution_mode(
-    mcp_version_env: bool,
-    no_args: bool,
-    stdin_is_pipe: bool,
-) -> ExecutionMode {
-    // Explicit MCP opt-in via env var always wins (e.g. Claude Desktop sets this).
-    if mcp_version_env {
-        return ExecutionMode::Mcp;
+    enum ExecutionMode {
+        Mcp,
+        Cli,
+        /// No subcommand given and stdin is piped (not a TTY) without an explicit
+        /// MCP opt-in. Print help and exit non-zero instead of blocking on stdin
+        /// (see GH-285).
+        HelpAndExit,
     }
 
-    // GH-285: If the user ran bare `pmat` with stdin piped (e.g. `echo "" | pmat`)
-    // without opting into MCP via `MCP_VERSION`, previous behavior entered the MCP
-    // server and blocked forever on stdin. Treat that case the same as bare `pmat`
-    // on a terminal: print help and exit non-zero.
-    if no_args && stdin_is_pipe {
-        return ExecutionMode::HelpAndExit;
+    /// POSIX-compliant exit codes for CLI interface
+    /// Per SPECIFICATION.md Section 23: CLI Interface
+    #[derive(Debug, Clone, Copy)]
+    pub enum ExitCode {
+        /// Success
+        Success = 0,
+        /// General error
+        GeneralError = 1,
+        /// Misuse of shell command
+        MisuseError = 2,
+        /// Permission denied
+        PermissionDenied = 126,
+        /// Command not found
+        CommandNotFound = 127,
+        /// Invalid argument to exit
+        InvalidExitArg = 128,
+        /// Quality gate failure (custom)
+        QualityGateFailure = 3,
+        /// Configuration error (custom)
+        ConfigurationError = 4,
+        /// Analysis error (custom)
+        AnalysisError = 5,
     }
 
-    ExecutionMode::Cli
-}
+    impl From<ExitCode> for i32 {
+        fn from(code: ExitCode) -> Self {
+            code as i32
+        }
+    }
 
-/// Initialize the enhanced tracing system based on CLI flags
-fn init_tracing(cli: &cli::EarlyCliArgs) -> Result<()> {
-    let filter = create_env_filter(cli)?;
-
-    tracing_subscriber::registry()
-        .with(filter)
-        .with(
-            tracing_subscriber::fmt::layer()
-                .with_target(cli.debug || cli.trace)
-                .with_thread_ids(cli.trace)
-                .with_file(cli.trace)
-                .with_line_number(cli.trace)
-                .compact()
-                .with_writer(std::io::stderr),
+    fn detect_execution_mode() -> ExecutionMode {
+        classify_execution_mode(
+            std::env::var("MCP_VERSION").is_ok(),
+            std::env::args().len() == 1,
+            !std::io::stdin().is_terminal(),
         )
-        .init();
-
-    Ok(())
-}
-
-/// Create environment filter based on CLI flags
-fn create_env_filter(cli: &cli::EarlyCliArgs) -> Result<EnvFilter> {
-    if cli.is_mcp_server {
-        Ok(create_mcp_filter(cli.debug))
-    } else {
-        create_cli_filter(cli)
-    }
-}
-
-/// Create filter for MCP server mode
-fn create_mcp_filter(debug: bool) -> EnvFilter {
-    if debug {
-        EnvFilter::new("warn,pmat=debug")
-    } else {
-        EnvFilter::new("off")
-    }
-}
-
-/// Create filter for CLI mode
-fn create_cli_filter(cli: &cli::EarlyCliArgs) -> Result<EnvFilter> {
-    if let Some(ref custom) = cli.trace_filter {
-        return Ok(EnvFilter::try_new(custom)?);
     }
 
-    let filter_str = match (cli.trace, cli.debug, cli.verbose) {
-        (true, _, _) => "debug,pmat=trace",
-        (_, true, _) => "warn,pmat=debug",
-        (_, _, true) => "warn,pmat=info",
-        _ => return Ok(get_default_filter()),
-    };
-
-    Ok(EnvFilter::new(filter_str))
-}
-
-/// Get default production filter
-fn get_default_filter() -> EnvFilter {
-    EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("warn"))
-}
-
-#[tokio::main]
-#[allow(unreachable_pub)]
-pub async fn real_main() {
-    let exit_code = match run_main().await {
-        Ok(()) => ExitCode::Success,
-        Err(e) => {
-            error!("Error: {:#}", e);
-            categorize_error(&e)
+    /// Pure decision function for execution mode so it can be unit-tested
+    /// without touching real stdin / env vars (see GH-285 regression test).
+    fn classify_execution_mode(
+        mcp_version_env: bool,
+        no_args: bool,
+        stdin_is_pipe: bool,
+    ) -> ExecutionMode {
+        // Explicit MCP opt-in via env var always wins (e.g. Claude Desktop sets this).
+        if mcp_version_env {
+            return ExecutionMode::Mcp;
         }
-    };
 
-    if exit_code as i32 != 0 {
-        process::exit(exit_code.into());
-    }
-}
+        // GH-285: If the user ran bare `pmat` with stdin piped (e.g. `echo "" | pmat`)
+        // without opting into MCP via `MCP_VERSION`, previous behavior entered the MCP
+        // server and blocked forever on stdin. Treat that case the same as bare `pmat`
+        // on a terminal: print help and exit non-zero.
+        if no_args && stdin_is_pipe {
+            return ExecutionMode::HelpAndExit;
+        }
 
-fn categorize_error(error: &anyhow::Error) -> ExitCode {
-    let error_str = error.to_string().to_lowercase();
-
-    match () {
-        _ if is_quality_gate_error(&error_str) => ExitCode::QualityGateFailure,
-        _ if is_configuration_error(&error_str) => ExitCode::ConfigurationError,
-        _ if is_analysis_error(&error_str) => ExitCode::AnalysisError,
-        _ if is_permission_error(&error_str) => ExitCode::PermissionDenied,
-        _ => ExitCode::GeneralError,
-    }
-}
-
-fn is_quality_gate_error(error_str: &str) -> bool {
-    error_str.contains("quality gate") || error_str.contains("violation")
-}
-
-fn is_configuration_error(error_str: &str) -> bool {
-    error_str.contains("config") || error_str.contains("parse")
-}
-
-fn is_analysis_error(error_str: &str) -> bool {
-    error_str.contains("analysis") || error_str.contains("complexity")
-}
-
-fn is_permission_error(error_str: &str) -> bool {
-    error_str.contains("permission") || error_str.contains("access")
-}
-
-async fn run_main() -> Result<()> {
-    // Parse CLI to get tracing configuration early
-    let cli = cli::parse_early_for_tracing();
-
-    // Initialize enhanced tracing system
-    init_tracing(&cli)?;
-
-    // Only log to stdout if not running MCP server mode
-    if !cli.is_mcp_server {
-        info!(
-            "Starting PAIML MCP Agent Toolkit v{}",
-            env!("CARGO_PKG_VERSION")
-        );
-        debug!("Debug logging enabled");
-        trace!("Trace logging enabled");
+        ExecutionMode::Cli
     }
 
-    // Create shared template server
-    let server = Arc::new(StatelessTemplateServer::new()?);
+    /// Initialize the enhanced tracing system based on CLI flags
+    fn init_tracing(cli: &cli::EarlyCliArgs) -> Result<()> {
+        let filter = create_env_filter(cli)?;
 
-    if !cli.is_mcp_server {
-        debug!("Template server initialized");
+        tracing_subscriber::registry()
+            .with(filter)
+            .with(
+                tracing_subscriber::fmt::layer()
+                    .with_target(cli.debug || cli.trace)
+                    .with_thread_ids(cli.trace)
+                    .with_file(cli.trace)
+                    .with_line_number(cli.trace)
+                    .compact()
+                    .with_writer(std::io::stderr),
+            )
+            .init();
+
+        Ok(())
     }
 
-    match detect_execution_mode() {
-        ExecutionMode::Mcp => {
-            if !cli.is_mcp_server {
-                info!("Running unified MCP server (pmcp SDK)");
+    /// Create environment filter based on CLI flags
+    fn create_env_filter(cli: &cli::EarlyCliArgs) -> Result<EnvFilter> {
+        if cli.is_mcp_server {
+            Ok(create_mcp_filter(cli.debug))
+        } else {
+            create_cli_filter(cli)
+        }
+    }
+
+    /// Create filter for MCP server mode
+    fn create_mcp_filter(debug: bool) -> EnvFilter {
+        if debug {
+            EnvFilter::new("warn,pmat=debug")
+        } else {
+            EnvFilter::new("off")
+        }
+    }
+
+    /// Create filter for CLI mode
+    fn create_cli_filter(cli: &cli::EarlyCliArgs) -> Result<EnvFilter> {
+        if let Some(ref custom) = cli.trace_filter {
+            return Ok(EnvFilter::try_new(custom)?);
+        }
+
+        let filter_str = match (cli.trace, cli.debug, cli.verbose) {
+            (true, _, _) => "debug,pmat=trace",
+            (_, true, _) => "warn,pmat=debug",
+            (_, _, true) => "warn,pmat=info",
+            _ => return Ok(get_default_filter()),
+        };
+
+        Ok(EnvFilter::new(filter_str))
+    }
+
+    /// Get default production filter
+    fn get_default_filter() -> EnvFilter {
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("warn"))
+    }
+
+    #[tokio::main]
+    #[allow(unreachable_pub)]
+    pub async fn real_main() {
+        let exit_code = match run_main().await {
+            Ok(()) => ExitCode::Success,
+            Err(e) => {
+                error!("Error: {:#}", e);
+                categorize_error(&e)
             }
-            let unified_server = pmat::mcp_pmcp::UnifiedServer::new()
-                .map_err(|e| anyhow::anyhow!("Failed to create unified server: {}", e))?;
-            unified_server
-                .run()
-                .await
-                .map_err(|e| anyhow::anyhow!("{}", e))
+        };
+
+        if exit_code as i32 != 0 {
+            process::exit(exit_code.into());
         }
-        ExecutionMode::Cli => {
-            if !cli.is_mcp_server {
-                info!("Running in CLI mode");
-            }
-            cli::run(server).await
+    }
+
+    fn categorize_error(error: &anyhow::Error) -> ExitCode {
+        let error_str = error.to_string().to_lowercase();
+
+        match () {
+            _ if is_quality_gate_error(&error_str) => ExitCode::QualityGateFailure,
+            _ if is_configuration_error(&error_str) => ExitCode::ConfigurationError,
+            _ if is_analysis_error(&error_str) => ExitCode::AnalysisError,
+            _ if is_permission_error(&error_str) => ExitCode::PermissionDenied,
+            _ => ExitCode::GeneralError,
         }
-        ExecutionMode::HelpAndExit => {
-            // GH-285: No subcommand + piped stdin + no MCP_VERSION. Print help on
-            // stderr and exit with code 2 (misuse), matching the convention for
-            // "no command supplied" on a terminal.
-            let mut cmd = <pmat::cli::Cli as clap::CommandFactory>::command();
-            let _ = cmd.print_help();
-            eprintln!(
-                "\nerror: no subcommand given and stdin is not a terminal. \
-                 Set MCP_VERSION=1 (or run `pmat agent mcp-server`) to start the MCP server."
+    }
+
+    fn is_quality_gate_error(error_str: &str) -> bool {
+        error_str.contains("quality gate") || error_str.contains("violation")
+    }
+
+    fn is_configuration_error(error_str: &str) -> bool {
+        error_str.contains("config") || error_str.contains("parse")
+    }
+
+    fn is_analysis_error(error_str: &str) -> bool {
+        error_str.contains("analysis") || error_str.contains("complexity")
+    }
+
+    fn is_permission_error(error_str: &str) -> bool {
+        error_str.contains("permission") || error_str.contains("access")
+    }
+
+    async fn run_main() -> Result<()> {
+        // Parse CLI to get tracing configuration early
+        let cli = cli::parse_early_for_tracing();
+
+        // Initialize enhanced tracing system
+        init_tracing(&cli)?;
+
+        // Only log to stdout if not running MCP server mode
+        if !cli.is_mcp_server {
+            info!(
+                "Starting PAIML MCP Agent Toolkit v{}",
+                env!("CARGO_PKG_VERSION")
             );
-            process::exit(ExitCode::MisuseError as i32);
+            debug!("Debug logging enabled");
+            trace!("Trace logging enabled");
+        }
+
+        // Create shared template server
+        let server = Arc::new(StatelessTemplateServer::new()?);
+
+        if !cli.is_mcp_server {
+            debug!("Template server initialized");
+        }
+
+        match detect_execution_mode() {
+            ExecutionMode::Mcp => {
+                if !cli.is_mcp_server {
+                    info!("Running unified MCP server (pmcp SDK)");
+                }
+                let unified_server = pmat::mcp_pmcp::UnifiedServer::new()
+                    .map_err(|e| anyhow::anyhow!("Failed to create unified server: {}", e))?;
+                unified_server
+                    .run()
+                    .await
+                    .map_err(|e| anyhow::anyhow!("{}", e))
+            }
+            ExecutionMode::Cli => {
+                if !cli.is_mcp_server {
+                    info!("Running in CLI mode");
+                }
+                cli::run(server).await
+            }
+            ExecutionMode::HelpAndExit => {
+                // GH-285: No subcommand + piped stdin + no MCP_VERSION. Print help on
+                // stderr and exit with code 2 (misuse), matching the convention for
+                // "no command supplied" on a terminal.
+                let mut cmd = <pmat::cli::Cli as clap::CommandFactory>::command();
+                let _ = cmd.print_help();
+                eprintln!(
+                    "\nerror: no subcommand given and stdin is not a terminal. \
+                 Set MCP_VERSION=1 (or run `pmat agent mcp-server`) to start the MCP server."
+                );
+                process::exit(ExitCode::MisuseError as i32);
+            }
         }
     }
-}
 
-#[cfg_attr(coverage_nightly, coverage(off))]
-#[cfg(test)]
-mod gh285_tests {
-    //! Regression tests for GH-285: `pmat` hangs when invoked with no args
-    //! and stdin is a pipe. See `classify_execution_mode`.
-    //!
-    //! Manual end-to-end repro (should NOT hang or exit 124):
-    //! ```text
-    //! echo "" | timeout 3 target/debug/pmat 2>&1; echo exit=$?
-    //! timeout 3 target/debug/pmat < /dev/null; echo exit=$?
-    //! ```
-    //! Both should print help and exit with code 2.
-    use super::{classify_execution_mode, ExecutionMode};
+    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg(test)]
+    mod gh285_tests {
+        //! Regression tests for GH-285: `pmat` hangs when invoked with no args
+        //! and stdin is a pipe. See `classify_execution_mode`.
+        //!
+        //! Manual end-to-end repro (should NOT hang or exit 124):
+        //! ```text
+        //! echo "" | timeout 3 target/debug/pmat 2>&1; echo exit=$?
+        //! timeout 3 target/debug/pmat < /dev/null; echo exit=$?
+        //! ```
+        //! Both should print help and exit with code 2.
+        use super::{classify_execution_mode, ExecutionMode};
 
-    #[test]
-    fn bare_invocation_on_tty_is_cli() {
-        // `pmat` typed into a terminal with no pipe -> normal CLI (clap
-        // will then print help on missing subcommand).
-        assert!(matches!(
-            classify_execution_mode(false, true, false),
-            ExecutionMode::Cli
-        ));
+        #[test]
+        fn bare_invocation_on_tty_is_cli() {
+            // `pmat` typed into a terminal with no pipe -> normal CLI (clap
+            // will then print help on missing subcommand).
+            assert!(matches!(
+                classify_execution_mode(false, true, false),
+                ExecutionMode::Cli
+            ));
+        }
+
+        #[test]
+        fn piped_stdin_with_no_args_prints_help_instead_of_hanging() {
+            // GH-285: This used to enter MCP mode and block on stdin forever.
+            assert!(matches!(
+                classify_execution_mode(false, true, true),
+                ExecutionMode::HelpAndExit
+            ));
+        }
+
+        #[test]
+        fn explicit_mcp_version_env_still_enters_mcp_mode() {
+            // Claude Desktop and similar hosts set MCP_VERSION; they must still
+            // get the MCP server regardless of TTY state.
+            assert!(matches!(
+                classify_execution_mode(true, true, true),
+                ExecutionMode::Mcp
+            ));
+            assert!(matches!(
+                classify_execution_mode(true, false, false),
+                ExecutionMode::Mcp
+            ));
+        }
+
+        #[test]
+        fn subcommand_with_piped_stdin_is_still_cli() {
+            // `echo foo | pmat analyze ...` must dispatch to the CLI subcommand,
+            // not to help-and-exit.
+            assert!(matches!(
+                classify_execution_mode(false, false, true),
+                ExecutionMode::Cli
+            ));
+        }
     }
-
-    #[test]
-    fn piped_stdin_with_no_args_prints_help_instead_of_hanging() {
-        // GH-285: This used to enter MCP mode and block on stdin forever.
-        assert!(matches!(
-            classify_execution_mode(false, true, true),
-            ExecutionMode::HelpAndExit
-        ));
-    }
-
-    #[test]
-    fn explicit_mcp_version_env_still_enters_mcp_mode() {
-        // Claude Desktop and similar hosts set MCP_VERSION; they must still
-        // get the MCP server regardless of TTY state.
-        assert!(matches!(
-            classify_execution_mode(true, true, true),
-            ExecutionMode::Mcp
-        ));
-        assert!(matches!(
-            classify_execution_mode(true, false, false),
-            ExecutionMode::Mcp
-        ));
-    }
-
-    #[test]
-    fn subcommand_with_piped_stdin_is_still_cli() {
-        // `echo foo | pmat analyze ...` must dispatch to the CLI subcommand,
-        // not to help-and-exit.
-        assert!(matches!(
-            classify_execution_mode(false, false, true),
-            ExecutionMode::Cli
-        ));
-    }
-}
 } // end of mod full
 
 #[cfg(feature = "standard-deps")]

--- a/src/cli/analysis_utilities/mod.rs
+++ b/src/cli/analysis_utilities/mod.rs
@@ -71,3 +71,285 @@ include!("defect_report.rs");
 // TEMPORARILY DISABLED: File splitting broke syntax (missing QualityGateResults import)
 #[cfg(all(test, feature = "broken-tests"))]
 mod tests;
+
+#[cfg(test)]
+mod churn_tests {
+    //! PMAT-650: cover churn.rs pure formatting helpers.
+    use super::*;
+    use crate::models::churn::{
+        ChurnOutputFormat, ChurnSummary, CodeChurnAnalysis, FileChurnMetrics,
+    };
+    use chrono::Utc;
+    use std::collections::HashMap;
+
+    fn empty_summary() -> ChurnSummary {
+        ChurnSummary {
+            total_commits: 0,
+            total_files_changed: 0,
+            hotspot_files: Vec::new(),
+            stable_files: Vec::new(),
+            author_contributions: HashMap::new(),
+            mean_churn_score: 0.0,
+            variance_churn_score: 0.0,
+            stddev_churn_score: 0.0,
+        }
+    }
+
+    fn empty_analysis() -> CodeChurnAnalysis {
+        CodeChurnAnalysis {
+            generated_at: Utc::now(),
+            period_days: 30,
+            repository_root: PathBuf::from("/tmp/repo"),
+            files: Vec::new(),
+            summary: empty_summary(),
+        }
+    }
+
+    fn metric(rel_path: &str, commits: usize, score: f32) -> FileChurnMetrics {
+        FileChurnMetrics {
+            path: PathBuf::from(rel_path),
+            relative_path: rel_path.to_string(),
+            commit_count: commits,
+            unique_authors: vec!["alice".to_string()],
+            additions: 10,
+            deletions: 5,
+            churn_score: score,
+            last_modified: Utc::now(),
+            first_seen: Utc::now(),
+        }
+    }
+
+    // --- format_churn_as_json ---
+
+    #[test]
+    fn test_format_churn_as_json_round_trip() {
+        let mut a = empty_analysis();
+        a.files.push(metric("src/a.rs", 5, 0.7));
+        a.summary.total_commits = 5;
+        let s = format_churn_as_json(&a).unwrap();
+        let back: CodeChurnAnalysis = serde_json::from_str(&s).unwrap();
+        assert_eq!(back.period_days, 30);
+        assert_eq!(back.files.len(), 1);
+        assert_eq!(back.files[0].relative_path, "src/a.rs");
+    }
+
+    // --- format_churn_as_csv ---
+
+    #[test]
+    fn test_format_churn_as_csv_emits_header_and_rows() {
+        let mut a = empty_analysis();
+        a.files.push(metric("src/a.rs", 5, 0.7));
+        a.files.push(metric("src/b.rs", 3, 0.3));
+        let csv = format_churn_as_csv(&a).unwrap();
+        assert!(csv.starts_with("file_path,relative_path,commit_count"));
+        assert!(csv.contains("src/a.rs,src/a.rs,5,1,10,5,0.700"));
+        assert!(csv.contains("src/b.rs,src/b.rs,3,1,10,5,0.300"));
+    }
+
+    #[test]
+    fn test_format_churn_as_csv_empty_only_header() {
+        let a = empty_analysis();
+        let csv = format_churn_as_csv(&a).unwrap();
+        assert_eq!(csv.lines().count(), 1);
+    }
+
+    // --- format_churn_as_summary integration ---
+
+    #[test]
+    fn test_format_churn_as_summary_empty_only_header() {
+        let a = empty_analysis();
+        let s = format_churn_as_summary(&a).unwrap();
+        assert!(s.contains("Code Churn Analysis Summary"));
+        assert!(s.contains("Period:"));
+        assert!(s.contains("Total commits:"));
+        assert!(!s.contains("Top Files by Churn"));
+        assert!(!s.contains("Hotspot Files"));
+        assert!(!s.contains("Stable Files"));
+        assert!(!s.contains("Top Contributors"));
+    }
+
+    #[test]
+    fn test_format_churn_as_summary_with_files_includes_top_files_section() {
+        let mut a = empty_analysis();
+        a.files.push(metric("src/a.rs", 10, 0.6));
+        a.files.push(metric("src/b.rs", 8, 0.4));
+        a.files.push(metric("src/c.rs", 5, 0.1));
+        let s = format_churn_as_summary(&a).unwrap();
+        assert!(s.contains("Top Files by Churn"));
+        assert!(s.contains("a.rs"));
+        assert!(s.contains("b.rs"));
+        assert!(s.contains("c.rs"));
+    }
+
+    #[test]
+    fn test_format_churn_as_summary_top_files_sorts_by_commit_count_desc() {
+        let mut a = empty_analysis();
+        a.files.push(metric("src/low.rs", 1, 0.1));
+        a.files.push(metric("src/high.rs", 99, 0.9));
+        let s = format_churn_as_summary(&a).unwrap();
+        let high_pos = s.find("high.rs").unwrap();
+        let low_pos = s.find("low.rs").unwrap();
+        assert!(
+            high_pos < low_pos,
+            "high commit count should appear before low"
+        );
+    }
+
+    #[test]
+    fn test_format_churn_as_summary_emits_hotspot_section_when_present() {
+        let mut a = empty_analysis();
+        a.summary.hotspot_files = vec![PathBuf::from("src/hot.rs")];
+        let s = format_churn_as_summary(&a).unwrap();
+        assert!(s.contains("Hotspot Files (High Churn)"));
+        assert!(s.contains("src/hot.rs"));
+    }
+
+    #[test]
+    fn test_format_churn_as_summary_emits_stable_section_when_present() {
+        let mut a = empty_analysis();
+        a.summary.stable_files = vec![PathBuf::from("src/cold.rs")];
+        let s = format_churn_as_summary(&a).unwrap();
+        assert!(s.contains("Stable Files (Low Churn)"));
+        assert!(s.contains("src/cold.rs"));
+    }
+
+    #[test]
+    fn test_format_churn_as_summary_emits_top_contributors_section() {
+        let mut a = empty_analysis();
+        a.summary.author_contributions =
+            HashMap::from([("alice".to_string(), 10), ("bob".to_string(), 3)]);
+        let s = format_churn_as_summary(&a).unwrap();
+        assert!(s.contains("Top Contributors"));
+        assert!(s.contains("alice"));
+        let alice = s.find("alice").unwrap();
+        let bob = s.find("bob").unwrap();
+        assert!(alice < bob);
+    }
+
+    // --- format_churn_as_markdown integration ---
+
+    #[test]
+    fn test_format_churn_as_markdown_full_pipeline() {
+        let mut a = empty_analysis();
+        a.summary.total_commits = 10;
+        a.summary.total_files_changed = 5;
+        a.summary.hotspot_files = vec![PathBuf::from("src/hot.rs")];
+        a.summary.stable_files = vec![PathBuf::from("src/stable.rs")];
+        a.summary
+            .author_contributions
+            .insert("alice".to_string(), 5);
+        a.files.push(metric("src/x.rs", 3, 0.4));
+        let md = format_churn_as_markdown(&a).unwrap();
+        assert!(md.starts_with("# Code Churn Analysis Report"));
+        assert!(md.contains("## Summary Statistics"));
+        assert!(md.contains("| Total Commits | 10 |"));
+        assert!(md.contains("| Files Changed | 5 |"));
+        assert!(md.contains("| Hotspot Files | 1 |"));
+        assert!(md.contains("| Stable Files | 1 |"));
+        assert!(md.contains("| Contributing Authors | 1 |"));
+        assert!(md.contains("## File Churn Details"));
+        assert!(md.contains("src/x.rs"));
+        assert!(md.contains("## Author Contributions"));
+        assert!(md.contains("| alice |"));
+        assert!(md.contains("## Recommendations"));
+        assert!(md.contains("Review Hotspot Files"));
+    }
+
+    #[test]
+    fn test_format_churn_as_markdown_empty_skips_optional_sections() {
+        let a = empty_analysis();
+        let md = format_churn_as_markdown(&a).unwrap();
+        assert!(md.contains("## Summary Statistics"));
+        assert!(!md.contains("## File Churn Details"));
+        assert!(!md.contains("## Author Contributions"));
+        assert!(md.contains("## Recommendations"));
+    }
+
+    // --- format_churn_content dispatcher ---
+
+    #[test]
+    fn test_format_churn_content_dispatches_each_format() {
+        let a = empty_analysis();
+        let json = format_churn_content(&a, ChurnOutputFormat::Json).unwrap();
+        let _: CodeChurnAnalysis = serde_json::from_str(&json).unwrap();
+        let summary = format_churn_content(&a, ChurnOutputFormat::Summary).unwrap();
+        assert!(summary.contains("Code Churn Analysis Summary"));
+        let md = format_churn_content(&a, ChurnOutputFormat::Markdown).unwrap();
+        assert!(md.contains("# Code Churn Analysis Report"));
+        let csv = format_churn_content(&a, ChurnOutputFormat::Csv).unwrap();
+        assert!(csv.starts_with("file_path,"));
+    }
+
+    // --- apply_churn_file_filtering ---
+
+    #[test]
+    fn test_apply_churn_file_filtering_zero_keeps_all() {
+        let mut a = empty_analysis();
+        for i in 0..5 {
+            a.files.push(metric(&format!("f{i}"), i, 0.1));
+        }
+        apply_churn_file_filtering(&mut a, 0);
+        assert_eq!(a.files.len(), 5);
+    }
+
+    #[test]
+    fn test_apply_churn_file_filtering_top_files_ge_len_no_op() {
+        let mut a = empty_analysis();
+        for i in 0..3 {
+            a.files.push(metric(&format!("f{i}"), i, 0.1));
+        }
+        apply_churn_file_filtering(&mut a, 10);
+        assert_eq!(a.files.len(), 3);
+    }
+
+    #[test]
+    fn test_apply_churn_file_filtering_truncates_keeps_top_by_commit_count() {
+        let mut a = empty_analysis();
+        a.files.push(metric("low.rs", 1, 0.1));
+        a.files.push(metric("mid.rs", 5, 0.1));
+        a.files.push(metric("high.rs", 10, 0.1));
+        apply_churn_file_filtering(&mut a, 2);
+        assert_eq!(a.files.len(), 2);
+        let names: Vec<_> = a.files.iter().map(|f| f.relative_path.clone()).collect();
+        assert!(names.contains(&"high.rs".to_string()));
+        assert!(names.contains(&"mid.rs".to_string()));
+        assert!(!names.contains(&"low.rs".to_string()));
+    }
+
+    // --- write_*_row helpers ---
+
+    #[test]
+    fn test_write_commits_row_format() {
+        let mut out = String::new();
+        write_commits_row(&mut out, 42).unwrap();
+        assert_eq!(out.trim(), "| Total Commits | 42 |");
+    }
+
+    #[test]
+    fn test_write_files_changed_row_format() {
+        let mut out = String::new();
+        write_files_changed_row(&mut out, 7).unwrap();
+        assert_eq!(out.trim(), "| Files Changed | 7 |");
+    }
+
+    #[test]
+    fn test_write_hotspot_files_row_format() {
+        let mut out = String::new();
+        write_hotspot_files_row(&mut out, 3).unwrap();
+        assert_eq!(out.trim(), "| Hotspot Files | 3 |");
+    }
+
+    #[test]
+    fn test_write_stable_files_row_format() {
+        let mut out = String::new();
+        write_stable_files_row(&mut out, 2).unwrap();
+        assert_eq!(out.trim(), "| Stable Files | 2 |");
+    }
+
+    #[test]
+    fn test_write_authors_row_format() {
+        let mut out = String::new();
+        write_authors_row(&mut out, 5).unwrap();
+        assert_eq!(out.trim(), "| Contributing Authors | 5 |");
+    }
+}

--- a/src/entropy/pattern_extractor_tests.rs
+++ b/src/entropy/pattern_extractor_tests.rs
@@ -845,7 +845,10 @@ fn test_calculate_pattern_match_variation_score_short_circuits_single_match() {
 
     let score =
         extractor.calculate_pattern_match_variation_score(&enums, &matches, &arrows, content);
-    assert_eq!(score, 0.0, "fewer than 2 match blocks must short-circuit to 0.0");
+    assert_eq!(
+        score, 0.0,
+        "fewer than 2 match blocks must short-circuit to 0.0"
+    );
 }
 
 /// pattern_extractor_ruchy.rs:405 — enum_matches.len() <= 1 low-variation arm (0.3).

--- a/src/maintenance/updater.rs
+++ b/src/maintenance/updater.rs
@@ -375,9 +375,13 @@ mod tests {
             files: vec!["src/lib.rs".into()], // no ticket file
         };
 
-        let result =
-            process_ticket_update(&mut roadmap, &commit, "TICKET-PMAT-5013", tickets_dir.path())
-                .unwrap();
+        let result = process_ticket_update(
+            &mut roadmap,
+            &commit,
+            "TICKET-PMAT-5013",
+            tickets_dir.path(),
+        )
+        .unwrap();
         assert!(!result, "must short-circuit when ticket file not in commit");
         assert!(!roadmap.sprints[0].tickets[0].completed);
     }
@@ -394,10 +398,17 @@ mod tests {
             files: vec!["docs/tickets/TICKET-PMAT-5013.md".into()],
         };
 
-        let result =
-            process_ticket_update(&mut roadmap, &commit, "TICKET-PMAT-5013", tickets_dir.path())
-                .unwrap();
-        assert!(!result, "missing ticket file must return Ok(false), not error");
+        let result = process_ticket_update(
+            &mut roadmap,
+            &commit,
+            "TICKET-PMAT-5013",
+            tickets_dir.path(),
+        )
+        .unwrap();
+        assert!(
+            !result,
+            "missing ticket file must return Ok(false), not error"
+        );
         assert!(!roadmap.sprints[0].tickets[0].completed);
     }
 
@@ -417,11 +428,7 @@ mod tests {
              Still failing.\n\n\
              ## Success Criteria\n\n\
              - [ ] One\n";
-        std::fs::write(
-            tickets_dir.path().join("TICKET-PMAT-5013.md"),
-            red_content,
-        )
-        .unwrap();
+        std::fs::write(tickets_dir.path().join("TICKET-PMAT-5013.md"), red_content).unwrap();
         let mut roadmap = create_test_roadmap();
         let commit = CommitInfo {
             hash: "deadbee".into(),
@@ -429,9 +436,13 @@ mod tests {
             files: vec!["docs/tickets/TICKET-PMAT-5013.md".into()],
         };
 
-        let result =
-            process_ticket_update(&mut roadmap, &commit, "TICKET-PMAT-5013", tickets_dir.path())
-                .unwrap();
+        let result = process_ticket_update(
+            &mut roadmap,
+            &commit,
+            "TICKET-PMAT-5013",
+            tickets_dir.path(),
+        )
+        .unwrap();
         assert!(!result, "RED ticket must not mark roadmap completed");
         assert!(!roadmap.sprints[0].tickets[0].completed);
     }
@@ -450,9 +461,13 @@ mod tests {
             files: vec!["docs/tickets/TICKET-PMAT-5013.md".into()],
         };
 
-        let result =
-            process_ticket_update(&mut roadmap, &commit, "TICKET-PMAT-5013", tickets_dir.path())
-                .unwrap();
+        let result = process_ticket_update(
+            &mut roadmap,
+            &commit,
+            "TICKET-PMAT-5013",
+            tickets_dir.path(),
+        )
+        .unwrap();
         assert!(result, "GREEN ticket must flip roadmap entry");
         assert!(roadmap.sprints[0].tickets[0].completed);
         assert_eq!(

--- a/src/mcp_pmcp/agent_context_handlers.rs
+++ b/src/mcp_pmcp/agent_context_handlers.rs
@@ -37,11 +37,7 @@ macro_rules! impl_pmat_handler {
 
         #[async_trait]
         impl ToolHandler for $wrapper {
-            async fn handle(
-                &self,
-                args: Value,
-                _extra: RequestHandlerExtra,
-            ) -> PmcpResult<Value> {
+            async fn handle(&self, args: Value, _extra: RequestHandlerExtra) -> PmcpResult<Value> {
                 self.inner.execute(args).await.map_err(PmcpError::internal)
             }
 

--- a/src/mcp_pmcp/analyze_handlers.rs
+++ b/src/mcp_pmcp/analyze_handlers.rs
@@ -32,7 +32,8 @@ use tracing::debug;
 // MCP tools (see R15 #3 bench matrix).
 pub use self::{
     ComplexityTool as AnalyzeComplexityTool, DeadCodeTool as AnalyzeDeadCodeTool,
-    SatdTool as AnalyzeSatdTool, TdgCompareTool as AnalyzeTdgCompareTool, TdgTool as AnalyzeTdgTool,
+    SatdTool as AnalyzeSatdTool, TdgCompareTool as AnalyzeTdgCompareTool,
+    TdgTool as AnalyzeTdgTool,
 };
 
 // Complexity analysis tool handler

--- a/src/mcp_pmcp/mod.rs
+++ b/src/mcp_pmcp/mod.rs
@@ -103,12 +103,12 @@ pub mod quality_handlers;
 pub mod quality_proxy_handler;
 pub mod server;
 pub mod simple_unified_server;
-pub mod tool_schemas;
 #[cfg_attr(coverage_nightly, coverage(off))]
 #[cfg(test)]
 pub mod tdg_git_context_tests;
 pub mod tdg_handlers;
 pub mod tool_functions;
+pub mod tool_schemas;
 pub mod tool_schemas_generated; // KAIZEN-0178: build.rs-generated tool schema registry
 pub mod tools; // Sprint 65 Phase 2B: MCP git-context integration
 

--- a/src/mcp_pmcp/tool_schemas.rs
+++ b/src/mcp_pmcp/tool_schemas.rs
@@ -45,7 +45,10 @@ pub fn paths_object_schema(extra_properties: Value, required: Vec<&str>) -> Valu
             base.insert(k.clone(), v.clone());
         }
     }
-    let req: Vec<Value> = required.into_iter().map(|s| Value::String(s.into())).collect();
+    let req: Vec<Value> = required
+        .into_iter()
+        .map(|s| Value::String(s.into()))
+        .collect();
     json!({
         "type": "object",
         "properties": base_props,


### PR DESCRIPTION
## Summary

Continues Phase-1 CLI pivot after PR #514/PMAT-649. \`cli/analysis_utilities/churn.rs\` is 498 lines, **230/230 missed** on master broad. handle_analyze_churn + write_churn_output are async; everything else is pure sync formatting.

**20 new tests** covering:

- format_churn_as_json round-trip
- format_churn_as_csv: empty header-only, populated rows
- format_churn_as_summary: empty only-header, with-files top-section (3 color branches), hotspot/stable/contributors conditional sections, top-files sorts by commit_count desc, contributors sorted desc by file count
- format_churn_as_markdown: full pipeline integration + empty skips optional sections
- format_churn_content dispatcher all 4 ChurnOutputFormat arms
- apply_churn_file_filtering: 0=keep-all, len-or-more=no-op, less-than-len truncates by commit_count desc
- write_*_row 5 helpers (commits, files_changed, hotspot, stable, authors)

## Coverage impact

Expected delta: **~+0.06pp** on broad.

## Note on cumulative measurement

Earlier integration measurement on a 14-PR-merged branch showed only +0.02pp delta vs master (despite per-PR measurements showing +0.17pp for PMAT-642 alone). \`cargo test --lib\` confirmed test code IS compiled & runs on the integration branch — likely stale build artifacts in the NVMe target dir during the coverage instrumented build. Per-PR measurements remain the ground truth; full impact will land when PRs merge.

## Test plan

- [x] \`cargo test --lib -- churn_tests\` — 20 passed, 0 failed
- [x] \`cargo fmt --all -- --check\` — clean
- [ ] CI gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)