### PR TITLE
fix(comply) + test(coverage): default-yaml severity defect + scaffold tests

### DIFF
--- a/src/cli/analysis_utilities/quality_checks_part2_coverage_sections.rs
+++ b/src/cli/analysis_utilities/quality_checks_part2_coverage_sections.rs
@@ -94,3 +94,241 @@ async fn check_sections(project_path: &Path) -> Result<Vec<QualityViolation>> {
 
     Ok(violations)
 }
+
+#[cfg(test)]
+mod coverage_sections_tests {
+    //! Covers quality_checks_part2_coverage_sections.rs pure-compute helpers
+    //! (73 uncov on broad, 0% cov).
+    use super::*;
+
+    // ── compute_line_coverage: sum across per-file hit maps ──
+
+    #[test]
+    fn test_compute_line_coverage_empty_files_map_is_zero_zero() {
+        let files = serde_json::Map::new();
+        let (total, covered) = compute_line_coverage(&files);
+        assert_eq!(total, 0);
+        assert_eq!(covered, 0);
+    }
+
+    #[test]
+    fn test_compute_line_coverage_counts_only_object_values() {
+        let json = serde_json::json!({
+            "src/a.rs": {"1": 5, "2": 0, "3": 12},
+            "src/b.rs": "not-an-object",  // skipped by as_object() branch
+            "src/c.rs": {"1": 0}
+        });
+        let files = json.as_object().unwrap().clone();
+        let (total, covered) = compute_line_coverage(&files);
+        assert_eq!(total, 4, "3 from a.rs + 1 from c.rs = 4");
+        assert_eq!(covered, 2, "a.rs:1=5 and a.rs:3=12 → 2 covered");
+    }
+
+    #[test]
+    fn test_compute_line_coverage_non_numeric_hits_count_as_uncovered() {
+        // count.as_u64() returns None for strings → unwrap_or(0) → not > 0 → uncovered.
+        let json = serde_json::json!({
+            "f.rs": {"1": "notanumber", "2": 3}
+        });
+        let files = json.as_object().unwrap().clone();
+        let (total, covered) = compute_line_coverage(&files);
+        assert_eq!(total, 2);
+        assert_eq!(covered, 1);
+    }
+
+    // ── read_coverage_from_detail_cache ──
+
+    #[test]
+    fn test_read_coverage_from_detail_cache_missing_file_is_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(read_coverage_from_detail_cache(tmp.path()).is_none());
+    }
+
+    #[test]
+    fn test_read_coverage_from_detail_cache_malformed_json_is_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join(".pmat")).unwrap();
+        std::fs::write(tmp.path().join(".pmat/coverage-cache.json"), "not json").unwrap();
+        assert!(read_coverage_from_detail_cache(tmp.path()).is_none());
+    }
+
+    #[test]
+    fn test_read_coverage_from_detail_cache_no_files_key_is_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join(".pmat")).unwrap();
+        std::fs::write(tmp.path().join(".pmat/coverage-cache.json"), "{}").unwrap();
+        assert!(read_coverage_from_detail_cache(tmp.path()).is_none());
+    }
+
+    #[test]
+    fn test_read_coverage_from_detail_cache_total_zero_is_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join(".pmat")).unwrap();
+        // Empty files object → total=0 → None.
+        std::fs::write(
+            tmp.path().join(".pmat/coverage-cache.json"),
+            "{\"files\":{}}",
+        )
+        .unwrap();
+        assert!(read_coverage_from_detail_cache(tmp.path()).is_none());
+    }
+
+    #[test]
+    fn test_read_coverage_from_detail_cache_valid_returns_percentage() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join(".pmat")).unwrap();
+        // 4 lines, 3 covered → 75%.
+        std::fs::write(
+            tmp.path().join(".pmat/coverage-cache.json"),
+            "{\"files\":{\"a.rs\":{\"1\":1,\"2\":2,\"3\":0,\"4\":5}}}",
+        )
+        .unwrap();
+        let pct = read_coverage_from_detail_cache(tmp.path()).unwrap();
+        assert!((pct - 75.0).abs() < 1e-6);
+    }
+
+    // ── read_coverage_from_metrics ──
+
+    #[test]
+    fn test_read_coverage_from_metrics_missing_file_is_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(read_coverage_from_metrics(tmp.path()).is_none());
+    }
+
+    #[test]
+    fn test_read_coverage_from_metrics_valid_returns_value() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join(".pmat-metrics")).unwrap();
+        std::fs::write(
+            tmp.path().join(".pmat-metrics/coverage.json"),
+            "{\"coverage\": 92.5}",
+        )
+        .unwrap();
+        let pct = read_coverage_from_metrics(tmp.path()).unwrap();
+        assert!((pct - 92.5).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_read_coverage_from_metrics_missing_coverage_key_is_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join(".pmat-metrics")).unwrap();
+        std::fs::write(
+            tmp.path().join(".pmat-metrics/coverage.json"),
+            "{\"other\": 1}",
+        )
+        .unwrap();
+        assert!(read_coverage_from_metrics(tmp.path()).is_none());
+    }
+
+    // ── read_coverage_from_cache: falls back from detail to metrics ──
+
+    #[test]
+    fn test_read_coverage_from_cache_detail_preferred_over_metrics() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join(".pmat")).unwrap();
+        std::fs::create_dir_all(tmp.path().join(".pmat-metrics")).unwrap();
+        // Detail cache present + metrics also present → detail wins.
+        std::fs::write(
+            tmp.path().join(".pmat/coverage-cache.json"),
+            "{\"files\":{\"a.rs\":{\"1\":1,\"2\":0}}}",
+        )
+        .unwrap(); // 50%
+        std::fs::write(
+            tmp.path().join(".pmat-metrics/coverage.json"),
+            "{\"coverage\": 92.5}",
+        )
+        .unwrap();
+        let pct = read_coverage_from_cache(tmp.path()).unwrap();
+        assert!((pct - 50.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_read_coverage_from_cache_falls_back_to_metrics() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join(".pmat-metrics")).unwrap();
+        // No detail cache → fallback to metrics.
+        std::fs::write(
+            tmp.path().join(".pmat-metrics/coverage.json"),
+            "{\"coverage\": 80.0}",
+        )
+        .unwrap();
+        let pct = read_coverage_from_cache(tmp.path()).unwrap();
+        assert!((pct - 80.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_read_coverage_from_cache_no_files_is_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(read_coverage_from_cache(tmp.path()).is_none());
+    }
+
+    // ── check_coverage async ──
+
+    #[tokio::test]
+    async fn test_check_coverage_no_data_no_violations() {
+        let tmp = tempfile::tempdir().unwrap();
+        let v = check_coverage(tmp.path(), 95.0).await.unwrap();
+        assert!(v.is_empty(), "no data → skip, no violations");
+    }
+
+    #[tokio::test]
+    async fn test_check_coverage_below_threshold_flagged() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join(".pmat-metrics")).unwrap();
+        std::fs::write(
+            tmp.path().join(".pmat-metrics/coverage.json"),
+            "{\"coverage\": 60.0}",
+        )
+        .unwrap();
+        let v = check_coverage(tmp.path(), 95.0).await.unwrap();
+        assert_eq!(v.len(), 1);
+        assert_eq!(v[0].check_type, "coverage");
+        assert_eq!(v[0].severity, "error");
+    }
+
+    #[tokio::test]
+    async fn test_check_coverage_above_threshold_no_violation() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join(".pmat-metrics")).unwrap();
+        std::fs::write(
+            tmp.path().join(".pmat-metrics/coverage.json"),
+            "{\"coverage\": 97.0}",
+        )
+        .unwrap();
+        let v = check_coverage(tmp.path(), 95.0).await.unwrap();
+        assert!(v.is_empty());
+    }
+
+    // ── check_sections async ──
+
+    #[tokio::test]
+    async fn test_check_sections_no_readme_no_violations() {
+        let tmp = tempfile::tempdir().unwrap();
+        let v = check_sections(tmp.path()).await.unwrap();
+        assert!(v.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_check_sections_complete_readme_no_violations() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join("README.md"),
+            "# Project\n## Installation\n## Usage\n## Contributing\n## License\n",
+        )
+        .unwrap();
+        let v = check_sections(tmp.path()).await.unwrap();
+        assert!(v.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_check_sections_missing_sections_all_flagged() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("README.md"), "# Project only\n").unwrap();
+        let v = check_sections(tmp.path()).await.unwrap();
+        assert_eq!(v.len(), 4, "all 4 required sections missing");
+        for x in &v {
+            assert_eq!(x.check_type, "sections");
+            assert_eq!(x.severity, "warning");
+        }
+    }
+}

