### PR TITLE
test(coverage): PmatYamlConfig::save + completion_percentage leaf arms

### DIFF
--- a/src/cli/analysis_utilities/comprehensive_formatting.rs
+++ b/src/cli/analysis_utilities/comprehensive_formatting.rs
@@ -156,4 +156,211 @@ fn write_comp_duplicates_section(output: &mut String, duplicates: &DuplicateRepo
     Ok(())
 }
 
+#[cfg(test)]
+mod comprehensive_formatting_tests {
+    //! PMAT-633 cohort: cover comprehensive_formatting.rs (0% on broad,
+    //! 106 missed lines). The Report* structs are module-private but
+    //! constructible inside this include!()'d scope.
+    use super::*;
+
+    fn complexity_report() -> ComplexityReport {
+        ComplexityReport {
+            total_functions: 42,
+            high_complexity_count: 3,
+            average_complexity: 4.5,
+            p99_complexity: 25,
+            hotspots: vec![ComplexityHotspot {
+                function: "foo".into(),
+                file: "src/a.rs".into(),
+                complexity: 30,
+            }],
+        }
+    }
+
+    fn satd_report() -> SatdReport {
+        let mut by_type = HashMap::new();
+        by_type.insert("TODO".to_string(), 5);
+        let mut by_sev = HashMap::new();
+        by_sev.insert("Low".to_string(), 5);
+        SatdReport {
+            total_items: 5,
+            by_type,
+            by_severity: by_sev,
+            items: vec![SatdItem {
+                file: "src/a.rs".into(),
+                line: 10,
+                text: "TODO fix".into(),
+                satd_type: "TODO".into(),
+                severity: "Low".into(),
+            }],
+        }
+    }
+
+    fn tdg_report() -> TdgReport {
+        TdgReport {
+            average_tdg: 2.5,
+            critical_files: vec![TdgFile {
+                file: "src/c.rs".into(),
+                tdg_score: 3.0,
+                complexity: 20,
+                churn: 8,
+            }],
+            hotspot_count: 1,
+        }
+    }
+
+    fn dead_code_report() -> DeadCodeReport {
+        DeadCodeReport {
+            total_items: 7,
+            dead_code_percentage: 1.5,
+            items: vec![DeadCodeItem {
+                name: "unused".into(),
+                file: "src/d.rs".into(),
+                line: 99,
+                item_type: "function".into(),
+            }],
+        }
+    }
+
+    fn defect_report() -> DefectReport {
+        DefectReport {
+            high_risk_files: vec![DefectPrediction {
+                file: "src/e.rs".into(),
+                probability: 0.85,
+                factors: vec!["high churn".into()],
+            }],
+            total_analyzed: 100,
+            high_risk_count: 1,
+        }
+    }
+
+    fn duplicate_report() -> DuplicateReport {
+        DuplicateReport {
+            duplicate_blocks: 3,
+            duplicate_lines: 150,
+            duplicate_percentage: 4.2,
+            blocks: vec![DuplicateBlock {
+                files: vec!["src/a.rs".into(), "src/b.rs".into()],
+                lines: 50,
+                tokens: 200,
+            }],
+        }
+    }
+
+    fn full_report() -> ComprehensiveReport {
+        ComprehensiveReport {
+            complexity: Some(complexity_report()),
+            satd: Some(satd_report()),
+            tdg: Some(tdg_report()),
+            dead_code: Some(dead_code_report()),
+            defects: Some(defect_report()),
+            duplicates: Some(duplicate_report()),
+        }
+    }
+
+    // ── format_comp_as_json ──
+
+    #[test]
+    fn test_format_comp_as_json_empty_report_is_valid_json() {
+        let report = ComprehensiveReport::default();
+        let out = format_comp_as_json(&report).unwrap();
+        // Should parse back as JSON.
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert!(parsed.is_object());
+    }
+
+    #[test]
+    fn test_format_comp_as_json_populated_contains_all_sections() {
+        let report = full_report();
+        let out = format_comp_as_json(&report).unwrap();
+        for section in ["complexity", "satd", "tdg", "dead_code", "defects", "duplicates"] {
+            assert!(out.contains(section), "missing {section} in JSON: {out}");
+        }
+    }
+
+    // ── format_comp_as_markdown ──
+
+    #[test]
+    fn test_format_comp_as_markdown_no_exec_summary() {
+        let out = format_comp_as_markdown(&full_report(), false).unwrap();
+        assert!(out.contains("# Comprehensive Code Analysis Report"));
+        assert!(!out.contains("Executive Summary"));
+    }
+
+    #[test]
+    fn test_format_comp_as_markdown_with_exec_summary() {
+        let out = format_comp_as_markdown(&full_report(), true).unwrap();
+        assert!(out.contains("# Comprehensive Code Analysis Report"));
+        assert!(out.contains("Executive Summary"));
+    }
+
+    #[test]
+    fn test_format_comp_as_markdown_none_sections_are_skipped() {
+        // Empty report → headers for individual analyses absent.
+        let report = ComprehensiveReport::default();
+        let out = format_comp_as_markdown(&report, false).unwrap();
+        assert!(!out.contains("## Complexity Analysis"));
+        assert!(!out.contains("## Technical Debt (SATD)"));
+    }
+
+    #[test]
+    fn test_format_comp_as_markdown_populated_contains_all_section_headers() {
+        let out = format_comp_as_markdown(&full_report(), false).unwrap();
+        for header in [
+            "## Complexity Analysis",
+            "## Technical Debt (SATD)",
+            "## Technical Debt Gradient",
+            "## Dead Code",
+            "## Defect Prediction",
+            "## Code Duplication",
+        ] {
+            assert!(out.contains(header), "missing header `{header}`");
+        }
+    }
+
+    // ── format_comprehensive_report top-level dispatcher ──
+
+    #[test]
+    fn test_format_comprehensive_report_json_dispatch() {
+        let out = format_comprehensive_report(
+            &full_report(),
+            ComprehensiveOutputFormat::Json,
+            false,
+        )
+        .unwrap();
+        let _: serde_json::Value = serde_json::from_str(&out).unwrap();
+    }
+
+    #[test]
+    fn test_format_comprehensive_report_markdown_dispatch() {
+        let out = format_comprehensive_report(
+            &full_report(),
+            ComprehensiveOutputFormat::Markdown,
+            false,
+        )
+        .unwrap();
+        assert!(out.contains("# Comprehensive Code Analysis Report"));
+    }
+
+    #[test]
+    fn test_format_comprehensive_report_unrecognized_format_fallback() {
+        // Summary / Detailed / Sarif all fall into the catch-all string arm.
+        let out = format_comprehensive_report(
+            &full_report(),
+            ComprehensiveOutputFormat::Summary,
+            false,
+        )
+        .unwrap();
+        assert_eq!(out, "Comprehensive analysis completed.");
+
+        let out = format_comprehensive_report(
+            &full_report(),
+            ComprehensiveOutputFormat::Sarif,
+            false,
+        )
+        .unwrap();
+        assert_eq!(out, "Comprehensive analysis completed.");
+    }
+}
+
 // Incremental coverage stub data structures

--- a/src/cli/analysis_utilities/provability.rs
+++ b/src/cli/analysis_utilities/provability.rs
@@ -297,3 +297,133 @@ async fn output_defect_result(content: String, output: Option<PathBuf>) -> Resul
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod provability_tests {
+    //! Covers the pure-compute helpers in provability.rs (158 uncov on broad, 0% cov).
+    //! The async handlers + pmat-query-spawning paths are skipped.
+    use super::*;
+    use crate::services::defect_probability::{DefectScore, RiskLevel};
+
+    fn score_with(probability: f32, risk: RiskLevel, confidence: f32) -> DefectScore {
+        DefectScore {
+            probability,
+            contributing_factors: vec![("churn".to_string(), 0.5)],
+            confidence,
+            risk_level: risk,
+            recommendations: vec!["refactor".to_string()],
+        }
+    }
+
+    #[test]
+    fn test_should_include_prediction_high_risk_only_rejects_low_and_medium() {
+        let low = score_with(0.1, RiskLevel::Low, 0.9);
+        assert!(!should_include_prediction(&low, true, true, 0.0));
+
+        let medium = score_with(0.5, RiskLevel::Medium, 0.9);
+        assert!(!should_include_prediction(&medium, true, true, 0.0));
+    }
+
+    #[test]
+    fn test_should_include_prediction_high_risk_only_accepts_high() {
+        let high = score_with(0.9, RiskLevel::High, 0.9);
+        assert!(should_include_prediction(&high, true, true, 0.0));
+    }
+
+    #[test]
+    fn test_should_include_prediction_low_confidence_filter_rejects_below_threshold() {
+        let low_prob = score_with(0.2, RiskLevel::Low, 0.9);
+        assert!(!should_include_prediction(&low_prob, false, false, 0.5));
+    }
+
+    #[test]
+    fn test_should_include_prediction_low_confidence_filter_accepts_at_or_above_threshold() {
+        let at_thresh = score_with(0.5, RiskLevel::Medium, 0.9);
+        assert!(should_include_prediction(&at_thresh, false, false, 0.5));
+    }
+
+    #[test]
+    fn test_should_include_prediction_include_low_confidence_bypasses_threshold() {
+        let low_prob = score_with(0.1, RiskLevel::Low, 0.9);
+        assert!(should_include_prediction(&low_prob, false, true, 0.99));
+    }
+
+    #[test]
+    fn test_filter_and_sort_predictions_orders_by_probability_desc() {
+        let preds = vec![
+            ("a.rs".to_string(), score_with(0.2, RiskLevel::Low, 0.9)),
+            ("b.rs".to_string(), score_with(0.8, RiskLevel::High, 0.9)),
+            ("c.rs".to_string(), score_with(0.5, RiskLevel::Medium, 0.9)),
+        ];
+        let sorted = filter_and_sort_predictions(preds, 10);
+        assert_eq!(sorted[0].0, "b.rs");
+        assert_eq!(sorted[1].0, "c.rs");
+        assert_eq!(sorted[2].0, "a.rs");
+    }
+
+    #[test]
+    fn test_filter_and_sort_predictions_truncates_to_top_n() {
+        let preds = vec![
+            ("a.rs".to_string(), score_with(0.2, RiskLevel::Low, 0.9)),
+            ("b.rs".to_string(), score_with(0.8, RiskLevel::High, 0.9)),
+            ("c.rs".to_string(), score_with(0.5, RiskLevel::Medium, 0.9)),
+        ];
+        let sorted = filter_and_sort_predictions(preds, 2);
+        assert_eq!(sorted.len(), 2);
+        assert_eq!(sorted[0].0, "b.rs");
+        assert_eq!(sorted[1].0, "c.rs");
+    }
+
+    #[test]
+    fn test_filter_and_sort_predictions_empty_is_empty() {
+        let sorted = filter_and_sort_predictions(vec![], 5);
+        assert!(sorted.is_empty());
+    }
+
+    #[test]
+    fn test_create_defect_config_copies_all_fields() {
+        let cfg = create_defect_config(
+            0.7,
+            100,
+            true,
+            false,
+            true,
+            Some("src/*".into()),
+            Some("tests/*".into()),
+        );
+        assert!((cfg.confidence_threshold - 0.7).abs() < 1e-6);
+        assert_eq!(cfg.min_lines, 100);
+        assert!(cfg.include_low_confidence);
+        assert!(!cfg.high_risk_only);
+        assert!(cfg.include_recommendations);
+        assert_eq!(cfg.include.as_deref(), Some("src/*"));
+        assert_eq!(cfg.exclude.as_deref(), Some("tests/*"));
+    }
+
+    #[test]
+    fn test_create_file_metrics_derives_from_line_count() {
+        let m = create_file_metrics(std::path::Path::new("src/a.rs"), 200);
+        assert_eq!(m.lines_of_code, 200);
+        assert_eq!(m.cyclomatic_complexity, 10);
+        assert_eq!(m.cognitive_complexity, 13);
+        assert_eq!(m.file_path, "src/a.rs");
+        assert!((m.churn_score - 0.5).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_create_file_metrics_small_file_floors_complexity() {
+        let m = create_file_metrics(std::path::Path::new("t.rs"), 5);
+        assert_eq!(m.cyclomatic_complexity, 0);
+        assert_eq!(m.cognitive_complexity, 0);
+    }
+
+    #[test]
+    fn test_print_defect_analysis_header_runs() {
+        print_defect_analysis_header(
+            std::path::Path::new("/tmp/x"),
+            true,
+            false,
+            &DefectPredictionOutputFormat::Summary,
+        );
+    }
+}

--- a/src/cli/analysis_utilities/quality_checks_part1_complexity.rs
+++ b/src/cli/analysis_utilities/quality_checks_part1_complexity.rs
@@ -203,3 +203,151 @@ fn process_complexity_violation(
         });
     }
 }
