### PR TITLE
fix(install.sh): correct URL pattern + musl default + tarball layout (closes #561)

### DIFF
--- a/contracts/pmat-install-v1.yaml
+++ b/contracts/pmat-install-v1.yaml
@@ -1,0 +1,82 @@
+metadata:
+  version: "1.0.0"
+  created: "2026-05-05"
+  author: PAIML Engineering
+  registry: true
+  description: >
+    Provable contract for scripts/install.sh — the documented one-liner
+    installer (curl ... | sh). Captures the URL pattern, tarball layout,
+    and Linux platform default that must hold for `curl ... | sh` to
+    succeed on every supported base image.
+  contract: pmat-install
+  status: enforced
+  references:
+    - scripts/install.sh
+    - https://github.com/paiml/paiml-mcp-agent-toolkit/issues/561
+
+equations:
+  url_pattern_matches_release_assets:
+    formula: download_url == "https://github.com/${REPO}/releases/download/v${VERSION}/pmat-v${VERSION}-${PLATFORM}.tar.gz"
+    domain: VERSION in semver, PLATFORM in supported_targets
+    codomain: download_url returns HTTP 302 (redirect to actual asset)
+    invariants:
+    - download_url contains "pmat-v${VERSION}-${PLATFORM}.tar.gz"
+    - download_url does NOT contain the legacy "paiml-mcp-agent-toolkit-" prefix
+    preconditions:
+    - Release v${VERSION} exists with the matching asset
+    lean_theorem: Theorems.Install_URL_Matches_Asset
+
+  tarball_extraction_handles_subdirectory:
+    formula: tar -xzf archive.tar.gz -C $TMP_DIR --strip-components=1
+    domain: archive.tar.gz contains "pmat-v${VERSION}-${PLATFORM}/pmat"
+    codomain: $TMP_DIR/pmat exists and is executable
+    invariants:
+    - Binary lands at $INSTALL_DIR/pmat (NOT nested under a subdirectory)
+    - $TMP_DIR/pmat is regular file after extraction
+    preconditions:
+    - download succeeded
+    - tar binary available
+    lean_theorem: Theorems.Install_Tarball_Flat
+
+  default_linux_platform_is_musl_for_glibc_independence:
+    formula: PLATFORM == "${arch}-unknown-linux-musl" when uname -s == "Linux"
+    domain: arch in {x86_64, aarch64}, os == Linux
+    codomain: PLATFORM ends with "-musl"
+    invariants:
+    - musl variant is static-pie (file output contains "static-pie linked")
+    - musl variant runs on Ubuntu 22.04 (GLIBC 2.35) without GLIBC_2.39 errors
+    preconditions:
+    - musl-target asset exists in the release
+    lean_theorem: Theorems.Install_Musl_Default
+
+preconditions:
+  - "GitHub release v${VERSION} exists"
+  - "Release contains pmat-v${VERSION}-x86_64-unknown-linux-musl.tar.gz asset"
+  - "Release contains pmat-v${VERSION}-aarch64-unknown-linux-musl.tar.gz asset"
+  - "curl, tar, sh available on the target machine"
+
+postconditions:
+  - "$INSTALL_DIR/pmat is an executable producing 'pmat ${VERSION}' on --version"
+  - "Binary is static-pie (no GLIBC dependency)"
+  - "INSTALL_DIR env var is honoured if set, falls back to ~/.local/bin"
+
+falsification:
+  - condition: "DOWNLOAD_URL still references 'paiml-mcp-agent-toolkit-' prefix"
+    severity: P0
+    action: reject_push
+  - condition: "Linux platform detection returns a -gnu target instead of -musl"
+    severity: P0
+    action: reject_push
+  - condition: "tar extraction fails to flatten subdirectory (binary not at $TMP_DIR/pmat)"
+    severity: P0
+    action: reject_push
+  - condition: "INSTALL_DIR env var is overwritten by unconditional assignment"
+    severity: P1
+    action: reject_push
+  - condition: "Smoke test `INSTALL_DIR=/tmp/x bash install.sh v${VERSION}` exits non-zero"
+    severity: P0
+    action: reject_push
+
+verification:
+  local: "INSTALL_DIR=/tmp/pmat-smoke bash scripts/install.sh v${VERSION} && /tmp/pmat-smoke/pmat --version"
+  ci: ".github/workflows/binary-release.yml"

--- a/scripts/install.integration.test.ts
+++ b/scripts/install.integration.test.ts
@@ -14,10 +14,13 @@ describe("GitHub Release Integration Tests", () => {
     const release = await response.json();
     const assets = release.assets || [];
 
-    // Expected platforms
+    // Expected platforms (musl variants added per issue #561 — installer
+    // defaults to musl on Linux for glibc-independence)
     const expectedPlatforms = [
       "x86_64-unknown-linux-gnu",
       "aarch64-unknown-linux-gnu",
+      "x86_64-unknown-linux-musl",
+      "aarch64-unknown-linux-musl",
       "x86_64-apple-darwin",
       "aarch64-apple-darwin",
       "x86_64-pc-windows-msvc",
@@ -40,16 +43,18 @@ describe("GitHub Release Integration Tests", () => {
       "No release assets found for any expected platform",
     );
 
-    // Verify asset naming convention
+    // Verify asset naming convention.
+    // Issue #561: assets use the new pmat-v<VERSION>-<PLATFORM>.tar.gz pattern
+    // (the binary was renamed from paiml-mcp-agent-toolkit to pmat at v3.0).
     for (const assetName of assetNames) {
       if (assetName.endsWith(".tar.gz")) {
-        // Should match pattern: paiml-mcp-agent-toolkit-{platform}.tar.gz
+        // Pattern: pmat-v{semver}-{rust-target-triple}.tar.gz
         const pattern =
-          /^paiml-mcp-agent-toolkit-[a-z0-9_]+-[a-z]+-[a-z]+(-[a-z]+)?\.tar\.gz$/;
+          /^pmat-v\d+\.\d+\.\d+(-[a-z0-9.]+)?-[a-z0-9_]+-[a-z]+-[a-z]+(-[a-z]+)?\.tar\.gz$/;
         assertEquals(
           pattern.test(assetName),
           true,
-          `Asset name '${assetName}' doesn't match expected pattern`,
+          `Asset name '${assetName}' doesn't match expected pattern 'pmat-v<VERSION>-<PLATFORM>.tar.gz'`,
         );
       }
     }
@@ -68,10 +73,12 @@ describe("GitHub Release Integration Tests", () => {
     const release = await response.json();
     const version = release.tag_name.replace(/^v/, "");
 
-    // Test constructing a download URL
-    const platform = "x86_64-unknown-linux-gnu";
+    // Test constructing a download URL using the post-#561 pattern.
+    // Default to musl since that is what the installer now picks.
+    const BINARY_NAME = "pmat";
+    const platform = "x86_64-unknown-linux-musl";
     const downloadUrl =
-      `https://github.com/${REPO}/releases/download/v${version}/paiml-mcp-agent-toolkit-${platform}.tar.gz`;
+      `https://github.com/${REPO}/releases/download/v${version}/${BINARY_NAME}-v${version}-${platform}.tar.gz`;
 
     // Check if URL is accessible (HEAD request to avoid downloading)
     const headResponse = await fetch(downloadUrl, { method: "HEAD" });
@@ -90,7 +97,7 @@ describe("GitHub Release Integration Tests", () => {
 
   it("should match installer script URL construction", async () => {
     // This test verifies that our URL construction in the installer
-    // matches the actual release asset URLs
+    // matches the actual release asset URLs (post-#561 pattern).
 
     const response = await fetch(
       `https://api.github.com/repos/${REPO}/releases/latest`,
@@ -99,17 +106,18 @@ describe("GitHub Release Integration Tests", () => {
     const version = release.tag_name.replace(/^v/, "");
     const assets = release.assets || [];
 
-    // Find a Linux x86_64 asset (most common)
+    // Find a Linux x86_64 musl asset (now the installer default)
     const linuxAsset = assets.find((
       asset: { name: string; browser_download_url: string },
-    ) => asset.name.includes("x86_64-unknown-linux-gnu"));
+    ) => asset.name.includes("x86_64-unknown-linux-musl"));
 
     if (linuxAsset) {
       // Construct URL as the installer would
-      const BINARY_NAME = "paiml-mcp-agent-toolkit";
-      const platform = "x86_64-unknown-linux-gnu";
+      const BINARY_NAME = "pmat";
+      const platform = "x86_64-unknown-linux-musl";
+      const assetBasename = `${BINARY_NAME}-v${version}-${platform}`;
       const constructedUrl =
-        `https://github.com/${REPO}/releases/download/v${version}/${BINARY_NAME}-${platform}.tar.gz`;
+        `https://github.com/${REPO}/releases/download/v${version}/${assetBasename}.tar.gz`;
 
       // The browser_download_url should match our constructed URL
       assertEquals(

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,19 +3,27 @@
 #
 # This is a standalone POSIX-compliant shell installer that works on Linux, macOS, and Windows (via WSL).
 # A TypeScript/Deno version is also available at scripts/install.ts for those who prefer it.
-# 
+#
 # Usage:
 #   curl -fsSL https://raw.githubusercontent.com/paiml/paiml-mcp-agent-toolkit/master/scripts/install.sh | sh
-#   
+#
 # Or to install a specific version:
 #   curl -fsSL https://raw.githubusercontent.com/paiml/paiml-mcp-agent-toolkit/master/scripts/install.sh | sh -s v0.1.0
+#
+# Notes on Linux platform default:
+#   The Linux build defaults to the *-unknown-linux-musl* target. The musl
+#   variant produces a static-pie binary that runs on every glibc version,
+#   while the gnu variant requires GLIBC >= 2.39 (which Ubuntu 22.04 / Debian
+#   bullseye / common CI base images do not ship). Choosing musl by default
+#   makes the one-liner install path work on every documented base image.
 
 set -euf
 
 # Configuration
 REPO="paiml/paiml-mcp-agent-toolkit"
 BINARY_NAME="pmat"
-INSTALL_DIR="${HOME}/.local/bin"
+# Honour pre-set INSTALL_DIR env var (documented in --help) — fall back to ~/.local/bin
+INSTALL_DIR="${INSTALL_DIR:-${HOME}/.local/bin}"
 
 # Colors for output
 RED='\033[0;31m'
@@ -55,9 +63,10 @@ detect_platform() {
     
     case "$os" in
         Linux*)
+            # Default to musl (static-pie, glibc-independent — works on Ubuntu 22.04+)
             case "$arch" in
-                x86_64)  echo "x86_64-unknown-linux-gnu";;
-                aarch64) echo "aarch64-unknown-linux-gnu";;
+                x86_64)  echo "x86_64-unknown-linux-musl";;
+                aarch64) echo "aarch64-unknown-linux-musl";;
                 *)       error "Unsupported Linux architecture: $arch";;
             esac
             ;;
@@ -97,33 +106,37 @@ install() {
     
     info "Installing ${BINARY_NAME} v${VERSION} for ${PLATFORM}..."
     
-    # Construct download URL
-    # Note: Release artifacts use full repo name, not just binary name
-    DOWNLOAD_URL="https://github.com/${REPO}/releases/download/v${VERSION}/paiml-mcp-agent-toolkit-${PLATFORM}.tar.gz"
-    
+    # Construct download URL.
+    # Release assets are published as `pmat-v<VERSION>-<PLATFORM>.tar.gz`
+    # (the binary was renamed from paiml-mcp-agent-toolkit to pmat at v3.0).
+    ASSET_BASENAME="pmat-v${VERSION}-${PLATFORM}"
+    DOWNLOAD_URL="https://github.com/${REPO}/releases/download/v${VERSION}/${ASSET_BASENAME}.tar.gz"
+
     # Create temp directory
     TMP_DIR=$(mktemp -d)
     # Enhanced cleanup trap that also removes any stray tar.gz files in CWD
     trap 'rm -rf "$TMP_DIR"; cleanup_artifacts' EXIT
-    
+
     # Download binary
     info "Downloading from ${DOWNLOAD_URL}..."
     if ! curl -fsSL "$DOWNLOAD_URL" -o "$TMP_DIR/archive.tar.gz"; then
         error "Failed to download binary. Please check if version ${VERSION} exists for ${PLATFORM}."
     fi
-    
-    # Extract binary
-    tar -xzf "$TMP_DIR/archive.tar.gz" -C "$TMP_DIR"
-    
+
+    # Extract binary. The tarball contains a top-level directory
+    # `pmat-v<VERSION>-<PLATFORM>/` holding the binary; --strip-components=1
+    # flattens it so the binary lands at $TMP_DIR/pmat directly.
+    tar -xzf "$TMP_DIR/archive.tar.gz" -C "$TMP_DIR" --strip-components=1
+
     # Create install directory
     mkdir -p "$INSTALL_DIR"
-    
+
     # Install binary
     if [ -f "$TMP_DIR/${BINARY_NAME}" ]; then
         mv "$TMP_DIR/${BINARY_NAME}" "$INSTALL_DIR/"
         chmod +x "$INSTALL_DIR/${BINARY_NAME}"
     else
-        error "Binary not found in archive"
+        error "Binary not found in archive (expected $TMP_DIR/${BINARY_NAME} after stripping ${ASSET_BASENAME}/ prefix)"
     fi
     
     info "Successfully installed ${BINARY_NAME} to ${INSTALL_DIR}/${BINARY_NAME}"

--- a/scripts/install.test.ts
+++ b/scripts/install.test.ts
@@ -13,6 +13,7 @@ import {
 // For now, we'll duplicate the detectPlatform function for testing
 
 // Detect platform (returns full Rust target triple)
+// Default to musl on Linux for glibc-independence (issue #561).
 function detectPlatform(): string {
   const os = Deno.build.os;
   const arch = Deno.build.arch;
@@ -20,9 +21,9 @@ function detectPlatform(): string {
   if (os === "linux") {
     switch (arch) {
       case "x86_64":
-        return "x86_64-unknown-linux-gnu";
+        return "x86_64-unknown-linux-musl";
       case "aarch64":
-        return "aarch64-unknown-linux-gnu";
+        return "aarch64-unknown-linux-musl";
       default:
         throw new Error(`Unsupported Linux architecture: ${arch}`);
     }
@@ -74,10 +75,12 @@ describe("detectPlatform", () => {
   });
 
   it("should return known Rust target triples", () => {
-    // Test that the function returns valid Rust target triples
+    // Test that the function returns valid Rust target triples.
+    // Linux defaults to musl (issue #561) for glibc-independence; the gnu
+    // variant is still published as an asset but not chosen by default.
     const validTargets = [
-      "x86_64-unknown-linux-gnu",
-      "aarch64-unknown-linux-gnu",
+      "x86_64-unknown-linux-musl",
+      "aarch64-unknown-linux-musl",
       "x86_64-apple-darwin",
       "aarch64-apple-darwin",
       "x86_64-pc-windows-msvc",
@@ -94,65 +97,82 @@ describe("detectPlatform", () => {
 
 describe("GitHub Release URL Construction", () => {
   it("should construct correct download URLs", () => {
+    // Issue #561: assets are published as `pmat-v<VERSION>-<PLATFORM>.tar.gz`
+    // (binary was renamed from paiml-mcp-agent-toolkit to pmat at v3.0).
     const REPO = "paiml/paiml-mcp-agent-toolkit";
-    const BINARY_NAME = "paiml-mcp-agent-toolkit";
-    const version = "0.1.15";
+    const BINARY_NAME = "pmat";
+    const version = "3.16.0";
     const platforms = [
       "x86_64-unknown-linux-gnu",
       "aarch64-unknown-linux-gnu",
+      "x86_64-unknown-linux-musl",
+      "aarch64-unknown-linux-musl",
       "x86_64-apple-darwin",
       "aarch64-apple-darwin",
       "x86_64-pc-windows-msvc",
     ];
 
     for (const platform of platforms) {
+      const assetBasename = `${BINARY_NAME}-v${version}-${platform}`;
       const downloadUrl =
-        `https://github.com/${REPO}/releases/download/v${version}/${BINARY_NAME}-${platform}.tar.gz`;
+        `https://github.com/${REPO}/releases/download/v${version}/${assetBasename}.tar.gz`;
 
       // URL should be properly formatted
       assertEquals(downloadUrl.startsWith("https://github.com/"), true);
       assertEquals(downloadUrl.includes("/releases/download/"), true);
       assertEquals(downloadUrl.endsWith(".tar.gz"), true);
       assertEquals(downloadUrl.includes(platform), true);
+      // Must use the new pmat-v<VERSION>- prefix (NOT the legacy paiml-...)
+      assertEquals(
+        downloadUrl.includes(`pmat-v${version}-`),
+        true,
+        `URL must contain 'pmat-v${version}-' prefix, got ${downloadUrl}`,
+      );
+      assertEquals(
+        downloadUrl.includes("paiml-mcp-agent-toolkit-"),
+        false,
+        `URL must NOT contain legacy 'paiml-mcp-agent-toolkit-' prefix`,
+      );
 
       // Check exact format
       const expectedUrl =
-        `https://github.com/paiml/paiml-mcp-agent-toolkit/releases/download/v0.1.15/paiml-mcp-agent-toolkit-${platform}.tar.gz`;
+        `https://github.com/paiml/paiml-mcp-agent-toolkit/releases/download/v3.16.0/pmat-v3.16.0-${platform}.tar.gz`;
       assertEquals(downloadUrl, expectedUrl);
     }
   });
 
   it("should handle version with and without 'v' prefix", () => {
     const REPO = "paiml/paiml-mcp-agent-toolkit";
-    const BINARY_NAME = "paiml-mcp-agent-toolkit";
-    const platform = "x86_64-unknown-linux-gnu";
+    const BINARY_NAME = "pmat";
+    const platform = "x86_64-unknown-linux-musl";
 
     // Test with 'v' prefix
-    let version = "v0.1.15";
+    let version = "v3.16.0";
     version = version.replace(/^v/, "");
-    assertEquals(version, "0.1.15");
+    assertEquals(version, "3.16.0");
 
     // Test without 'v' prefix
-    version = "0.1.15";
+    version = "3.16.0";
     version = version.replace(/^v/, "");
-    assertEquals(version, "0.1.15");
+    assertEquals(version, "3.16.0");
 
     // Construct URL
+    const assetBasename = `${BINARY_NAME}-v${version}-${platform}`;
     const downloadUrl =
-      `https://github.com/${REPO}/releases/download/v${version}/${BINARY_NAME}-${platform}.tar.gz`;
+      `https://github.com/${REPO}/releases/download/v${version}/${assetBasename}.tar.gz`;
     assertEquals(
       downloadUrl,
-      "https://github.com/paiml/paiml-mcp-agent-toolkit/releases/download/v0.1.15/paiml-mcp-agent-toolkit-x86_64-unknown-linux-gnu.tar.gz",
+      "https://github.com/paiml/paiml-mcp-agent-toolkit/releases/download/v3.16.0/pmat-v3.16.0-x86_64-unknown-linux-musl.tar.gz",
     );
   });
 });
 
 describe("Platform compatibility tests", () => {
   it("should support all major platforms", () => {
-    // Simulate different platforms
+    // Simulate different platforms (Linux defaults to musl per issue #561)
     const testCases = [
-      { os: "linux", arch: "x86_64", expected: "x86_64-unknown-linux-gnu" },
-      { os: "linux", arch: "aarch64", expected: "aarch64-unknown-linux-gnu" },
+      { os: "linux", arch: "x86_64", expected: "x86_64-unknown-linux-musl" },
+      { os: "linux", arch: "aarch64", expected: "aarch64-unknown-linux-musl" },
       { os: "darwin", arch: "x86_64", expected: "x86_64-apple-darwin" },
       { os: "darwin", arch: "aarch64", expected: "aarch64-apple-darwin" },
       { os: "windows", arch: "x86_64", expected: "x86_64-pc-windows-msvc" },
@@ -177,9 +197,9 @@ describe("Platform compatibility tests", () => {
       if (os === "linux") {
         switch (arch) {
           case "x86_64":
-            return "x86_64-unknown-linux-gnu";
+            return "x86_64-unknown-linux-musl";
           case "aarch64":
-            return "aarch64-unknown-linux-gnu";
+            return "aarch64-unknown-linux-musl";
           default:
             throw new Error(`Unsupported Linux architecture: ${arch}`);
         }

--- a/scripts/install.ts
+++ b/scripts/install.ts
@@ -15,7 +15,9 @@
 // Configuration
 const REPO = "paiml/paiml-mcp-agent-toolkit";
 const BINARY_NAME = "pmat";
-const INSTALL_DIR = `${Deno.env.get("HOME")}/.local/bin`;
+// Honour pre-set INSTALL_DIR env var, fall back to ~/.local/bin
+const INSTALL_DIR = Deno.env.get("INSTALL_DIR") ??
+  `${Deno.env.get("HOME")}/.local/bin`;
 
 // Colors for output
 const RED = "\x1b[31m";
@@ -43,11 +45,12 @@ function detectPlatform(): string {
   const arch = Deno.build.arch;
 
   if (os === "linux") {
+    // Default to musl (static-pie, glibc-independent — works on Ubuntu 22.04+)
     switch (arch) {
       case "x86_64":
-        return "x86_64-unknown-linux-gnu";
+        return "x86_64-unknown-linux-musl";
       case "aarch64":
-        return "aarch64-unknown-linux-gnu";
+        return "aarch64-unknown-linux-musl";
       default:
         error(`Unsupported Linux architecture: ${arch}`);
     }
@@ -96,13 +99,15 @@ async function downloadFile(url: string, destination: string): Promise<void> {
   await Deno.writeFile(destination, new Uint8Array(data));
 }
 
-// Extract tar.gz file
+// Extract tar.gz file. The release tarball wraps the binary in a top-level
+// `pmat-v<VERSION>-<PLATFORM>/` directory; --strip-components=1 flattens it
+// so the binary lands at <destDir>/pmat directly.
 async function extractTarGz(
   archivePath: string,
   destDir: string,
 ): Promise<void> {
   const cmd = new Deno.Command("tar", {
-    args: ["-xzf", archivePath, "-C", destDir],
+    args: ["-xzf", archivePath, "-C", destDir, "--strip-components=1"],
   });
   const { code, stderr } = await cmd.output();
 
@@ -127,9 +132,12 @@ async function install(version?: string): Promise<void> {
 
   info(`Installing ${BINARY_NAME} v${version} for ${platform}...`);
 
-  // Construct download URL
+  // Construct download URL.
+  // Release assets are published as `pmat-v<VERSION>-<PLATFORM>.tar.gz`
+  // (the binary was renamed from paiml-mcp-agent-toolkit to pmat at v3.0).
+  const assetBasename = `${BINARY_NAME}-v${version}-${platform}`;
   const downloadUrl =
-    `https://github.com/${REPO}/releases/download/v${version}/${BINARY_NAME}-${platform}.tar.gz`;
+    `https://github.com/${REPO}/releases/download/v${version}/${assetBasename}.tar.gz`;
 
   // Create temp directory
   const tmpDir = await Deno.makeTempDir();


### PR DESCRIPTION
## Summary

Three sub-fixes for `scripts/install.sh` (and the parallel Deno `install.ts`) that were broken by the v3.0 binary rename and the GLIBC mismatch between the gnu variant and common base images. All from issue #561.

1. **URL pattern.** Assets are published as `pmat-v<VERSION>-<PLATFORM>.tar.gz` (renamed at v3.0 from `paiml-mcp-agent-toolkit-`). Every `curl ... | sh` returned 404 against any v3.x release.
2. **Tarball layout.** The archive contains a `pmat-v<VERSION>-<PLATFORM>/` top-level directory; extraction now uses `--strip-components=1` so the binary lands at `$TMP_DIR/pmat` directly.
3. **Default Linux platform.** Switch from `-gnu` to `-musl` so the static-pie binary works on Ubuntu 22.04 (GLIBC 2.35) and other older base images. The gnu variant requires GLIBC 2.39.

Bystander fix: `INSTALL_DIR=/path/to/x bash install.sh` was ignored because the script unconditionally re-assigned the variable. Now uses `${INSTALL_DIR:-${HOME}/.local/bin}`.

Same fixes applied to `scripts/install.ts` (Deno variant) for parity.

## Provable contract

New `contracts/pmat-install-v1.yaml` captures the three invariants and feeds `pv lint`. Passes `pv lint` cleanly in isolation (1 contract, 0 errors, mean score 0.40).

## Test plan

- [x] `deno test scripts/install.test.ts` — 5 tests, all pass
- [x] Local smoke test: `INSTALL_DIR=/tmp/pmat-smoke bash scripts/install.sh v3.16.0`
- [x] `/tmp/pmat-smoke/pmat --version` -> `pmat 3.16.0`
- [x] `file /tmp/pmat-smoke/pmat` -> `static-pie linked` (musl confirmed)
- [x] `pv lint contracts/pmat-install-v1.yaml` (in isolated dir) -> PASS
- [x] `shellcheck scripts/install.sh` -> clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)