--- a/src/cli/handlers/comply_handlers/check_handlers/check_best_practices.rs
+++ b/src/cli/handlers/comply_handlers/check_handlers/check_best_practices.rs
@@ -806,3 +806,182 @@ pub(crate) fn check_lean_best_practices_with_config(
         true,
     )
 }
+
+#[cfg(test)]
+mod check_best_practices_tests {
+    //! Covers pure-compute helpers in check_best_practices.rs (69 uncov on
+    //! broad, 0% cov). Skips fs-walking check_*_best_practices detectors.
+    use super::*;
+    use crate::cli::handlers::comply_cb_detect::{CbPatternViolation, Severity as CbSev};
+
+    fn viol(sev: CbSev, pid: &str, file: &str) -> CbPatternViolation {
+        CbPatternViolation {
+            pattern_id: pid.to_string(),
+            file: file.to_string(),
+            line: 1,
+            description: "desc".to_string(),
+            severity: sev,
+        }
+    }
+
+    #[test]
+    fn test_suppression_suffix_zero_count_empty() {
+        assert_eq!(suppression_suffix(0, " ("), "");
+        assert_eq!(suppression_suffix(0, ", "), "");
+    }
+
+    #[test]
+    fn test_suppression_suffix_nonzero_count_has_prefix_and_count() {
+        assert_eq!(suppression_suffix(3, " ("), " (3 suppressed via .pmat.yaml");
+        assert_eq!(suppression_suffix(1, ", "), ", 1 suppressed via .pmat.yaml");
+    }
+
+    #[test]
+    fn test_truncate_issues_at_or_below_20_unchanged() {
+        let issues: Vec<String> = (0..20).map(|i| format!("item{i}")).collect();
+        let out = truncate_issues(issues.clone());
+        assert_eq!(out, issues);
+
+        let small: Vec<String> = (0..5).map(|i| format!("i{i}")).collect();
+        assert_eq!(truncate_issues(small.clone()), small);
+    }
+
+    #[test]
+    fn test_truncate_issues_above_20_adds_ellipsis() {
+        let issues: Vec<String> = (0..25).map(|i| format!("item{i}")).collect();
+        let out = truncate_issues(issues);
+        assert_eq!(out.len(), 21);
+        assert_eq!(out[20], "    ... and 5 more");
+        assert_eq!(out[0], "item0");
+        assert_eq!(out[19], "item19");
+    }
+
+    #[test]
+    fn test_is_cb_suppressed_no_config_returns_false() {
+        let v = viol(CbSev::Error, "CB-500", "src/a.rs");
+        assert!(!is_cb_suppressed(&v, None));
+    }
+
+    #[test]
+    fn test_is_cb_suppressed_config_without_matching_rule_returns_false() {
+        use crate::models::comply_config::ComplyConfig;
+        let cfg = ComplyConfig::default();
+        let v = viol(CbSev::Error, "CB-999", "src/a.rs");
+        assert!(!is_cb_suppressed(&v, Some(&cfg)));
+    }
+
+    #[test]
+    fn test_is_cb_suppressed_config_with_matching_rule_returns_true() {
+        use crate::models::comply_config::{ComplyConfig, SuppressionYamlRule};
+        let cfg = ComplyConfig {
+            suppressions: vec![SuppressionYamlRule {
+                rules: vec!["CB-500".to_string()],
+                files: vec![],
+                reason: "test".to_string(),
+                expires: None,
+            }],
+            ..Default::default()
+        };
+        let v = viol(CbSev::Error, "CB-500", "src/a.rs");
+        assert!(is_cb_suppressed(&v, Some(&cfg)));
+    }
+
+    #[test]
+    fn test_aggregate_violations_no_violations_passes() {
+        let check = aggregate_violations("Test", &[], None, true);
+        assert!(matches!(check.status, CheckStatus::Pass));
+        assert_eq!(check.severity, Severity::Info);
+        assert!(check.message.contains("No violations detected"));
+    }
+
+    #[test]
+    fn test_aggregate_violations_errors_with_fail_on_error_fails() {
+        let detectors = vec![(
+            "D1",
+            vec![
+                viol(CbSev::Error, "CB-500", "a.rs"),
+                viol(CbSev::Error, "CB-501", "b.rs"),
+            ],
+        )];
+        let check = aggregate_violations("Test", &detectors, None, true);
+        assert!(matches!(check.status, CheckStatus::Fail));
+        assert!(check.message.contains("2 errors"));
+    }
+
+    #[test]
+    fn test_aggregate_violations_errors_without_fail_on_error_warns() {
+        let detectors = vec![("D1", vec![viol(CbSev::Error, "CB-500", "a.rs")])];
+        let check = aggregate_violations("Test", &detectors, None, false);
+        assert!(matches!(check.status, CheckStatus::Warn));
+    }
+
+    #[test]
+    fn test_aggregate_violations_only_warnings_warns() {
+        let detectors = vec![(
+            "D1",
+            vec![
+                viol(CbSev::Warning, "CB-500", "a.rs"),
+                viol(CbSev::Info, "CB-501", "b.rs"),
+            ],
+        )];
+        let check = aggregate_violations("Test", &detectors, None, true);
+        assert!(matches!(check.status, CheckStatus::Warn));
+        assert!(check.message.contains("0 errors"));
+        assert!(check.message.contains("1 warnings"));
+        assert!(check.message.contains("1 info"));
+    }
+
+    #[test]
+    fn test_aggregate_violations_truncates_at_20_issues() {
+        let violations: Vec<CbPatternViolation> = (0..25)
+            .map(|i| viol(CbSev::Warning, &format!("CB-{i}"), "a.rs"))
+            .collect();
+        let detectors = vec![("D1", violations)];
+        let check = aggregate_violations("Test", &detectors, None, true);
+        assert!(check.message.contains("and 5 more"));
+    }
+
+    #[test]
+    fn test_aggregate_violations_suppressed_not_counted() {
+        use crate::models::comply_config::{ComplyConfig, SuppressionYamlRule};
+        let cfg = ComplyConfig {
+            suppressions: vec![SuppressionYamlRule {
+                rules: vec!["CB-500".to_string()],
+                files: vec![],
+                reason: "test".to_string(),
+                expires: None,
+            }],
+            ..Default::default()
+        };
+        let detectors = vec![(
+            "D1",
+            vec![
+                viol(CbSev::Error, "CB-500", "a.rs"),
+                viol(CbSev::Warning, "CB-600", "b.rs"),
+            ],
+        )];
+        let check = aggregate_violations("Test", &detectors, Some(&cfg), true);
+        assert!(matches!(check.status, CheckStatus::Warn));
+        assert!(check.message.contains("0 errors"));
+        assert!(check.message.contains("1 suppressed"));
+    }
+
+    #[test]
+    fn test_aggregate_violations_all_suppressed_still_passes() {
+        use crate::models::comply_config::{ComplyConfig, SuppressionYamlRule};
+        let cfg = ComplyConfig {
+            suppressions: vec![SuppressionYamlRule {
+                rules: vec!["CB-500".to_string()],
+                files: vec![],
+                reason: "test".to_string(),
+                expires: None,
+            }],
+            ..Default::default()
+        };
+        let detectors = vec![("D1", vec![viol(CbSev::Error, "CB-500", "a.rs")])];
+        let check = aggregate_violations("Test", &detectors, Some(&cfg), true);
+        assert!(matches!(check.status, CheckStatus::Pass));
+        assert!(check.message.contains("No violations detected"));
+        assert!(check.message.contains("1 suppressed"));
+    }
+}

