### PR TITLE
test(coverage): wave-4 0%-cov helpers

### DIFF
--- a/src/cli/handlers/comply_cb_detect/quality_checks_coverage_gaming.rs
+++ b/src/cli/handlers/comply_cb_detect/quality_checks_coverage_gaming.rs
@@ -85,3 +85,121 @@ fn classify_exclusion_severity(
         severity,
     }]
 }
+
+#[cfg(test)]
+mod coverage_gaming_tests {
+    //! Covers CB-125 coverage-gaming detection (59 uncov on broad, 0% cov).
+    use super::*;
+
+    // ── detect_cb125_coverage_exclusion_gaming: no Makefile → empty ──
+
+    #[test]
+    fn test_detect_missing_makefile_returns_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        let v = detect_cb125_coverage_exclusion_gaming(tmp.path());
+        assert!(v.is_empty());
+    }
+
+    // ── count_exclusion_patterns: counting pipe-separated patterns ──
+
+    #[test]
+    fn test_count_exclusion_patterns_no_ignore_lines_returns_zero() {
+        let content = "all:\n\techo ok\n";
+        let (count, line) = count_exclusion_patterns(content);
+        assert_eq!(count, 0);
+        assert_eq!(line, 0);
+    }
+
+    #[test]
+    fn test_count_exclusion_patterns_single_pattern_single_line() {
+        // One pattern = 0 pipes + 1 = 1.
+        let content = "t:\n\tcargo llvm-cov --ignore-filename-regex 'tests/' -- --lib\n";
+        let (count, line) = count_exclusion_patterns(content);
+        assert_eq!(count, 1);
+        assert_eq!(line, 2); // 1-based line of last matching --ignore
+    }
+
+    #[test]
+    fn test_count_exclusion_patterns_multiple_patterns_via_pipes() {
+        // Three patterns: 2 pipes + 1 = 3.
+        let content = "t:\n\tcargo llvm-cov --ignore-filename-regex 'tests/|benches/|examples/' -- --lib\n";
+        let (count, line) = count_exclusion_patterns(content);
+        assert_eq!(count, 3);
+        assert_eq!(line, 2);
+    }
+
+    #[test]
+    fn test_count_exclusion_patterns_multiple_ignore_lines_accumulate() {
+        // Two separate --ignore-filename-regex lines, each contributing pattern count.
+        let content = "t1:\n\tllvm-cov --ignore-filename-regex 'a|b' --lib\nt2:\n\tllvm-cov --ignore-filename-regex 'c|d|e' --lib\n";
+        let (count, line) = count_exclusion_patterns(content);
+        assert_eq!(count, 2 + 3); // 'a|b' = 2, 'c|d|e' = 3
+        assert_eq!(line, 4); // last matching line
+    }
+
+    #[test]
+    fn test_count_exclusion_patterns_no_single_quotes_yields_zero() {
+        // Without matching single quotes, start < end is false → no increment.
+        let content = "t:\n\tllvm-cov --ignore-filename-regex \"tests/\" --lib\n";
+        let (count, _line) = count_exclusion_patterns(content);
+        assert_eq!(count, 0, "double-quoted pattern should not count");
+    }
+
+    // ── classify_exclusion_severity: all 4 tier arms ──
+
+    #[test]
+    fn test_classify_below_10_no_violations() {
+        // count <= 10 → no violations.
+        let v = classify_exclusion_severity(0, 1, std::path::Path::new("Makefile"));
+        assert!(v.is_empty());
+
+        let v = classify_exclusion_severity(10, 1, std::path::Path::new("Makefile"));
+        assert!(v.is_empty());
+    }
+
+    #[test]
+    fn test_classify_11_to_20_is_warning_cb125a() {
+        let v = classify_exclusion_severity(15, 5, std::path::Path::new("Makefile"));
+        assert_eq!(v.len(), 1);
+        assert_eq!(v[0].pattern_id, "CB-125-A");
+        assert_eq!(v[0].line, 5);
+        assert!(matches!(v[0].severity, Severity::Warning));
+    }
+
+    #[test]
+    fn test_classify_21_to_50_is_error_cb125b() {
+        let v = classify_exclusion_severity(35, 7, std::path::Path::new("Makefile"));
+        assert_eq!(v.len(), 1);
+        assert_eq!(v[0].pattern_id, "CB-125-B");
+        assert!(matches!(v[0].severity, Severity::Error));
+    }
+
+    #[test]
+    fn test_classify_above_50_is_critical_cb125c() {
+        let v = classify_exclusion_severity(75, 9, std::path::Path::new("Makefile"));
+        assert_eq!(v.len(), 1);
+        assert_eq!(v[0].pattern_id, "CB-125-C");
+        assert!(matches!(v[0].severity, Severity::Critical));
+        assert!(v[0].description.contains("CRITICAL"));
+    }
+
+    // ── Integration via detect_cb125 ──
+
+    #[test]
+    fn test_detect_cb125_with_many_exclusions_emits_violation() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Craft a Makefile with 12 pipe-separated patterns → tier A (Warning).
+        let patterns = (0..12)
+            .map(|i| format!("pat{i}"))
+            .collect::<Vec<_>>()
+            .join("|");
+        let content = format!(
+            "t:\n\tcargo llvm-cov --ignore-filename-regex '{patterns}' -- --lib\n"
+        );
+        std::fs::write(tmp.path().join("Makefile"), content).unwrap();
+
+        let v = detect_cb125_coverage_exclusion_gaming(tmp.path());
+        assert_eq!(v.len(), 1);
+        assert_eq!(v[0].pattern_id, "CB-125-A");
+    }
+}

