### PR TITLE
feat(semantic): persist the vector store across processes (closes #568)

### DIFF
--- a/src/cli/semantic_commands.rs
+++ b/src/cli/semantic_commands.rs
@@ -17,6 +17,8 @@ pub struct SemanticCli {
     hybrid_engine: Arc<HybridSearchEngine>,
     clustering_engine: Arc<ClusteringEngine>,
     topic_engine: Arc<TopicEngine>,
+    /// Vector DB path — used by `embed status` / `embed clear` (#568).
+    db_path: String,
 }
 
 impl SemanticCli {
@@ -41,6 +43,7 @@ impl SemanticCli {
             hybrid_engine,
             clustering_engine,
             topic_engine,
+            db_path: db_path.to_string(),
         })
     }
 
@@ -52,6 +55,9 @@ impl SemanticCli {
         language: Option<String>,
     ) -> Result<String, String> {
         let stats = self.search_engine.index_directory(directory).await?;
+        // #568: persist the freshly-indexed embeddings so a later
+        // `semantic search` / `embed status` process can load them.
+        self.search_engine.save().await?;
 
         let msg = format!(
             "Synced {} chunks ({} created, {} updated)",
@@ -68,8 +74,9 @@ impl SemanticCli {
     /// Get embedding status
     #[provable_contracts_macros::contract("pmat-core.yaml", equation = "check_compliance")]
     pub async fn embed_status(&self) -> Result<String, String> {
-        // Query database for statistics
-        Ok("Embedding database status: 0 chunks indexed".to_string())
+        // #568: report the real count from the (loaded) persisted store.
+        let count = self.search_engine.entry_count().await?;
+        Ok(format!("Embedding database status: {count} chunks indexed"))
     }
 
     /// Clear all embeddings
@@ -79,7 +86,12 @@ impl SemanticCli {
             return Err("Clear operation requires --confirm flag".to_string());
         }
 
-        // Clear database
+        // #568: remove the persisted vector DB; the next process loads empty.
+        let path = std::path::Path::new(&self.db_path);
+        if path.exists() {
+            std::fs::remove_file(path)
+                .map_err(|e| format!("Failed to remove {}: {e}", self.db_path))?;
+        }
         Ok("All embeddings cleared".to_string())
     }
 

--- a/src/services/semantic/search_engine_core.rs
+++ b/src/services/semantic/search_engine_core.rs
@@ -27,6 +27,16 @@ impl SemanticSearchEngine {
         Self::new(db_path).await
     }
 
+    /// Persist the indexed embeddings to disk (#568). No-op for in-memory stores.
+    pub async fn save(&self) -> Result<(), String> {
+        self.vector_db.save().await
+    }
+
+    /// Number of indexed chunks currently in the store.
+    pub async fn entry_count(&self) -> Result<usize, String> {
+        Ok(self.vector_db.get_stats().await?.total_entries)
+    }
+
     /// Search code by natural language query
     ///
     /// # Arguments

--- a/src/services/semantic/turso_vector_db_impl.rs
+++ b/src/services/semantic/turso_vector_db_impl.rs
@@ -1,13 +1,12 @@
 impl TursoVectorDB {
-    /// Create new local in-memory database
+    /// Open a local vector database, loading persisted entries from `path` if it
+    /// exists (#568). Pass `":memory:"` for a non-persistent store.
     ///
-    /// # Arguments
-    /// * `_path` - Path parameter (kept for API compatibility, now ignored)
-    ///
-    /// # Returns
-    /// Database instance
+    /// The SIMD `VectorStore` (aprender-rag) is in-memory only, so persistence is
+    /// implemented by serializing entries on [`save`](Self::save) and rebuilding
+    /// the store here via re-insert.
     #[provable_contracts_macros::contract("pmat-core.yaml", equation = "path_exists")]
-    pub async fn new_local<P: AsRef<Path>>(_path: P) -> Result<Self, String> {
+    pub async fn new_local<P: AsRef<Path>>(path: P) -> Result<Self, String> {
         // Default to 256 dimensions to match the in-binary local embedder
         // (`LocalEmbedder`, search_engine_embedder.rs). pmat uses local TF-IDF
         // embeddings only (no OpenAI/API keys), so a fresh store searched before
@@ -19,12 +18,85 @@ impl TursoVectorDB {
             ..Default::default()
         };
 
-        Ok(Self {
+        let path_ref = path.as_ref();
+        let db_path = if path_ref.as_os_str() == ":memory:" || path_ref.as_os_str().is_empty() {
+            None
+        } else {
+            Some(path_ref.to_path_buf())
+        };
+
+        let db = Self {
             store: RwLock::new(VectorStore::new(config)),
             file_index: RwLock::new(HashMap::new()),
             metadata: RwLock::new(HashMap::new()),
             next_id: RwLock::new(1),
-        })
+            db_path,
+        };
+
+        // Rebuild the in-memory store from the persisted entries, if any.
+        // A corrupt or stale db file must not break startup — start empty.
+        if let Some(p) = db.db_path.as_ref() {
+            if p.exists() {
+                if let Err(e) = db.load_persisted(p).await {
+                    eprintln!("⚠️  ignoring unreadable vector db {}: {e}", p.display());
+                }
+            }
+        }
+
+        Ok(db)
+    }
+
+    /// Reconstruct every stored entry (metadata + its embedding) for persistence.
+    fn collect_entries(&self) -> Result<Vec<EmbeddingEntry>, String> {
+        let metadata = self.metadata.read().map_err(|e| format!("Lock error: {e}"))?;
+        let store = self.store.read().map_err(|e| format!("Lock error: {e}"))?;
+        let mut entries = Vec::with_capacity(metadata.len());
+        for (chunk_id, meta) in metadata.iter() {
+            let embedding = store
+                .get(*chunk_id)
+                .and_then(|c| c.embedding.clone())
+                .unwrap_or_default();
+            entries.push(EmbeddingEntry {
+                file_path: meta.file_path.clone(),
+                chunk_name: meta.chunk_name.clone(),
+                chunk_type: meta.chunk_type.clone(),
+                language: meta.language.clone(),
+                start_line: meta.start_line,
+                end_line: meta.end_line,
+                content_checksum: meta.content_checksum.clone(),
+                embedding,
+                model: meta.model.clone(),
+            });
+        }
+        Ok(entries)
+    }
+
+    /// Persist all entries to `db_path` (no-op for in-memory stores). #568.
+    pub async fn save(&self) -> Result<(), String> {
+        let Some(path) = self.db_path.as_ref() else {
+            return Ok(());
+        };
+        let entries = self.collect_entries()?;
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| format!("create db dir: {e}"))?;
+        }
+        let json = serde_json::to_string(&entries).map_err(|e| format!("serialize db: {e}"))?;
+        std::fs::write(path, json).map_err(|e| format!("write db: {e}"))?;
+        Ok(())
+    }
+
+    /// Load persisted entries from `path` and re-insert them into the store.
+    async fn load_persisted(&self, path: &Path) -> Result<(), String> {
+        let content = std::fs::read_to_string(path).map_err(|e| format!("read db: {e}"))?;
+        if content.trim().is_empty() {
+            return Ok(());
+        }
+        let entries: Vec<EmbeddingEntry> =
+            serde_json::from_str(&content).map_err(|e| format!("parse db: {e}"))?;
+        for entry in &entries {
+            self.insert(entry).await?;
+        }
+        Ok(())
     }
 
     /// Insert or update embedding entry

--- a/src/services/semantic/turso_vector_db_tests_unit.rs
+++ b/src/services/semantic/turso_vector_db_tests_unit.rs
@@ -207,6 +207,42 @@
     }
 
     #[tokio::test]
+    async fn test_persistence_round_trip() {
+        // #568: entries saved by one TursoVectorDB load into a fresh one opened
+        // on the same path (this is what makes `embed sync` -> `semantic search`
+        // work across separate CLI processes).
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("embeddings.db");
+        let path_str = db_path.to_string_lossy().to_string();
+
+        let make = |name: &str, file: &str| EmbeddingEntry {
+            file_path: file.to_string(),
+            chunk_name: name.to_string(),
+            chunk_type: "function".to_string(),
+            language: "rust".to_string(),
+            start_line: 1,
+            end_line: 10,
+            content_checksum: format!("sum_{name}"),
+            embedding: vec![0.1, 0.2, 0.3, 0.4],
+            model: "aprender-tfidf-local".to_string(),
+        };
+
+        {
+            let db = TursoVectorDB::new_local(path_str.as_str()).await.unwrap();
+            db.insert(&make("alpha", "src/a.rs")).await.unwrap();
+            db.insert(&make("beta", "src/b.rs")).await.unwrap();
+            db.save().await.unwrap();
+        }
+        assert!(db_path.exists(), "save() must write the db file");
+
+        // A fresh instance rebuilds the store from the persisted entries.
+        let reloaded = TursoVectorDB::new_local(path_str.as_str()).await.unwrap();
+        let stats = reloaded.get_stats().await.unwrap();
+        assert_eq!(stats.total_entries, 2, "reloaded store must have both entries");
+        assert_eq!(stats.unique_files, 2);
+    }
+
+    #[tokio::test]
     async fn test_get_entry() {
         let db = TursoVectorDB::new_local(":memory:").await.unwrap();
 

--- a/src/services/semantic/turso_vector_db_types.rs
+++ b/src/services/semantic/turso_vector_db_types.rs
@@ -8,6 +8,10 @@ pub struct TursoVectorDB {
     metadata: RwLock<HashMap<ChunkId, EmbeddingMetadata>>,
     /// Auto-increment ID counter
     next_id: RwLock<i64>,
+    /// On-disk persistence path (`None` for in-memory / `:memory:`).
+    /// #568: the SIMD `VectorStore` is in-memory only, so entries are serialized
+    /// here on `save()` and rebuilt on `new_local()`.
+    db_path: Option<std::path::PathBuf>,
 }
 
 /// Internal metadata for each embedding
@@ -24,8 +28,9 @@ struct EmbeddingMetadata {
     model: String,
 }
 
-/// Embedding entry to insert into database
-#[derive(Debug, Clone)]
+/// Embedding entry to insert into database. Also the #568 persistence unit
+/// (serialized to `db_path` on save, re-inserted on load).
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct EmbeddingEntry {
     pub file_path: String,
     pub chunk_name: String,


### PR DESCRIPTION
## What
Makes the `embed sync` → `semantic search` workflow actually work. Sprint 76 moved to aprender-rag's in-memory SIMD `VectorStore` and dropped persistence, so across separate CLI processes search returned 0 results, and `embed status`/`embed clear` were hardcoded stubs.

## Approach — Path A (your call)
Keep the SIMD dense store; add **serde persistence** of the entries.
- **`aprender-db`** rejected — it's a GPU OLAP analytics DB (Parquet/aggregations), wrong abstraction.
- **`aprender-rag::SqliteStore`** rejected — it's FTS/sparse (not dense cosine) and re-adds rusqlite that Sprint 76 removed for SIMD.
- So: serialize the chunk/embedding data (aprender-rag's `Chunk` is serde-able) on sync, rebuild the SIMD store on load.

## Changes
- `TursoVectorDB`: stores `db_path`; `new_local()` loads + rebuilds via re-insert; `save()`/`collect_entries()` persist. Corrupt/stale db is non-fatal.
- `SemanticSearchEngine`: `save()` + `entry_count()` passthroughs.
- `SemanticCli`: persist after `embed_sync`; **real** `embed_status` count; `embed_clear` deletes the file.

## Verified end-to-end (separate processes)
```
embed sync   -> Synced 3 chunks
embed status -> 3 chunks indexed     (was always 0)
semantic search 'add numbers' -> Found 5 results   (was Found 0)
embed clear  -> cleared; status -> 0 chunks indexed
```
+ persistence round-trip unit test (turso 31, +1); clippy clean.

## Follow-up
The TF-IDF `LocalEmbedder` uses feature hashing (token→hash%256), so query and stored embeddings share the hash space without persisting the fitted IDF vocabulary — persisting IDF weights is a future ranking refinement, not needed for retrieval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)