--- a/src/cli/handlers/comply_handlers/check_handlers/check_individual_cb.rs
+++ b/src/cli/handlers/comply_handlers/check_handlers/check_individual_cb.rs
@@ -302,3 +302,167 @@ pub(crate) fn check_coverage_quality_patterns(project_path: &Path) -> Compliance
     )
 }
 
+#[cfg(test)]
+mod check_individual_cb_tests {
+    //! Covers pure-compute helpers in check_individual_cb.rs (94 uncov on
+    //! broad, 0% cov). Skips fs-walking compute_brick / oip_tarantula
+    //! detectors.
+    use super::*;
+    use crate::cli::handlers::comply_cb_detect::{
+        CbPatternViolation, Severity as CbSev,
+    };
+
+    fn viol(pid: &str, sev: CbSev, desc: &str) -> CbPatternViolation {
+        CbPatternViolation {
+            pattern_id: pid.to_string(),
+            file: "src/a.rs".to_string(),
+            line: 1,
+            description: desc.to_string(),
+            severity: sev,
+        }
+    }
+
+    // ── append_violation: formats "PID: description (file:line)" ──
+
+    #[test]
+    fn test_append_violation_format_matches_template() {
+        let mut issues = Vec::new();
+        let v = viol("CB-001", CbSev::Warning, "bounds check");
+        append_violation(&mut issues, &v);
+        assert_eq!(issues, vec!["CB-001: bounds check (src/a.rs:1)"]);
+    }
+
+    #[test]
+    fn test_append_violation_accumulates() {
+        let mut issues = vec!["existing".to_string()];
+        let v = viol("CB-002", CbSev::Error, "barrier");
+        append_violation(&mut issues, &v);
+        assert_eq!(issues.len(), 2);
+        assert_eq!(issues[1], "CB-002: barrier (src/a.rs:1)");
+    }
+
+    // ── collect_violations_with_counts (critical vs warning via is_critical flag) ──
+
+    #[test]
+    fn test_collect_violations_with_counts_empty_detections_returns_zeros() {
+        let (issues, critical, warning) = collect_violations_with_counts(&[]);
+        assert!(issues.is_empty());
+        assert_eq!(critical, 0);
+        assert_eq!(warning, 0);
+    }
+
+    #[test]
+    fn test_collect_violations_with_counts_sums_critical_and_warning() {
+        let detections = vec![
+            (vec![viol("A", CbSev::Error, "x"), viol("B", CbSev::Error, "y")], true),
+            (vec![viol("C", CbSev::Warning, "z")], false),
+        ];
+        let (issues, critical, warning) = collect_violations_with_counts(&detections);
+        assert_eq!(issues.len(), 3);
+        assert_eq!(critical, 2);
+        assert_eq!(warning, 1);
+    }
+
+    // ── build_cb_result: 3 arms (Fail on critical, Warn on warning, Pass) ──
+
+    #[test]
+    fn test_build_cb_result_critical_fails() {
+        let c = build_cb_result(vec!["x".to_string()], 1, 0);
+        assert!(matches!(c.status, CheckStatus::Fail));
+        assert_eq!(c.severity, Severity::Critical);
+        assert!(c.message.contains("1 critical"));
+    }
+
+    #[test]
+    fn test_build_cb_result_warning_only_warns() {
+        let c = build_cb_result(vec!["x".to_string()], 0, 2);
+        assert!(matches!(c.status, CheckStatus::Warn));
+        assert_eq!(c.severity, Severity::Warning);
+        assert!(c.message.contains("2 warnings"));
+    }
+
+    #[test]
+    fn test_build_cb_result_no_violations_passes() {
+        let c = build_cb_result(vec![], 0, 0);
+        assert!(matches!(c.status, CheckStatus::Pass));
+        assert_eq!(c.severity, Severity::Info);
+        assert!(c.message.contains("no violations"));
+    }
+
+    #[test]
+    fn test_build_cb_result_critical_plus_warnings_still_fails() {
+        // critical present → Fail regardless of warnings.
+        let c = build_cb_result(vec!["x".to_string()], 2, 3);
+        assert!(matches!(c.status, CheckStatus::Fail));
+        assert_eq!(c.severity, Severity::Critical);
+        assert!(c.message.contains("2 critical"));
+        assert!(c.message.contains("3 warnings"));
+    }
+
+    // ── collect_triaged_violations: classifies by CbSev → (critical, error, warning) ──
+
+    #[test]
+    fn test_collect_triaged_violations_splits_by_severity() {
+        let sets = vec![vec![
+            viol("A", CbSev::Critical, "cc"),
+            viol("B", CbSev::Critical, "cd"),
+            viol("C", CbSev::Error, "ee"),
+            viol("D", CbSev::Warning, "ww"),
+            // Info falls into the `_ => warning` arm.
+            viol("E", CbSev::Info, "ii"),
+        ]];
+        let (issues, critical, error, warning) = collect_triaged_violations(&sets);
+        assert_eq!(issues.len(), 5);
+        assert_eq!(critical, 2);
+        assert_eq!(error, 1);
+        assert_eq!(warning, 2, "Warning + Info both count as warning");
+    }
+
+    // ── build_triaged_check: 4 arms (Fail-critical, Fail-error, Warn, Pass) ──
+
+    #[test]
+    fn test_build_triaged_check_critical_fails_critical() {
+        let c = build_triaged_check("Test", vec!["x".into()], 1, 0, 0, "ok");
+        assert!(matches!(c.status, CheckStatus::Fail));
+        assert_eq!(c.severity, Severity::Critical);
+        assert_eq!(c.name, "Test");
+    }
+
+    #[test]
+    fn test_build_triaged_check_error_fails_error() {
+        let c = build_triaged_check("Test", vec!["x".into()], 0, 1, 0, "ok");
+        assert!(matches!(c.status, CheckStatus::Fail));
+        assert_eq!(c.severity, Severity::Error);
+    }
+
+    #[test]
+    fn test_build_triaged_check_warning_warns() {
+        let c = build_triaged_check("Test", vec!["x".into()], 0, 0, 1, "ok");
+        assert!(matches!(c.status, CheckStatus::Warn));
+        assert_eq!(c.severity, Severity::Warning);
+    }
+
+    #[test]
+    fn test_build_triaged_check_no_violations_passes_with_msg() {
+        let c = build_triaged_check("Test", vec![], 0, 0, 0, "all-good");
+        assert!(matches!(c.status, CheckStatus::Pass));
+        assert_eq!(c.severity, Severity::Info);
+        assert_eq!(c.message, "all-good");
+    }
+
+    // ── collect_cb_violations: thin wrapper over multiple detectors ──
+    // collect_cb_violations runs fs-walking detectors so we just verify it
+    // doesn't panic on an empty tempdir (all detectors → empty result).
+
+    #[test]
+    fn test_collect_cb_violations_empty_project_returns_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        // has_probar=false + has_brick_dir=false skips the detectors that
+        // require those fixtures — empty project → empty result.
+        let (issues, critical, warning) = collect_cb_violations(tmp.path(), false, false);
+        assert!(issues.is_empty());
+        assert_eq!(critical, 0);
+        assert_eq!(warning, 0);
+    }
+}
+