+
+#[cfg(test)]
+mod part1_complexity_tests {
+    //! Covers the pure-compute helpers in quality_checks_part1_complexity.rs
+    //! (77 uncov on broad, 0% cov).
+    use super::*;
+    use crate::services::complexity::Violation;
+
+    fn error_violation(file: &str, value: u16, threshold: u16) -> Violation {
+        Violation::Error {
+            rule: "cyclomatic".into(),
+            message: "too complex".into(),
+            value,
+            threshold,
+            file: file.into(),
+            line: 42,
+            function: Some("my_fn".into()),
+        }
+    }
+
+    fn warning_violation(file: &str, value: u16, threshold: u16) -> Violation {
+        Violation::Warning {
+            rule: "cyclomatic".into(),
+            message: "too complex".into(),
+            value,
+            threshold,
+            file: file.into(),
+            line: 42,
+            function: None, // exercises `.unwrap_or("global")` branch
+        }
+    }
+
+    // ── load_exclude_paths ──
+
+    #[test]
+    fn test_load_exclude_paths_no_config_returns_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = load_exclude_paths(tmp.path());
+        assert!(paths.is_empty());
+    }
+
+    #[test]
+    fn test_load_exclude_paths_invalid_toml_returns_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join(".pmat-metrics.toml"), "not = [valid toml").unwrap();
+        let paths = load_exclude_paths(tmp.path());
+        assert!(paths.is_empty());
+    }
+
+    #[test]
+    fn test_load_exclude_paths_missing_section_returns_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join(".pmat-metrics.toml"), "[thresholds]\n").unwrap();
+        let paths = load_exclude_paths(tmp.path());
+        assert!(paths.is_empty());
+    }
+
+    #[test]
+    fn test_load_exclude_paths_parses_array_of_patterns() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join(".pmat-metrics.toml"),
+            "exclude_paths = [\"tests/**\", \"benches/**\", \"vendor/*\"]\n",
+        )
+        .unwrap();
+        let paths = load_exclude_paths(tmp.path());
+        assert_eq!(paths.len(), 3);
+    }
+
+    #[test]
+    fn test_load_exclude_paths_skips_invalid_globs() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join(".pmat-metrics.toml"),
+            // `[` is an invalid glob start (unclosed char class).
+            "exclude_paths = [\"tests/**\", \"[bad\"]\n",
+        )
+        .unwrap();
+        let paths = load_exclude_paths(tmp.path());
+        assert_eq!(paths.len(), 1, "invalid glob dropped via filter_map");
+    }
+
+    // ── is_violation_excluded ──
+
+    #[test]
+    fn test_is_violation_excluded_no_globs_never_excluded() {
+        let v = error_violation("src/a.rs", 50, 10);
+        assert!(!is_violation_excluded(&v, &[]));
+    }
+
+    #[test]
+    fn test_is_violation_excluded_matching_glob_excluded() {
+        let v = error_violation("tests/foo.rs", 50, 10);
+        let globs = vec![glob::Pattern::new("tests/**").unwrap()];
+        assert!(is_violation_excluded(&v, &globs));
+    }
+
+    #[test]
+    fn test_is_violation_excluded_nonmatching_glob_not_excluded() {
+        let v = error_violation("src/a.rs", 50, 10);
+        let globs = vec![glob::Pattern::new("tests/**").unwrap()];
+        assert!(!is_violation_excluded(&v, &globs));
+    }
+
+    #[test]
+    fn test_is_violation_excluded_matches_warning_variant_too() {
+        let v = warning_violation("benches/bench.rs", 20, 10);
+        let globs = vec![glob::Pattern::new("benches/**").unwrap()];
+        assert!(is_violation_excluded(&v, &globs));
+    }
+
+    // ── process_complexity_violation ──
+
+    #[test]
+    fn test_process_complexity_violation_error_above_threshold_pushes() {
+        let v = error_violation("src/a.rs", 50, 10);
+        let mut out = Vec::new();
+        process_complexity_violation(&v, &mut out);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].check_type, "complexity");
+        assert_eq!(out[0].severity, "error");
+        assert_eq!(out[0].line, Some(42));
+        // Function name embedded in message.
+        assert!(out[0].message.contains("my_fn"));
+        assert!(out[0].message.contains("complexity: 50"));
+        assert!(out[0].message.contains("threshold: 10"));
+    }
+
+    #[test]
+    fn test_process_complexity_violation_warning_above_threshold_uses_global_fn() {
+        let v = warning_violation("src/b.rs", 20, 10);
+        let mut out = Vec::new();
+        process_complexity_violation(&v, &mut out);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].severity, "warning");
+        // function=None → unwrap_or("global") arm.
+        assert!(out[0].message.starts_with("global:"));
+    }
+
+    #[test]
+    fn test_process_complexity_violation_below_threshold_not_pushed() {
+        // value ≤ threshold → skipped.
+        let v = error_violation("src/a.rs", 10, 10);
+        let mut out = Vec::new();
+        process_complexity_violation(&v, &mut out);
+        assert!(out.is_empty());
+    }
+}

--- a/src/cli/analysis_utilities/quality_checks_part2_security_duplicates.rs
+++ b/src/cli/analysis_utilities/quality_checks_part2_security_duplicates.rs
@@ -261,3 +261,176 @@ pub fn calculate_content_hash(content: &str) -> u64 {
     content.hash(&mut hasher);
     hasher.finish()
 }
