### PR TITLE
fix(semantic): run embed/search out of the box; fix 1536→256 dim mismatch (closes #563)

### DIFF
--- a/src/cli/command_dispatcher/semantic_commands.rs
+++ b/src/cli/command_dispatcher/semantic_commands.rs
@@ -23,14 +23,12 @@ impl CommandDispatcher {
         let config_service = ConfigurationService::new(None);
         let semantic_config = config_service.get_semantic_config_with_env_fallback()?;
 
-        // Check if semantic search is enabled
-        if !semantic_config.enabled {
-            anyhow::bail!(
-                "Semantic search is not enabled.\n\
-                 To enable, set semantic.enabled = true in config file.\n\
-                 No API keys required - uses local embeddings."
-            );
-        }
+        // Issue #563: an explicit `pmat embed …` / `pmat semantic …` invocation
+        // IS the opt-in. The local-embedding stack (aprender/trueno-rag) ships
+        // in-binary and needs no API key or network, so these commands run out of
+        // the box instead of bailing on a `semantic.enabled` flag that isn't
+        // surfaced in --help. The toggle still gates passive/auto behavior
+        // (auto-sync, MCP tool registration) elsewhere.
 
         // Get database path
         let db_path = semantic_config.vector_db_path.unwrap_or_else(|| {
@@ -111,14 +109,12 @@ impl CommandDispatcher {
         let config_service = ConfigurationService::new(None);
         let semantic_config = config_service.get_semantic_config_with_env_fallback()?;
 
-        // Check if semantic search is enabled
-        if !semantic_config.enabled {
-            anyhow::bail!(
-                "Semantic search is not enabled.\n\
-                 To enable, set semantic.enabled = true in config file.\n\
-                 No API keys required - uses local embeddings."
-            );
-        }
+        // Issue #563: an explicit `pmat embed …` / `pmat semantic …` invocation
+        // IS the opt-in. The local-embedding stack (aprender/trueno-rag) ships
+        // in-binary and needs no API key or network, so these commands run out of
+        // the box instead of bailing on a `semantic.enabled` flag that isn't
+        // surfaced in --help. The toggle still gates passive/auto behavior
+        // (auto-sync, MCP tool registration) elsewhere.
 
         // Get database path
         let db_path = semantic_config.vector_db_path.unwrap_or_else(|| {

--- a/src/services/semantic/turso_vector_db_impl.rs
+++ b/src/services/semantic/turso_vector_db_impl.rs
@@ -8,10 +8,14 @@ impl TursoVectorDB {
     /// Database instance
     #[provable_contracts_macros::contract("pmat-core.yaml", equation = "path_exists")]
     pub async fn new_local<P: AsRef<Path>>(_path: P) -> Result<Self, String> {
-        // Default to 1536 dimensions (OpenAI text-embedding-3-small)
-        // The dimension will be auto-adjusted on first insert
+        // Default to 256 dimensions to match the in-binary local embedder
+        // (`LocalEmbedder`, search_engine_embedder.rs). pmat uses local TF-IDF
+        // embeddings only (no OpenAI/API keys), so a fresh store searched before
+        // any insert must not assume the old 1536-dim OpenAI default — that
+        // produced `dimension mismatch: expected 1536, got 256` on first search.
+        // `insert` still auto-adjusts if a different dimension is ever used.
         let config = VectorStoreConfig {
-            dimension: 1536,
+            dimension: 256,
             ..Default::default()
         };
 


### PR DESCRIPTION
## What

Closes #563. `pmat embed sync`/`embed status`/`semantic search` errored with *"Semantic search is not enabled"* out of the box, even though local embeddings ship in-binary (no API key).

## Changes
- **Remove the two `semantic.enabled` bails** (`semantic_commands.rs`). An explicit `pmat embed`/`semantic` invocation *is* the opt-in; the gate was vestigial from the API-key era of #147.
- **Fix vector-store dimension default 1536→256** (`turso_vector_db_impl.rs`). 1536 is OpenAI ada-002; the in-binary `LocalEmbedder` is 256, so a fresh store searched before any insert errored `dimension mismatch: expected 1536, got 256`. `insert()` still auto-adjusts.

## Verification
- Issue repro: `embed status`/`embed sync` now succeed (were erroring).
- `semantic search` no longer crashes.
- turso tests **30/30**; clippy clean.

## Follow-up (not this PR)
The `embed`/`semantic` CLI has a deeper pre-existing gap — no cross-process persistence, `embed_status`/`embed_clear` are stubs, sync/search use disconnected engines. Tracked in #568. This PR makes the commands *run cleanly*; wiring real persistence is a separate effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)