### PR TITLE
test(coverage): git_history_annotations.rs pure helpers (PMAT-653)

### DIFF
--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -3217,7 +3217,7 @@ roadmap:
   github_issue: null
   item_type: task
   title: 'Phase 1 pivot: cli/handlers/query_handler/git_history_annotations.rs coverage'
-  status: inprogress
+  status: review
   priority: medium
   assigned_to: null
   created: 2026-04-24T10:20:47Z

--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -3213,3 +3213,20 @@ roadmap:
   estimated_effort: null
   labels: []
   notes: null
+- id: PMAT-653
+  github_issue: null
+  item_type: task
+  title: 'Phase 1 pivot: cli/handlers/query_handler/git_history_annotations.rs coverage'
+  status: inprogress
+  priority: medium
+  assigned_to: null
+  created: 2026-04-24T10:20:47Z
+  updated: 2026-04-24T10:20:47Z
+  spec: null
+  acceptance_criteria:
+  - 'Phase 1 CLI pivot — git_history_annotations.rs is 319 lines, 235/262 missed broad, 0 async. 13 pure helpers. Cover count_pairwise_cochanges (empty, 2 files, 3 files), aggregate_hotspots (multi-commit accumulation, >15-file-skip for co-change, fix/feat flags), compute_decay_score (all 5 TDG grades + unknown + zero commits + with dead code), compute_impact_risk (zero commits, with pagerank+fault), compute_cochange_pairs (filter <3 threshold, sort desc, truncate to 5, jaccard calc), load_work_ticket (non-PMAT/non-# prefix → None, # prefix → PMAT- format, missing contract.json → None, valid contract counts passed vs falsified), load_commit_quality (missing → None), aggregate_bug_hunter_faults (missing dir → empty).'
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels: []
+  notes: null

--- a/examples/mcp_agent_context_demo.rs
+++ b/examples/mcp_agent_context_demo.rs
@@ -54,68 +54,132 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     thread::sleep(Duration::from_secs(10));
 
     // 1. initialize handshake
-    let resp = rpc(&mut writer, &mut reader, 1, "initialize", json!({
-        "protocolVersion": "2024-11-05",
-        "capabilities": {},
-        "clientInfo": { "name": "mcp_agent_context_demo", "version": "1.0" }
-    }))?;
-    let server_info = resp.pointer("/result/serverInfo/name").cloned().unwrap_or(json!("?"));
+    let resp = rpc(
+        &mut writer,
+        &mut reader,
+        1,
+        "initialize",
+        json!({
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": { "name": "mcp_agent_context_demo", "version": "1.0" }
+        }),
+    )?;
+    let server_info = resp
+        .pointer("/result/serverInfo/name")
+        .cloned()
+        .unwrap_or(json!("?"));
     println!("[initialize] server={}", server_info);
 
     // 2. tools/list — sanity check that the 4 pmat_* tools are registered
     let resp = rpc(&mut writer, &mut reader, 2, "tools/list", json!({}))?;
-    let tools = resp.pointer("/result/tools").and_then(|v| v.as_array()).cloned().unwrap_or_default();
-    let pmat_tools: Vec<&str> = tools.iter()
+    let tools = resp
+        .pointer("/result/tools")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+    let pmat_tools: Vec<&str> = tools
+        .iter()
         .filter_map(|t| t.get("name").and_then(|n| n.as_str()))
         .filter(|n| n.starts_with("pmat_"))
         .collect();
-    println!("[tools/list] total={} pmat_*={} ({:?})", tools.len(), pmat_tools.len(), pmat_tools);
+    println!(
+        "[tools/list] total={} pmat_*={} ({:?})",
+        tools.len(),
+        pmat_tools.len(),
+        pmat_tools
+    );
 
     // 3. pmat_index_stats — pick up a real function_id we can reuse below
-    let resp = call_tool(&mut writer, &mut reader, 3, "pmat_index_stats",
-        json!({ "rebuild": false }))?;
+    let resp = call_tool(
+        &mut writer,
+        &mut reader,
+        3,
+        "pmat_index_stats",
+        json!({ "rebuild": false }),
+    )?;
     let index_result = extract_tool_result(&resp);
-    let fn_count = index_result.pointer("/manifest/function_count").cloned().unwrap_or(json!(0));
-    let file_count = index_result.pointer("/manifest/file_count").cloned().unwrap_or(json!(0));
-    println!("[pmat_index_stats] ok: functions={} files={}", fn_count, file_count);
+    let fn_count = index_result
+        .pointer("/manifest/function_count")
+        .cloned()
+        .unwrap_or(json!(0));
+    let file_count = index_result
+        .pointer("/manifest/file_count")
+        .cloned()
+        .unwrap_or(json!(0));
+    println!(
+        "[pmat_index_stats] ok: functions={} files={}",
+        fn_count, file_count
+    );
 
     // 4. pmat_query_code — realistic semantic query
-    let resp = call_tool(&mut writer, &mut reader, 4, "pmat_query_code",
-        json!({ "query": "error handling", "limit": 3 }))?;
+    let resp = call_tool(
+        &mut writer,
+        &mut reader,
+        4,
+        "pmat_query_code",
+        json!({ "query": "error handling", "limit": 3 }),
+    )?;
     let query_result = extract_tool_result(&resp);
-    let result_count = query_result.get("results")
+    let result_count = query_result
+        .get("results")
         .or_else(|| query_result.get("functions"))
         .and_then(|v| v.as_array())
         .map(|a| a.len())
         .unwrap_or(0);
-    let first_id = query_result.pointer("/results/0/id")
+    let first_id = query_result
+        .pointer("/results/0/id")
         .or_else(|| query_result.pointer("/functions/0/id"))
         .and_then(|v| v.as_str())
         .map(|s| s.to_string());
-    println!("[pmat_query_code] ok: {} results; first_id={:?}", result_count, first_id);
+    println!(
+        "[pmat_query_code] ok: {} results; first_id={:?}",
+        result_count, first_id
+    );
 
     // 5. pmat_get_function — use the first id from query_code, or fall back to "main"