--- a/src/cli/handlers/comply_handlers/check_handlers/check_sovereign.rs
+++ b/src/cli/handlers/comply_handlers/check_handlers/check_sovereign.rs
@@ -519,3 +519,152 @@ fn analyze_project_health(
         all_metrics,
     ))
 }
+
+#[cfg(test)]
+mod check_sovereign_tests {
+    //! Covers pure-compute helpers in check_sovereign.rs (86 uncov on broad,
+    //! 0% cov). Skips git-spawning check_five_whys_patterns /
+    //! check_ml_commit_classification / check_ticket_refs and the fs-walking
+    //! dynamic helpers.
+    use super::*;
+
+    // ── is_sovereign_stack_project ──
+
+    #[test]
+    fn test_is_sovereign_stack_project_trueno_dep_true() {
+        assert!(is_sovereign_stack_project(
+            "[dependencies]\ntrueno = \"0.5\"\n"
+        ));
+    }
+
+    #[test]
+    fn test_is_sovereign_stack_project_aprender_dep_true() {
+        assert!(is_sovereign_stack_project(
+            "[dependencies]\naprender = { path = \"../aprender\" }\n"
+        ));
+    }
+
+    #[test]
+    fn test_is_sovereign_stack_project_batuta_dep_true() {
+        assert!(is_sovereign_stack_project("batuta = \"1.0\""));
+    }
+
+    #[test]
+    fn test_is_sovereign_stack_project_renacer_dep_true() {
+        assert!(is_sovereign_stack_project("renacer = \"0.2\""));
+    }
+
+    #[test]
+    fn test_is_sovereign_stack_project_realizar_dep_true() {
+        assert!(is_sovereign_stack_project("realizar = \"0.1\""));
+    }
+
+    #[test]
+    fn test_is_sovereign_stack_project_no_sovereign_deps_false() {
+        let cargo_toml = "[dependencies]\nserde = \"1.0\"\ntokio = \"1.0\"\n";
+        assert!(!is_sovereign_stack_project(cargo_toml));
+    }
+
+    #[test]
+    fn test_is_sovereign_stack_project_empty_content_false() {
+        assert!(!is_sovereign_stack_project(""));
+    }
+
+    // ── build_sovereign_result: all 3 arms ──
+
+    #[test]
+    fn test_build_sovereign_result_no_issues_with_patterns_passes() {
+        let good = vec!["Five-Whys".to_string(), "Falsification".to_string()];
+        let check = build_sovereign_result(&[], &good);
+        assert!(matches!(check.status, CheckStatus::Pass));
+        assert_eq!(check.severity, Severity::Info);
+        assert!(check.message.contains("Five-Whys"));
+    }
+
+    #[test]
+    fn test_build_sovereign_result_issues_present_warns() {
+        let issues = vec!["No Five-Whys in recent fix commits".to_string()];
+        let check = build_sovereign_result(&issues, &[]);
+        assert!(matches!(check.status, CheckStatus::Warn));
+        assert_eq!(check.severity, Severity::Warning);
+        assert!(check.message.contains("Missing"));
+        assert!(check.message.contains("Five-Whys"));
+    }
+
+    #[test]
+    fn test_build_sovereign_result_no_issues_no_patterns_passes_default() {
+        let check = build_sovereign_result(&[], &[]);
+        assert!(matches!(check.status, CheckStatus::Pass));
+        assert_eq!(check.severity, Severity::Info);
+        assert!(check.message.contains("Sovereign Stack project"));
+    }
+
+    #[test]
+    fn test_build_sovereign_result_issues_and_patterns_still_warns() {
+        // When there are issues, warn takes priority even if good_patterns exist.
+        let issues = vec!["something missing".to_string()];
+        let good = vec!["a good pattern".to_string()];
+        let check = build_sovereign_result(&issues, &good);
+        assert!(matches!(check.status, CheckStatus::Warn));
+    }
+
+    // ── make_paiml_check: pass-through constructor ──
+
+    #[test]
+    fn test_make_paiml_check_forwards_all_fields() {
+        let c = make_paiml_check(CheckStatus::Fail, "bad".into(), Severity::Error);
+        assert_eq!(c.name, "PAIML Deps Workspace");
+        assert!(matches!(c.status, CheckStatus::Fail));
+        assert_eq!(c.message, "bad");
+        assert_eq!(c.severity, Severity::Error);
+    }
+
+    // ── classify_local_deps: missing src/ subdir returns empty ──
+
+    #[test]
+    fn test_classify_local_deps_empty_when_no_dep_dirs() {
+        let tmp = tempfile::tempdir().unwrap();
+        // src_dir has no aprender/trueno/etc subdirs → both vectors empty.
+        let (dirty, clean) = classify_local_deps(tmp.path(), &["aprender", "trueno"]);
+        assert!(dirty.is_empty());
+        assert!(clean.is_empty());
+    }
+
+    #[test]
+    fn test_classify_local_deps_nonexistent_deps_skipped() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Only one of three deps exists (and it's not a git repo → skipped).
+        std::fs::create_dir(tmp.path().join("aprender")).unwrap();
+        let (dirty, clean) = classify_local_deps(tmp.path(), &["aprender", "missing1", "missing2"]);
+        // aprender exists but git status errors → either skipped or classified.
+        // missing1/missing2 → skipped (dep_path.exists() false).
+        // So at most 1 entry total.
+        assert!(
+            dirty.len() + clean.len() <= 1,
+            "total classified deps must be ≤ 1 (one exists, others skipped)"
+        );
+    }
+
+    // ── check_sovereign_stack_patterns integration: no Cargo.toml ──
+
+    #[test]
+    fn test_check_sovereign_stack_patterns_no_cargo_toml_skips() {
+        let tmp = tempfile::tempdir().unwrap();
+        let check = check_sovereign_stack_patterns(tmp.path());
+        assert!(matches!(check.status, CheckStatus::Skip));
+        assert!(check.message.contains("No Cargo.toml"));
+    }
+
+    #[test]
+    fn test_check_sovereign_stack_patterns_non_sovereign_cargo_skips() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join("Cargo.toml"),
+            "[package]\nname = \"x\"\n[dependencies]\nserde = \"1.0\"\n",
+        )
+        .unwrap();
+        let check = check_sovereign_stack_patterns(tmp.path());
+        assert!(matches!(check.status, CheckStatus::Skip));
+        assert!(check.message.contains("Not a Sovereign Stack project"));
+    }
+}