+
+#[cfg(test)]
+mod security_duplicates_tests {
+    //! Covers pure-compute helpers in quality_checks_part2_security_duplicates.rs
+    //! (129 uncov on broad, 0% cov).
+    use super::*;
+
+    // ── get_security_patterns: regex list ──
+
+    #[test]
+    fn test_get_security_patterns_contains_password_api_key_secret() {
+        let patterns = get_security_patterns();
+        assert_eq!(patterns.len(), 3);
+        let messages: Vec<&str> = patterns.iter().map(|(_, m)| *m).collect();
+        assert!(messages.iter().any(|m| m.contains("password")));
+        assert!(messages.iter().any(|m| m.contains("API key")));
+        assert!(messages.iter().any(|m| m.contains("secret")));
+    }
+
+    #[test]
+    fn test_get_security_patterns_regexes_compile() {
+        for (pat, _msg) in get_security_patterns() {
+            regex::Regex::new(pat).expect("pattern must be a valid regex");
+        }
+    }
+
+    // ── scan_content_for_pattern: match / no-match + line numbers ──
+
+    #[test]
+    fn test_scan_content_for_pattern_match_adds_violation_with_1based_line() {
+        let re = regex::Regex::new(r#"(?i)password\s*=\s*["'][^"']+["']"#).unwrap();
+        let content = "// comment\nlet password = \"hunter2\"\nok";
+        let mut v: Vec<QualityViolation> = Vec::new();
+        scan_content_for_pattern(
+            content,
+            &re,
+            "password!",
+            std::path::Path::new("src/a.rs"),
+            &mut v,
+        );
+        assert_eq!(v.len(), 1);
+        assert_eq!(v[0].line, Some(2));
+        assert_eq!(v[0].check_type, "security");
+        assert_eq!(v[0].message, "password!");
+    }
+
+    #[test]
+    fn test_scan_content_for_pattern_miss_adds_nothing() {
+        let re = regex::Regex::new(r#"NEVER_MATCHES"#).unwrap();
+        let mut v = Vec::new();
+        scan_content_for_pattern(
+            "plain code",
+            &re,
+            "unused",
+            std::path::Path::new("f.rs"),
+            &mut v,
+        );
+        assert!(v.is_empty());
+    }
+
+    // ── is_file_large_enough ──
+
+    #[test]
+    fn test_is_file_large_enough_at_or_below_50_is_false() {
+        assert!(!is_file_large_enough(""));
+        assert!(!is_file_large_enough(&"x".repeat(50)));
+    }
+
+    #[test]
+    fn test_is_file_large_enough_above_50_is_true() {
+        assert!(is_file_large_enough(&"x".repeat(51)));
+        assert!(is_file_large_enough(&"x".repeat(1000)));
+    }
+
+    // ── generate_duplicate_violations + create_violations_for_duplicate_group ──
+
+    #[test]
+    fn test_generate_duplicate_violations_emits_one_per_file_in_dup_group() {
+        let mut map: std::collections::HashMap<u64, Vec<PathBuf>> =
+            std::collections::HashMap::new();
+        map.insert(
+            42,
+            vec![PathBuf::from("src/a.rs"), PathBuf::from("src/b.rs")],
+        );
+        // Singleton group should be ignored.
+        map.insert(99, vec![PathBuf::from("src/solo.rs")]);
+        let mut v: Vec<QualityViolation> = Vec::new();
+        generate_duplicate_violations(&map, &mut v);
+        assert_eq!(v.len(), 2);
+        assert!(v.iter().all(|x| x.check_type == "duplicate"));
+        assert!(v.iter().all(|x| x.severity == "warning"));
+    }
+
+    #[test]
+    fn test_generate_duplicate_violations_empty_map_produces_nothing() {
+        let map: std::collections::HashMap<u64, Vec<PathBuf>> = std::collections::HashMap::new();
+        let mut v: Vec<QualityViolation> = Vec::new();
+        generate_duplicate_violations(&map, &mut v);
+        assert!(v.is_empty());
+    }
+
+    // ── format_file_list ──
+
+    #[test]
+    fn test_format_file_list_joins_with_comma_space() {
+        let out = format_file_list(&[PathBuf::from("a.rs"), PathBuf::from("b.rs")]);
+        assert_eq!(out, "a.rs, b.rs");
+    }
+
+    #[test]
+    fn test_format_file_list_single_has_no_separator() {
+        let out = format_file_list(&[PathBuf::from("only.rs")]);
+        assert_eq!(out, "only.rs");
+    }
+
+    #[test]
+    fn test_format_file_list_empty_produces_empty_string() {
+        let out = format_file_list(&[]);
+        assert_eq!(out, "");
+    }
+
+    // ── normalize_code_content ──
+
+    #[test]
+    fn test_normalize_code_content_strips_blank_and_comment_lines() {
+        let src = "\n// comment\n/* block-start\nreal line\n  indented line  \n\n";
+        let norm = normalize_code_content(src);
+        // Blank + `//` + `/*` lines filtered; real lines trimmed; joined by "\n".
+        assert!(norm.contains("real line"));
+        assert!(norm.contains("indented line"));
+        assert!(!norm.contains("// comment"));
+        assert!(!norm.contains("/* block-start"));
+    }
+
+    #[test]
+    fn test_normalize_code_content_empty_input_is_empty_output() {
+        assert_eq!(normalize_code_content(""), "");
+    }
+
+    // ── calculate_content_hash: deterministic + collision-free on distinct input ──
+
+    #[test]
+    fn test_calculate_content_hash_deterministic() {
+        let a = calculate_content_hash("pmat");
+        let b = calculate_content_hash("pmat");
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn test_calculate_content_hash_distinct_for_distinct_input() {
+        let a = calculate_content_hash("pmat");
+        let b = calculate_content_hash("pmat ");
+        assert_ne!(a, b);
+    }
+
+    // ── should_process_file_for_duplicates: delegates to helpers, exercise
+    //    the `is_file()` false branch via a path that's not a file ──
+
+    #[test]
+    fn test_should_process_file_for_duplicates_non_file_path_rejected() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Directory, not a file → false.
+        assert!(!should_process_file_for_duplicates(tmp.path()));
+    }
+
+    #[test]
+    fn test_should_process_file_for_duplicates_accepts_rust_source() {
+        let tmp = tempfile::tempdir().unwrap();
+        let src = tmp.path().join("a.rs");
+        std::fs::write(&src, "fn x() {}").unwrap();
+        assert!(should_process_file_for_duplicates(&src));
+    }
+}

--- a/src/cli/analysis_utilities/quality_gate_part2b.rs
+++ b/src/cli/analysis_utilities/quality_gate_part2b.rs
@@ -168,6 +168,161 @@ fn parse_loc_reduction(message: &str) -> usize {
         .unwrap_or(0)
 }
 
+#[cfg(test)]
+mod part2b_pure_tests {
+    //! Covers the pure-compute helpers in quality_gate_part2b.rs (145 uncov
+    //! on broad, 0% cov). The SQLite persistence async fn's are skipped.
+    use super::*;
+
+    // ── print_quality_gate_final_status: both branches (eprintln-only) ──
+
+    #[test]
+    fn test_print_quality_gate_final_status_passed_path() {
+        let mut r = QualityGateResults::default();
+        r.passed = true;
+        print_quality_gate_final_status(&r, &[]);
+    }
+
+    #[test]
+    fn test_print_quality_gate_final_status_failed_path() {
+        let mut r = QualityGateResults::default();
+        r.passed = false;
+        let v = vec![QualityViolation::new(
+            "satd",
+            "warn",
+            "f.rs",
+            Some(1),
+            "TODO",
+        )];
+        print_quality_gate_final_status(&r, &v);
+    }
+
+    // ── handle_quality_gate_exit_status: no-exit branches only ──
+    // (The `std::process::exit(1)` branch would terminate the test process,
+    // so we only drive the three non-exiting combos.)
+
+    #[test]
+    fn test_handle_quality_gate_exit_status_not_fail_on_violation_noop() {
+        // fail_on_violation=false: never exits regardless of passed flag.
+        handle_quality_gate_exit_status(false, false);
+        handle_quality_gate_exit_status(false, true);
+    }
+
+    #[test]
+    fn test_handle_quality_gate_exit_status_passed_fail_on_violation_noop() {
+        // fail_on_violation=true + passed=true: no exit.
+        handle_quality_gate_exit_status(true, true);
+    }
+
+    // ── parse_entropy_score_factors: all three prefix arms + unknown skipped ──
+
+    #[test]
+    fn test_parse_entropy_score_factors_extracts_all_fields() {
+        let factors = vec![
+            "pattern_type: AST_A".to_string(),
+            "repetitions: 7".to_string(),
+            "variation_score: 0.42".to_string(),
+            "ignored_factor: nothing".to_string(),
+        ];
+        let (pt, reps, vs) = parse_entropy_score_factors(&factors);
+        assert_eq!(pt, "AST_A");
+        assert_eq!(reps, 7);
+        assert!((vs - 0.42).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_parse_entropy_score_factors_missing_fields_default_to_zero() {
+        let (pt, reps, vs) = parse_entropy_score_factors(&[]);
+        assert_eq!(pt, "");
+        assert_eq!(reps, 0);
+        assert_eq!(vs, 0.0);
+    }
+
+    #[test]
+    fn test_parse_entropy_score_factors_malformed_values_fall_back_to_zero() {
+        let factors = vec![
+            "repetitions: not-a-number".to_string(),
+            "variation_score: NaN".to_string(),
+        ];
+        let (_, reps, vs) = parse_entropy_score_factors(&factors);
+        assert_eq!(reps, 0, "unparseable → 0 via unwrap_or");
+        // "NaN".parse::<f64>() ACCEPTS "NaN" and returns NaN.
+        assert!(vs.is_nan() || vs == 0.0);
+    }
+
+    // ── parse_loc_reduction: present vs absent "saves N" patterns ──
+
+    #[test]
+    fn test_parse_loc_reduction_parses_saves_prefix_number() {
+        assert_eq!(
+            parse_loc_reduction("Entropy pattern saves 42 lines"),
+            42
+        );
+        assert_eq!(parse_loc_reduction("prefix saves 0 lines"), 0);
+    }
+
+    #[test]
+    fn test_parse_loc_reduction_missing_prefix_returns_zero() {
+        assert_eq!(parse_loc_reduction("no savings mentioned"), 0);
+        assert_eq!(parse_loc_reduction(""), 0);
+    }
+
+    #[test]
+    fn test_parse_loc_reduction_saves_with_nonnumeric_returns_zero() {
+        assert_eq!(parse_loc_reduction("saves many lines"), 0);
+    }
+
+    // ── entropy_violation_to_tuple: None when details missing, Some when present ──
+
+    #[test]
+    fn test_entropy_violation_to_tuple_none_when_details_missing() {
+        let v = QualityViolation::new("entropy", "warn", "f.rs", Some(1), "msg saves 3 lines");
+        // `QualityViolation::new` produces `details: None`.
+        assert!(entropy_violation_to_tuple(&v).is_none());
+    }
+
+    #[test]
+    fn test_entropy_violation_to_tuple_some_when_details_present() {
+        let mut v = QualityViolation::new(
+            "entropy",
+            "warn",
+            "src/a.rs",
+            Some(10),
+            "entropy saves 12 lines",
+        );
+        v.details = Some(ViolationDetails {
+            affected_files: vec!["src/a.rs".into()],
+            example_code: Some("fn x() {}".into()),
+            fix_suggestion: None,
+            score_factors: vec![
+                "pattern_type: AST_Z".into(),
+                "repetitions: 4".into(),
+                "variation_score: 0.25".into(),
+            ],
+        });
+        let tup = entropy_violation_to_tuple(&v).expect("details present → Some");
+        // (file, pattern_type, pattern_hash, repetitions, variation_score,
+        //  loc_reduction, severity, example_code)
+        assert_eq!(tup.0, "src/a.rs");
+        assert_eq!(tup.1, "AST_Z");
+        assert_eq!(tup.2, "AST_Z:src/a.rs");
+        assert_eq!(tup.3, 4);
+        assert!((tup.4 - 0.25).abs() < 1e-6);
+        assert_eq!(tup.5, 12);
+        assert_eq!(tup.6, "warn");
+        assert_eq!(tup.7.as_deref(), Some("fn x() {}"));
+    }
+
+    // ── persist_violations_to_sqlite early-return when no DB ──
+
+    #[test]
+    fn test_persist_violations_to_sqlite_no_db_is_noop() {
+        let tmp = tempfile::tempdir().unwrap();
+        // tempdir has no .pmat/context.db → early-return, should not panic.
+        persist_violations_to_sqlite(tmp.path(), &[], true);
+    }
+}
+
 /// Run lightweight provability analysis and persist per-function scores (#231).
 ///
 /// Must be called from async context. Runs the analyzer on sampled functions

--- a/src/cli/analysis_utilities/quality_gate_part2b.rs
+++ b/src/cli/analysis_utilities/quality_gate_part2b.rs
@@ -169,6 +169,7 @@ fn parse_loc_reduction(message: &str) -> usize {
 }
 
 #[cfg(test)]
+#[allow(clippy::field_reassign_with_default)]
 mod part2b_pure_tests {
     //! Covers the pure-compute helpers in quality_gate_part2b.rs (145 uncov
     //! on broad, 0% cov). The SQLite persistence async fn's are skipped.

--- a/src/cli/analysis_utilities/quality_gate_part2c.rs
+++ b/src/cli/analysis_utilities/quality_gate_part2c.rs
@@ -267,3 +267,144 @@ async fn check_single_file_security(
 
     Ok(violations)
 }
+
+#[cfg(test)]
+mod quality_gate_part2c_pure_tests {
+    //! Covers the pure-compute helpers in quality_gate_part2c.rs (202 uncov
+    //! on broad, 0% cov). Skipped: async fn's that hit disk / AST analysis.
+    use super::*;
+    use crate::services::complexity::{ComplexityMetrics, FunctionComplexity};
+
+    fn make_func(name: &str, cyclomatic: u16) -> FunctionComplexity {
+        FunctionComplexity {
+            name: name.to_string(),
+            line_start: 10,
+            line_end: 30,
+            metrics: ComplexityMetrics {
+                cyclomatic,
+                cognitive: cyclomatic,
+                nesting_max: 3,
+                lines: 20,
+                halstead: None,
+            },
+        }
+    }
+
+    // ── resolve_absolute_file_path: both branches ──
+
+    #[test]
+    fn test_resolve_absolute_file_path_absolute_input_preserved() {
+        let abs = std::path::Path::new("/tmp/a.rs");
+        let result = resolve_absolute_file_path(std::path::Path::new("/ignored"), abs);
+        assert_eq!(result, std::path::PathBuf::from("/tmp/a.rs"));
+    }
+
+    #[test]
+    fn test_resolve_absolute_file_path_relative_joined_with_project() {
+        let base = std::path::Path::new("/home/proj");
+        let rel = std::path::Path::new("src/a.rs");
+        let result = resolve_absolute_file_path(base, rel);
+        assert_eq!(result, std::path::PathBuf::from("/home/proj/src/a.rs"));
+    }
+
+    // ── validate_file_exists: ok + err arms ──
+
+    #[test]
+    fn test_validate_file_exists_missing_returns_err() {
+        let missing = std::path::Path::new("/tmp/pmat_nope_0xDEADBEEF.rs");
+        let err = validate_file_exists(missing).unwrap_err();
+        assert!(err.to_string().contains("File not found"));
+    }
+
+    #[test]
+    fn test_validate_file_exists_existing_path_returns_ok() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        assert!(validate_file_exists(tmp.path()).is_ok());
+    }
+
+    // ── function_exceeds_complexity_threshold: both branches ──
+
+    #[test]
+    fn test_function_exceeds_complexity_threshold_below_is_false() {
+        let f = make_func("f", 5);
+        assert!(!function_exceeds_complexity_threshold(&f, 10));
+    }
+
+    #[test]
+    fn test_function_exceeds_complexity_threshold_equal_is_false() {
+        let f = make_func("f", 10);
+        // Uses > (strict), so equal to max_complexity does NOT exceed.
+        assert!(!function_exceeds_complexity_threshold(&f, 10));
+    }
+
+    #[test]
+    fn test_function_exceeds_complexity_threshold_above_is_true() {
+        let f = make_func("f", 25);
+        assert!(function_exceeds_complexity_threshold(&f, 10));
+    }
+
+    // ── create_complexity_violation: shape of emitted violation ──
+
+    #[test]
+    fn test_create_complexity_violation_fills_all_fields() {
+        let f = make_func("foo_bar", 42);
+        let violation =
+            create_complexity_violation(&f, std::path::Path::new("src/foo.rs"), 10);
+        assert_eq!(violation.check_type, "complexity");
+        assert_eq!(violation.severity, "error");
+        assert_eq!(violation.file, "src/foo.rs");
+        assert_eq!(violation.line, Some(10)); // line_start=10
+        assert!(
+            violation.message.contains("foo_bar"),
+            "msg must name the function: {}",
+            violation.message
+        );
+        assert!(
+            violation.message.contains("42"),
+            "msg must carry cyclomatic value"
+        );
+        assert!(
+            violation.message.contains("max: 10"),
+            "msg must carry threshold"
+        );
+        assert!(violation.details.is_none());
+    }
+
+    // ── analyze_file_complexity early-return on non-rust extensions ──
+
+    #[tokio::test]
+    async fn test_analyze_file_complexity_non_rust_extension_is_no_op() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("a.py");
+        std::fs::write(&path, "print(1)").unwrap();
+        let mut violations = Vec::new();
+        // Non-rust extension → early return without touching the analyzer.
+        let res = analyze_file_complexity(&path, std::path::Path::new("a.py"), 10, &mut violations)
+            .await;
+        assert!(res.is_ok());
+        assert!(violations.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_analyze_file_complexity_no_extension_is_no_op() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("README");
+        std::fs::write(&path, "hi").unwrap();
+        let mut violations = Vec::new();
+        let res =
+            analyze_file_complexity(&path, std::path::Path::new("README"), 10, &mut violations)
+                .await;
+        assert!(res.is_ok());
+        assert!(violations.is_empty());
+    }
+
+    // ── check_single_file_dead_code on missing file short-circuits ──
+
+    #[tokio::test]
+    async fn test_check_single_file_dead_code_missing_file_returns_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        let missing = tmp.path().join("nope.rs");
+        let res = check_single_file_dead_code(tmp.path(), &missing).await.unwrap();
+        assert!(res.is_empty(), "missing file → 0 violations");
+    }
+}

--- a/src/cli/analysis_utilities/quality_gate_part2f.rs
+++ b/src/cli/analysis_utilities/quality_gate_part2f.rs
@@ -335,4 +335,159 @@ exclude = ["**/gqa.rs"]
         assert_eq!(results.total_violations, 3);
         assert_eq!(results.entropy_violations, 0);
     }
+
+    // ===================
+    // Filesystem helpers: count_source_files / has_matching_extension /
+    // is_traversable_dir / count_files_recursive / scale_entropy_for_project_size
+    // (0%-covered leaves of load_entropy_threshold; quality_gate_config.rs:91..142)
+    // ===================
+
+    #[test]
+    fn test_has_matching_extension_hit_and_miss() {
+        let exts = &["rs", "py"];
+        assert!(has_matching_extension(std::path::Path::new("foo.rs"), exts));
+        assert!(has_matching_extension(std::path::Path::new("bar/baz.py"), exts));
+        assert!(!has_matching_extension(
+            std::path::Path::new("foo.md"),
+            exts
+        ));
+        // No extension at all — extension() returns None, so is_some_and is false.
+        assert!(!has_matching_extension(std::path::Path::new("README"), exts));
+    }
+
+    #[test]
+    fn test_is_traversable_dir_rejects_hidden_target_node_modules() {
+        assert!(is_traversable_dir(std::path::Path::new("src")));
+        assert!(is_traversable_dir(std::path::Path::new("lib/nested")));
+        // Hidden dot-dir
+        assert!(!is_traversable_dir(std::path::Path::new(".git")));
+        assert!(!is_traversable_dir(std::path::Path::new("foo/.hidden")));
+        // Explicit disallow list
+        assert!(!is_traversable_dir(std::path::Path::new("target")));
+        assert!(!is_traversable_dir(std::path::Path::new("node_modules")));
+        // Non-UTF8 / no file name (root) — and_then(to_str) → None → is_some_and = false.
+        assert!(!is_traversable_dir(std::path::Path::new("/")));
+    }
+
+    #[test]
+    fn test_count_files_recursive_counts_only_matching_extensions() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        // Matching: 3 .rs
+        std::fs::write(tmp.path().join("a.rs"), "").unwrap();
+        std::fs::write(tmp.path().join("b.rs"), "").unwrap();
+        let nested = tmp.path().join("nested");
+        std::fs::create_dir(&nested).unwrap();
+        std::fs::write(nested.join("c.rs"), "").unwrap();
+        // Non-matching
+        std::fs::write(tmp.path().join("d.md"), "").unwrap();
+        std::fs::write(nested.join("e.txt"), "").unwrap();
+
+        let count = count_files_recursive(tmp.path(), &["rs"], 0);
+        assert_eq!(count, 3, "should count only .rs files, not .md/.txt");
+    }
+
+    #[test]
+    fn test_count_files_recursive_skips_target_and_hidden_dirs() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        // Top-level match counts.
+        std::fs::write(tmp.path().join("top.rs"), "").unwrap();
+        // target/ is skipped by is_traversable_dir.
+        let target = tmp.path().join("target");
+        std::fs::create_dir(&target).unwrap();
+        std::fs::write(target.join("inside.rs"), "").unwrap();
+        // .git/ (hidden) is skipped.
+        let git = tmp.path().join(".git");
+        std::fs::create_dir(&git).unwrap();
+        std::fs::write(git.join("hook.rs"), "").unwrap();
+
+        let count = count_files_recursive(tmp.path(), &["rs"], 0);
+        assert_eq!(count, 1, "only the top-level .rs should be counted");
+    }
+
+    #[test]
+    fn test_count_files_recursive_depth_limit_returns_zero() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::fs::write(tmp.path().join("x.rs"), "").unwrap();
+        // Pass depth=11 (> max 10) — hits the early-return arm.
+        assert_eq!(count_files_recursive(tmp.path(), &["rs"], 11), 0);
+    }
+
+    #[test]
+    fn test_count_files_recursive_read_dir_error_returns_zero() {
+        // Point at a non-existent path so std::fs::read_dir returns Err.
+        let missing = std::path::Path::new("/nonexistent/pmat/dir/0xC0FFEE");
+        assert_eq!(count_files_recursive(missing, &["rs"], 0), 0);
+    }
+
+    #[test]
+    fn test_count_source_files_uses_src_dir_when_present() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let src = tmp.path().join("src");
+        std::fs::create_dir(&src).unwrap();
+        std::fs::write(src.join("lib.rs"), "").unwrap();
+        std::fs::write(src.join("main.rs"), "").unwrap();
+        // Outside src/ — should NOT be counted once src/ exists.
+        std::fs::write(tmp.path().join("root.rs"), "").unwrap();
+
+        let count = count_source_files(tmp.path());
+        assert_eq!(count, 2, "only src/ contents should count");
+    }
+
+    #[test]
+    fn test_count_source_files_falls_back_to_root_when_no_source_dir() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        // No src/lib/app/pkg/crates — fall back to root shallow count.
+        std::fs::write(tmp.path().join("script.py"), "").unwrap();
+        std::fs::write(tmp.path().join("README.md"), "").unwrap();
+
+        let count = count_source_files(tmp.path());
+        assert_eq!(count, 1, ".py counts, .md does not");
+    }
+
+    #[test]
+    fn test_scale_entropy_for_project_size_all_bands() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let src = tmp.path().join("src");
+        std::fs::create_dir(&src).unwrap();
+
+        // < 10 files → scale 0.5
+        for i in 0..5 {
+            std::fs::write(src.join(format!("a{i}.rs")), "").unwrap();
+        }
+        let scaled = scale_entropy_for_project_size(tmp.path(), 1.0);
+        assert!(
+            (scaled - 0.5).abs() < f64::EPSILON,
+            "< 10 files → 0.5 (got {scaled})"
+        );
+
+        // 10–24 files → scale 0.7
+        for i in 5..15 {
+            std::fs::write(src.join(format!("a{i}.rs")), "").unwrap();
+        }
+        let scaled = scale_entropy_for_project_size(tmp.path(), 1.0);
+        assert!(
+            (scaled - 0.7).abs() < f64::EPSILON,
+            "10–24 files → 0.7 (got {scaled})"
+        );
+
+        // 25–49 files → scale 0.85
+        for i in 15..35 {
+            std::fs::write(src.join(format!("a{i}.rs")), "").unwrap();
+        }
+        let scaled = scale_entropy_for_project_size(tmp.path(), 1.0);
+        assert!(
+            (scaled - 0.85).abs() < f64::EPSILON,
+            "25–49 files → 0.85 (got {scaled})"
+        );
+
+        // ≥ 50 files → scale 1.0 (no scaling)
+        for i in 35..60 {
+            std::fs::write(src.join(format!("a{i}.rs")), "").unwrap();
+        }
+        let scaled = scale_entropy_for_project_size(tmp.path(), 0.42);
+        assert!(
+            (scaled - 0.42).abs() < f64::EPSILON,
+            "≥ 50 files → identity (got {scaled})"
+        );
+    }
 }