-    let function_id = first_id.clone().unwrap_or_else(|| "src/bin/pmat.rs::main".to_string());
-    let resp = call_tool(&mut writer, &mut reader, 5, "pmat_get_function",
-        json!({ "function_id": function_id, "include_source": false }))?;
+    let function_id = first_id
+        .clone()
+        .unwrap_or_else(|| "src/bin/pmat.rs::main".to_string());
+    let resp = call_tool(
+        &mut writer,
+        &mut reader,
+        5,
+        "pmat_get_function",
+        json!({ "function_id": function_id, "include_source": false }),
+    )?;
     match resp.get("error") {
-        Some(err) => println!("[pmat_get_function] graceful miss for {:?}: {}", function_id,
-            err.get("message").and_then(|m| m.as_str()).unwrap_or("?")),
+        Some(err) => println!(
+            "[pmat_get_function] graceful miss for {:?}: {}",
+            function_id,
+            err.get("message").and_then(|m| m.as_str()).unwrap_or("?")
+        ),
         None => {
             let gf = extract_tool_result(&resp);
-            println!("[pmat_get_function] ok: name={} grade={}",
+            println!(
+                "[pmat_get_function] ok: name={} grade={}",
                 gf.get("name").and_then(|v| v.as_str()).unwrap_or("?"),
-                gf.pointer("/quality/grade").and_then(|v| v.as_str()).unwrap_or("?"));
+                gf.pointer("/quality/grade")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("?")
+            );
         }
     }
 
     // 6. pmat_find_similar — only meaningful if we got a real id from the query
     if let Some(id) = first_id {
-        let resp = call_tool(&mut writer, &mut reader, 6, "pmat_find_similar",
-            json!({ "function_id": id, "limit": 3, "min_similarity": 0.3 }))?;
+        let resp = call_tool(
+            &mut writer,
+            &mut reader,
+            6,
+            "pmat_find_similar",
+            json!({ "function_id": id, "limit": 3, "min_similarity": 0.3 }),
+        )?;
         match resp.get("error") {
-            Some(err) => println!("[pmat_find_similar] error: {}",
-                err.get("message").and_then(|m| m.as_str()).unwrap_or("?")),
+            Some(err) => println!(
+                "[pmat_find_similar] error: {}",
+                err.get("message").and_then(|m| m.as_str()).unwrap_or("?")
+            ),
             None => {
                 let sim = extract_tool_result(&resp);
                 let total = sim.get("total").and_then(|v| v.as_u64()).unwrap_or(0);
@@ -162,7 +226,13 @@ fn call_tool(
     name: &str,
     args: Value,
 ) -> Result<Value, Box<dyn std::error::Error>> {
-    rpc(writer, reader, id, "tools/call", json!({ "name": name, "arguments": args }))
+    rpc(
+        writer,
+        reader,
+        id,
+        "tools/call",
+        json!({ "name": name, "arguments": args }),
+    )
 }
 
 /// MCP `tools/call` wraps results in `result.content[0].text` (JSON string) or
@@ -171,7 +241,10 @@ fn extract_tool_result(resp: &Value) -> Value {
     if let Some(sc) = resp.pointer("/result/structuredContent") {
         return sc.clone();
     }
-    if let Some(text) = resp.pointer("/result/content/0/text").and_then(|v| v.as_str()) {
+    if let Some(text) = resp
+        .pointer("/result/content/0/text")
+        .and_then(|v| v.as_str())
+    {
         if let Ok(parsed) = serde_json::from_str::<Value>(text) {
             return parsed;
         }

--- a/src/bin/pmat.rs
+++ b/src/bin/pmat.rs
@@ -16,301 +16,301 @@ fn main() {
 
 #[cfg(feature = "standard-deps")]
 mod full {
-use anyhow::Result;
-use pmat::{cli, stateless_server::StatelessTemplateServer};
-use std::io::IsTerminal;
-use std::process;
-use std::sync::Arc;
-use tracing::{debug, error, info, trace};
-use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
+    use anyhow::Result;
+    use pmat::{cli, stateless_server::StatelessTemplateServer};
+    use std::io::IsTerminal;
+    use std::process;
+    use std::sync::Arc;
+    use tracing::{debug, error, info, trace};
+    use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 
-enum ExecutionMode {
-    Mcp,
-    Cli,
-    /// No subcommand given and stdin is piped (not a TTY) without an explicit
-    /// MCP opt-in. Print help and exit non-zero instead of blocking on stdin
-    /// (see GH-285).
-    HelpAndExit,
-}
-
-/// POSIX-compliant exit codes for CLI interface
-/// Per SPECIFICATION.md Section 23: CLI Interface
-#[derive(Debug, Clone, Copy)]
-pub enum ExitCode {
-    /// Success
-    Success = 0,
-    /// General error
-    GeneralError = 1,
-    /// Misuse of shell command
-    MisuseError = 2,
-    /// Permission denied
-    PermissionDenied = 126,
-    /// Command not found
-    CommandNotFound = 127,
-    /// Invalid argument to exit
-    InvalidExitArg = 128,
-    /// Quality gate failure (custom)
-    QualityGateFailure = 3,
-    /// Configuration error (custom)
-    ConfigurationError = 4,
-    /// Analysis error (custom)
-    AnalysisError = 5,
-}
-
-impl From<ExitCode> for i32 {
-    fn from(code: ExitCode) -> Self {
-        code as i32
-    }
-}
-
-fn detect_execution_mode() -> ExecutionMode {
-    classify_execution_mode(
-        std::env::var("MCP_VERSION").is_ok(),
-        std::env::args().len() == 1,
-        !std::io::stdin().is_terminal(),
-    )
-}
-
-/// Pure decision function for execution mode so it can be unit-tested
-/// without touching real stdin / env vars (see GH-285 regression test).
-fn classify_execution_mode(
-    mcp_version_env: bool,
-    no_args: bool,
-    stdin_is_pipe: bool,
-) -> ExecutionMode {
-    // Explicit MCP opt-in via env var always wins (e.g. Claude Desktop sets this).
-    if mcp_version_env {
-        return ExecutionMode::Mcp;
+    enum ExecutionMode {
+        Mcp,
+        Cli,
+        /// No subcommand given and stdin is piped (not a TTY) without an explicit
+        /// MCP opt-in. Print help and exit non-zero instead of blocking on stdin
+        /// (see GH-285).
+        HelpAndExit,
     }
 
-    // GH-285: If the user ran bare `pmat` with stdin piped (e.g. `echo "" | pmat`)
-    // without opting into MCP via `MCP_VERSION`, previous behavior entered the MCP
-    // server and blocked forever on stdin. Treat that case the same as bare `pmat`
-    // on a terminal: print help and exit non-zero.
-    if no_args && stdin_is_pipe {
-        return ExecutionMode::HelpAndExit;
+    /// POSIX-compliant exit codes for CLI interface
+    /// Per SPECIFICATION.md Section 23: CLI Interface
+    #[derive(Debug, Clone, Copy)]
+    pub enum ExitCode {
+        /// Success
+        Success = 0,
+        /// General error
+        GeneralError = 1,
+        /// Misuse of shell command
+        MisuseError = 2,
+        /// Permission denied
+        PermissionDenied = 126,
+        /// Command not found
+        CommandNotFound = 127,
+        /// Invalid argument to exit
+        InvalidExitArg = 128,
+        /// Quality gate failure (custom)
+        QualityGateFailure = 3,
+        /// Configuration error (custom)
+        ConfigurationError = 4,
+        /// Analysis error (custom)
+        AnalysisError = 5,
     }
 
-    ExecutionMode::Cli
-}
+    impl From<ExitCode> for i32 {
+        fn from(code: ExitCode) -> Self {
+            code as i32
+        }
+    }
 
-/// Initialize the enhanced tracing system based on CLI flags
-fn init_tracing(cli: &cli::EarlyCliArgs) -> Result<()> {
-    let filter = create_env_filter(cli)?;
-
-    tracing_subscriber::registry()
-        .with(filter)
-        .with(
-            tracing_subscriber::fmt::layer()
-                .with_target(cli.debug || cli.trace)
-                .with_thread_ids(cli.trace)
-                .with_file(cli.trace)
-                .with_line_number(cli.trace)
-                .compact()
-                .with_writer(std::io::stderr),
+    fn detect_execution_mode() -> ExecutionMode {
+        classify_execution_mode(
+            std::env::var("MCP_VERSION").is_ok(),
+            std::env::args().len() == 1,
+            !std::io::stdin().is_terminal(),
         )
-        .init();
-
-    Ok(())
-}
-
-/// Create environment filter based on CLI flags
-fn create_env_filter(cli: &cli::EarlyCliArgs) -> Result<EnvFilter> {
-    if cli.is_mcp_server {
-        Ok(create_mcp_filter(cli.debug))
-    } else {
-        create_cli_filter(cli)
-    }
-}
-
-/// Create filter for MCP server mode
-fn create_mcp_filter(debug: bool) -> EnvFilter {
-    if debug {
-        EnvFilter::new("warn,pmat=debug")
-    } else {
-        EnvFilter::new("off")
-    }
-}
-
-/// Create filter for CLI mode
-fn create_cli_filter(cli: &cli::EarlyCliArgs) -> Result<EnvFilter> {
-    if let Some(ref custom) = cli.trace_filter {
-        return Ok(EnvFilter::try_new(custom)?);
     }
 
-    let filter_str = match (cli.trace, cli.debug, cli.verbose) {
-        (true, _, _) => "debug,pmat=trace",
-        (_, true, _) => "warn,pmat=debug",
-        (_, _, true) => "warn,pmat=info",
-        _ => return Ok(get_default_filter()),
-    };
-
-    Ok(EnvFilter::new(filter_str))
-}
-
-/// Get default production filter
-fn get_default_filter() -> EnvFilter {
-    EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("warn"))
-}
-
-#[tokio::main]
-#[allow(unreachable_pub)]
-pub async fn real_main() {
-    let exit_code = match run_main().await {
-        Ok(()) => ExitCode::Success,
-        Err(e) => {
-            error!("Error: {:#}", e);
-            categorize_error(&e)
+    /// Pure decision function for execution mode so it can be unit-tested
+    /// without touching real stdin / env vars (see GH-285 regression test).
+    fn classify_execution_mode(
+        mcp_version_env: bool,
+        no_args: bool,
+        stdin_is_pipe: bool,
+    ) -> ExecutionMode {
+        // Explicit MCP opt-in via env var always wins (e.g. Claude Desktop sets this).
+        if mcp_version_env {
+            return ExecutionMode::Mcp;
         }
-    };
 
-    if exit_code as i32 != 0 {
-        process::exit(exit_code.into());
-    }
-}
+        // GH-285: If the user ran bare `pmat` with stdin piped (e.g. `echo "" | pmat`)
+        // without opting into MCP via `MCP_VERSION`, previous behavior entered the MCP
+        // server and blocked forever on stdin. Treat that case the same as bare `pmat`
+        // on a terminal: print help and exit non-zero.
+        if no_args && stdin_is_pipe {
+            return ExecutionMode::HelpAndExit;
+        }
 
-fn categorize_error(error: &anyhow::Error) -> ExitCode {
-    let error_str = error.to_string().to_lowercase();
-
-    match () {
-        _ if is_quality_gate_error(&error_str) => ExitCode::QualityGateFailure,
-        _ if is_configuration_error(&error_str) => ExitCode::ConfigurationError,
-        _ if is_analysis_error(&error_str) => ExitCode::AnalysisError,
-        _ if is_permission_error(&error_str) => ExitCode::PermissionDenied,
-        _ => ExitCode::GeneralError,
-    }
-}
-
-fn is_quality_gate_error(error_str: &str) -> bool {
-    error_str.contains("quality gate") || error_str.contains("violation")
-}
-
-fn is_configuration_error(error_str: &str) -> bool {
-    error_str.contains("config") || error_str.contains("parse")
-}
-
-fn is_analysis_error(error_str: &str) -> bool {
-    error_str.contains("analysis") || error_str.contains("complexity")
-}
-
-fn is_permission_error(error_str: &str) -> bool {
-    error_str.contains("permission") || error_str.contains("access")
-}
-
-async fn run_main() -> Result<()> {
-    // Parse CLI to get tracing configuration early
-    let cli = cli::parse_early_for_tracing();
-
-    // Initialize enhanced tracing system
-    init_tracing(&cli)?;
-
-    // Only log to stdout if not running MCP server mode
-    if !cli.is_mcp_server {
-        info!(
-            "Starting PAIML MCP Agent Toolkit v{}",
-            env!("CARGO_PKG_VERSION")
-        );
-        debug!("Debug logging enabled");
-        trace!("Trace logging enabled");
+        ExecutionMode::Cli
     }
 
-    // Create shared template server
-    let server = Arc::new(StatelessTemplateServer::new()?);
+    /// Initialize the enhanced tracing system based on CLI flags
+    fn init_tracing(cli: &cli::EarlyCliArgs) -> Result<()> {
+        let filter = create_env_filter(cli)?;
 
-    if !cli.is_mcp_server {
-        debug!("Template server initialized");
+        tracing_subscriber::registry()
+            .with(filter)
+            .with(
+                tracing_subscriber::fmt::layer()
+                    .with_target(cli.debug || cli.trace)
+                    .with_thread_ids(cli.trace)
+                    .with_file(cli.trace)
+                    .with_line_number(cli.trace)
+                    .compact()
+                    .with_writer(std::io::stderr),
+            )
+            .init();
+
+        Ok(())
     }
 
-    match detect_execution_mode() {
-        ExecutionMode::Mcp => {
-            if !cli.is_mcp_server {
-                info!("Running unified MCP server (pmcp SDK)");
+    /// Create environment filter based on CLI flags
+    fn create_env_filter(cli: &cli::EarlyCliArgs) -> Result<EnvFilter> {
+        if cli.is_mcp_server {
+            Ok(create_mcp_filter(cli.debug))
+        } else {
+            create_cli_filter(cli)
+        }
+    }
+
+    /// Create filter for MCP server mode
+    fn create_mcp_filter(debug: bool) -> EnvFilter {
+        if debug {
+            EnvFilter::new("warn,pmat=debug")
+        } else {
+            EnvFilter::new("off")
+        }
+    }
+
+    /// Create filter for CLI mode
+    fn create_cli_filter(cli: &cli::EarlyCliArgs) -> Result<EnvFilter> {
+        if let Some(ref custom) = cli.trace_filter {
+            return Ok(EnvFilter::try_new(custom)?);
+        }
+
+        let filter_str = match (cli.trace, cli.debug, cli.verbose) {
+            (true, _, _) => "debug,pmat=trace",
+            (_, true, _) => "warn,pmat=debug",
+            (_, _, true) => "warn,pmat=info",
+            _ => return Ok(get_default_filter()),
+        };
+
+        Ok(EnvFilter::new(filter_str))
+    }
+
+    /// Get default production filter
+    fn get_default_filter() -> EnvFilter {
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("warn"))
+    }
+
+    #[tokio::main]
+    #[allow(unreachable_pub)]
+    pub async fn real_main() {
+        let exit_code = match run_main().await {
+            Ok(()) => ExitCode::Success,
+            Err(e) => {
+                error!("Error: {:#}", e);
+                categorize_error(&e)
             }
-            let unified_server = pmat::mcp_pmcp::UnifiedServer::new()
-                .map_err(|e| anyhow::anyhow!("Failed to create unified server: {}", e))?;
-            unified_server
-                .run()
-                .await
-                .map_err(|e| anyhow::anyhow!("{}", e))
+        };
+
+        if exit_code as i32 != 0 {
+            process::exit(exit_code.into());
         }
-        ExecutionMode::Cli => {
-            if !cli.is_mcp_server {
-                info!("Running in CLI mode");
-            }
-            cli::run(server).await
+    }
+
+    fn categorize_error(error: &anyhow::Error) -> ExitCode {
+        let error_str = error.to_string().to_lowercase();
+
+        match () {
+            _ if is_quality_gate_error(&error_str) => ExitCode::QualityGateFailure,
+            _ if is_configuration_error(&error_str) => ExitCode::ConfigurationError,
+            _ if is_analysis_error(&error_str) => ExitCode::AnalysisError,
+            _ if is_permission_error(&error_str) => ExitCode::PermissionDenied,
+            _ => ExitCode::GeneralError,
         }
-        ExecutionMode::HelpAndExit => {
-            // GH-285: No subcommand + piped stdin + no MCP_VERSION. Print help on
-            // stderr and exit with code 2 (misuse), matching the convention for
-            // "no command supplied" on a terminal.
-            let mut cmd = <pmat::cli::Cli as clap::CommandFactory>::command();
-            let _ = cmd.print_help();
-            eprintln!(
-                "\nerror: no subcommand given and stdin is not a terminal. \
-                 Set MCP_VERSION=1 (or run `pmat agent mcp-server`) to start the MCP server."
+    }
+
+    fn is_quality_gate_error(error_str: &str) -> bool {
+        error_str.contains("quality gate") || error_str.contains("violation")
+    }
+
+    fn is_configuration_error(error_str: &str) -> bool {
+        error_str.contains("config") || error_str.contains("parse")
+    }
+
+    fn is_analysis_error(error_str: &str) -> bool {
+        error_str.contains("analysis") || error_str.contains("complexity")
+    }
+
+    fn is_permission_error(error_str: &str) -> bool {
+        error_str.contains("permission") || error_str.contains("access")
+    }
+
+    async fn run_main() -> Result<()> {
+        // Parse CLI to get tracing configuration early
+        let cli = cli::parse_early_for_tracing();
+
+        // Initialize enhanced tracing system
+        init_tracing(&cli)?;
+
+        // Only log to stdout if not running MCP server mode
+        if !cli.is_mcp_server {
+            info!(
+                "Starting PAIML MCP Agent Toolkit v{}",
+                env!("CARGO_PKG_VERSION")
             );
-            process::exit(ExitCode::MisuseError as i32);
+            debug!("Debug logging enabled");
+            trace!("Trace logging enabled");
+        }
+
+        // Create shared template server
+        let server = Arc::new(StatelessTemplateServer::new()?);
+
+        if !cli.is_mcp_server {
+            debug!("Template server initialized");
+        }
+
+        match detect_execution_mode() {
+            ExecutionMode::Mcp => {
+                if !cli.is_mcp_server {
+                    info!("Running unified MCP server (pmcp SDK)");
+                }
+                let unified_server = pmat::mcp_pmcp::UnifiedServer::new()
+                    .map_err(|e| anyhow::anyhow!("Failed to create unified server: {}", e))?;
+                unified_server
+                    .run()
+                    .await
+                    .map_err(|e| anyhow::anyhow!("{}", e))
+            }
+            ExecutionMode::Cli => {
+                if !cli.is_mcp_server {
+                    info!("Running in CLI mode");
+                }
+                cli::run(server).await
+            }
+            ExecutionMode::HelpAndExit => {
+                // GH-285: No subcommand + piped stdin + no MCP_VERSION. Print help on
+                // stderr and exit with code 2 (misuse), matching the convention for
+                // "no command supplied" on a terminal.
+                let mut cmd = <pmat::cli::Cli as clap::CommandFactory>::command();
+                let _ = cmd.print_help();
+                eprintln!(
+                    "\nerror: no subcommand given and stdin is not a terminal. \
+                 Set MCP_VERSION=1 (or run `pmat agent mcp-server`) to start the MCP server."
+                );
+                process::exit(ExitCode::MisuseError as i32);
+            }
         }
     }
-}
 
-#[cfg_attr(coverage_nightly, coverage(off))]
-#[cfg(test)]
-mod gh285_tests {
-    //! Regression tests for GH-285: `pmat` hangs when invoked with no args
-    //! and stdin is a pipe. See `classify_execution_mode`.
-    //!
-    //! Manual end-to-end repro (should NOT hang or exit 124):
-    //! ```text
-    //! echo "" | timeout 3 target/debug/pmat 2>&1; echo exit=$?
-    //! timeout 3 target/debug/pmat < /dev/null; echo exit=$?
-    //! ```
-    //! Both should print help and exit with code 2.
-    use super::{classify_execution_mode, ExecutionMode};
+    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg(test)]
+    mod gh285_tests {
+        //! Regression tests for GH-285: `pmat` hangs when invoked with no args
+        //! and stdin is a pipe. See `classify_execution_mode`.
+        //!
+        //! Manual end-to-end repro (should NOT hang or exit 124):
+        //! ```text
+        //! echo "" | timeout 3 target/debug/pmat 2>&1; echo exit=$?
+        //! timeout 3 target/debug/pmat < /dev/null; echo exit=$?
+        //! ```
+        //! Both should print help and exit with code 2.
+        use super::{classify_execution_mode, ExecutionMode};
 
-    #[test]
-    fn bare_invocation_on_tty_is_cli() {
-        // `pmat` typed into a terminal with no pipe -> normal CLI (clap
-        // will then print help on missing subcommand).
-        assert!(matches!(
-            classify_execution_mode(false, true, false),
-            ExecutionMode::Cli
-        ));
+        #[test]
+        fn bare_invocation_on_tty_is_cli() {
+            // `pmat` typed into a terminal with no pipe -> normal CLI (clap
+            // will then print help on missing subcommand).
+            assert!(matches!(
+                classify_execution_mode(false, true, false),
+                ExecutionMode::Cli
+            ));
+        }
+
+        #[test]
+        fn piped_stdin_with_no_args_prints_help_instead_of_hanging() {
+            // GH-285: This used to enter MCP mode and block on stdin forever.
+            assert!(matches!(
+                classify_execution_mode(false, true, true),
+                ExecutionMode::HelpAndExit
+            ));
+        }
+
+        #[test]
+        fn explicit_mcp_version_env_still_enters_mcp_mode() {
+            // Claude Desktop and similar hosts set MCP_VERSION; they must still
+            // get the MCP server regardless of TTY state.
+            assert!(matches!(
+                classify_execution_mode(true, true, true),
+                ExecutionMode::Mcp
+            ));
+            assert!(matches!(
+                classify_execution_mode(true, false, false),
+                ExecutionMode::Mcp
+            ));
+        }
+
+        #[test]
+        fn subcommand_with_piped_stdin_is_still_cli() {
+            // `echo foo | pmat analyze ...` must dispatch to the CLI subcommand,
+            // not to help-and-exit.
+            assert!(matches!(
+                classify_execution_mode(false, false, true),
+                ExecutionMode::Cli
+            ));
+        }
     }
-
-    #[test]
-    fn piped_stdin_with_no_args_prints_help_instead_of_hanging() {
-        // GH-285: This used to enter MCP mode and block on stdin forever.
-        assert!(matches!(
-            classify_execution_mode(false, true, true),
-            ExecutionMode::HelpAndExit
-        ));
-    }
-
-    #[test]
-    fn explicit_mcp_version_env_still_enters_mcp_mode() {
-        // Claude Desktop and similar hosts set MCP_VERSION; they must still
-        // get the MCP server regardless of TTY state.
-        assert!(matches!(
-            classify_execution_mode(true, true, true),
-            ExecutionMode::Mcp
-        ));
-        assert!(matches!(
-            classify_execution_mode(true, false, false),
-            ExecutionMode::Mcp
-        ));
-    }
-
-    #[test]
-    fn subcommand_with_piped_stdin_is_still_cli() {
-        // `echo foo | pmat analyze ...` must dispatch to the CLI subcommand,
-        // not to help-and-exit.
-        assert!(matches!(
-            classify_execution_mode(false, false, true),
-            ExecutionMode::Cli
-        ));
-    }
-}
 } // end of mod full
 
 #[cfg(feature = "standard-deps")]

--- a/src/cli/handlers/query_handler/git_history.rs
+++ b/src/cli/handlers/query_handler/git_history.rs
@@ -24,3 +24,407 @@ include!("git_history_formatting.rs");
 
 // Git log parsing (PMAT_START block format) and commit classification
 include!("git_history_parsing.rs");
+
+#[cfg(test)]
+mod annotations_tests {
+    //! PMAT-653: cover git_history_annotations.rs pure helpers.
+    use super::*;
+    use crate::services::git_history::{ChangeType, CommitInfo, FileChange};
+    use std::collections::HashMap;
+    use tempfile::TempDir;
+
+    fn fc(path: &str, add: u32, del: u32) -> FileChange {
+        FileChange {
+            path: path.to_string(),
+            change_type: ChangeType::Modified,
+            lines_added: add,
+            lines_deleted: del,
+        }
+    }
+
+    fn commit(
+        hash: &str,
+        author: &str,
+        files: Vec<FileChange>,
+        is_fix: bool,
+        is_feat: bool,
+    ) -> CommitInfo {
+        CommitInfo {
+            hash: hash.to_string(),
+            message_subject: String::new(),
+            message_body: None,
+            author_name: author.to_string(),
+            author_email: String::new(),
+            timestamp: 0,
+            is_merge: false,
+            is_fix,
+            is_feat,
+            issue_refs: Vec::new(),
+            files,
+        }
+    }
+
+    fn write(p: &std::path::Path, content: &str) {
+        if let Some(parent) = p.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(p, content).unwrap();
+    }
+
+    // --- count_pairwise_cochanges ---
+
+    #[test]
+    fn test_count_pairwise_cochanges_empty() {
+        let mut m = HashMap::new();
+        count_pairwise_cochanges(&[], &mut m);
+        assert!(m.is_empty());
+    }
+
+    #[test]
+    fn test_count_pairwise_cochanges_single_file_no_pair() {
+        let mut m = HashMap::new();
+        count_pairwise_cochanges(&["a.rs"], &mut m);
+        assert!(m.is_empty());
+    }
+
+    #[test]
+    fn test_count_pairwise_cochanges_two_files_sorted() {
+        let mut m = HashMap::new();
+        count_pairwise_cochanges(&["b.rs", "a.rs"], &mut m);
+        assert_eq!(m.get(&("a.rs".to_string(), "b.rs".to_string())), Some(&1));
+    }
+
+    #[test]
+    fn test_count_pairwise_cochanges_three_files_makes_3_pairs() {
+        let mut m = HashMap::new();
+        count_pairwise_cochanges(&["a.rs", "b.rs", "c.rs"], &mut m);
+        assert_eq!(m.len(), 3);
+        assert_eq!(m[&("a.rs".to_string(), "b.rs".to_string())], 1);
+        assert_eq!(m[&("a.rs".to_string(), "c.rs".to_string())], 1);
+        assert_eq!(m[&("b.rs".to_string(), "c.rs".to_string())], 1);
+    }
+
+    // --- aggregate_hotspots ---
+
+    #[test]
+    fn test_aggregate_hotspots_accumulates_commit_counts_and_flags() {
+        let commits = vec![
+            commit("h1", "alice", vec![fc("a.rs", 10, 5)], true, false),
+            commit("h2", "alice", vec![fc("a.rs", 3, 1)], false, true),
+        ];
+        let (hotspots, cochange) = aggregate_hotspots(&commits);
+        let a = hotspots.get("a.rs").unwrap();
+        assert_eq!(a.commit_count, 2);
+        assert_eq!(a.fix_count, 1);
+        assert_eq!(a.feat_count, 1);
+        assert_eq!(a.lines_added, 13);
+        assert_eq!(a.lines_deleted, 6);
+        assert_eq!(a.authors.get("alice"), Some(&2));
+        assert!(cochange.is_empty());
+    }
+
+    #[test]
+    fn test_aggregate_hotspots_cochange_skipped_over_15_files() {
+        let files: Vec<FileChange> = (0..16).map(|i| fc(&format!("f{i}.rs"), 1, 0)).collect();
+        let commits = vec![commit("h", "a", files, false, false)];
+        let (_hotspots, cochange) = aggregate_hotspots(&commits);
+        assert!(
+            cochange.is_empty(),
+            "expected co-change skipped for merge-like commit"
+        );
+    }
+
+    #[test]
+    fn test_aggregate_hotspots_cochange_counted_2_files() {
+        let commits = vec![commit(
+            "h",
+            "a",
+            vec![fc("a.rs", 1, 0), fc("b.rs", 1, 0)],
+            false,
+            false,
+        )];
+        let (_hotspots, cochange) = aggregate_hotspots(&commits);
+        assert_eq!(cochange.len(), 1);
+    }
+
+    // --- compute_cochange_pairs ---
+
+    /// Helper: build a hotspots map where every file has `commit_count` ≥ any
+    /// observed co-change count. Prevents `ca + cb - count` underflow when
+    /// the production code's `hotspots.get(...)` default-maps to 1.
+    fn hotspots_with_counts(files: &[&str], commit_count: usize) -> HashMap<String, FileHotspot> {
+        let mut m = HashMap::new();
+        for f in files {
+            let mut h = FileHotspot::default();
+            h.commit_count = commit_count;
+            m.insert((*f).to_string(), h);
+        }
+        m
+    }
+
+    #[test]
+    fn test_compute_cochange_pairs_filters_below_3_threshold() {
+        let mut cc = HashMap::new();
+        cc.insert(("a.rs".to_string(), "b.rs".to_string()), 2);
+        cc.insert(("a.rs".to_string(), "c.rs".to_string()), 5);
+        let hotspots = hotspots_with_counts(&["a.rs", "b.rs", "c.rs"], 10);
+        let pairs = compute_cochange_pairs(cc, &hotspots);
+        // Only the (a,c)=5 pair passes >=3 threshold.
+        assert_eq!(pairs.len(), 1);
+        assert_eq!(pairs[0].count, 5);
+    }
+
+    #[test]
+    fn test_compute_cochange_pairs_sorts_desc_and_truncates_to_5() {
+        let mut cc = HashMap::new();
+        let mut paths: Vec<String> = Vec::new();
+        for i in 0..8 {
+            let a = format!("a{i}.rs");
+            let b = format!("b{i}.rs");
+            cc.insert((a.clone(), b.clone()), 10 + i as usize);
+            paths.push(a);
+            paths.push(b);
+        }
+        let path_refs: Vec<&str> = paths.iter().map(String::as_str).collect();
+        let hotspots = hotspots_with_counts(&path_refs, 50);
+        let pairs = compute_cochange_pairs(cc, &hotspots);
+        assert_eq!(pairs.len(), 5);
+        for i in 0..4 {
+            assert!(pairs[i].count >= pairs[i + 1].count, "not sorted desc");
+        }
+        assert_eq!(pairs[0].count, 17);
+    }
+
+    #[test]
+    fn test_compute_cochange_pairs_jaccard_calc() {
+        let mut cc = HashMap::new();
+        cc.insert(("a.rs".to_string(), "b.rs".to_string()), 10);
+        let mut hotspots: HashMap<String, FileHotspot> = HashMap::new();
+        let mut ha = FileHotspot::default();
+        ha.commit_count = 20;
+        hotspots.insert("a.rs".to_string(), ha);
+        let mut hb = FileHotspot::default();
+        hb.commit_count = 15;
+        hotspots.insert("b.rs".to_string(), hb);
+        let pairs = compute_cochange_pairs(cc, &hotspots);
+        // union = 20+15-10 = 25; jaccard = 10/25 = 0.4
+        assert!((pairs[0].jaccard - 0.4).abs() < 1e-6);
+    }
+
+    // --- compute_decay_score ---
+
+    fn hotspot_with(
+        grade: Option<&str>,
+        commit_count: usize,
+        fix_count: usize,
+        dead_pct: f32,
+    ) -> FileHotspot {
+        let mut h = FileHotspot::default();
+        h.annotation.tdg_grade = grade.map(String::from);
+        h.commit_count = commit_count;
+        h.fix_count = fix_count;
+        h.annotation.dead_code_pct = dead_pct;
+        h
+    }
+
+    #[test]
+    fn test_compute_decay_score_grade_a_is_zero() {
+        let h = hotspot_with(Some("A"), 10, 5, 0.0);
+        assert_eq!(compute_decay_score(&h, 100), 0.0);
+    }
+
+    #[test]
+    fn test_compute_decay_score_grade_f_with_heavy_churn_clamps_to_1() {
+        let h = hotspot_with(Some("F"), 100, 100, 50.0);
+        assert_eq!(compute_decay_score(&h, 100), 1.0);
+    }
+
+    #[test]
+    fn test_compute_decay_score_zero_commits_zero_score() {
+        let h = hotspot_with(Some("F"), 0, 0, 0.0);
+        assert_eq!(compute_decay_score(&h, 0), 0.0);
+    }
+
+    #[test]
+    fn test_compute_decay_score_grades_mapping() {
+        for (g, expected_tdg) in [
+            ("A", 0.0f32),
+            ("B", 0.25),
+            ("C", 0.5),
+            ("D", 0.75),
+            ("F", 1.0),
+        ] {
+            let h = hotspot_with(Some(g), 10, 0, 0.0);
+            let decay = compute_decay_score(&h, 10);
+            assert!(
+                (decay - expected_tdg).abs() < 1e-6,
+                "grade {g}: expected {expected_tdg}, got {decay}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_compute_decay_score_unknown_grade_maps_to_0_5() {
+        let h = hotspot_with(Some("X"), 10, 0, 0.0);
+        assert!((compute_decay_score(&h, 10) - 0.5).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_compute_decay_score_missing_grade_defaults_to_0_5() {
+        let h = hotspot_with(None, 10, 0, 0.0);
+        assert!((compute_decay_score(&h, 10) - 0.5).abs() < 1e-6);
+    }
+
+    // --- compute_impact_risk ---
+
+    #[test]
+    fn test_compute_impact_risk_zero_commits_zero() {
+        let h = FileHotspot::default();
+        assert_eq!(compute_impact_risk(&h, 0), 0.0);
+    }
+
+    #[test]
+    fn test_compute_impact_risk_with_pagerank_and_faults() {
+        let mut h = FileHotspot::default();
+        h.annotation.max_pagerank = Some(0.0005);
+        h.annotation.fault_count = 2;
+        h.commit_count = 10;
+        // pagerank*10000 = 5.0, churn = 10/100 = 0.1, (1+2) = 3 → 5 * 0.1 * 3 = 1.5
+        let r = compute_impact_risk(&h, 100);
+        assert!((r - 1.5).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_compute_impact_risk_clamps_to_100() {
+        let mut h = FileHotspot::default();
+        h.annotation.max_pagerank = Some(1.0);
+        h.annotation.fault_count = 100;
+        h.commit_count = 100;
+        assert_eq!(compute_impact_risk(&h, 100), 100.0);
+    }
+
+    // --- load_work_ticket ---
+
+    #[test]
+    fn test_load_work_ticket_non_pmat_prefix_returns_none() {
+        let tmp = TempDir::new().unwrap();
+        assert!(load_work_ticket(tmp.path(), "random-ref").is_none());
+    }
+
+    #[test]
+    fn test_load_work_ticket_missing_contract_returns_none() {
+        let tmp = TempDir::new().unwrap();
+        assert!(load_work_ticket(tmp.path(), "PMAT-99").is_none());
+    }
+
+    #[test]
+    fn test_load_work_ticket_hash_prefix_maps_to_pmat() {
+        let tmp = TempDir::new().unwrap();
+        let contract = serde_json::json!({
+            "claims": [
+                {"result": {"falsified": false}},
+                {"result": {"falsified": true}},
+                {"result": {"falsified": false}},
+            ],
+            "baseline_tdg": 1.5,
+        });
+        write(
+            &tmp.path().join(".pmat-work/PMAT-100/contract.json"),
+            &contract.to_string(),
+        );
+        let t = load_work_ticket(tmp.path(), "#100").expect("some");
+        assert_eq!(t.ticket_id, "PMAT-100");
+        assert_eq!(t.claims_total, 3);
+        assert_eq!(t.claims_passed, 2);
+        assert!((t.baseline_tdg - 1.5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_load_work_ticket_lowercase_pmat_uppercased() {
+        let tmp = TempDir::new().unwrap();
+        let contract = serde_json::json!({
+            "claims": [{"result": {"falsified": false}}],
+        });
+        write(
+            &tmp.path().join(".pmat-work/PMAT-7/contract.json"),
+            &contract.to_string(),
+        );
+        let t = load_work_ticket(tmp.path(), "pmat-7").expect("some");
+        assert_eq!(t.ticket_id, "PMAT-7");
+    }
+
+    // --- load_commit_quality ---
+
+    #[test]
+    fn test_load_commit_quality_missing_returns_none() {
+        let tmp = TempDir::new().unwrap();
+        assert!(load_commit_quality(tmp.path(), "abc1234").is_none());
+    }
+
+    #[test]
+    fn test_load_commit_quality_valid_parse() {
+        let tmp = TempDir::new().unwrap();
+        let meta = serde_json::json!({
+            "work_item_id": "PMAT-1",
+            "tdg_score": 85.5,
+            "repo_score": 90.0,
+        });
+        write(
+            &tmp.path().join(".pmat-metrics/commit-abc1234-meta.json"),
+            &meta.to_string(),
+        );
+        let q = load_commit_quality(tmp.path(), "abc1234567").expect("some");
+        assert!((q.tdg_score - 85.5).abs() < 1e-9);
+    }
+
+    // --- aggregate_bug_hunter_faults ---
+
+    #[test]
+    fn test_aggregate_bug_hunter_faults_missing_dir_empty() {
+        let tmp = TempDir::new().unwrap();
+        let counts = aggregate_bug_hunter_faults(&tmp.path().join("nonexistent"));
+        assert!(counts.is_empty());
+    }
+
+    #[test]
+    fn test_aggregate_bug_hunter_faults_counts_per_file() {
+        let tmp = TempDir::new().unwrap();
+        let cache = serde_json::json!({
+            "findings": [
+                {"file": "a.rs"},
+                {"file": "a.rs"},
+                {"file": "b.rs"},
+            ],
+        });
+        write(&tmp.path().join("cache.json"), &cache.to_string());
+        let counts = aggregate_bug_hunter_faults(tmp.path());
+        assert_eq!(counts.get("a.rs"), Some(&2));
+        assert_eq!(counts.get("b.rs"), Some(&1));
+    }
+
+    // --- load_bug_hunter_annotations ---
+
+    #[test]
+    fn test_load_bug_hunter_annotations_missing_dir_is_no_op() {
+        let tmp = TempDir::new().unwrap();
+        let mut annots: HashMap<String, FileAnnotation> = HashMap::new();
+        load_bug_hunter_annotations(tmp.path(), &mut annots);
+        assert!(annots.is_empty());
+    }
+
+    #[test]
+    fn test_load_bug_hunter_annotations_updates_fault_count_when_higher() {
+        let tmp = TempDir::new().unwrap();
+        let cache = serde_json::json!({
+            "findings": [{"file": "a.rs"}, {"file": "a.rs"}, {"file": "a.rs"}],
+        });
+        write(
+            &tmp.path().join(".pmat/bug-hunter-cache/cache.json"),
+            &cache.to_string(),
+        );
+        let mut annots: HashMap<String, FileAnnotation> = HashMap::new();
+        annots.insert("a.rs".to_string(), FileAnnotation::default());
+        load_bug_hunter_annotations(tmp.path(), &mut annots);
+        assert_eq!(annots["a.rs"].fault_count, 3);
+    }
+}

--- a/src/cli/handlers/query_handler/git_history.rs
+++ b/src/cli/handlers/query_handler/git_history.rs
@@ -26,6 +26,7 @@ include!("git_history_formatting.rs");
 include!("git_history_parsing.rs");
 
 #[cfg(test)]
+#[allow(clippy::field_reassign_with_default)]
 mod annotations_tests {
     //! PMAT-653: cover git_history_annotations.rs pure helpers.
     use super::*;

--- a/src/entropy/pattern_extractor_tests.rs
+++ b/src/entropy/pattern_extractor_tests.rs
@@ -845,7 +845,10 @@ fn test_calculate_pattern_match_variation_score_short_circuits_single_match() {
 
     let score =
         extractor.calculate_pattern_match_variation_score(&enums, &matches, &arrows, content);
-    assert_eq!(score, 0.0, "fewer than 2 match blocks must short-circuit to 0.0");
+    assert_eq!(
+        score, 0.0,
+        "fewer than 2 match blocks must short-circuit to 0.0"
+    );
 }
 
 /// pattern_extractor_ruchy.rs:405 — enum_matches.len() <= 1 low-variation arm (0.3).

--- a/src/maintenance/updater.rs
+++ b/src/maintenance/updater.rs
@@ -375,9 +375,13 @@ mod tests {
             files: vec!["src/lib.rs".into()], // no ticket file
         };
 
-        let result =
-            process_ticket_update(&mut roadmap, &commit, "TICKET-PMAT-5013", tickets_dir.path())
-                .unwrap();
+        let result = process_ticket_update(
+            &mut roadmap,
+            &commit,
+            "TICKET-PMAT-5013",
+            tickets_dir.path(),
+        )
+        .unwrap();
         assert!(!result, "must short-circuit when ticket file not in commit");
         assert!(!roadmap.sprints[0].tickets[0].completed);
     }
@@ -394,10 +398,17 @@ mod tests {
             files: vec!["docs/tickets/TICKET-PMAT-5013.md".into()],
         };
 
-        let result =
-            process_ticket_update(&mut roadmap, &commit, "TICKET-PMAT-5013", tickets_dir.path())
-                .unwrap();
-        assert!(!result, "missing ticket file must return Ok(false), not error");
+        let result = process_ticket_update(
+            &mut roadmap,
+            &commit,
+            "TICKET-PMAT-5013",
+            tickets_dir.path(),
+        )
+        .unwrap();
+        assert!(
+            !result,
+            "missing ticket file must return Ok(false), not error"
+        );
         assert!(!roadmap.sprints[0].tickets[0].completed);
     }
 
@@ -417,11 +428,7 @@ mod tests {
              Still failing.\n\n\
              ## Success Criteria\n\n\
              - [ ] One\n";
-        std::fs::write(
-            tickets_dir.path().join("TICKET-PMAT-5013.md"),
-            red_content,
-        )
-        .unwrap();
+        std::fs::write(tickets_dir.path().join("TICKET-PMAT-5013.md"), red_content).unwrap();
         let mut roadmap = create_test_roadmap();
         let commit = CommitInfo {
             hash: "deadbee".into(),
@@ -429,9 +436,13 @@ mod tests {
             files: vec!["docs/tickets/TICKET-PMAT-5013.md".into()],
         };
 
-        let result =
-            process_ticket_update(&mut roadmap, &commit, "TICKET-PMAT-5013", tickets_dir.path())
-                .unwrap();
+        let result = process_ticket_update(
+            &mut roadmap,
+            &commit,
+            "TICKET-PMAT-5013",
+            tickets_dir.path(),
+        )
+        .unwrap();
         assert!(!result, "RED ticket must not mark roadmap completed");
         assert!(!roadmap.sprints[0].tickets[0].completed);
     }
@@ -450,9 +461,13 @@ mod tests {
             files: vec!["docs/tickets/TICKET-PMAT-5013.md".into()],
         };
 
-        let result =
-            process_ticket_update(&mut roadmap, &commit, "TICKET-PMAT-5013", tickets_dir.path())
-                .unwrap();
+        let result = process_ticket_update(
+            &mut roadmap,
+            &commit,
+            "TICKET-PMAT-5013",
+            tickets_dir.path(),
+        )
+        .unwrap();
         assert!(result, "GREEN ticket must flip roadmap entry");
         assert!(roadmap.sprints[0].tickets[0].completed);
         assert_eq!(

--- a/src/mcp_pmcp/agent_context_handlers.rs
+++ b/src/mcp_pmcp/agent_context_handlers.rs
@@ -37,11 +37,7 @@ macro_rules! impl_pmat_handler {
 
         #[async_trait]
         impl ToolHandler for $wrapper {
-            async fn handle(
-                &self,
-                args: Value,
-                _extra: RequestHandlerExtra,
-            ) -> PmcpResult<Value> {
+            async fn handle(&self, args: Value, _extra: RequestHandlerExtra) -> PmcpResult<Value> {
                 self.inner.execute(args).await.map_err(PmcpError::internal)
             }
 

--- a/src/mcp_pmcp/analyze_handlers.rs
+++ b/src/mcp_pmcp/analyze_handlers.rs
@@ -32,7 +32,8 @@ use tracing::debug;
 // MCP tools (see R15 #3 bench matrix).
 pub use self::{
     ComplexityTool as AnalyzeComplexityTool, DeadCodeTool as AnalyzeDeadCodeTool,
-    SatdTool as AnalyzeSatdTool, TdgCompareTool as AnalyzeTdgCompareTool, TdgTool as AnalyzeTdgTool,
+    SatdTool as AnalyzeSatdTool, TdgCompareTool as AnalyzeTdgCompareTool,
+    TdgTool as AnalyzeTdgTool,
 };
 
 // Complexity analysis tool handler

--- a/src/mcp_pmcp/mod.rs
+++ b/src/mcp_pmcp/mod.rs
@@ -103,12 +103,12 @@ pub mod quality_handlers;
 pub mod quality_proxy_handler;
 pub mod server;
 pub mod simple_unified_server;
-pub mod tool_schemas;
 #[cfg_attr(coverage_nightly, coverage(off))]
 #[cfg(test)]
 pub mod tdg_git_context_tests;
 pub mod tdg_handlers;
 pub mod tool_functions;
+pub mod tool_schemas;
 pub mod tool_schemas_generated; // KAIZEN-0178: build.rs-generated tool schema registry
 pub mod tools; // Sprint 65 Phase 2B: MCP git-context integration
 

--- a/src/mcp_pmcp/tool_schemas.rs
+++ b/src/mcp_pmcp/tool_schemas.rs
@@ -45,7 +45,10 @@ pub fn paths_object_schema(extra_properties: Value, required: Vec<&str>) -> Valu
             base.insert(k.clone(), v.clone());
         }
     }
-    let req: Vec<Value> = required.into_iter().map(|s| Value::String(s.into())).collect();
+    let req: Vec<Value> = required
+        .into_iter()
+        .map(|s| Value::String(s.into()))
+        .collect();
     json!({
         "type": "object",
         "properties": base_props,


### PR DESCRIPTION
## Summary

Continues Phase-1 CLI pivot after PR #517/PMAT-652. \`git_history_annotations.rs\` is 319 lines, **235/262 missed broad**, 0 async. 13 pure helpers.

**29 new tests** covering:

- count_pairwise_cochanges (4): empty, single, 2-file sort, 3-file 3-pairs
- aggregate_hotspots (3): multi-commit accumulation, >15-file skip, 2-file co-change
- compute_cochange_pairs (3): <3 filter, sort-desc+truncate-5, jaccard calc
- compute_decay_score (6): grade A=0, F+heavy clamps to 1, zero-commits, full 5-grade map, unknown + missing default to 0.5
- compute_impact_risk (3): zero commits, pagerank+fault (1.5), clamp to 100
- load_work_ticket (4): non-PMAT / missing / #X→PMAT-X / pmat-X→PMAT-X
- load_commit_quality (2): missing, valid parse
- aggregate_bug_hunter_faults (2): missing dir, per-file counting
- load_bug_hunter_annotations (2): missing dir no-op, fault_count upgrade

## Gotcha: underflow in production code

\`compute_cochange_pairs\` has an \`attempt to subtract with overflow\` panic path when \`hotspots.get(...)\`'s default (1) is smaller than the observed co-change count. Tests use a \`hotspots_with_counts\` helper to keep \`ca + cb - count\` non-negative. **Not fixed in this PR** — raising it to surface if the user wants a separate bug-fix PR.

## Coverage impact

Expected delta: **~+0.07pp** on broad.

## Test plan

- [x] \`cargo test --lib -- annotations_tests\` — 29 passed, 0 failed
- [x] \`cargo fmt --all -- --check\` — clean
- [ ] CI gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)