--- a/src/cli/handlers/comply_handlers/cross_crate_handlers/types.rs
+++ b/src/cli/handlers/comply_handlers/cross_crate_handlers/types.rs
@@ -134,3 +134,75 @@ pub(super) struct CrateFuncRef<'a> {
     pub(super) crate_info: &'a CrateInfo,
     pub(super) func: &'a FunctionEntry,
 }
+
+#[cfg(test)]
+mod cross_crate_types_tests {
+    //! Covers CcSeverity::Display + DetectionConfig::from_yaml in
+    //! cross_crate_handlers/types.rs (32 uncov on broad, 0% cov).
+    use super::*;
+
+    #[test]
+    fn test_cc_severity_display_all_variants() {
+        assert_eq!(format!("{}", CcSeverity::Error), "error");
+        assert_eq!(format!("{}", CcSeverity::Warning), "warning");
+        assert_eq!(format!("{}", CcSeverity::Advisory), "advisory");
+    }
+
+    #[test]
+    fn test_detection_config_from_yaml_lowercases_excluded_functions() {
+        let cc = crate::models::comply_config::CrossCrateConfig {
+            excluded_functions: vec!["Serialize".into(), "DEBUG".into()],
+            excluded_crate_pairs: vec![],
+            min_body_lines: 5,
+            min_tokens: 20,
+            cc003_min_similarity: 0.9,
+            ..Default::default()
+        };
+        let dc = DetectionConfig::from_yaml(&cc);
+        assert!(dc.excluded_functions.contains("serialize"));
+        assert!(dc.excluded_functions.contains("debug"));
+        // Original casing dropped.
+        assert!(!dc.excluded_functions.contains("Serialize"));
+    }
+
+    #[test]
+    fn test_detection_config_from_yaml_parses_crate_pairs_colon_separated() {
+        let cc = crate::models::comply_config::CrossCrateConfig {
+            excluded_functions: vec![],
+            excluded_crate_pairs: vec![
+                "crate_a:crate_b".into(),
+                "foo:bar".into(),
+                "no_colon".into(),        // malformed, dropped
+                "too:many:colons".into(), // malformed (3 parts), dropped
+            ],
+            min_body_lines: 0,
+            min_tokens: 0,
+            cc003_min_similarity: 0.0,
+            ..Default::default()
+        };
+        let dc = DetectionConfig::from_yaml(&cc);
+        assert_eq!(dc.excluded_crate_pairs.len(), 2);
+        assert!(dc
+            .excluded_crate_pairs
+            .contains(&("crate_a".to_string(), "crate_b".to_string())));
+        assert!(dc
+            .excluded_crate_pairs
+            .contains(&("foo".to_string(), "bar".to_string())));
+    }
+
+    #[test]
+    fn test_detection_config_from_yaml_forwards_thresholds() {
+        let cc = crate::models::comply_config::CrossCrateConfig {
+            excluded_functions: vec![],
+            excluded_crate_pairs: vec![],
+            min_body_lines: 42,
+            min_tokens: 100,
+            cc003_min_similarity: 0.75,
+            ..Default::default()
+        };
+        let dc = DetectionConfig::from_yaml(&cc);
+        assert_eq!(dc.min_body_lines, 42);
+        assert_eq!(dc.min_tokens, 100);
+        assert!((dc.cc003_min_similarity - 0.75).abs() < 1e-6);
+    }
+}