--- a/src/cli/analysis_utilities/satd_formatting.rs
+++ b/src/cli/analysis_utilities/satd_formatting.rs
@@ -191,3 +191,124 @@ fn print_satd_metrics(items: &[crate::services::satd_detector::TechnicalDebt]) {
     eprintln!("  Files affected: {}", files_with_satd.len());
 }
 
+#[cfg(test)]
+mod satd_formatting_tests {
+    use super::*;
+    use crate::services::satd_detector::{DebtCategory, Severity, TechnicalDebt};
+    use std::path::PathBuf;
+
+    fn make_debt(sev: Severity, cat: DebtCategory, file: &str, line: u32) -> TechnicalDebt {
+        TechnicalDebt {
+            category: cat,
+            severity: sev,
+            text: format!("{cat:?} at {file}:{line}"),
+            file: PathBuf::from(file),
+            line,
+            column: 1,
+            context_hash: [0u8; 16],
+        }
+    }
+
+    #[test]
+    fn test_format_satd_json_without_metrics_or_evolution() {
+        let items = vec![make_debt(Severity::Low, DebtCategory::Design, "a.rs", 1)];
+        let out = format_satd_json(&items, false, false);
+        assert!(out.contains("\"total_items\""));
+        assert!(out.contains("\"items\""));
+        assert!(!out.contains("\"metrics\""));
+    }
+
+    #[test]
+    fn test_format_satd_json_with_metrics_emits_severity_counts() {
+        let items = vec![
+            make_debt(Severity::High, DebtCategory::Defect, "a.rs", 1),
+            make_debt(Severity::High, DebtCategory::Defect, "b.rs", 2),
+            make_debt(Severity::Low, DebtCategory::Requirement, "c.rs", 3),
+        ];
+        let out = format_satd_json(&items, true, false);
+        assert!(out.contains("\"metrics\""));
+        assert!(out.contains("High"));
+        assert!(out.contains("Low"));
+    }
+
+    #[test]
+    fn test_format_satd_json_empty_items_produces_zero_total() {
+        let items: Vec<TechnicalDebt> = vec![];
+        let out = format_satd_json(&items, true, true);
+        // Accept pretty or compact JSON formatting.
+        assert!(
+            out.contains("\"total_items\":0") || out.contains("\"total_items\": 0"),
+            "expected zero total in output: {out}"
+        );
+    }
+
+    #[test]
+    fn test_format_satd_sarif_has_sarif_envelope() {
+        let items = vec![make_debt(Severity::High, DebtCategory::Security, "s.rs", 42)];
+        let out = format_satd_sarif(&items);
+        assert!(out.contains("sarif") || out.contains("\"version\""));
+    }
+
+    #[test]
+    fn test_format_satd_sarif_empty_items_still_emits_valid_envelope() {
+        let out = format_satd_sarif(&[]);
+        assert!(!out.is_empty());
+    }
+
+    #[test]
+    fn test_format_satd_markdown_empty_produces_nonempty() {
+        let out = format_satd_markdown(&[], false, 0);
+        assert!(!out.is_empty());
+    }
+
+    #[test]
+    fn test_format_satd_markdown_with_items_contains_file_paths() {
+        let items = vec![
+            make_debt(Severity::Medium, DebtCategory::Test, "tests/foo.rs", 10),
+            make_debt(Severity::Low, DebtCategory::Performance, "src/p.rs", 20),
+        ];
+        let out = format_satd_markdown(&items, false, 0);
+        assert!(out.contains("tests/foo.rs") || out.contains("foo.rs"));
+        assert!(out.contains("src/p.rs") || out.contains("p.rs"));
+    }
+
+    #[test]
+    fn test_format_satd_markdown_with_evolution_flag_does_not_panic() {
+        let items = vec![make_debt(Severity::Low, DebtCategory::Design, "x.rs", 1)];
+        let out = format_satd_markdown(&items, true, 30);
+        assert!(!out.is_empty());
+    }
+
+    #[test]
+    fn test_format_satd_summary_empty_is_nonempty_string() {
+        let out = format_satd_summary(&[]);
+        assert!(!out.is_empty());
+    }
+
+    #[test]
+    fn test_format_satd_summary_reports_total_count() {
+        let items = vec![
+            make_debt(Severity::Low, DebtCategory::Requirement, "a.rs", 1),
+            make_debt(Severity::High, DebtCategory::Defect, "b.rs", 2),
+            make_debt(Severity::Critical, DebtCategory::Security, "c.rs", 3),
+        ];
+        let out = format_satd_summary(&items);
+        assert!(out.contains("3") || out.contains("total"));
+    }
+
+    #[test]
+    fn test_print_satd_metrics_runs_across_severity_mix() {
+        let items = vec![
+            make_debt(Severity::Low, DebtCategory::Test, "a.rs", 1),
+            make_debt(Severity::High, DebtCategory::Defect, "a.rs", 2),
+            make_debt(Severity::High, DebtCategory::Security, "b.rs", 3),
+        ];
+        print_satd_metrics(&items);
+    }
+
+    #[test]
+    fn test_print_satd_metrics_empty_is_safe() {
+        print_satd_metrics(&[]);
+    }
+}
+

