### PR TITLE
fix(complexity): stop counting `?` toward cyclomatic/cognitive (closes #573)

### DIFF
--- a/src/services/accurate_complexity_analyzer_visitor.rs
+++ b/src/services/accurate_complexity_analyzer_visitor.rs
@@ -127,11 +127,12 @@ impl<'ast> Visit<'ast> for ComplexityVisitor {
                 }
                 syn::visit::visit_expr(self, expr);
             }
-            Expr::Try(_) => {
-                self.add_cyclomatic(1);
-                self.add_cognitive(1);
-                syn::visit::visit_expr(self, expr);
-            }
+            // GH-573: `?` is error propagation, not a McCabe decision point.
+            // Counting it inflated cyclomatic for idiomatic Rust (e.g.
+            // `format_as_text`: 46 here vs 19 from the per-file gate analyzer)
+            // and diverged from the analyzer the pre-commit gate enforces.
+            // Standard cyclomatic/cognitive definitions don't count `?`.
+            Expr::Try(_) => syn::visit::visit_expr(self, expr),
             Expr::Break(_) | Expr::Continue(_) => {
                 self.add_cognitive(1);
                 syn::visit::visit_expr(self, expr);

--- a/src/services/complexity_analyzer_tests.rs
+++ b/src/services/complexity_analyzer_tests.rs
@@ -306,7 +306,9 @@ mod accurate_complexity_tests {
         );
     }
 
-    /// Test ? operator adds to complexity
+    /// Test the `?` operator does NOT add to cyclomatic complexity (GH-573).
+    /// `?` is error propagation, not a McCabe decision point; standard
+    /// cyclomatic and the per-file gate analyzer don't count it.
     #[tokio::test]
     async fn test_question_mark_operator() {
         let temp_dir = TempDir::new().unwrap();
@@ -316,15 +318,15 @@ mod accurate_complexity_tests {
             &test_file,
             r#"
             fn try_function() -> Result<i32, String> {
-                let x = some_operation()?;  // +1
-                let y = another_op()?;       // +1
+                let x = some_operation()?;
+                let y = another_op()?;
                 Ok(x + y)
             }
-            
+
             fn some_operation() -> Result<i32, String> {
                 Ok(42)
             }
-            
+
             fn another_op() -> Result<i32, String> {
                 Ok(10)
             }
@@ -341,8 +343,8 @@ mod accurate_complexity_tests {
             .find(|f| f.name.contains("try_function"))
             .unwrap();
         assert_eq!(
-            try_fn.cyclomatic_complexity, 3,
-            "? operator should add 1 to complexity per use"
+            try_fn.cyclomatic_complexity, 1,
+            "? operator must not add to cyclomatic complexity (base 1, no branches)"
         );
     }
 


### PR DESCRIPTION
## Bug
`pmat analyze complexity` (project scan, AST-based `AccurateComplexityAnalyzer`) counted every `?` operator as +1 cyclomatic/cognitive; the per-file gate analyzer doesn't. The two disagreed by up to **2.4×** for the same function (`format_as_text`: **46** vs the gate's **19**) — a trust defect in a complexity tool, and the source of #572's inflated over-gate list.

## Fix
`?` is error propagation, not a McCabe decision point — standard cyclomatic/cognitive definitions and the gate analyzer don't count it. Removed both increments for `Expr::Try` (`accurate_complexity_analyzer_visitor.rs`).

## Safety
Only **lowers** numbers, so it can never newly fail the gate, rust-project-score, or TDG.

## Verification
- `format_as_text` project scan **46 → below the cyclomatic-30 gate**, now matching the gate analyzer's verdict.
- `--file` gate unchanged (19).
- Analyzer suites pass (**42 + 63**); `test_question_mark_operator` updated to assert the corrected value; clippy clean.

## Residual
The gate's `--file` path is still a line heuristic (misses match-arms/`&&`/`||`); reconciling that fully would change enforced gate numbers and is a separate, deliberate call. This PR fixes the dominant divergence (`?`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)