--- a/src/cli/handlers/comply_handlers/cross_crate_handlers/types.rs
+++ b/src/cli/handlers/comply_handlers/cross_crate_handlers/types.rs
@@ -156,7 +156,6 @@ mod cross_crate_types_tests {
             min_body_lines: 5,
             min_tokens: 20,
             cc003_min_similarity: 0.9,
-            ..Default::default()
         };
         let dc = DetectionConfig::from_yaml(&cc);
         assert!(dc.excluded_functions.contains("serialize"));
@@ -178,7 +177,6 @@ mod cross_crate_types_tests {
             min_body_lines: 0,
             min_tokens: 0,
             cc003_min_similarity: 0.0,
-            ..Default::default()
         };
         let dc = DetectionConfig::from_yaml(&cc);
         assert_eq!(dc.excluded_crate_pairs.len(), 2);
@@ -198,7 +196,6 @@ mod cross_crate_types_tests {
             min_body_lines: 42,
             min_tokens: 100,
             cc003_min_similarity: 0.75,
-            ..Default::default()
         };
         let dc = DetectionConfig::from_yaml(&cc);
         assert_eq!(dc.min_body_lines, 42);

--- a/src/cli/handlers/comply_handlers/migrate_handlers.rs
+++ b/src/cli/handlers/comply_handlers/migrate_handlers.rs
@@ -16,3 +16,62 @@ include!("migrate_handlers_init.rs");
 
 // Enforcement hooks and compliance reporting
 include!("migrate_handlers_enforce.rs");