--- a/src/cli/handlers/complexity_handlers/churn.rs
+++ b/src/cli/handlers/complexity_handlers/churn.rs
@@ -100,3 +100,128 @@ async fn format_and_write_churn_output(
 
     crate::cli::analysis_utilities::write_churn_output(content, output).await
 }
+
+#[cfg(test)]
+#[allow(clippy::field_reassign_with_default)]
+mod churn_handler_tests {
+    //! Covers the pure-compute helpers in complexity_handlers/churn.rs
+    //! (50 uncov on broad, 0% cov).
+    use super::*;
+    use crate::models::churn::{ChurnSummary, CodeChurnAnalysis, FileChurnMetrics};
+    use crate::utils::file_filter::FileFilter;
+    use chrono::Utc;
+    use std::path::PathBuf;
+
+    fn make_file(path: &str, commits: usize) -> FileChurnMetrics {
+        FileChurnMetrics {
+            path: PathBuf::from(path),
+            relative_path: path.to_string(),
+            commit_count: commits,
+            unique_authors: vec!["a".into()],
+            additions: 10,
+            deletions: 5,
+            churn_score: commits as f32 * 0.1,
+            last_modified: Utc::now(),
+            first_seen: Utc::now(),
+        }
+    }
+
+    fn make_analysis(files: Vec<FileChurnMetrics>) -> CodeChurnAnalysis {
+        let total_commits: usize = files.iter().map(|f| f.commit_count).sum();
+        CodeChurnAnalysis {
+            generated_at: Utc::now(),
+            period_days: 30,
+            repository_root: PathBuf::from("."),
+            files,
+            summary: ChurnSummary {
+                total_commits,
+                total_files_changed: 0,
+                hotspot_files: vec![],
+                stable_files: vec![],
+                author_contributions: Default::default(),
+                mean_churn_score: 0.0,
+                variance_churn_score: 0.0,
+                stddev_churn_score: 0.0,
+            },
+        }
+    }
+
+    // ── create_and_report_file_filter ──
+
+    #[test]
+    fn test_create_and_report_file_filter_no_patterns() {
+        let filter = create_and_report_file_filter(vec![], vec![]).unwrap();
+        assert!(!filter.has_filters());
+    }
+
+    #[test]
+    fn test_create_and_report_file_filter_include_only() {
+        let filter = create_and_report_file_filter(vec!["src/**".into()], vec![]).unwrap();
+        assert!(filter.has_filters());
+    }
+
+    #[test]
+    fn test_create_and_report_file_filter_exclude_only() {
+        let filter = create_and_report_file_filter(vec![], vec!["tests/**".into()]).unwrap();
+        assert!(filter.has_filters());
+    }
+
+    #[test]
+    fn test_create_and_report_file_filter_both_sides() {
+        let filter =
+            create_and_report_file_filter(vec!["src/**".into()], vec!["tests/**".into()]).unwrap();
+        assert!(filter.has_filters());
+    }
+
+    // ── apply_churn_filters ──
+
+    #[test]
+    fn test_apply_churn_filters_no_filters_and_no_limit_keeps_all() {
+        let mut a = make_analysis(vec![
+            make_file("a.rs", 3),
+            make_file("b.rs", 1),
+            make_file("c.rs", 5),
+        ]);
+        let filter = FileFilter::new(vec![], vec![]).unwrap();
+        apply_churn_filters(&mut a, &filter, 0);
+        assert_eq!(a.files.len(), 3);
+    }
+
+    #[test]
+    fn test_apply_churn_filters_top_limit_truncates_by_commit_count_desc() {
+        let mut a = make_analysis(vec![
+            make_file("a.rs", 3),
+            make_file("b.rs", 10),
+            make_file("c.rs", 1),
+        ]);
+        let filter = FileFilter::new(vec![], vec![]).unwrap();
+        apply_churn_filters(&mut a, &filter, 2);
+        assert_eq!(a.files.len(), 2);
+        assert_eq!(a.files[0].commit_count, 10); // highest first
+        assert_eq!(a.files[1].commit_count, 3);
+    }
+
+    #[test]
+    fn test_apply_churn_filters_limit_larger_than_count_keeps_all() {
+        let mut a = make_analysis(vec![make_file("a.rs", 1), make_file("b.rs", 2)]);
+        let filter = FileFilter::new(vec![], vec![]).unwrap();
+        apply_churn_filters(&mut a, &filter, 99);
+        assert_eq!(a.files.len(), 2);
+    }
+
+    #[test]
+    fn test_apply_churn_filters_with_include_pattern_retains_only_match() {
+        let mut a = make_analysis(vec![
+            make_file("src/a.rs", 3),
+            make_file("tests/b.rs", 5),
+            make_file("src/c.rs", 1),
+        ]);
+        let filter = FileFilter::new(vec!["src/**".into()], vec![]).unwrap();
+        apply_churn_filters(&mut a, &filter, 0);
+        assert_eq!(a.files.len(), 2);
+        assert!(a.files.iter().all(|f| f.relative_path.starts_with("src/")));
+        // Summary totals must have been recomputed.
+        assert_eq!(a.summary.total_files_changed, 2);
+        assert_eq!(a.summary.total_commits, 4); // 3 + 1
+    }
+}

--- a/src/cli/handlers/query_handler/modes_raw_search.rs
+++ b/src/cli/handlers/query_handler/modes_raw_search.rs
@@ -245,3 +245,129 @@ pub(super) fn run_raw_counts_for_merge(
     }
 }
 
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg(test)]
+mod modes_raw_search_tests {
+    use super::*;
+
+    /// Drives print_raw_match_context through all four arms:
+    /// empty/non-empty context_before × empty/non-empty context_after.
+    #[test]
+    fn test_print_raw_match_context_all_context_shapes() {
+        // No context either side — skips both for/iter blocks.
+        print_raw_match_context("a.rs", 10, "let x = 1;", &[], &[]);
+        // Before only.
+        print_raw_match_context(
+            "a.rs",
+            10,
+            "let x = 1;",
+            &["fn foo() {".to_string(), "    // body".to_string()],
+            &[],
+        );
+        // After only.
+        print_raw_match_context(
+            "a.rs",
+            10,
+            "let x = 1;",
+            &[],
+            &["    return x;".to_string(), "}".to_string()],
+        );
+        // Both.
+        print_raw_match_context(
+            "a.rs",
+            10,
+            "let x = 1;",
+            &["before".to_string()],
+            &["after".to_string()],
+        );
+    }
+
+    /// print_raw_search_output dispatches on the RawSearchOutput variant.
+    /// Each arm only does println!, so just calling it ticks coverage.
+    #[test]
+    fn test_print_raw_search_output_files_variant() {
+        let out = RawSearchOutput::Files(vec!["a.rs".into(), "b.rs".into()]);
+        print_raw_search_output(&out, &QueryOutputFormat::Text, true).unwrap();
+    }
+
+    #[test]
+    fn test_print_raw_search_output_counts_variant() {
+        let out = RawSearchOutput::Counts(vec![
+            crate::services::agent_context::FileMatchCount {
+                file_path: "a.rs".into(),
+                count: 3,
+            },
+            crate::services::agent_context::FileMatchCount {
+                file_path: "b.rs".into(),
+                count: 1,
+            },
+        ]);
+        print_raw_search_output(&out, &QueryOutputFormat::Text, true).unwrap();
+    }
+
+    #[test]
+    fn test_print_raw_search_output_lines_variant_text_format() {
+        let out = RawSearchOutput::Lines(vec![RawSearchResult {
+            file_path: "a.rs".into(),
+            line_number: 1,
+            line_content: "fn x() {}".into(),
+            context_before: vec![],
+            context_after: vec![],
+        }]);
+        // Text format → delegates to print_raw_lines → print_raw_match_context.
+        print_raw_search_output(&out, &QueryOutputFormat::Text, true).unwrap();
+    }
+
+    #[test]
+    fn test_print_raw_search_output_lines_variant_json_format() {
+        let out = RawSearchOutput::Lines(vec![RawSearchResult {
+            file_path: "a.rs".into(),
+            line_number: 1,
+            line_content: "fn x() {}".into(),
+            context_before: vec!["before".into()],
+            context_after: vec!["after".into()],
+        }]);
+        // JSON format → serializes via serde_json::to_string_pretty.
+        print_raw_search_output(&out, &QueryOutputFormat::Json, true).unwrap();
+    }
+
+    /// print_raw_lines non-quiet vs quiet: the trailing "N matches" eprintln
+    /// only fires when quiet=false.
+    #[test]
+    fn test_print_raw_lines_quiet_vs_verbose() {
+        let lines = vec![RawSearchResult {
+            file_path: "a.rs".into(),
+            line_number: 1,
+            line_content: "x".into(),
+            context_before: vec![],
+            context_after: vec![],
+        }];
+        // Verbose: hits the `!quiet` eprintln branch.
+        print_raw_lines(&lines, &QueryOutputFormat::Text, false).unwrap();
+        // Quiet: skips it.
+        print_raw_lines(&lines, &QueryOutputFormat::Text, true).unwrap();
+    }
+
+    /// run_raw_search_for_merge should return empty when `remaining = 0`
+    /// (the early-exit branch on line 147). limit=0 with empty indexed =>
+    /// 0.saturating_sub(0) == 0 => early return.
+    #[test]
+    fn test_run_raw_search_for_merge_early_exit_on_zero_limit() {
+        let tmp = tempfile::tempdir().unwrap();
+        let out = run_raw_search_for_merge(
+            "fn",
+            0, // limit=0 → remaining=0 → early exit
+            false,
+            false,
+            &None,
+            &[],
+            &[],
+            None,
+            None,
+            None,
+            tmp.path(),
+            &[],
+        );
+        assert!(out.is_empty(), "limit=0 → empty merge result");
+    }
+}

