### PR TITLE
test(coverage): next-wave pure-compute helpers

### DIFF
--- a/src/cli/handlers/comply_cb_detect/quality_checks.rs
+++ b/src/cli/handlers/comply_cb_detect/quality_checks.rs
@@ -136,3 +136,174 @@ include!("quality_checks_slow_tests.rs");
 
 // CB-400/401/402: Shell & Makefile quality (bashrs integration)
 include!("quality_checks_bashrs.rs");
+
+#[cfg(test)]
+#[allow(clippy::field_reassign_with_default)]
+mod coverage_target_state_tests {
+    //! Covers the CoverageTargetState state machine in quality_checks.rs
+    //! (68 uncov on broad, 0% cov). Exercises reset, update_from_line, and
+    //! collect_violations without needing a full Makefile fixture.
+    use super::*;
+
+    // ── reset: restores a clean `active=true` state with a new line ──
+
+    #[test]
+    fn test_coverage_target_state_reset_clears_all_flags_and_sets_line() {
+        let mut s = CoverageTargetState::default();
+        // Pre-populate to verify reset actually clears things.
+        s.has_nextest = true;
+        s.has_llvm_cov = true;
+        s.has_proptest_cases = true;
+        s.has_lib_flag = true;
+        s.runs_cargo_tests = true;
+        s.line = 999;
+        s.active = false;
+
+        s.reset(42);
+
+        assert!(s.active, "reset must activate the target");
+        assert_eq!(s.line, 42);
+        assert!(!s.has_nextest);
+        assert!(!s.has_llvm_cov);
+        assert!(!s.has_proptest_cases);
+        assert!(!s.has_lib_flag);
+        assert!(!s.runs_cargo_tests);
+    }
+
+    // ── update_from_line: each detector arm ──
+
+    #[test]
+    fn test_update_from_line_detects_nextest_and_marks_runs_cargo_tests() {
+        let mut s = CoverageTargetState::default();
+        s.update_from_line("\tcargo nextest run --lib");
+        assert!(s.has_nextest);
+        assert!(s.runs_cargo_tests);
+    }
+
+    #[test]
+    fn test_update_from_line_detects_llvm_cov_does_not_mark_runs_cargo_tests() {
+        let mut s = CoverageTargetState::default();
+        s.update_from_line("\tcargo llvm-cov report --html");
+        assert!(s.has_llvm_cov);
+        assert!(
+            !s.runs_cargo_tests,
+            "plain llvm-cov report must NOT mark runs_cargo_tests"
+        );
+    }
+
+    #[test]
+    fn test_update_from_line_detects_cargo_llvm_cov_test_marks_runs_cargo_tests() {
+        let mut s = CoverageTargetState::default();
+        s.update_from_line("\tcargo llvm-cov test --lib");
+        assert!(s.has_llvm_cov);
+        assert!(s.runs_cargo_tests, "llvm-cov TEST marks runs_cargo_tests");
+    }
+
+    #[test]
+    fn test_update_from_line_detects_cargo_test_alone() {
+        let mut s = CoverageTargetState::default();
+        s.update_from_line("\tcargo test --lib --quiet");
+        assert!(s.runs_cargo_tests);
+        assert!(s.has_lib_flag);
+    }
+
+    #[test]
+    fn test_update_from_line_detects_proptest_cases_env_var() {
+        let mut s = CoverageTargetState::default();
+        s.update_from_line("\tPROPTEST_CASES=1000 cargo test");
+        assert!(s.has_proptest_cases);
+
+        let mut s = CoverageTargetState::default();
+        s.update_from_line("\tQUICKCHECK_TESTS=1000 cargo test");
+        assert!(s.has_proptest_cases);
+    }
+
+    #[test]
+    fn test_update_from_line_comment_lines_are_skipped() {
+        let mut s = CoverageTargetState::default();
+        s.update_from_line("# cargo test --lib with nextest");
+        assert!(!s.runs_cargo_tests);
+        assert!(!s.has_nextest);
+    }
+
+    #[test]
+    fn test_update_from_line_echo_lines_do_not_mark_runs_cargo_tests() {
+        let mut s = CoverageTargetState::default();
+        s.update_from_line("\t@echo \"Running nextest...\"");
+        // `echo` should suppress the nextest + cargo test signals.
+        assert!(!s.has_nextest);
+        assert!(!s.runs_cargo_tests);
+    }
+
+    // ── collect_violations: gating + per-rule firing ──
+
+    #[test]
+    fn test_collect_violations_empty_when_not_running_cargo_tests() {
+        let mut s = CoverageTargetState::default();
+        s.reset(10);
+        // runs_cargo_tests=false → all violations suppressed.
+        let v = s.collect_violations("Makefile");
+        assert!(v.is_empty());
+    }
+
+    #[test]
+    fn test_collect_violations_cb127a_fires_for_nextest_plus_llvm_cov() {
+        let mut s = CoverageTargetState::default();
+        s.reset(20);
+        s.runs_cargo_tests = true;
+        s.has_nextest = true;
+        s.has_llvm_cov = true;
+        // Also meet proptest/lib requirements so those rules don't fire.
+        s.has_proptest_cases = true;
+        s.has_lib_flag = true;
+        let v = s.collect_violations("Makefile");
+        assert!(v.iter().any(|x| x.pattern_id == "CB-127-A"));
+    }
+
+    #[test]
+    fn test_collect_violations_cb127b_fires_when_proptest_cases_missing() {
+        let mut s = CoverageTargetState::default();
+        s.reset(20);
+        s.runs_cargo_tests = true;
+        // has_proptest_cases=false by default.
+        let v = s.collect_violations("Makefile");
+        assert!(v.iter().any(|x| x.pattern_id == "CB-127-B"));
+    }
+
+    #[test]
+    fn test_collect_violations_cb127c_fires_for_llvm_cov_without_lib_flag() {
+        let mut s = CoverageTargetState::default();
+        s.reset(20);
+        s.runs_cargo_tests = true;
+        s.has_llvm_cov = true;
+        s.has_proptest_cases = true; // avoid CB-127-B
+                                     // has_lib_flag=false by default.
+        let v = s.collect_violations("Makefile");
+        assert!(v.iter().any(|x| x.pattern_id == "CB-127-C"));
+    }
+
+    #[test]
+    fn test_collect_violations_no_violations_when_all_good() {
+        let mut s = CoverageTargetState::default();
+        s.reset(20);
+        s.runs_cargo_tests = true;
+        s.has_llvm_cov = true;
+        s.has_proptest_cases = true;
+        s.has_lib_flag = true;
+        // No nextest+llvm-cov combo; proptest+lib present → zero violations.
+        let v = s.collect_violations("Makefile");
+        assert!(v.is_empty());
+    }
+
+    #[test]
+    fn test_collect_violations_carries_file_path_and_line() {
+        let mut s = CoverageTargetState::default();
+        s.reset(77);
+        s.runs_cargo_tests = true;
+        // Force CB-127-B to fire.
+        let v = s.collect_violations("sub/Makefile");
+        let cb_b = v.iter().find(|x| x.pattern_id == "CB-127-B").unwrap();
+        assert_eq!(cb_b.file, "sub/Makefile");
+        assert_eq!(cb_b.line, 77);
+    }
+}

