### PR TITLE
test(coverage): wave-3 pure-compute helpers

### DIFF
--- a/src/cli/analysis_utilities/incremental_coverage_analysis.rs
+++ b/src/cli/analysis_utilities/incremental_coverage_analysis.rs
@@ -56,3 +56,175 @@ fn convert_coverage_update_to_report(
         summary,
     })
 }
+
+#[cfg(test)]
+mod incremental_coverage_analysis_tests {
+    //! Covers convert_coverage_update_to_report in
+    //! incremental_coverage_analysis.rs (52 uncov on broad, 0% cov).
+    use super::*;
+    use crate::services::incremental_coverage_analyzer::{
+        AggregateCoverage, CoverageUpdate, DeltaCoverage, FileCoverage, FileId,
+    };
+    use std::collections::HashMap;
+
+    fn file_id(path: &str) -> FileId {
+        FileId {
+            path: PathBuf::from(path),
+            hash: [0u8; 32],
+        }
+    }
+
+    fn coverage_for(line_cov: f64, covered_lines: usize, total_lines: usize) -> FileCoverage {
+        FileCoverage {
+            line_coverage: line_cov,
+            branch_coverage: line_cov,
+            function_coverage: line_cov,
+            covered_lines: (0..covered_lines).collect(),
+            total_lines,
+        }
+    }
+
+    fn update_with(
+        file_cov_pairs: Vec<(FileId, FileCoverage)>,
+        delta_percentage: f64,
+    ) -> CoverageUpdate {
+        let mut map = HashMap::new();
+        for (k, v) in file_cov_pairs {
+            map.insert(k, v);
+        }
+        CoverageUpdate {
+            file_coverage: map,
+            aggregate_coverage: AggregateCoverage {
+                line_percentage: 0.0,
+                branch_percentage: 0.0,
+                function_percentage: 0.0,
+                total_files: 0,
+                covered_files: 0,
+            },
+            delta_coverage: DeltaCoverage {
+                new_lines_covered: 0,
+                new_lines_total: 0,
+                percentage: delta_percentage,
+            },
+        }
+    }
+
+    #[test]
+    fn test_convert_empty_update_produces_empty_report() {
+        let report = convert_coverage_update_to_report(
+            update_with(vec![], 0.0),
+            "main".into(),
+            "HEAD".into(),
+            0.9,
+            vec![],
+        )
+        .unwrap();
+        assert_eq!(report.base_branch, "main");
+        assert_eq!(report.target_branch, "HEAD");
+        assert_eq!(report.coverage_threshold, 0.9);
+        assert!(report.files.is_empty());
+        assert_eq!(report.summary.total_files_changed, 0);
+    }
+
+    #[test]
+    fn test_convert_matches_file_id_to_changed_file_and_computes_delta() {
+        let fid = file_id("src/a.rs");
+        // target_coverage = 85.0, simulated base = max(85, 50) - 10 = 75 → delta = 10.
+        let cov = coverage_for(85.0, 17, 20);
+        let update = update_with(vec![(fid, cov)], 5.0);
+        let changed = vec![(PathBuf::from("src/a.rs"), "M".to_string())];
+        let report = convert_coverage_update_to_report(
+            update,
+            "main".into(),
+            "HEAD".into(),
+            0.8,
+            changed,
+        )
+        .unwrap();
+        assert_eq!(report.files.len(), 1);
+        let f = &report.files[0];
+        assert_eq!(f.path, PathBuf::from("src/a.rs"));
+        assert_eq!(f.target_coverage, 85.0);
+        assert!((f.base_coverage - 75.0).abs() < 1e-6);
+        assert!((f.coverage_delta - 10.0).abs() < 1e-6);
+        assert_eq!(f.lines_covered, 17);
+        assert_eq!(f.lines_uncovered, 3);
+        assert_eq!(f.lines_added, 20);
+        assert_eq!(report.summary.files_improved, 1);
+        assert_eq!(report.summary.files_degraded, 0);
+        assert_eq!(report.summary.overall_delta, 5.0);
+        assert!(report.summary.meets_threshold);
+    }
+
+    #[test]
+    fn test_convert_base_coverage_floor_at_50_minus_10() {
+        // line_coverage < 50 → max(line_cov, 50.0) → 50.0, base = 50 - 10 = 40.
+        let fid = file_id("src/b.rs");
+        let cov = coverage_for(20.0, 4, 20);
+        let update = update_with(vec![(fid, cov)], 0.0);
+        let changed = vec![(PathBuf::from("src/b.rs"), "A".to_string())];
+        let report = convert_coverage_update_to_report(
+            update,
+            "main".into(),
+            "HEAD".into(),
+            0.5,
+            changed,
+        )
+        .unwrap();
+        let f = &report.files[0];
+        assert!((f.base_coverage - 40.0).abs() < 1e-6);
+        assert!(f.coverage_delta < 0.0);
+        assert_eq!(report.summary.files_degraded, 1);
+    }
+
+    #[test]
+    fn test_convert_meets_threshold_false_when_overall_below() {
+        let fid = file_id("src/c.rs");
+        let cov = coverage_for(80.0, 16, 20);
+        let update = update_with(vec![(fid, cov)], 0.3);
+        let changed = vec![(PathBuf::from("src/c.rs"), "M".to_string())];
+        let report = convert_coverage_update_to_report(
+            update,
+            "main".into(),
+            "HEAD".into(),
+            0.9,
+            changed,
+        )
+        .unwrap();
+        assert!(!report.summary.meets_threshold);
+    }
+
+    #[test]
+    fn test_convert_file_id_not_in_changed_files_is_skipped() {
+        let fid = file_id("src/untracked.rs");
+        let cov = coverage_for(80.0, 16, 20);
+        let update = update_with(vec![(fid, cov)], 0.0);
+        let changed = vec![(PathBuf::from("src/different.rs"), "M".to_string())];
+        let report = convert_coverage_update_to_report(
+            update,
+            "main".into(),
+            "HEAD".into(),
+            0.5,
+            changed,
+        )
+        .unwrap();
+        assert!(report.files.is_empty());
+    }
+
+    #[test]
+    fn test_convert_lines_uncovered_saturates_when_covered_exceeds_total() {
+        let fid = file_id("src/d.rs");
+        let cov = coverage_for(100.0, 30, 20);
+        let update = update_with(vec![(fid, cov)], 0.0);
+        let changed = vec![(PathBuf::from("src/d.rs"), "M".to_string())];
+        let report = convert_coverage_update_to_report(
+            update,
+            "main".into(),
+            "HEAD".into(),
+            0.5,
+            changed,
+        )
+        .unwrap();
+        assert_eq!(report.files[0].lines_uncovered, 0);
+    }
+}