--- a/src/cli/handlers/query_handler/modes_raw_search.rs
+++ b/src/cli/handlers/query_handler/modes_raw_search.rs
@@ -245,6 +245,12 @@ pub(super) fn run_raw_counts_for_merge(
     }
 }
 
+// `items_after_test_module` fires because `modes_raw_search.rs` is
+// include!()'d into modes.rs ahead of the other `modes_*.rs` siblings —
+// so this test module is *textually* followed by production items from
+// other include files. Silence the lint since reordering the includes
+// would churn the entire handler module for no gain.
+#[allow(clippy::items_after_test_module)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 #[cfg(test)]
 mod modes_raw_search_tests {

--- a/src/cli/handlers/tdg_handlers/baseline.rs
+++ b/src/cli/handlers/tdg_handlers/baseline.rs
@@ -389,3 +389,91 @@ async fn update_baseline(
 
     Ok(())
 }
+
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg(test)]
+mod baseline_tests {
+    use super::*;
+    use crate::tdg::TdgBaseline;
+
+    /// extract_git_context returns None immediately when with_git_context=false,
+    /// skipping the GitContext::try_from_current_dir path.
+    #[test]
+    fn test_extract_git_context_disabled_returns_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        let result = extract_git_context(tmp.path(), false);
+        assert!(result.is_none());
+    }
+
+    /// extract_git_context on a non-git directory hits the None arm
+    /// of try_from_current_dir (logs "Not in a git repository").
+    #[test]
+    fn test_extract_git_context_non_git_dir_returns_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Tempdir is not a git repo → try_from_current_dir returns None →
+        // the warning-log arm fires and returns None.
+        let result = extract_git_context(tmp.path(), true);
+        assert!(result.is_none());
+    }
+
+    /// find_baseline_files returns empty for a dir with no baseline files.
+    #[test]
+    fn test_find_baseline_files_empty_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let out = find_baseline_files(tmp.path());
+        assert!(out.is_empty());
+    }
+
+    /// find_baseline_files picks up a real baseline file written with the
+    /// canonical `-baseline.json` suffix at the project root.
+    #[test]
+    fn test_find_baseline_files_matches_suffix() {
+        let tmp = tempfile::tempdir().unwrap();
+        let baseline = TdgBaseline::new(None);
+        let out_path = tmp.path().join("my-baseline.json");
+        baseline.save(&out_path).unwrap();
+
+        let found = find_baseline_files(tmp.path());
+        assert_eq!(found.len(), 1, "must find the -baseline.json file");
+        assert_eq!(found[0].0, out_path);
+    }
+
+    /// find_baseline_files picks up the canonical `.pmat-baseline.json` dotfile
+    /// name (second name arm of the `||` match).
+    #[test]
+    fn test_find_baseline_files_matches_pmat_dotfile_name() {
+        let tmp = tempfile::tempdir().unwrap();
+        let baseline = TdgBaseline::new(None);
+        let out_path = tmp.path().join(".pmat-baseline.json");
+        baseline.save(&out_path).unwrap();
+
+        let found = find_baseline_files(tmp.path());
+        assert_eq!(found.len(), 1, "must find .pmat-baseline.json");
+        assert_eq!(found[0].0, out_path);
+    }
+
+    /// find_baseline_files ignores files that don't match either naming rule.
+    #[test]
+    fn test_find_baseline_files_ignores_unrelated_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("unrelated.json"), "{}").unwrap();
+        std::fs::write(tmp.path().join("baseline.json"), "{}").unwrap(); // no `-` prefix
+        std::fs::write(tmp.path().join("notes.txt"), "hi").unwrap();
+
+        let found = find_baseline_files(tmp.path());
+        assert!(found.is_empty(), "must not pick up non-matching names");
+    }
+
+    /// find_baseline_files gracefully skips baseline files that fail to load
+    /// (invalid JSON content) — the `TdgBaseline::load(...).ok().map(...)`
+    /// returns None and filter_map drops the entry.
+    #[test]
+    fn test_find_baseline_files_skips_unreadable_baseline() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Matching name but invalid JSON → load returns Err, filter_map drops.
+        std::fs::write(tmp.path().join("bad-baseline.json"), "not json").unwrap();
+
+        let found = find_baseline_files(tmp.path());
+        assert!(found.is_empty(), "invalid content must be dropped");
+    }
+}

--- a/src/handlers/tools_advanced.rs
+++ b/src/handlers/tools_advanced.rs
@@ -406,3 +406,187 @@ mod part2_tests {
         assert!(content.contains("# Technical Debt Gradient Analysis"));
     }
 }
+
+#[cfg(test)]
+mod part1_pure_helpers_tests {
+    //! Cover the pure-compute helpers in tools_advanced_part1.rs that
+    //! were 0%-covered on broad (259 missed lines). Handlers themselves are
+    //! async and hit disk/analysis pipelines — skipped here.
+    use super::*;
+
+    // ── require_project_path_advanced (D101 guard) ──
+
+    #[test]
+    fn test_require_project_path_advanced_none_is_rejected() {
+        let err = require_project_path_advanced(None).unwrap_err();
+        assert!(err.contains("'project_path' is required"), "got: {err}");
+        assert!(err.contains("R22-1"), "must tag R22-1/D101: {err}");
+    }
+
+    #[test]
+    fn test_require_project_path_advanced_empty_string_is_rejected() {
+        let err = require_project_path_advanced(Some(String::new())).unwrap_err();
+        assert!(err.contains("non-empty string"), "got: {err}");
+    }
+
+    #[test]
+    fn test_require_project_path_advanced_whitespace_is_rejected() {
+        let err = require_project_path_advanced(Some("   \t\n  ".to_string())).unwrap_err();
+        assert!(err.contains("non-empty string"), "got: {err}");
+    }
+
+    #[test]
+    fn test_require_project_path_advanced_valid_returns_pathbuf() {
+        let path = require_project_path_advanced(Some("/tmp/proj".to_string())).unwrap();
+        assert_eq!(path, std::path::PathBuf::from("/tmp/proj"));
+    }
+
+    // ── require_non_empty_path ──
+
+    #[test]
+    fn test_require_non_empty_path_empty_rejected() {
+        let err = require_non_empty_path("", "output").unwrap_err();
+        assert!(err.contains("'output'"), "field name must appear: {err}");
+        assert!(err.contains("non-empty string"), "got: {err}");
+    }
+
+    #[test]
+    fn test_require_non_empty_path_whitespace_rejected() {
+        let err = require_non_empty_path("   ", "project_path").unwrap_err();
+        assert!(err.contains("'project_path'"), "got: {err}");
+    }
+
+    #[test]
+    fn test_require_non_empty_path_valid_returns_pathbuf() {
+        let path = require_non_empty_path("/tmp/x", "project_path").unwrap();
+        assert_eq!(path, std::path::PathBuf::from("/tmp/x"));
+    }
+
+    // ── get_relative_path ──
+
+    #[test]
+    fn test_get_relative_path_strips_prefix() {
+        let base = std::path::Path::new("/home/noah/project");
+        let file = std::path::Path::new("/home/noah/project/src/main.rs");
+        assert_eq!(get_relative_path(file, base), "src/main.rs");
+    }
+
+    #[test]
+    fn test_get_relative_path_no_prefix_match_returns_original() {
+        let base = std::path::Path::new("/home/noah/project");
+        let file = std::path::Path::new("/tmp/other.rs");
+        // strip_prefix returns Err → unwrap_or(path) → original.
+        assert_eq!(get_relative_path(file, base), "/tmp/other.rs");
+    }
+
+    // ── calculate_cyclomatic_complexity + calculate_cognitive_complexity ──
+
+    #[test]
+    fn test_calculate_cyclomatic_complexity_trivial() {
+        // No control flow → base complexity 1.
+        assert_eq!(calculate_cyclomatic_complexity("fn f() {}"), 1);
+    }
+
+    #[test]
+    fn test_calculate_cyclomatic_complexity_counts_control_flow() {
+        let src = "if cond { for x in xs { while y { match z {} } } }";
+        let c = calculate_cyclomatic_complexity(src);
+        assert!(c >= 5, "if+for+while+match should count: got {c}");
+    }
+
+    #[test]
+    fn test_calculate_cognitive_complexity_is_1_5x_cyclomatic() {
+        assert_eq!(calculate_cognitive_complexity(10), 15);
+        assert_eq!(calculate_cognitive_complexity(1), 1); // (1 * 1.5) as u32 == 1
+        assert_eq!(calculate_cognitive_complexity(0), 0);
+    }
+
+    // ── calculate_duplicate_ratio ──
+
+    #[test]
+    fn test_calculate_duplicate_ratio_empty_returns_zero() {
+        let lines: Vec<&str> = vec![];
+        let r = calculate_duplicate_ratio(&lines);
+        assert_eq!(r, 0.0);
+    }
+
+    #[test]
+    fn test_calculate_duplicate_ratio_all_unique_is_zero() {
+        let lines = vec!["let a = 1;", "let b = 2;", "let c = 3;"];
+        assert_eq!(calculate_duplicate_ratio(&lines), 0.0);
+    }
+
+    #[test]
+    fn test_calculate_duplicate_ratio_duplicates_counted() {
+        let lines = vec!["let x = 1;", "let x = 1;", "let y = 2;"];
+        // line_counts: "let x = 1;" → 2, "let y = 2;" → 1
+        // duplicates = (2-1) = 1; total lines = 3; ratio = 1/3
+        let r = calculate_duplicate_ratio(&lines);
+        assert!((r - (1.0f32 / 3.0f32)).abs() < 1e-5, "got {r}");
+    }
+
+    #[test]
+    fn test_calculate_duplicate_ratio_skips_comments_and_blanks() {
+        // // comment lines and blanks are ignored in the count but still
+        // contribute to the denominator (lines.len()).
+        let lines = vec!["// comment", "", "let x = 1;", "let x = 1;", "// another"];
+        let r = calculate_duplicate_ratio(&lines);
+        // duplicates = 1 (one extra "let x = 1;"); total lines = 5; ratio = 0.2
+        assert!((r - 0.2).abs() < 1e-5, "got {r}");
+    }
+
+    // ── calculate_efferent_coupling ──
+
+    #[test]
+    fn test_calculate_efferent_coupling_counts_use_lines() {
+        let src = "use foo::bar;\nuse x::y::z;\nfn main() {}\n// use commented";
+        assert_eq!(calculate_efferent_coupling(src), 2.0);
+    }
+
+    #[test]
+    fn test_calculate_efferent_coupling_zero_when_no_imports() {
+        assert_eq!(calculate_efferent_coupling("fn main() {}"), 0.0);
+    }
+
+    // ── is_public_declaration ──
+
+    #[test]
+    fn test_is_public_declaration_recognizes_pub_items() {
+        assert!(is_public_declaration("pub fn foo() {}"));
+        assert!(is_public_declaration("    pub struct Bar;"));
+        assert!(is_public_declaration("pub enum E { A }"));
+    }
+
+    #[test]
+    fn test_is_public_declaration_rejects_non_pub() {
+        assert!(!is_public_declaration("fn foo() {}"));
+        assert!(!is_public_declaration("struct S;"));
+        assert!(!is_public_declaration("// pub fn comment"));
+    }
+
+    // ── get_churn_score ──
+
+    #[test]
+    fn test_get_churn_score_found() {
+        let mut m = std::collections::HashMap::new();
+        m.insert("src/foo.rs".to_string(), 0.75_f32);
+        assert!((get_churn_score("src/foo.rs", &m) - 0.75).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_get_churn_score_not_found_returns_default_floor() {
+        // Fallback is 0.1 (not 0.0) — get(key).copied().unwrap_or(0.1).
+        let m: std::collections::HashMap<String, f32> = std::collections::HashMap::new();
+        assert!((get_churn_score("src/missing.rs", &m) - 0.1).abs() < 1e-6);
+    }
+
+    // ── calculate_afferent_coupling (constant in this implementation) ──
+
+    #[test]
+    fn test_calculate_afferent_coupling_is_deterministic() {
+        // Both calls on the same content produce the same value.
+        let a = calculate_afferent_coupling("fn x() {}");
+        let b = calculate_afferent_coupling("fn x() {}");
+        assert!((a - b).abs() < 1e-6);
+    }
+}

--- a/src/models/comply_config_tests.rs
+++ b/src/models/comply_config_tests.rs
@@ -345,4 +345,48 @@ work: {}
             other => panic!("expected ParseError for malformed yaml, got {other:?}"),
         }
     }