--- a/src/cli/handlers/comply_cb_detect/safety_checks_profiler.rs
+++ b/src/cli/handlers/comply_cb_detect/safety_checks_profiler.rs
@@ -158,3 +158,192 @@ pub fn extract_brick_name(content: &str, target_line: &str) -> String {
     }
     "unknown".to_string()
 }
+
+#[cfg(test)]
+mod safety_checks_profiler_tests {
+    //! Covers safety_checks_profiler.rs pure helpers (79 uncov on broad, 0% cov).
+    use super::*;
+
+    // ── extract_json_number ──
+
+    #[test]
+    fn test_extract_json_number_parses_plain_value() {
+        assert_eq!(extract_json_number("\"cv\": 0.18,"), Some(0.18));
+    }
+
+    #[test]
+    fn test_extract_json_number_strips_trailing_comma_and_brace() {
+        assert_eq!(extract_json_number("\"cv\": 20.5}"), Some(20.5));
+    }
+
+    #[test]
+    fn test_extract_json_number_no_colon_returns_none() {
+        assert_eq!(extract_json_number("just a string"), None);
+    }
+
+    #[test]
+    fn test_extract_json_number_non_numeric_returns_none() {
+        assert_eq!(extract_json_number("\"x\": not_a_number,"), None);
+    }
+
+    // ── extract_brick_name ──
+
+    #[test]
+    fn test_extract_brick_name_finds_name_field_above_target() {
+        let content = "  \"name\": \"my_brick\",\n  \"cv\": 0.25,\n";
+        let name = extract_brick_name(content, "  \"cv\": 0.25,");
+        assert_eq!(name, "my_brick");
+    }
+
+    #[test]
+    fn test_extract_brick_name_finds_brick_name_field() {
+        let content = "  \"brick_name\": \"other_brick\",\n  \"cv\": 0.25,\n";
+        let name = extract_brick_name(content, "  \"cv\": 0.25,");
+        assert_eq!(name, "other_brick");
+    }
+
+    #[test]
+    fn test_extract_brick_name_target_missing_returns_unknown() {
+        let content = "  \"name\": \"x\",\n  \"other\": 1,\n";
+        assert_eq!(extract_brick_name(content, "does not appear"), "unknown");
+    }
+
+    #[test]
+    fn test_extract_brick_name_target_found_but_no_name_above_returns_unknown() {
+        let content = "  \"other\": 1,\n  \"cv\": 0.25,\n";
+        assert_eq!(extract_brick_name(content, "  \"cv\": 0.25,"), "unknown");
+    }
+
+    // ── check_cv_anomaly ──
+
+    #[test]
+    fn test_check_cv_anomaly_non_cv_line_returns_none() {
+        assert!(check_cv_anomaly("\"other\": 0.5", "").is_none());
+    }
+
+    #[test]
+    fn test_check_cv_anomaly_below_threshold_returns_none() {
+        // cv = 0.1 * 100 = 10% < 15%
+        let line = "\"cv\": 0.1,";
+        assert!(check_cv_anomaly(line, line).is_none());
+    }
+
+    #[test]
+    fn test_check_cv_anomaly_above_threshold_ratio_form() {
+        // cv = 0.25 * 100 = 25% > 15%
+        let line = "\"cv\": 0.25,";
+        let a = check_cv_anomaly(line, line).unwrap();
+        assert_eq!(a.anomaly_type, "HIGH_CV");
+        assert!((a.value - 25.0).abs() < 1e-6);
+        assert_eq!(a.threshold, 15.0);
+    }
+
+    #[test]
+    fn test_check_cv_anomaly_above_threshold_percent_form() {
+        // Already a percent (value >= 1.0) → used as-is.
+        let line = "\"cv_percent\": 20.0";
+        let a = check_cv_anomaly(line, line).unwrap();
+        assert!((a.value - 20.0).abs() < 1e-6);
+    }
+
+    // ── check_efficiency_anomaly ──
+
+    #[test]
+    fn test_check_efficiency_anomaly_non_eff_line_returns_none() {
+        assert!(check_efficiency_anomaly("\"cv\": 0.1", "").is_none());
+    }
+
+    #[test]
+    fn test_check_efficiency_anomaly_above_threshold_returns_none() {
+        // 0.5 * 100 = 50% > 25% (threshold is LOW efficiency, so >25 is OK).
+        let line = "\"efficiency\": 0.5";
+        assert!(check_efficiency_anomaly(line, line).is_none());
+    }
+
+    #[test]
+    fn test_check_efficiency_anomaly_below_threshold_emits() {
+        // 0.1 * 100 = 10% < 25%
+        let line = "\"efficiency\": 0.1,";
+        let a = check_efficiency_anomaly(line, line).unwrap();
+        assert_eq!(a.anomaly_type, "LOW_EFFICIENCY");
+        assert!((a.value - 10.0).abs() < 1e-6);
+        assert_eq!(a.threshold, 25.0);
+    }
+
+    // ── check_profiler_file: combines CV + efficiency over all lines ──
+
+    #[test]
+    fn test_check_profiler_file_empty_returns_empty() {
+        let v = check_profiler_file("");
+        assert!(v.is_empty());
+    }
+
+    #[test]
+    fn test_check_profiler_file_detects_both_anomaly_types() {
+        let content = "  \"name\": \"b1\",\n  \"cv\": 0.25,\n  \"efficiency\": 0.1,\n";
+        let v = check_profiler_file(content);
+        assert_eq!(v.len(), 2);
+        assert!(v.iter().any(|a| a.anomaly_type == "HIGH_CV"));
+        assert!(v.iter().any(|a| a.anomaly_type == "LOW_EFFICIENCY"));
+    }
+
+    // ── detect_profiler_anomalies: no file → empty ──
+
+    #[test]
+    fn test_detect_profiler_anomalies_missing_file_returns_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        let v = detect_profiler_anomalies(tmp.path());
+        assert!(v.is_empty());
+    }
+
+    #[test]
+    fn test_detect_profiler_anomalies_reads_brick_profile_json() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join("brick-profile.json"),
+            "{\n  \"name\": \"bad\",\n  \"cv\": 0.8\n}",
+        )
+        .unwrap();
+        let v = detect_profiler_anomalies(tmp.path());
+        assert!(!v.is_empty());
+    }
+
+    // ── detect_bricks_without_assertions: missing src/brick/ → empty ──
+
+    #[test]
+    fn test_detect_bricks_without_assertions_missing_dir_returns_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        let v = detect_bricks_without_assertions(tmp.path());
+        assert!(v.is_empty());
+    }
+
+    #[test]
+    fn test_detect_bricks_without_assertions_brick_without_assertions_flagged() {
+        let tmp = tempfile::tempdir().unwrap();
+        let brick_dir = tmp.path().join("src").join("brick");
+        std::fs::create_dir_all(&brick_dir).unwrap();
+        // impl + Brick + no assert/debug_assert/validate/etc → flagged.
+        std::fs::write(
+            brick_dir.join("a.rs"),
+            "impl Brick for Foo { fn run(&self) {} }\n",
+        )
+        .unwrap();
+        let v = detect_bricks_without_assertions(tmp.path());
+        assert_eq!(v.len(), 1);
+        assert_eq!(v[0].pattern_id, "CB-BUDGET");
+    }
+
+    #[test]
+    fn test_detect_bricks_without_assertions_brick_with_assertion_not_flagged() {
+        let tmp = tempfile::tempdir().unwrap();
+        let brick_dir = tmp.path().join("src").join("brick");
+        std::fs::create_dir_all(&brick_dir).unwrap();
+        std::fs::write(
+            brick_dir.join("a.rs"),
+            "impl Brick for Foo { fn run(&self) { assert!(true); } }\n",
+        )
+        .unwrap();
+        let v = detect_bricks_without_assertions(tmp.path());
+        assert!(v.is_empty());
+    }
+}

