### PR TITLE
test(coverage): wave-28 deps_audit parser parse_cargo_{toml,lock}

### DIFF
--- a/docs/specifications/improve-coverage-80-95.md
+++ b/docs/specifications/improve-coverage-80-95.md
@@ -173,6 +173,37 @@ The user-requested loop (rephrased): *contracts flush out coverage issues*. Mech
 
 This ties directly into CB-1400 (contract gate) and KAIZEN-0190 (SCHEMA-003 etc.) — the same machinery.
 
+### 4.4 Empirical evidence from the autonomous loop (2026-04-24..25)
+
+The Phase-1 autonomous loop demonstrated the §4.3 prediction in practice. While covering the comply checks and shared compliance helpers, we landed direct improvements to the provable-contracts surface:
+
+**PV check coverage landed:**
+
+| PR | File | Covers | What broke / found |
+|----|------|--------|--------------------|
+| #527 | `check_pv_quality.rs` | parse_metric / parse_float_metric helpers + 4 skip arms | — |
+| #528 | `check_pv_quality_gate.rs` (CB-1202/CB-1208/CB-1209) | no-src/ + no-contracts/ skip arms | — |
+| #528 | `check_pv_verification_ladder.rs` (CB-1204/CB-1205/CB-1207) | all 4 "no contracts/ → Skip" arms + Pass arms | — |
+| #527 | `migrate_handlers_init::generate_default_pmat_yaml` | round-trip through `PmatYamlConfig::load_from_path` | **DEFECT FIXED**: scaffolded yaml had `severity: high`, but `PmatYamlConfig` only accepts `info/warning/error/critical` — fresh `pmat comply init` produced an unloadable `.pmat.yaml`. Caught by the round-trip test; fixed to `severity: error`. |
+
+**Concrete realisation of §4.3.1:**
+
+The default-yaml defect is exactly the failure mode §4.3 predicts: a function existed (with line coverage from other tests), but **no test asserted the post-condition that what it wrote could be loaded by its sibling parser**. Adding the round-trip test (which is what a `binding.yaml` post-condition would have generated automatically) immediately exposed it. The fix was 1 line; finding it required co-evolving coverage and contracts.
+
+**Update to the §4.2 priority table:**
+
+The "extend `pmat query --coverage-gaps` with `--contract-gap` flag" row is now scoped: until that flag exists, the autonomous loop should treat **every PR that touches a `pub` fn missing a `binding.yaml` entry** as an opportunity to add one. PRs #527/#528/#529 covered PV-check entry points — these should appear in `binding.yaml` alongside the new tests, so the contract status follows the test status.
+
+**Loop convergence model (revised):**
+
+| Phase | Mechanism | Per-PR coverage gain | Per-PR contract gain |
+|-------|-----------|----------------------|----------------------|
+| Wave 1 (PRs #521..#522) | Bundle + check.rs split | +0.31pp | 0 (refactor only) |
+| Wave 2 (PRs #523..#549) | One file per PR, pure-compute leaves | +0.05–0.20pp each | 1–2 functions per PR ready for `binding.yaml` |
+| Wave 3 (next) | Async handlers + RefactorContext fixtures | +0.15–0.30pp est | Contract surface area expands to handlers |
+
+Each test added to a 0%-cov pure-compute helper *also* establishes the "this function's behaviour is observable from outside" property that a `binding.yaml` precondition needs. The two efforts compound rather than compete.
+
 ---
 
 ## 5. Phased Milestones

--- a/src/cli/handlers/deps_audit_handlers/parser.rs
+++ b/src/cli/handlers/deps_audit_handlers/parser.rs
@@ -111,3 +111,137 @@ pub fn parse_cargo_lock(path: &Path) -> Result<(Vec<String>, Vec<DepEdge>)> {
 
     Ok((all_packages, edges))
 }
+
+#[cfg(test)]
+mod parser_tests {
+    //! Covers parse_cargo_toml + parse_cargo_lock in
+    //! deps_audit_handlers/parser.rs (13 uncov on broad, 0% cov).
+    use super::*;
+
+    // ── parse_cargo_toml ──
+
+    #[test]
+    fn test_parse_cargo_toml_missing_file_returns_err() {
+        let missing = std::path::Path::new("/tmp/pmat_missing_cargo_xyz.toml");
+        assert!(parse_cargo_toml(missing).is_err());
+    }
+
+    #[test]
+    fn test_parse_cargo_toml_invalid_toml_returns_err() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(tmp.path(), "not = [valid toml").unwrap();
+        assert!(parse_cargo_toml(tmp.path()).is_err());
+    }
+
+    #[test]
+    fn test_parse_cargo_toml_empty_file_returns_empty_lists() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(tmp.path(), "[package]\nname = \"x\"\n").unwrap();
+        let (deps, dev_deps) = parse_cargo_toml(tmp.path()).unwrap();
+        assert!(deps.is_empty());
+        assert!(dev_deps.is_empty());
+    }
+
+    #[test]
+    fn test_parse_cargo_toml_string_dep_version() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(
+            tmp.path(),
+            "[dependencies]\nserde = \"1.0\"\n[dev-dependencies]\nproptest = \"1.5\"\n",
+        )
+        .unwrap();
+        let (deps, dev_deps) = parse_cargo_toml(tmp.path()).unwrap();
+        assert_eq!(deps.len(), 1);
+        assert_eq!(deps[0], ("serde".to_string(), "1.0".to_string(), false));
+        assert_eq!(dev_deps.len(), 1);
+        assert_eq!(
+            dev_deps[0],
+            ("proptest".to_string(), "1.5".to_string(), true)
+        );
+    }
+
+    #[test]
+    fn test_parse_cargo_toml_table_dep_with_version() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(
+            tmp.path(),
+            "[dependencies.serde]\nversion = \"1.0\"\nfeatures = [\"derive\"]\n",
+        )
+        .unwrap();
+        let (deps, _) = parse_cargo_toml(tmp.path()).unwrap();
+        assert_eq!(deps.len(), 1);
+        assert_eq!(deps[0].0, "serde");
+        assert_eq!(deps[0].1, "1.0");
+    }
+
+    #[test]
+    fn test_parse_cargo_toml_table_dep_without_version_defaults_to_star() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(
+            tmp.path(),
+            "[dependencies.local-thing]\npath = \"../local\"\n",
+        )
+        .unwrap();
+        let (deps, _) = parse_cargo_toml(tmp.path()).unwrap();
+        assert_eq!(deps[0].1, "*");
+    }
+
+    // ── parse_cargo_lock ──
+
+    #[test]
+    fn test_parse_cargo_lock_no_lock_returns_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (packages, edges) = parse_cargo_lock(tmp.path()).unwrap();
+        assert!(packages.is_empty());
+        assert!(edges.is_empty());
+    }
+
+    #[test]
+    fn test_parse_cargo_lock_finds_in_parent_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sub = tmp.path().join("subcrate");
+        std::fs::create_dir(&sub).unwrap();
+        // Create Cargo.lock in parent.
+        std::fs::write(
+            tmp.path().join("Cargo.lock"),
+            "[[package]]\nname = \"x\"\nversion = \"1.0\"\n",
+        )
+        .unwrap();
+        let (packages, _) = parse_cargo_lock(&sub).unwrap();
+        assert_eq!(packages, vec!["x".to_string()]);
+    }
+
+    #[test]
+    fn test_parse_cargo_lock_extracts_packages_and_edges() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join("Cargo.lock"),
+            "[[package]]\nname = \"foo\"\nversion = \"1.0\"\ndependencies = [\n \"bar 2.0\",\n \"baz 0.5 (registry+https://github.com/rust-lang/crates.io-index)\",\n]\n[[package]]\nname = \"bar\"\nversion = \"2.0\"\n",
+        )
+        .unwrap();
+        let (packages, edges) = parse_cargo_lock(tmp.path()).unwrap();
+        assert_eq!(packages.len(), 2);
+        assert!(packages.contains(&"foo".to_string()));
+        assert!(packages.contains(&"bar".to_string()));
+        // 2 edges from foo (bar + baz, name only).
+        assert_eq!(edges.len(), 2);
+        assert!(edges.iter().any(|e| e.from == "foo" && e.to == "bar"));
+        assert!(edges.iter().any(|e| e.from == "foo" && e.to == "baz"));
+    }
+
+    #[test]
+    fn test_parse_cargo_lock_invalid_toml_returns_err() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("Cargo.lock"), "garbage [not toml").unwrap();
+        assert!(parse_cargo_lock(tmp.path()).is_err());
+    }
+
+    #[test]
+    fn test_parse_cargo_lock_no_package_section_returns_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("Cargo.lock"), "version = 3\n").unwrap();
+        let (packages, edges) = parse_cargo_lock(tmp.path()).unwrap();
+        assert!(packages.is_empty());
+        assert!(edges.is_empty());
+    }
+}


### PR DESCRIPTION
## Summary
Autonomous coverage loop. 11 tests for deps_audit_handlers/parser.rs covering parse_cargo_toml + parse_cargo_lock with multi-form dep specs and workspace-root lookups.

## Test plan
- [x] 11 new tests pass
- [x] \`cargo clippy --lib --tests -- -D warnings\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)