### PR TITLE
fix(release): bump Cargo.lock pmat pin to 3.17.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6325,7 +6325,7 @@ dependencies = [
 
 [[package]]
 name = "pmat"
-version = "3.16.0"
+version = "3.17.0"
 dependencies = [
  "actix",
  "actix-rt",
@@ -6457,7 +6457,7 @@ dependencies = [
 
 [[package]]
 name = "pmat-dashboard"
-version = "3.16.0"
+version = "3.17.0"
 dependencies = [
  "aprender-present-core 0.30.0",
  "aprender-present-layout",


### PR DESCRIPTION
Cargo.lock still pinned at 3.16.0 after the version bump in #566. Binary Release workflow uses --locked which refuses to regenerate; both x86_64 jobs failed in run 25407951686. aarch64 jobs succeeded because cross handles this differently.

After merge, re-trigger the Binary Release workflow with workflow_dispatch input `v3.17.0` to publish the missing x86_64-{musl,gnu} assets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)