--- a/src/cli/handlers/comply_cb_detect/safety_checks_simd.rs
+++ b/src/cli/handlers/comply_cb_detect/safety_checks_simd.rs
@@ -82,3 +82,121 @@ pub fn detect_cb021_simd_without_target_feature(project_path: &Path) -> Vec<CbPa
         .flat_map(|e| check_file_for_simd_violations(e))
         .collect()
 }
+
+#[cfg(test)]
+mod safety_checks_simd_tests {
+    //! Covers safety_checks_simd.rs pure helpers (55 uncov on broad, 0% cov).
+    use super::*;
+
+    // ── mark_function_body: brace tracking ──
+
+    #[test]
+    fn test_mark_function_body_single_line_braces_closes_immediately() {
+        let lines = vec!["fn inline() { body(); }", "after();"];
+        let mut protected: HashSet<usize> = HashSet::new();
+        mark_function_body(&lines, 0, &mut protected);
+        assert!(protected.contains(&0));
+        assert!(!protected.contains(&1), "after() line must not be protected");
+    }
+
+    #[test]
+    fn test_mark_function_body_multi_line_tracks_nested_braces() {
+        // fn on line 0; body spans 0..=4; line 5 is outside.
+        let lines = vec![
+            "fn example() {",
+            "    if cond {",
+            "        inner();",
+            "    }",
+            "}",
+            "outside();",
+        ];
+        let mut protected = HashSet::new();
+        mark_function_body(&lines, 0, &mut protected);
+        for i in 0..=4 {
+            assert!(protected.contains(&i), "line {i} must be protected");
+        }
+        assert!(!protected.contains(&5));
+    }
+
+    // ── compute_target_feature_protected_lines ──
+
+    #[test]
+    fn test_compute_target_feature_protected_lines_empty_when_no_attr() {
+        let lines = vec!["fn foo() {}", "fn bar() {}"];
+        assert!(compute_target_feature_protected_lines(&lines).is_empty());
+    }
+
+    #[test]
+    fn test_compute_target_feature_protected_lines_marks_target_feature_fn_body() {
+        let lines = vec![
+            "#[target_feature(enable = \"avx2\")]",
+            "unsafe fn avx_fn() {",
+            "    _mm256_add_ps(a, b);",
+            "}",
+            "fn other() {}",
+        ];
+        let prot = compute_target_feature_protected_lines(&lines);
+        // Lines 1..=3 (the fn body) must be protected.
+        for i in 1..=3 {
+            assert!(prot.contains(&i), "line {i} must be protected");
+        }
+    }
+
+    #[test]
+    fn test_compute_target_feature_protected_lines_handles_cfg_target_feature() {
+        // `#[cfg(... target_feature ...)]` also counts as protection.
+        let lines = vec![
+            "#[cfg(target_feature = \"avx2\")]",
+            "fn avx_fn() {",
+            "    body();",
+            "}",
+        ];
+        let prot = compute_target_feature_protected_lines(&lines);
+        assert!(prot.contains(&1));
+        assert!(prot.contains(&3));
+    }
+
+    // ── detect_cb021 top-level: missing src/ → empty ──
+
+    #[test]
+    fn test_detect_cb021_missing_src_returns_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        let v = detect_cb021_simd_without_target_feature(tmp.path());
+        assert!(v.is_empty());
+    }
+
+    // ── check_file_for_simd_violations: read error = empty ──
+
+    #[test]
+    fn test_check_file_for_simd_violations_missing_file_returns_empty() {
+        let missing = std::path::Path::new("/tmp/pmat_nope_xyz_0xC0FFEE.rs");
+        let v = check_file_for_simd_violations(missing);
+        assert!(v.is_empty());
+    }
+
+    #[test]
+    fn test_check_file_for_simd_violations_clean_file_returns_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        let f = tmp.path().join("a.rs");
+        std::fs::write(&f, "fn add(a: f32, b: f32) -> f32 { a + b }\n").unwrap();
+        let v = check_file_for_simd_violations(&f);
+        assert!(v.is_empty());
+    }
+
+    #[test]
+    fn test_check_file_for_simd_violations_protected_fn_body_not_flagged() {
+        // SIMD intrinsic inside a #[target_feature]-protected fn → no violation.
+        let tmp = tempfile::tempdir().unwrap();
+        let f = tmp.path().join("a.rs");
+        std::fs::write(
+            &f,
+            "#[target_feature(enable = \"avx2\")]\nunsafe fn x() {\n    _mm256_add_ps(a, b);\n}\n",
+        )
+        .unwrap();
+        let v = check_file_for_simd_violations(&f);
+        assert!(
+            v.is_empty(),
+            "protected fn body must suppress CB-021: {v:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
Continuing autonomous coverage loop. First commit covers CB-125 coverage-exclusion-gaming detection.

## Test plan
- [x] 11 new tests pass
- [x] \`cargo clippy --lib --tests -- -D warnings\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)