### PR TITLE
fix(hooks): make pre-push gate truly O(1) — drop check/clippy/test

### DIFF
--- a/src/cli/handlers/hooks_command_handlers/hooks_command.rs
+++ b/src/cli/handlers/hooks_command_handlers/hooks_command.rs
@@ -329,11 +329,10 @@ impl HooksCommand {
         let hook_path = self.hooks_dir.join("pre-push");
 
         let hook_content = r#"#!/usr/bin/env bash
-# PMAT Pre-Push Quality Gate
+# PMAT Pre-Push Quality Gate (O(1))
 # auto-managed by PMAT — DO NOT EDIT
 #
-# Fast local gate (~1-3 min) to catch issues before push.
-# Full clean-room verification runs remotely after push.
+# Fast local gate (<2s). CI owns build/clippy/test.
 # Bypass with: git push --no-verify
 
 set -euo pipefail
@@ -348,7 +347,7 @@ echo "=============================="
 
 FAILED=0
 
-# 1. Format check (fastest, ~2s)
+# 1. Format check (fast, ~1s — stylistic only, pre-commit handles per-file)
 echo -n "  Format check... "
 if cargo fmt --all -- --check > /dev/null 2>&1; then
     echo "✅"
@@ -358,32 +357,8 @@ else
     FAILED=1
 fi
 
-# 2. Compilation check (~10-30s)
-echo -n "  Cargo check... "
-if cargo check --all-targets 2> /dev/null; then
-    echo "✅"
-else
-    echo "❌"
-    FAILED=1
-fi
-
-# 3. Clippy (~10-30s, incremental)
-echo -n "  Clippy... "
-if cargo clippy --all-targets -- -D warnings 2> /dev/null; then
-    echo "✅"
-else
-    echo "❌"
-    FAILED=1
-fi
-
-# 4. Unit tests (~30-60s)
-echo -n "  Unit tests... "
-if cargo test --lib --quiet 2> /dev/null; then
-    echo "✅"
-else
-    echo "❌"
-    FAILED=1
-fi
+# Build/clippy/test are intentionally NOT run here — they belong in CI
+# so `git push` stays O(1). Pre-push is for local sanity (format only).
 
 if [ "$FAILED" -ne 0 ]; then
     echo ""


### PR DESCRIPTION
## Summary

The `pmat hooks install`-generated pre-push hook claimed "Fast local gate (~1-3 min)" but ran `cargo fmt + check + clippy + test --lib`. On non-trivial workspaces (including pmat itself: 18,537 tests, ~20 min) this far exceeds the SSH idle timeout — the hook prints `✅ Pre-push gate passed` but `git push` never lands the refs because the underlying SSH connection has already been killed by the server.

This PR makes the CLI generator (`src/cli/handlers/hooks_command_handlers/hooks_command.rs:328`) emit the same content the **scaffold path** already emits via `src/quality/git_hooks_install.rs:144` — fmt-check only.

## Why

- **Pre-push hooks must be O(1)** in workspace size. They run in the user's foreground while the SSH connection is held idle.
- **Build/clippy/test belong in CI**, where they're parallel, cached across runs, and don't block local pushes.
- The fast generator already exists and is labeled `(O(1))`. This PR just makes the slow generator match.

## Reproduction of the bug

Three consecutive `git push origin feat/binary-release-workflow` attempts on pmat all reported:
```
test result: ok. 18537 passed; 0 failed; 141 ignored; 0 measured; 0 filtered out; finished in 1197.97s
Connection to github.com closed by remote host.
✅ Pre-push gate passed
```

Hook returned 0, but `git ls-remote --heads origin feat/binary-release-workflow` was empty after each attempt. SSH had timed out mid-hook (around the 5-min mark, visible in the test progress log). The git push transport silently failed after the hook completed.

After applying this PR's hook content locally, the same push completed in **4.8s** and the branch landed.

## Diff

`src/cli/handlers/hooks_command_handlers/hooks_command.rs` — the heredoc string in `install_pre_push_hook()` is reduced from 4 cargo invocations to one (`cargo fmt --all -- --check`), with a comment explaining that build/clippy/test belong in CI.

## Test plan

- [ ] `cargo test --lib` (existing tests don't assert on the removed strings — verified via grep)
- [ ] After merge: in any pmat-managed repo, run `pmat hooks install` and confirm the new pre-push hook completes in <2s regardless of workspace size
- [ ] Verify the scaffold path (`src/quality/git_hooks_install.rs`) and CLI path now emit byte-identical hook content

🤖 Generated with [Claude Code](https://claude.com/claude-code)