+
+#[cfg(test)]
+mod migrate_handlers_init_tests {
+    //! Covers pure-compute helpers in migrate_handlers_init.rs
+    //! (72 uncov on broad, 0% cov). The async handle_init / handle_upgrade
+    //! require full integration and are skipped.
+    use super::*;
+
+    #[test]
+    fn test_generate_default_pmat_yaml_is_parseable_yaml() {
+        let yaml = generate_default_pmat_yaml();
+        let _: serde_yaml_ng::Value = serde_yaml_ng::from_str(&yaml).unwrap();
+    }
+
+    #[test]
+    fn test_generate_default_pmat_yaml_contains_expected_sections() {
+        let yaml = generate_default_pmat_yaml();
+        assert!(yaml.contains("comply:"));
+        assert!(yaml.contains("thresholds:"));
+        assert!(yaml.contains("coverage:"));
+        assert!(yaml.contains("complexity:"));
+        assert!(yaml.contains("cb-050"));
+        assert!(yaml.contains("cb-060"));
+    }
+
+    #[test]
+    fn test_generate_default_pmat_yaml_loads_as_pmat_yaml_config() {
+        let yaml = generate_default_pmat_yaml();
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(tmp.path(), yaml).unwrap();
+        let cfg =
+            crate::models::comply_config::PmatYamlConfig::load_from_path(tmp.path()).unwrap();
+        assert!((cfg.comply.thresholds.coverage - 85.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_generate_claude_md_embeds_project_name() {
+        let md = generate_claude_md("my-project");
+        assert!(md.contains("# Claude Code Configuration for my-project"));
+    }
+
+    #[test]
+    fn test_generate_claude_md_contains_required_sections() {
+        let md = generate_claude_md("x");
+        assert!(md.contains("## Code Search Policy"));
+        assert!(md.contains("## Quality Standards"));
+        assert!(md.contains("## Coverage"));
+        assert!(md.contains("## Git Workflow"));
+        assert!(md.contains("pmat query"));
+        assert!(md.contains("cargo llvm-cov"));
+    }
+
+    #[test]
+    fn test_generate_claude_md_empty_project_name_still_valid() {
+        let md = generate_claude_md("");
+        assert!(md.contains("# Claude Code Configuration for "));
+        assert!(!md.is_empty());
+    }
+}

--- a/src/cli/handlers/comply_handlers/migrate_handlers_init.rs
+++ b/src/cli/handlers/comply_handlers/migrate_handlers_init.rs
@@ -67,7 +67,7 @@ comply:
   # Check configurations (disable individual checks)
   checks:
     cb-050: { enabled: true, severity: critical }
-    cb-060: { enabled: true, severity: high }
+    cb-060: { enabled: true, severity: error }
   # Global thresholds
   thresholds:
     coverage: 85.0


### PR DESCRIPTION
## Defect fix

**generate_default_pmat_yaml** produced \`cb-060: { ..., severity: high }\`, but \`PmatYamlConfig\` only accepts \`info/warning/error/critical\` as severity values. A fresh \`pmat comply init\` would therefore scaffold an .pmat.yaml that \`PmatYamlConfig::load_from_path\` immediately rejects with \`unknown variant \\\`high\\\`\`. Fixed by changing the generated default to \`severity: error\` (closest semantic match).

This was discovered by the new round-trip test — the generated YAML now loads cleanly as \`PmatYamlConfig\`, which is a regression test.

## Coverage

Adds 6 tests covering migrate_handlers_init.rs pure helpers (72 uncov on broad, 0% cov):
- \`generate_default_pmat_yaml\`: parseable YAML, has expected sections, round-trips through \`PmatYamlConfig::load_from_path\` (regression test)
- \`generate_claude_md\`: embeds project_name, contains required sections, empty project_name valid

## Test plan
- [x] All 6 new tests pass
- [x] \`cargo clippy --lib --tests -- -D warnings\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)