### PR TITLE
chore(tooling): fix server/-layout rot across release tooling + scripts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,7 +218,7 @@ Installation: `pmat hooks install --tdg-enforcement`. Bug reports: https://githu
 
 ## Test Coverage
 
-**Total: ~94 tests ignored** (82 in server/src, remainder in server/tests). Tests marked `#[ignore]` for stable coverage metrics.
+**Total: ~94 tests ignored** (82 in src/, remainder in tests/). Tests marked `#[ignore]` for stable coverage metrics.
 
 | Category | Count | Status |
 |----------|-------|--------|
@@ -277,7 +277,7 @@ pmat rust-project-score --failures-only    # Show only failures
 
 **Categories**: Rust Tooling & CI/CD (130pts), Code Quality (26pts), Testing (20pts), Known Defects (20pts), Formal Verification (16pts), Documentation (15pts), Reproducibility (15pts), Build Performance (15pts), Dependency Health (12pts), Performance & Benchmarking (10pts), GPU/SIMD Quality (10pts).
 
-Spec: `docs/specifications/components/repo-health.md` | Location: `server/src/services/rust_project_score/`
+Spec: `docs/specifications/components/repo-health.md` | Location: `src/services/rust_project_score/`
 
 ---
 

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@
 # Delete partially-built files on error for safety (bashrs lint compliance)
 .DELETE_ON_ERROR:
 
-.PHONY: all validate format lint lint-main check test test-doc test-fast coverage coverage-ci coverage-summary coverage-open coverage-clean clean-coverage build release clean clean-tmp install install-latest reinstall status check-rebuild uninstall help format-scripts lint-scripts check-scripts test-scripts lint-makefile fix validate-docs ci-status validate-naming validate-book context setup audit docs run-mcp run-mcp-test test-actions install-act check-act deps-validate dogfood dogfood-ci update-rust-docs size-report size-track size-check size-compare test-all-interfaces test-feature-all-interfaces test-interface-consistency benchmark-all-interfaces load-test-interfaces context-json context-sarif context-llm context-legacy context-benchmark analyze-top-files analyze-composite analyze-health-dashboard profile-binary-performance profile-deep-context analyze-memory-usage analyze-scaling kaizen test-slow-integration test-safe test-dogfood test-critical-scripts coverage-scripts test-workflow-dag test-workflow-dag-verbose context-root context-simple context-json-root context-benchmark-legacy local-install server-build-binary server-build-docker server-run-mcp server-run-mcp-test server-benchmark server-test server-test-all server-outdated server-tokei build-target cargo-doc cargo-geiger update-deps update-deps-aggressive update-deps-security upgrade-deps audit-fix benchmark coverage-report outdated test-all-features clippy-strict server-build-release create-release test-curl-install cargo-rustdoc install-dev-tools tokei quickstart context-fast clear-swap config-swap overnight-improve overnight-monitor overnight-swap-cron test-unit test-services test-protocols test-e2e test-performance test-property test-property-slow test-all test-stratified coverage-stratified crate-release crate-docs dev commit sprint-close setup-quality quality-gate-full help-toyota-way test-examples examples example clean-quick clean-deep validate-doc-links validate-contracts release-dry release-verify coverage-fast coverage-invalidate coverage-full coverage-broad check-install
+.PHONY: all validate format lint lint-main check test test-doc test-fast coverage coverage-ci coverage-summary coverage-open coverage-clean clean-coverage clean-profraw build release clean clean-tmp install install-latest reinstall status check-rebuild uninstall help format-scripts lint-scripts check-scripts test-scripts lint-makefile fix validate-docs ci-status validate-naming validate-book context setup audit docs run-mcp run-mcp-test test-actions install-act check-act deps-validate dogfood dogfood-ci update-rust-docs size-report size-track size-check size-compare test-all-interfaces test-feature-all-interfaces test-interface-consistency benchmark-all-interfaces load-test-interfaces context-json context-sarif context-llm context-legacy context-benchmark analyze-top-files analyze-composite analyze-health-dashboard profile-binary-performance profile-deep-context analyze-memory-usage analyze-scaling kaizen test-slow-integration test-safe test-dogfood test-critical-scripts coverage-scripts test-workflow-dag test-workflow-dag-verbose context-root context-simple context-json-root context-benchmark-legacy local-install server-build-binary server-build-docker server-run-mcp server-run-mcp-test server-benchmark server-test server-test-all server-outdated server-tokei build-target cargo-doc cargo-geiger update-deps update-deps-aggressive update-deps-security upgrade-deps audit-fix benchmark coverage-report outdated test-all-features clippy-strict server-build-release create-release test-curl-install cargo-rustdoc install-dev-tools tokei quickstart context-fast clear-swap config-swap overnight-improve overnight-monitor overnight-swap-cron test-unit test-services test-protocols test-e2e test-performance test-property test-property-slow test-all test-stratified coverage-stratified crate-release crate-docs dev commit sprint-close setup-quality quality-gate-full help-toyota-way test-examples examples example clean-quick clean-deep validate-doc-links validate-contracts release-dry release-verify coverage-fast coverage-invalidate coverage-full coverage-broad check-install
 
 # Define sub-projects
 # NOTE: client project will be added when implemented
