### PR TITLE
chore(deps): migrate trueno_rag → aprender_rag (bump aprender-rag 0.30 → 0.41)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -731,9 +731,9 @@ dependencies = [
 
 [[package]]
 name = "aprender-rag"
-version = "0.30.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c3873da61c11b9a94e529cc8d05b092d21f4e4471c5b4574d4e53a85f7c474"
+checksum = "4d02c8d1e73c6fdad1d34f87cc5547a7ea3f07f7fccf07496e68b0106a676d91"
 dependencies = [
  "async-trait",
  "batuta-common",
@@ -8288,7 +8288,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ aprender-db = { version = "0.30", optional = true, default-features = false }
 # Semantic Search Stack (Pure Rust - Zero API Keys)
 # See: docs/specifications/semantic-search-feature.md
 aprender-graph = { version = "0.30", default-features = false }  # CSR graph, PageRank, Louvain
-aprender-rag = { version = "0.30", optional = true }  # RAG pipeline
+aprender-rag = { version = "0.41", optional = true }  # RAG pipeline
 aprender-viz = { version = "0.30", optional = true, features = ["terminal", "graph"] }
 
 # Analytics GPU dependencies (optional, gated by analytics-gpu feature)

--- a/src/services/local_semantic_tests.rs
+++ b/src/services/local_semantic_tests.rs
@@ -193,8 +193,8 @@ mod tests {
 
     /// Test trueno-rag TfIdfEmbedder can produce embeddings
     #[test]
-    fn test_trueno_rag_tfidf_embedder_basic() {
-        use trueno_rag::embed::{Embedder, TfIdfEmbedder};
+    fn test_aprender_rag_tfidf_embedder_basic() {
+        use aprender_rag::embed::{Embedder, TfIdfEmbedder};
 
         let documents = ["fn main() { println!(\"hello world\"); }",
             "fn add(a: i32, b: i32) -> i32 { a + b }",
@@ -219,8 +219,8 @@ mod tests {
 
     /// Test TfIdfEmbedder produces normalized vectors
     #[test]
-    fn test_trueno_rag_tfidf_normalization() {
-        use trueno_rag::embed::{Embedder, TfIdfEmbedder};
+    fn test_aprender_rag_tfidf_normalization() {
+        use aprender_rag::embed::{Embedder, TfIdfEmbedder};
 
         let documents = vec![
             "rust code function implementation",
@@ -250,8 +250,8 @@ mod tests {
 
     /// Test TfIdfEmbedder similarity correlates with document similarity
     #[test]
-    fn test_trueno_rag_tfidf_similarity() {
-        use trueno_rag::embed::{Embedder, TfIdfEmbedder};
+    fn test_aprender_rag_tfidf_similarity() {
+        use aprender_rag::embed::{Embedder, TfIdfEmbedder};
 
         let documents = [
             "fn main() { println!(\"hello\"); }",
@@ -281,8 +281,8 @@ mod tests {
 
     /// Test batch embedding
     #[test]
-    fn test_trueno_rag_tfidf_batch() {
-        use trueno_rag::embed::{Embedder, TfIdfEmbedder};
+    fn test_aprender_rag_tfidf_batch() {
+        use aprender_rag::embed::{Embedder, TfIdfEmbedder};
 
         let documents = ["function first() { return 1; }",
             "function second() { return 2; }",
@@ -303,8 +303,8 @@ mod tests {
 
     /// Test memory efficiency: trueno-rag uses f32 instead of f64
     #[test]
-    fn test_trueno_rag_tfidf_memory_efficiency() {
-        use trueno_rag::embed::{Embedder, TfIdfEmbedder};
+    fn test_aprender_rag_tfidf_memory_efficiency() {
+        use aprender_rag::embed::{Embedder, TfIdfEmbedder};
 
         // trueno-rag uses f32 (4 bytes) vs aprender uses f64 (8 bytes)
         // This means 50% memory savings for large document collections
@@ -330,8 +330,8 @@ mod tests {
 
     /// Test sparse embedding (most values should be zero for short docs)
     #[test]
-    fn test_trueno_rag_tfidf_sparsity() {
-        use trueno_rag::embed::{Embedder, TfIdfEmbedder};
+    fn test_aprender_rag_tfidf_sparsity() {
+        use aprender_rag::embed::{Embedder, TfIdfEmbedder};
 
         let documents = ["fn main() {}", "def test(): pass", "function x() {}"];
 
@@ -354,8 +354,8 @@ mod tests {
 
     /// Test IDF computation correctness
     #[test]
-    fn test_trueno_rag_tfidf_idf_correctness() {
-        use trueno_rag::embed::{Embedder, TfIdfEmbedder};
+    fn test_aprender_rag_tfidf_idf_correctness() {
+        use aprender_rag::embed::{Embedder, TfIdfEmbedder};
 
         // Document frequency test:
         // "common" appears in all docs (high DF -> low IDF)

--- a/src/services/semantic/chunker_tests_rag.rs
+++ b/src/services/semantic/chunker_tests_rag.rs
@@ -225,9 +225,9 @@ fn another_function() {
 
     /// Test that trueno-rag Chunker trait can be used
     #[test]
-    fn test_trueno_rag_chunker_integration() {
-        use trueno_rag::chunk::{Chunker, RecursiveChunker};
-        use trueno_rag::Document;
+    fn test_aprender_rag_chunker_integration() {
+        use aprender_rag::chunk::{Chunker, RecursiveChunker};
+        use aprender_rag::Document;
 
         let chunker = RecursiveChunker::new(50, 10);
         let doc = Document::new(

--- a/src/services/semantic/chunker_text.rs
+++ b/src/services/semantic/chunker_text.rs
@@ -24,8 +24,8 @@ pub fn chunk_text_with_overlap(text: &str, chunk_size: usize, overlap: usize) ->
     }
 
     // Use trueno-rag's RecursiveChunker internally
-    use trueno_rag::chunk::{Chunker, RecursiveChunker};
-    use trueno_rag::Document;
+    use aprender_rag::chunk::{Chunker, RecursiveChunker};
+    use aprender_rag::Document;
 
     let chunker = RecursiveChunker::new(chunk_size, overlap);
     let doc = Document::new(text);
@@ -33,7 +33,7 @@ pub fn chunk_text_with_overlap(text: &str, chunk_size: usize, overlap: usize) ->
     match chunker.chunk(&doc) {
         Ok(chunks) => chunks
             .into_iter()
-            .map(|c: trueno_rag::Chunk| c.content)
+            .map(|c: aprender_rag::Chunk| c.content)
             .collect(),
         Err(_) => {
             // Fallback to simple fixed-size chunking
@@ -65,8 +65,8 @@ pub fn chunk_text_recursive(text: &str, chunk_size: usize, overlap: usize) -> Ve
     }
 
     // Use trueno-rag's RecursiveChunker with custom separators
-    use trueno_rag::chunk::{Chunker, RecursiveChunker};
-    use trueno_rag::Document;
+    use aprender_rag::chunk::{Chunker, RecursiveChunker};
+    use aprender_rag::Document;
 
     let chunker = RecursiveChunker::new(chunk_size, overlap).with_separators(vec![
         "\n\n".to_string(), // Paragraph boundary
@@ -81,7 +81,7 @@ pub fn chunk_text_recursive(text: &str, chunk_size: usize, overlap: usize) -> Ve
     match chunker.chunk(&doc) {
         Ok(chunks) => chunks
             .into_iter()
-            .map(|c: trueno_rag::Chunk| c.content)
+            .map(|c: aprender_rag::Chunk| c.content)
             .collect(),
         Err(_) => {
             // Fallback to overlap chunking

--- a/src/services/semantic/hybrid_search.rs
+++ b/src/services/semantic/hybrid_search.rs
@@ -15,8 +15,8 @@ use std::path::Path;
 use std::process::Command;
 use std::sync::Arc;
 
-use trueno_rag::index::BM25Index;
-use trueno_rag::{Chunk, ChunkId, DocumentId, SparseIndex};
+use aprender_rag::index::BM25Index;
+use aprender_rag::{Chunk, ChunkId, DocumentId, SparseIndex};
 
 /// Search mode for hybrid engine
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/services/semantic/turso_vector_db.rs
+++ b/src/services/semantic/turso_vector_db.rs
@@ -6,11 +6,11 @@
 // GREEN Phase: Full implementation with cosine similarity search
 // Sprint 76: Migrated from rusqlite to trueno-rag VectorStore for SIMD acceleration
 
+use aprender_rag::index::{VectorStore, VectorStoreConfig};
+use aprender_rag::{Chunk, ChunkId, DocumentId};
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::RwLock;
-use trueno_rag::index::{VectorStore, VectorStoreConfig};
-use trueno_rag::{Chunk, ChunkId, DocumentId};
 
 // Type definitions: TursoVectorDB, EmbeddingMetadata, EmbeddingEntry, SearchResult, DbStats
 include!("turso_vector_db_types.rs");


### PR DESCRIPTION
## Why
The batuta stack moved into the **aprender monorepo** — standalone `trueno-rag` became `aprender-rag`. The published `aprender-rag 0.30` still exposed the back-compat lib name `trueno_rag`, so pmat's semantic code kept importing the old name. **aprender-rag 0.41** (paiml/aprender) renamed `[lib] name` → `aprender_rag` and exports the same API.

## Change
- Bump `aprender-rag` 0.30 → 0.41 (resolved cleanly — *177 deps unchanged*, no coordinated batuta-stack bump needed).
- Convert the 5 `use trueno_rag::` call sites → `aprender_rag::` (turso_vector_db, chunker_text, hybrid_search + 2 test files).

## Verification
- `cargo check` clean against 0.41.
- **turso_vector_db (30) + local_semantic (15) tests pass** — aprender-rag 0.41 is behavior-compatible across the version jump.
- clippy clean; fmt clean.

Resolves the source-conversion half of the monorepo migration (aprender#1930, closed). Unblocks future #568 persistence work on aprender-rag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)