--- a/src/cli/analysis_utilities/proof_coverage.rs
+++ b/src/cli/analysis_utilities/proof_coverage.rs
@@ -417,3 +417,151 @@ async fn output_coverage_result(content: String, output: Option<PathBuf>) -> Res
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod proof_coverage_tests {
+    //! Covers 0%-covered pure-compute helpers in proof_coverage.rs
+    //! (60 uncov on broad).
+    use super::*;
+
+    fn empty_report() -> IncrementalCoverageReport {
+        IncrementalCoverageReport {
+            base_branch: "main".into(),
+            target_branch: "HEAD".into(),
+            coverage_threshold: 0.9,
+            files: vec![],
+            summary: CoverageSummary {
+                total_files_changed: 0,
+                files_improved: 0,
+                files_degraded: 0,
+                overall_delta: 0.0,
+                meets_threshold: true,
+            },
+        }
+    }
+
+    // ── print_coverage_analysis_header: exercise both target_branch arms ──
+
+    #[test]
+    fn test_print_coverage_analysis_header_with_target_branch() {
+        print_coverage_analysis_header(
+            std::path::Path::new("/tmp/proj"),
+            "main",
+            &Some("feat/x".to_string()),
+            0.95,
+            &IncrementalCoverageOutputFormat::Summary,
+        );
+    }
+
+    #[test]
+    fn test_print_coverage_analysis_header_target_branch_defaults_to_head() {
+        print_coverage_analysis_header(
+            std::path::Path::new("/tmp/proj"),
+            "main",
+            &None, // triggers unwrap_or("HEAD") arm
+            0.95,
+            &IncrementalCoverageOutputFormat::Json,
+        );
+    }
+
+    // ── create_file_ids_from_changes: only "M" and "A" entries kept, hashes distinct ──
+
+    #[test]
+    fn test_create_file_ids_from_changes_keeps_modified_and_added_only() {
+        let changes = vec![
+            (std::path::PathBuf::from("a.rs"), "M".to_string()),
+            (std::path::PathBuf::from("b.rs"), "A".to_string()),
+            (std::path::PathBuf::from("c.rs"), "D".to_string()), // deleted
+            (std::path::PathBuf::from("d.rs"), "R".to_string()), // renamed
+        ];
+        let ids = create_file_ids_from_changes(&changes).unwrap();
+        assert_eq!(ids.len(), 2);
+        assert!(ids.iter().any(|f| f.path == std::path::PathBuf::from("a.rs")));
+        assert!(ids.iter().any(|f| f.path == std::path::PathBuf::from("b.rs")));
+    }
+
+    #[test]
+    fn test_create_file_ids_from_changes_empty_input_returns_empty() {
+        let ids = create_file_ids_from_changes(&[]).unwrap();
+        assert!(ids.is_empty());
+    }
+
+    #[test]
+    fn test_create_file_ids_from_changes_distinct_paths_produce_distinct_hashes() {
+        let changes = vec![
+            (std::path::PathBuf::from("a.rs"), "M".to_string()),
+            (std::path::PathBuf::from("b.rs"), "M".to_string()),
+        ];
+        let ids = create_file_ids_from_changes(&changes).unwrap();
+        assert_eq!(ids.len(), 2);
+        assert_ne!(
+            ids[0].hash, ids[1].hash,
+            "different paths must yield different SHA256 hashes"
+        );
+    }
+
+    #[test]
+    fn test_create_file_ids_from_changes_same_path_produces_same_hash() {
+        let changes = vec![(std::path::PathBuf::from("a.rs"), "M".to_string())];
+        let a = create_file_ids_from_changes(&changes).unwrap();
+        let b = create_file_ids_from_changes(&changes).unwrap();
+        assert_eq!(a[0].hash, b[0].hash, "hash must be deterministic");
+    }
+
+    // ── format_coverage_report: dispatcher hits Summary/Detailed/Json/Markdown/Lcov/Delta/Sarif arms ──
+
+    #[test]
+    fn test_format_coverage_report_json_variant_round_trips_as_json() {
+        let report = empty_report();
+        let out =
+            format_coverage_report(&report, IncrementalCoverageOutputFormat::Json, 10).unwrap();
+        let _: serde_json::Value = serde_json::from_str(&out).unwrap();
+    }
+
+    #[test]
+    fn test_format_coverage_report_summary_variant_returns_nonempty() {
+        let report = empty_report();
+        let out =
+            format_coverage_report(&report, IncrementalCoverageOutputFormat::Summary, 10).unwrap();
+        assert!(!out.is_empty());
+    }
+
+    #[test]
+    fn test_format_coverage_report_lcov_variant_returns_string() {
+        let report = empty_report();
+        let out =
+            format_coverage_report(&report, IncrementalCoverageOutputFormat::Lcov, 10).unwrap();
+        // LCOV format is always string (even if empty).
+        let _ = out;
+    }
+
+    #[test]
+    fn test_format_coverage_report_delta_variant_returns_string() {
+        let report = empty_report();
+        let _out =
+            format_coverage_report(&report, IncrementalCoverageOutputFormat::Delta, 10).unwrap();
+    }
+
+    #[test]
+    fn test_format_coverage_report_sarif_variant_returns_string() {
+        let report = empty_report();
+        let _out =
+            format_coverage_report(&report, IncrementalCoverageOutputFormat::Sarif, 10).unwrap();
+    }
+
+    #[test]
+    fn test_format_coverage_report_markdown_variant_returns_string() {
+        let report = empty_report();
+        let _out =
+            format_coverage_report(&report, IncrementalCoverageOutputFormat::Markdown, 10)
+                .unwrap();
+    }
+
+    #[test]
+    fn test_format_coverage_report_detailed_variant_returns_string() {
+        let report = empty_report();
+        let _out =
+            format_coverage_report(&report, IncrementalCoverageOutputFormat::Detailed, 10)
+                .unwrap();
+    }
+}

--- a/src/cli/analysis_utilities/proof_coverage.rs
+++ b/src/cli/analysis_utilities/proof_coverage.rs
@@ -476,8 +476,8 @@ mod proof_coverage_tests {
         ];
         let ids = create_file_ids_from_changes(&changes).unwrap();
         assert_eq!(ids.len(), 2);
-        assert!(ids.iter().any(|f| f.path == std::path::PathBuf::from("a.rs")));
-        assert!(ids.iter().any(|f| f.path == std::path::PathBuf::from("b.rs")));
+        assert!(ids.iter().any(|f| f.path == std::path::Path::new("a.rs")));
+        assert!(ids.iter().any(|f| f.path == std::path::Path::new("b.rs")));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Continued autonomous coverage work on next-wave 0%-covered files.

- proof_coverage.rs: header + file_id hashing + format dispatcher (13 tests)

Additional PRs expected to follow in this branch as the loop continues.

## Test plan
- [x] All new tests pass
- [x] \`cargo clippy --lib --tests -- -D warnings\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)