+
+    /// comply_config_impls.rs:94 — `PmatYamlConfig::save` happy path.
+    /// Writes the serialized YAML to `<project_path>/.pmat.yaml` and a fresh
+    /// `load_from_path` of the same file returns an equivalent config.
+    #[test]
+    fn test_save_roundtrip_to_temp_dir() {
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let cfg = PmatYamlConfig::default();
+
+        cfg.save(tmp.path()).expect("save must succeed in tempdir");
+
+        let yaml_path = tmp.path().join(".pmat.yaml");
+        assert!(yaml_path.exists(), ".pmat.yaml must be created by save()");
+
+        let reloaded = PmatYamlConfig::load_from_path(&yaml_path)
+            .expect("saved file must be parseable as PmatYamlConfig");
+        assert_eq!(
+            reloaded.comply.thresholds.coverage,
+            cfg.comply.thresholds.coverage,
+            "round-trip must preserve coverage threshold",
+        );
+        assert_eq!(
+            reloaded.comply.thresholds.complexity,
+            cfg.comply.thresholds.complexity,
+            "round-trip must preserve complexity threshold",
+        );
+    }
+
+    /// comply_config_impls.rs:99 — `std::fs::write(...).map_err(IoError)` fires
+    /// when the target path cannot be created (e.g. parent directory is missing
+    /// and not auto-created by `save`). `save` does not create the parent, so
+    /// pointing at a non-existent nested directory triggers the IoError arm.
+    #[test]
+    fn test_save_returns_io_error_when_parent_missing() {
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let missing_parent = tmp.path().join("does").join("not").join("exist");
+        let cfg = PmatYamlConfig::default();
+
+        let result = cfg.save(&missing_parent);
+        match result {
+            Err(ConfigError::IoError(_)) => {}
+            other => panic!("expected IoError when parent missing, got {other:?}"),
+        }
+    }
 }

--- a/src/models/roadmap_phases_tests.rs
+++ b/src/models/roadmap_phases_tests.rs
@@ -120,4 +120,45 @@ phases:
             "got: {err}"
         );
     }
+
+    /// roadmap_types.rs:216 — `PhasesVisitor::expecting` fires when the YAML
+    /// supplies a non-sequence value (string, mapping, scalar) where a
+    /// `Vec<Phase>` is expected. Serde's default visit_* impls call
+    /// expecting() to build the error message.
+    #[test]
+    fn test_phases_non_sequence_surfaces_expecting_message() {
+        // A bare string is neither a sequence nor null — default visit_str
+        // generates an Unexpected error that embeds expecting()'s output.
+        let yaml = "\
+id: T-1
+title: t
+status: planned
+phases: \"not a list\"
+";
+        let err = parse_item(yaml).unwrap_err().to_string();
+        assert!(
+            err.contains("a sequence of Phase structs"),
+            "expecting() message must appear in error: {err}"
+        );
+    }
+
+    /// Mapping at the top-level `phases:` key (not a sequence) — also a
+    /// non-sequence input, triggers the expecting message through
+    /// visit_map's default impl.
+    #[test]
+    fn test_phases_mapping_instead_of_sequence_surfaces_expecting() {
+        let yaml = "\
+id: T-1
+title: t
+status: planned
+phases:
+  name: not-a-list
+  status: planned
+";
+        let err = parse_item(yaml).unwrap_err().to_string();
+        assert!(
+            err.contains("a sequence of Phase structs"),
+            "expecting() message must appear: {err}"
+        );
+    }
 }

--- a/src/models/roadmap_tests.rs
+++ b/src/models/roadmap_tests.rs
@@ -534,4 +534,36 @@ roadmap:
             assert_eq!(roadmap.roadmap[2].status, ItemStatus::Blocked);
         }
     }
+
+    /// roadmap_impl.rs:152 — `completion_percentage` leaf-status branches.
+    /// Fires the ItemStatus match arms that run only when the item has no
+    /// subtasks, no phases, and no acceptance_criteria (the "leaf" path).
+    #[test]
+    fn test_completion_percentage_leaf_status_arms() {
+        let mut item = RoadmapItem::new("LEAF-001".to_string(), "leaf".to_string());
+        // Freshly constructed — subtasks, phases, acceptance_criteria all empty.
+        item.status = ItemStatus::Planned;
+        assert_eq!(item.completion_percentage(), 0, "Planned → 0");
+        item.status = ItemStatus::InProgress;
+        assert_eq!(item.completion_percentage(), 50, "InProgress → 50");
+        item.status = ItemStatus::Review;
+        assert_eq!(item.completion_percentage(), 90, "Review → 90");
+        item.status = ItemStatus::Completed;
+        assert_eq!(item.completion_percentage(), 100, "Completed → 100");
+        item.status = ItemStatus::Cancelled;
+        assert_eq!(item.completion_percentage(), 0, "Cancelled → 0");
+        item.status = ItemStatus::Blocked;
+        assert_eq!(item.completion_percentage(), 0, "Blocked → 0");
+    }
+
+    /// roadmap_impl.rs:161 — acceptance_criteria non-empty, subtasks & phases
+    /// empty. Falls through to the `0` placeholder branch.
+    #[test]
+    fn test_completion_percentage_acceptance_criteria_returns_zero() {
+        let mut item = RoadmapItem::new("AC-001".to_string(), "ac".to_string());
+        item.acceptance_criteria = vec!["criterion 1".to_string(), "criterion 2".to_string()];
+        // Status shouldn't affect this branch — the AC branch returns 0 unconditionally.
+        item.status = ItemStatus::Completed;
+        assert_eq!(item.completion_percentage(), 0);
+    }
 }

--- a/src/services/language_analyzer.rs
+++ b/src/services/language_analyzer.rs
@@ -135,3 +135,132 @@ include!("language_analyzer_core.rs");
 
 // Individual analysis implementations: complexity, SATD, security, style, etc.
 include!("language_analyzer_analyses.rs");
+
+// Pure-compute helpers in language_analyzer_analyses.rs were 0%-covered on
+// broad (239 missed lines). The legacy `language_analyzer_tests.rs` split
+// across part1..4.rs has unbalanced braces per file and cannot be wired into
+// the module tree as-is. This inline test module covers the key leaf
+// helpers (keyword lists, pattern counters) that don't require async setup.
+#[cfg(test)]
+mod inline_tests {
+    use super::*;
+
+    /// get_complexity_keywords returns language-specific control-flow tokens.
+    #[test]
+    fn test_get_complexity_keywords_returns_nonempty_for_known_languages() {
+        let a = LanguageAnalyzer::new();
+        for lang in [
+            Language::Rust,
+            Language::Python,
+            Language::JavaScript,
+            Language::TypeScript,
+            Language::Go,
+            Language::Java,
+        ] {
+            let kws = a.get_complexity_keywords(lang);
+            assert!(
+                !kws.is_empty(),
+                "language {lang:?} must have complexity keywords"
+            );
+            for kw in &kws {
+                assert!(!kw.is_empty(), "no empty keyword for {lang:?}");
+            }
+        }
+    }
+
+    /// calculate_keyword_complexity counts occurrences of any of the given
+    /// keywords plus 1 base complexity (mirrors cyclomatic McCabe).
+    #[test]
+    fn test_calculate_keyword_complexity_counts_matches_plus_base() {
+        let a = LanguageAnalyzer::new();
+        let content = "if a { for b in c { while d { if e {} } } }";
+        let count = a.calculate_keyword_complexity(content, &["if", "for", "while"]);
+        // 2*"if" + 1*"for" + 1*"while" = 4, + 1 base = 5
+        assert_eq!(count, 5);
+    }
+
+    #[test]
+    fn test_calculate_keyword_complexity_returns_base_on_no_match() {
+        let a = LanguageAnalyzer::new();
+        let count = a.calculate_keyword_complexity("plain text", &["if", "for"]);
+        assert_eq!(count, 1, "base complexity is 1 when no keyword matches");
+    }
+
+    #[test]
+    fn test_calculate_keyword_complexity_empty_keyword_list_returns_base() {
+        let a = LanguageAnalyzer::new();
+        let count = a.calculate_keyword_complexity("if a { for b {} }", &[]);
+        assert_eq!(count, 1);
+    }
+
+    /// get_security_patterns returns language-specific known-bad patterns.
+    #[test]
+    fn test_get_security_patterns_nonempty_for_common_langs() {
+        let a = LanguageAnalyzer::new();
+        for lang in [Language::Python, Language::JavaScript, Language::Rust] {
+            let pats = a.get_security_patterns(lang);
+            // Not every language has a pattern list but these common ones do.
+            assert!(!pats.is_empty(), "expected security patterns for {lang:?}");
+        }
+    }
+
+    /// find_security_issues returns a non-empty vec when the content contains
+    /// the pattern, empty otherwise. Drives both arms.
+    #[test]
+    fn test_find_security_issues_match_vs_miss() {
+        let a = LanguageAnalyzer::new();
+        let patterns = ["eval("];
+        let hits = a.find_security_issues("x = eval(expr)", &patterns);
+        assert!(!hits.is_empty(), "must detect eval(");
+
+        let misses = a.find_security_issues("x = 1 + 2", &patterns);
+        assert!(misses.is_empty(), "clean code → no hits");
+    }
+
+    /// get_import_patterns returns language-specific import-statement prefixes.
+    #[test]
+    fn test_get_import_patterns_nonempty_for_common_langs() {
+        let a = LanguageAnalyzer::new();
+        for lang in [
+            Language::Rust,
+            Language::Python,
+            Language::JavaScript,
+            Language::Go,
+        ] {
+            let pats = a.get_import_patterns(lang);
+            assert!(!pats.is_empty(), "{lang:?} should have import patterns");
+        }
+    }
+
+    /// find_imports collects lines matching any of the import-prefix patterns.
+    #[test]
+    fn test_find_imports_match_vs_miss() {
+        let a = LanguageAnalyzer::new();
+        let patterns = ["use ", "import "];
+        let src = "use foo::bar;\nlet x = 1;\nimport baz;\n// use commented";
+        let hits = a.find_imports(src, &patterns);
+        // Two matches: `use foo::bar;` and `import baz;`
+        assert_eq!(hits.len(), 2);
+    }
+
+    #[test]
+    fn test_find_imports_empty_on_no_match() {
+        let a = LanguageAnalyzer::new();
+        let hits = a.find_imports("fn main() {}\n", &["use ", "import "]);
+        assert!(hits.is_empty());
+    }
+
+    /// create_unsupported_analysis_result returns a result flagged as
+    /// unsuccessful with an error field that names the language + analysis.
+    #[test]
+    fn test_create_unsupported_analysis_result_shape() {
+        let a = LanguageAnalyzer::new();
+        let result =
+            a.create_unsupported_analysis_result(AnalysisType::Security, Language::Markdown);
+        assert!(!result.success, "unsupported → success=false");
+        assert!(
+            result.error.is_some(),
+            "unsupported → must carry an error message"
+        );
+    }
+}