@@ -549,7 +549,16 @@ coverage-open: ## Open HTML coverage report in browser
 		echo "❌ Run 'make coverage' first"; \
 	fi
 
-coverage-clean: ## Clean coverage artifacts
+clean-profraw: ## Remove stale root-level *.profraw/*.profdata + generated defect reports
+	@echo "🧹 Removing stale root coverage scratch + generated reports..."
+	@# cargo llvm-cov writes *.profraw to CWD; left unchecked these reach hundreds
+	@# of MB and slow every directory walk (pmat indexing, walkdir). Plain rm only —
+	@# this does NOT run `cargo llvm-cov clean` (forbidden: it kills build caching).
+	@rm -f ./*.profraw ./*.profdata
+	@rm -f ./defect-report-*.csv ./defect-report-*.json ./defect-report-*.md ./defect-report-*.txt
+	@echo "✓ Root coverage scratch + stale defect-reports removed"
+
+coverage-clean: clean-profraw ## Clean coverage artifacts
 	@rm -f lcov.info target/coverage/lcov.info
 	@rm -rf target/coverage
 	@echo "✓ Coverage artifacts cleaned"
@@ -688,7 +697,7 @@ build: validate-docs validate-naming validate-book
 	@echo "   To build Docker: make server-build-docker"
 
 # Clean all projects
-clean:
+clean: clean-profraw
 	@echo "🧹 Cleaning build artifacts..."
 	@cargo clean --manifest-path Cargo.toml
 	@rm -rf coverage/ artifacts/ target/
@@ -1440,13 +1449,13 @@ pre-release-checks:
 	@./target/debug/pmat analyze satd --strict 2>/dev/null || cargo run --bin pmat -- analyze satd --strict || echo "⚠️  SATD check skipped (pmat not built)"
 	@echo ""
 	@echo "4️⃣ Security audit..."
-	@if [ -d "server" ]; then cargo audit || echo "⚠️  Some vulnerabilities found (review before release)"; else cd .. && cargo audit || echo "⚠️  Some vulnerabilities found (review before release)"; fi
+	@cargo audit || echo "⚠️  Some vulnerabilities found (review before release)"
 	@echo ""
 	@echo "5️⃣ Checking outdated dependencies..."
-	@if [ -d "server" ]; then cargo outdated --root-deps-only || true; else cd .. && cargo outdated --root-deps-only || true; fi
+	@cargo outdated --root-deps-only || true
 	@echo ""
 	@echo "6️⃣ SemVer compatibility check..."
-	@if [ -d "server" ]; then cargo semver-checks check-release || echo "⚠️  SemVer check completed (review any warnings)"; else cd .. && cargo semver-checks check-release || echo "⚠️  SemVer check completed (review any warnings)"; fi
+	@cargo semver-checks check-release || echo "⚠️  SemVer check completed (review any warnings)"
 	@echo ""
 	@echo "✅ All pre-release checks completed!"
 
@@ -1468,8 +1477,7 @@ release-major: install-release-tools pre-release-checks
 # Auto-determine version bump based on changes
 release-auto: install-release-tools pre-release-checks
 	@echo "🤖 Auto-determining version bump type..."
-	@if [ -d "server" ]; then SEMVER_CMD="cargo semver-checks check-release"; else SEMVER_CMD="cd .. && cargo semver-checks check-release"; fi; \
-	if $$SEMVER_CMD 2>&1 | grep -q "MAJOR"; then \
+	@if cargo semver-checks check-release 2>&1 | grep -q "MAJOR"; then \
 		echo "💥 Breaking changes detected - MAJOR release required"; \
 		$(MAKE) release-major; \
 	elif git log --oneline $(shell git describe --tags --abbrev=0 2>/dev/null || echo HEAD~10)..HEAD | grep -qE '^[a-f0-9]+ feat:'; then \

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,20 @@
 # PMAT Agent System Roadmap
 
-## 🎉 CURRENT STATUS: v2.192.0 - Sprint 81 Feature Complete + Maintenance ✅
+> ⚠️ **HISTORICAL — SUPERSEDED (do not treat as current).**
+> This file is frozen at **v2.192.0 (Nov 2025)** and is no longer the source of truth
+> (the project is on **3.17.0+**). It also references the old `server/src/` layout
+> (source now lives in `src/`).
+>
+> **For the live roadmap / status, use:**
+> - `CHANGELOG.md` — actively maintained, current release trajectory
+> - `gh issue list` — the open backlog
+> - `docs/specifications/components/*.md` — component-level plans
+>
+> Kept for historical reference only.
+
+---
+
+## 🎉 HISTORICAL STATUS: v2.192.0 - Sprint 81 Feature Complete + Maintenance ✅
 
 **Current Version**: v2.192.0 (Released November 1, 2025)
 **Latest Sprint**: Sprint 81 - Issue #53 Complete: MCP Tool Placeholder Elimination (COMPLETE ✅)

--- a/assets/project-state.json
+++ b/assets/project-state.json
@@ -6,10 +6,10 @@
     "version": "0.18.0"
   },
   "package": {
-    "name": "paiml-mcp-agent-toolkit",
+    "name": "pmat",
     "binary": {
       "main": "pmat",
-      "allowed_additional": ["generate-installer"]
+      "allowed_additional": ["pmat-agent"]
     }
   },
   "organization": {
@@ -29,9 +29,7 @@
     "binaryNames": [
       "mcp_server_stateless",
       "mcp-template-server",
-      "mcp_template_server",
-      "mcp-server",
-      "mcp_server"
+      "mcp_template_server"
     ],
     "repositoryUrls": [
       "paiml/mcp-agent-toolkit",

--- a/roadmap.yaml
+++ b/roadmap.yaml
@@ -1,5 +1,13 @@
 # PMAT Implementation Roadmap
 # Extreme TDD with Zero Tolerance Quality Gates
+#
+# ============================================================================
+# ⚠️ HISTORICAL — SUPERSEDED (do not treat as current).
+# Frozen at v2.180.x (Oct 2025); the project is on 3.17.0+. Contains only
+# `completed_sprints` with no pending section, so it is not a live plan.
+# Live roadmap/status lives in: CHANGELOG.md, `gh issue list`, and
+# docs/specifications/components/*.md. Kept for historical reference only.
+# ============================================================================
 
 meta:
   project: PMAT - Pragmatic AI Labs Multi-language Agent Toolkit

--- a/scripts/run-fuzzing.ts
+++ b/scripts/run-fuzzing.ts
@@ -225,12 +225,12 @@ async function generateCoverage(fuzzerName: string) {
     const htmlDir = "fuzz/coverage/html";
     await ensureDir(htmlDir);
 
-    // Extract coverage for server sources
+    // Extract coverage for crate sources
     const lcovResult = await new Deno.Command("lcov", {
       args: [
         "--extract",
         `${coverageDir}/coverage.profdata`,
-        "*/server/src/*",
+        "*/src/*",
         "-o",
         "fuzz/coverage/filtered.lcov",
       ],

--- a/scripts/test-curl-install.ts
+++ b/scripts/test-curl-install.ts
@@ -144,7 +144,7 @@ async function main(): Promise<void> {
     console.log("\nTo test locally, you can:");
     console.log("1. Build the binary: make server-build-binary");
     console.log(
-      "2. Create a test tarball: tar -czf paiml-mcp-agent-toolkit-linux-x86_64.tar.gz -C server/target/release paiml-mcp-agent-toolkit",
+      "2. Create a test tarball: tar -czf pmat-x86_64-unknown-linux-musl.tar.gz -C target/release pmat",
     );
     console.log("3. Upload as a GitHub release asset");
   } else {

--- a/scripts/test-workflow-dag.ts
+++ b/scripts/test-workflow-dag.ts
@@ -98,7 +98,6 @@ class WorkflowSimulator {
     // Copy essential files to temp dir
     const filesToCopy = [
       "Cargo.toml",
-      "server/Cargo.toml",
       "installer-macro/Cargo.toml",
       "assets/project-state.json",
       "scripts/update-version.ts",
@@ -297,7 +296,7 @@ class WorkflowSimulator {
 
   private async updateVersionFiles(version: string): Promise<void> {
     // Simulate version update
-    const files = ["Cargo.toml", "server/Cargo.toml"];
+    const files = ["Cargo.toml"];
 
     for (const file of files) {
       try {

--- a/scripts/update-version.ts
+++ b/scripts/update-version.ts
@@ -14,12 +14,10 @@ interface VersionUpdate {
 // Files that need version updates
 const VERSION_UPDATES: VersionUpdate[] = [
   {
+    // Root crate manifest (the `pmat` package lives at the repo root; the old
+    // `server/Cargo.toml` was removed in the layout flattening — listing it here
+    // aborted the whole bump with "File not found").
     file: "Cargo.toml",
-    pattern: /^version = ".*"$/m,
-    replacement: (v) => `version = "${v}"`,
-  },
-  {
-    file: "server/Cargo.toml",
     pattern: /^version = ".*"$/m,
     replacement: (v) => `version = "${v}"`,
   },
@@ -132,11 +130,13 @@ async function updateAllVersions(newVersion: string): Promise<void> {
   const successCount = results.filter((r) => r).length;
   console.log(`\n✅ Updated ${successCount}/${VERSION_UPDATES.length} files`);
 
-  // Update Cargo.lock
+  // Update Cargo.lock so its `pmat` pin matches the new Cargo.toml version.
+  // (Package is `pmat` and the manifest is at the repo root — the old
+  // `-p paiml-mcp-agent-toolkit` / `cwd: "server"` silently failed every
+  // release, which is why the lock pin had to be bumped in a follow-up commit.)
   console.log("\n🔄 Updating Cargo.lock...");
   const cargoUpdate = new Deno.Command("cargo", {
-    args: ["update", "-p", "paiml-mcp-agent-toolkit"],
-    cwd: "server",
+    args: ["update", "-p", "pmat"],
   });
 
   const { success } = await cargoUpdate.output();

--- a/scripts/validate-naming.ts
+++ b/scripts/validate-naming.ts
@@ -44,7 +44,7 @@ async function runCommand(
 
 async function checkCargoToml(): Promise<ValidationResult> {
   try {
-    const cargoToml = await Deno.readTextFile("server/Cargo.toml");
+    const cargoToml = await Deno.readTextFile("Cargo.toml");
     const lines = cargoToml.split("\n");
 
     let packageName = "";
@@ -120,7 +120,7 @@ async function checkSourceCode(): Promise<ValidationResult> {
       "-r",
       "-w", // Match whole words only
       oldName,
-      "server/src/",
+      "src/",
       "--include=*.rs",
       "--exclude=build_naming_validation.rs",
       "--exclude=claude_code_e2e.rs",
@@ -259,7 +259,7 @@ async function checkDocumentation(): Promise<ValidationResult> {
 
 async function checkMakefiles(): Promise<ValidationResult> {
   const issues: string[] = [];
-  const makefiles = ["Makefile", "server/Makefile"];
+  const makefiles = ["Makefile"];
 
   for (const makefile of makefiles) {
     try {
@@ -323,7 +323,7 @@ async function runValidation() {
   if (hasFailures) {
     console.log("\n❌ Naming validation failed!");
     console.log("\n💡 To fix:");
-    console.log("  1. Update all references to use 'paiml-mcp-agent-toolkit'");
+    console.log(`  1. Update the crate name to '${CORRECT_PACKAGE_NAME}'`);
     console.log(
       "  2. Update repository URLs to 'paiml/paiml-mcp-agent-toolkit'",
     );


### PR DESCRIPTION
## Why
The crate was flattened from `server/` to the repo root (source now `src/`, package `paiml-mcp-agent-toolkit` → `pmat`). Stale `server/` references were left across build tooling and caused real release bugs — **#561** (install.sh) and **#567** (Cargo.lock pin lag).

## Release pipeline — root cause of #567
- `update-version.ts` listed the phantom `server/Cargo.toml` in its must-exist check → **the whole version bump aborted**; and ran `cargo update -p paiml-mcp-agent-toolkit` in `cwd: server` (wrong package + dead dir) → **Cargo.lock pin silently never synced**. Fixed to root + `pmat`.
- Makefile `pre-release-checks`: 4 `[ -d server ]` blocks ran `cargo audit`/`outdated`/`semver-checks` **in the parent directory**. Now run at repo root.

## Naming validation — unblocks `make build`
`make build` depends on `validate-naming`, which was failing.
- `project-state.json`: stale crate name → `pmat`, binary → `[pmat-agent]`, and dropped `mcp-server`/`mcp_server` from `deprecated.binaryNames` (now the live `pmat agent mcp-server` subcommand + `mcp_server` module, not old binaries).
- 4 scripts: `server/` → `src/` paths.
- **`validate-naming` now passes 5/5.**

## Hygiene
- New `clean-profraw` make target (wired into `coverage-clean` + `clean`) — `cargo llvm-cov` leaves `*.profraw` in CWD; this had grown to **291 MB / 1023 files**. Plain `rm` only (not `cargo llvm-cov clean`, which kills caching).
- CLAUDE.md `server/src` → `src/`.
- ROADMAP.md / roadmap.yaml marked **HISTORICAL** (frozen at v2.192/v2.180) pointing to CHANGELOG + issues.

## Verification
4 scripts type-check (`deno check`); `validate-naming` 5/5; Makefile parses; `project-state.json` valid JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)