--- a/src/cli/handlers/comply_cb_detect/stale_paths.rs
+++ b/src/cli/handlers/comply_cb_detect/stale_paths.rs
@@ -114,3 +114,205 @@ fn check_ci_workflows(project_path: &Path, violations: &mut Vec<CbPatternViolati
         }
     }
 }
+
+#[cfg(test)]
+mod stale_paths_tests {
+    //! Covers detect_cb533_stale_path_references + check_makefile + check_ci_workflows
+    //! (81 uncov on broad, 0% cov).
+    use super::*;
+
+    // ── project without Makefile or .github: no violations ──
+
+    #[test]
+    fn test_detect_empty_project_no_violations() {
+        let tmp = tempfile::tempdir().unwrap();
+        let v = detect_cb533_stale_path_references(tmp.path());
+        assert!(v.is_empty());
+    }
+
+    // ── check_makefile: comment/empty/cd . / cd .. / cd $VAR / cd -p all skipped ──
+
+    #[test]
+    fn test_check_makefile_no_cd_no_violations() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("Makefile"), "all:\n\techo hello\n").unwrap();
+        let mut v = Vec::new();
+        check_makefile(tmp.path(), &mut v);
+        assert!(v.is_empty());
+    }
+
+    #[test]
+    fn test_check_makefile_cd_to_missing_dir_flagged() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join("Makefile"),
+            "build:\n\tcd nonexistent && cargo build\n",
+        )
+        .unwrap();
+        let mut v = Vec::new();
+        check_makefile(tmp.path(), &mut v);
+        assert_eq!(v.len(), 1);
+        assert_eq!(v[0].pattern_id, "CB-533");
+        assert_eq!(v[0].file, "Makefile");
+        assert!(v[0].description.contains("nonexistent"));
+    }
+
+    #[test]
+    fn test_check_makefile_cd_to_existing_dir_not_flagged() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir(tmp.path().join("src")).unwrap();
+        std::fs::write(
+            tmp.path().join("Makefile"),
+            "build:\n\tcd src && cargo build\n",
+        )
+        .unwrap();
+        let mut v = Vec::new();
+        check_makefile(tmp.path(), &mut v);
+        assert!(v.is_empty());
+    }
+
+    #[test]
+    fn test_check_makefile_cd_dot_and_dotdot_skipped() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join("Makefile"),
+            "t:\n\tcd . && echo ok\n\tcd .. && echo ok\n",
+        )
+        .unwrap();
+        let mut v = Vec::new();
+        check_makefile(tmp.path(), &mut v);
+        assert!(v.is_empty(), "'.' and '..' must be skipped");
+    }
+
+    #[test]
+    fn test_check_makefile_cd_variable_skipped() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join("Makefile"),
+            "t:\n\tcd $(PROJECT) && echo ok\n",
+        )
+        .unwrap();
+        let mut v = Vec::new();
+        check_makefile(tmp.path(), &mut v);
+        assert!(v.is_empty(), "`$` prefix must be skipped");
+    }
+
+    #[test]
+    fn test_check_makefile_cd_flag_skipped() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("Makefile"), "t:\n\tcd -p some/dir\n").unwrap();
+        let mut v = Vec::new();
+        check_makefile(tmp.path(), &mut v);
+        // `-p` starts with '-' → skipped.
+        assert!(v.is_empty());
+    }
+
+    #[test]
+    fn test_check_makefile_comment_lines_skipped() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join("Makefile"),
+            "# cd nonexistent\n\ntarget:\n\techo ok\n",
+        )
+        .unwrap();
+        let mut v = Vec::new();
+        check_makefile(tmp.path(), &mut v);
+        assert!(v.is_empty());
+    }
+
+    #[test]
+    fn test_check_makefile_missing_makefile_is_noop() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut v = Vec::new();
+        check_makefile(tmp.path(), &mut v);
+        assert!(v.is_empty());
+    }
+
+    // ── check_ci_workflows: missing dir / non-yaml / working-directory ──
+
+    #[test]
+    fn test_check_ci_workflows_missing_dir_is_noop() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut v = Vec::new();
+        check_ci_workflows(tmp.path(), &mut v);
+        assert!(v.is_empty());
+    }
+
+    #[test]
+    fn test_check_ci_workflows_working_directory_to_missing_flagged() {
+        let tmp = tempfile::tempdir().unwrap();
+        let wf = tmp.path().join(".github/workflows");
+        std::fs::create_dir_all(&wf).unwrap();
+        std::fs::write(
+            wf.join("ci.yml"),
+            "jobs:\n  build:\n    steps:\n      - run: cargo test\n        working-directory: nonexistent_dir\n",
+        )
+        .unwrap();
+        let mut v = Vec::new();
+        check_ci_workflows(tmp.path(), &mut v);
+        assert_eq!(v.len(), 1);
+        assert_eq!(v[0].pattern_id, "CB-533");
+        assert!(v[0].file.contains("ci.yml"));
+    }
+
+    #[test]
+    fn test_check_ci_workflows_working_directory_to_existing_not_flagged() {
+        let tmp = tempfile::tempdir().unwrap();
+        let wf = tmp.path().join(".github/workflows");
+        std::fs::create_dir_all(&wf).unwrap();
+        std::fs::create_dir(tmp.path().join("sub")).unwrap();
+        std::fs::write(
+            wf.join("ci.yml"),
+            "jobs:\n  build:\n    working-directory: sub\n",
+        )
+        .unwrap();
+        let mut v = Vec::new();
+        check_ci_workflows(tmp.path(), &mut v);
+        assert!(v.is_empty());
+    }
+
+    #[test]
+    fn test_check_ci_workflows_non_yaml_files_ignored() {
+        let tmp = tempfile::tempdir().unwrap();
+        let wf = tmp.path().join(".github/workflows");
+        std::fs::create_dir_all(&wf).unwrap();
+        std::fs::write(wf.join("README.md"), "working-directory: missing_dir\n").unwrap();
+        let mut v = Vec::new();
+        check_ci_workflows(tmp.path(), &mut v);
+        assert!(v.is_empty(), "non-yaml workflow files must be skipped");
+    }
+
+    #[test]
+    fn test_check_ci_workflows_working_directory_dot_prefix_skipped() {
+        let tmp = tempfile::tempdir().unwrap();
+        let wf = tmp.path().join(".github/workflows");
+        std::fs::create_dir_all(&wf).unwrap();
+        std::fs::write(wf.join("ci.yaml"), "working-directory: ./relative\n").unwrap();
+        let mut v = Vec::new();
+        check_ci_workflows(tmp.path(), &mut v);
+        assert!(v.is_empty(), "'./' prefix must be skipped");
+    }
+
+    // ── Integration: detect_cb533 combines both checks ──
+
+    #[test]
+    fn test_detect_cb533_combines_makefile_and_ci_violations() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join("Makefile"),
+            "t:\n\tcd missing_makefile_dir\n",
+        )
+        .unwrap();
+        let wf = tmp.path().join(".github/workflows");
+        std::fs::create_dir_all(&wf).unwrap();
+        std::fs::write(wf.join("ci.yml"), "working-directory: missing_ci_dir\n").unwrap();
+        let violations = detect_cb533_stale_path_references(tmp.path());
+        assert_eq!(violations.len(), 2);
+        assert!(violations
+            .iter()
+            .any(|v| v.description.contains("missing_makefile_dir")));
+        assert!(violations
+            .iter()
+            .any(|v| v.description.contains("missing_ci_dir")));
+    }
+}


### PR DESCRIPTION
## Summary
Continued autonomous coverage work. Starts with CoverageTargetState state machine tests in comply_cb_detect/quality_checks.rs (68 uncov on broad, 0% cov).

## Test plan
- [x] \`cargo test --lib -- coverage_target_state_tests\` — 14 passing
- [x] \`cargo clippy --lib --tests -- -D warnings\` — clean
- [x] \`cargo fmt --all -- --check\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)