--- a/src/services/spec_falsification_tests.rs
+++ b/src/services/spec_falsification_tests.rs
@@ -270,4 +270,152 @@ This line SHOULD be extracted.
         // health = 1 survived / 2 testable = 0.5
         assert!((summary.health_score - 0.5).abs() < f64::EPSILON);
     }
+
+    fn make_claim(
+        id: &str,
+        original_text: &str,
+        category: SpecClaimCategory,
+    ) -> SpecClaim {
+        SpecClaim {
+            id: id.to_string(),
+            original_text: original_text.to_string(),
+            source_line: 1,
+            category,
+            priority: ClaimPriority::P3Default,
+            is_absolute: false,
+            path_refs: vec![],
+            entity_refs: vec![],
+            numeric_value: None,
+            numeric_comparator: None,
+        }
+    }
+
+    // ── check_metric_claim: canned inconclusive evidence ──
+
+    #[test]
+    fn check_metric_claim_returns_single_inconclusive_evidence() {
+        let engine = FalsificationEngine::new(Path::new("."));
+        let claim = make_claim("m1", "coverage >= 95%", SpecClaimCategory::MetricClaim);
+        let evidence = engine.check_metric_claim(&claim);
+        assert_eq!(
+            evidence.len(),
+            1,
+            "metric claims always return one evidence entry"
+        );
+        assert_eq!(evidence[0].check, "Metric claim");
+        assert_eq!(
+            evidence[0].contradiction_score, 0.0,
+            "metric claim is neither supported nor refuted by the MVP"
+        );
+    }
+
+    // ── determine_verdict: unfalsifiable + inconclusive + boundary arms ──
+
+    #[test]
+    fn determine_verdict_unfalsifiable_category_short_circuits() {
+        let engine = FalsificationEngine::new(Path::new("."));
+        let claim = make_claim("u1", "t", SpecClaimCategory::Unfalsifiable);
+        // Even a falsified-looking evidence vector is ignored for this category.
+        let strong_ev = vec![SpecEvidence {
+            check: "x".to_string(),
+            finding: "y".to_string(),
+            contradiction_score: 1.0,
+        }];
+        assert_eq!(
+            engine.determine_verdict(&claim, &strong_ev),
+            VerdictStatus::Unfalsifiable
+        );
+    }
+
+    #[test]
+    fn determine_verdict_architectural_claim_also_unfalsifiable() {
+        let engine = FalsificationEngine::new(Path::new("."));
+        let claim = make_claim("u2", "t", SpecClaimCategory::ArchitecturalClaim);
+        assert_eq!(
+            engine.determine_verdict(&claim, &[]),
+            VerdictStatus::Unfalsifiable
+        );
+    }
+
+    #[test]
+    fn determine_verdict_empty_evidence_is_inconclusive() {
+        let engine = FalsificationEngine::new(Path::new("."));
+        let claim = make_claim("e1", "t", SpecClaimCategory::PathReference);
+        assert_eq!(
+            engine.determine_verdict(&claim, &[]),
+            VerdictStatus::Inconclusive
+        );
+    }
+
+    #[test]
+    fn determine_verdict_contradiction_between_0_4_and_0_8_is_inconclusive() {
+        let engine = FalsificationEngine::new(Path::new("."));
+        let claim = make_claim("m1", "t", SpecClaimCategory::PathReference);
+        let ev = vec![SpecEvidence {
+            check: "x".to_string(),
+            finding: "y".to_string(),
+            contradiction_score: 0.5,
+        }];
+        assert_eq!(
+            engine.determine_verdict(&claim, &ev),
+            VerdictStatus::Inconclusive
+        );
+    }
+
+    // ── compute_summary health_score edge cases ──
+
+    #[test]
+    fn compute_summary_empty_verdicts_yields_perfect_health() {
+        let summary = FalsificationEngine::compute_summary(&[]);
+        assert_eq!(summary.total_claims, 0);
+        // No testable claims → health_score defaults to 1.0 (perfect).
+        assert!((summary.health_score - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn compute_summary_all_unfalsifiable_yields_perfect_health() {
+        let c = make_claim("u", "t", SpecClaimCategory::Unfalsifiable);
+        let verdicts = vec![
+            SpecVerdict {
+                claim: c.clone(),
+                status: VerdictStatus::Unfalsifiable,
+                evidence: vec![],
+                contradiction_score: 0.0,
+            },
+            SpecVerdict {
+                claim: c,
+                status: VerdictStatus::Unfalsifiable,
+                evidence: vec![],
+                contradiction_score: 0.0,
+            },
+        ];
+        let s = FalsificationEngine::compute_summary(&verdicts);
+        assert_eq!(s.unfalsifiable, 2);
+        // 2 - 2 = 0 testable → defaults to 1.0.
+        assert!((s.health_score - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn compute_summary_counts_inconclusive() {
+        let c = make_claim("i", "t", SpecClaimCategory::PathReference);
+        let verdicts = vec![
+            SpecVerdict {
+                claim: c.clone(),
+                status: VerdictStatus::Inconclusive,
+                evidence: vec![],
+                contradiction_score: 0.5,
+            },
+            SpecVerdict {
+                claim: c,
+                status: VerdictStatus::Survived,
+                evidence: vec![],
+                contradiction_score: 0.0,
+            },
+        ];
+        let s = FalsificationEngine::compute_summary(&verdicts);
+        assert_eq!(s.inconclusive, 1);
+        assert_eq!(s.survived, 1);
+        // testable = 2 (0 unfalsifiable); survived/testable = 0.5.
+        assert!((s.health_score - 0.5).abs() < f64::EPSILON);
+    }
 }

--- a/src/tdg/analyzer_simple_tests.rs
+++ b/src/tdg/analyzer_simple_tests.rs
@@ -579,6 +579,158 @@ def foo : Nat := 42
         let score = analyzer.analyze_documentation(source, Language::Lean, &mut tracker);
         assert!(score > 0.0, "Lean documentation analysis should detect doc comments");
     }
+
+    // === analyze_source dispatcher: language arms missing from existing
+    // JavaScript/TypeScript/Go coverage. Each test drives analyze_source
+    // through a distinct Language arm to fire the respective analyze_*_ast
+    // or analyze_*_heuristic branch in analyzer_impl1_source_dispatch.rs. ===
+
+    #[test]
+    fn test_analyze_source_java() {
+        let source = r#"
+/** Javadoc block */
+public class Greeter {
+    public void greet(String name) {
+        System.out.println("Hello, " + name);
+    }
+}
+"#;
+        let analyzer = TdgAnalyzer::new().unwrap();
+        let score = analyzer
+            .analyze_source(source, Language::Java, None)
+            .expect("Java dispatch must succeed");
+        assert_eq!(score.language, Language::Java);
+    }
+
+    #[test]
+    fn test_analyze_source_c() {
+        let source = r#"
+/* A C function */
+#include <stdio.h>
+int main(void) {
+    printf("hello\n");
+    return 0;
+}
+"#;
+        let analyzer = TdgAnalyzer::new().unwrap();
+        let score = analyzer
+            .analyze_source(source, Language::C, None)
+            .expect("C dispatch must succeed");
+        assert_eq!(score.language, Language::C);
+    }
+
+    #[test]
+    fn test_analyze_source_cpp() {
+        let source = r#"
+/// C++ class
+class Foo {
+public:
+    Foo() = default;
+    void bar() const {}
+};
+"#;
+        let analyzer = TdgAnalyzer::new().unwrap();
+        let score = analyzer
+            .analyze_source(source, Language::Cpp, None)
+            .expect("C++ dispatch must succeed");
+        // C++ goes through the same analyze_c_ast arm — confidence set per language
+        assert_eq!(score.language, Language::Cpp);
+    }
+
+    #[test]
+    fn test_analyze_source_lua() {
+        let source = r#"
+-- Module docstring
+local M = {}
+function M.greet(name)
+    print("Hello, " .. name)
+end
+return M
+"#;
+        let analyzer = TdgAnalyzer::new().unwrap();
+        let score = analyzer
+            .analyze_source(source, Language::Lua, None)
+            .expect("Lua dispatch must succeed");
+        assert_eq!(score.language, Language::Lua);
+    }
+
+    #[test]
+    fn test_analyze_source_sql() {
+        let source = r#"
+-- Select all users
+SELECT id, name
+FROM users
+WHERE active = TRUE
+ORDER BY id ASC;
+"#;
+        let analyzer = TdgAnalyzer::new().unwrap();
+        let score = analyzer
+            .analyze_source(source, Language::Sql, None)
+            .expect("SQL dispatch must succeed");
+        assert_eq!(score.language, Language::Sql);
+    }
+
+    #[test]
+    fn test_analyze_source_scala() {
+        let source = r#"
+/** Scala greeter */
+object Greeter {
+  def greet(name: String): String = s"Hello, $name"
+}
+"#;
+        let analyzer = TdgAnalyzer::new().unwrap();
+        let score = analyzer
+            .analyze_source(source, Language::Scala, None)
+            .expect("Scala dispatch must succeed");
+        assert_eq!(score.language, Language::Scala);
+    }
+
+    #[test]
+    fn test_analyze_source_yaml() {
+        let source = r#"
+# YAML config
+name: pmat
+version: "3.15.0"
+deps:
+  - serde
+  - tokio
+"#;
+        let analyzer = TdgAnalyzer::new().unwrap();
+        let score = analyzer
+            .analyze_source(source, Language::Yaml, None)
+            .expect("YAML dispatch must succeed");
+        assert_eq!(score.language, Language::Yaml);
+    }
+
+    #[test]
+    fn test_analyze_source_lean() {
+        let source = r#"
+-- | A documented definition
+def answer : Nat := 42
+"#;
+        let analyzer = TdgAnalyzer::new().unwrap();
+        let score = analyzer
+            .analyze_source(source, Language::Lean, None)
+            .expect("Lean dispatch must succeed");
+        assert_eq!(score.language, Language::Lean);
+    }
+
+    #[test]
+    fn test_analyze_source_markdown() {
+        let source = r#"# Heading
+
+Some prose.
+
+```rust
+fn main() {}
+```
+"#;
+        let analyzer = TdgAnalyzer::new().unwrap();
+        let score = analyzer
+            .analyze_source(source, Language::Markdown, None)
+            .expect("Markdown dispatch must succeed");
+        assert_eq!(score.language, Language::Markdown);
+    }
 }
 
 #[cfg_attr(coverage_nightly, coverage(off))]


### PR DESCRIPTION
## Summary
- Covers 0%-covered `PmatYamlConfig::save` (comply_config_impls.rs:94) — happy path + IoError arm
- Covers uncovered leaf-status + acceptance_criteria branches of `RoadmapItem::completion_percentage` (roadmap_impl.rs:152, 161)
- Targets picked via `pmat query --coverage-gaps --rank-by impact`

## Test plan
- [x] `cargo test --lib test_save_roundtrip_to_temp_dir` — pass
- [x] `cargo test --lib test_save_returns_io_error_when_parent_missing` — pass
- [x] `cargo test --lib test_completion_percentage_leaf_status_arms` — pass
- [x] `cargo test --lib test_completion_percentage_acceptance_criteria_returns_zero` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)