### PR TITLE
fix(concurrency): lost updates, global scratch paths, nondeterministic baselines (v3.18.1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -253,6 +253,7 @@ pmat-*.tar.gz
 *-x86_64-apple-darwin.tar.gz
 *-aarch64-apple-darwin.tar.gz
 /.pmat-metrics/
+**/.pmat-metrics/
 
 # PMAT artifacts (machine-generated, auto-rebuilt) — recursive for subcrates
 **/.pmat/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,55 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.18.1] - 2026-06-12
+
+Concurrency and determinism fixes for multi-agent / parallel-invocation use.
+All were found by an adversarially-verified audit of pmat 3.18.0 and each fix
+ships with a regression test.
+
+### Fixed
+- **`pmat record-metric` no longer loses history**: `MetricTrendStore::record()`
+  overwrote `.pmat-metrics/trends/<metric>.json` with only its own observation
+  because a fresh store instance (one per CLI invocation) never loaded existing
+  observations before persisting. `record()` now reloads from disk before
+  appending, holds an exclusive advisory lock (fs2) on `<metric>.lock` for the
+  read-modify-write (bounded 5s wait — a stuck holder can't hang recording),
+  and persists via write-scratch-then-rename so readers never see a torn file.
+  A torn/corrupt history file left behind by pre-3.18.1 writes is moved aside
+  to `<metric>.json.corrupt` and recording continues, instead of failing every
+  future record. `metrics()` now lists only `.json` observation files,
+  ignoring lock/scratch files.
+- **Fixed machine-global temp paths in TDG comparison commands**:
+  `tdg check-regression`, `tdg baseline compare`, and `tdg check-quality` wrote
+  their ephemeral "current state" baseline to fixed paths
+  (`/tmp/pmat-regression-check.json`, `/tmp/pmat-current-baseline.json`,
+  `/tmp/pmat-quality-check.json`) — two concurrent pmat invocations would
+  overwrite each other's scratch baseline mid-comparison. Ephemeral paths now
+  embed the PID plus a per-process counter.
+- **Deterministic baseline serialization**: `TdgBaseline.files`,
+  `BaselineSummary.grade_distribution`, and `BaselineSummary.languages` were
+  HashMaps, so baseline JSON key order was nondeterministic across runs (and
+  across machines). All three are now BTreeMaps — same JSON shape, stable
+  sorted ordering; existing baseline files load unchanged.
+- **`TdgBaseline::save()` is now atomic** (write to a process-unique scratch
+  file, then rename) so concurrent readers never observe a partial baseline.
+- **SQLite index save scratch path is process-unique**: `save_to_sqlite()`
+  built every save into a fixed shared `<db>.db.tmp`, letting two concurrent
+  savers rename each other's half-built database into place. The scratch path
+  now embeds the PID; the write remains atomic-rename. Scratch files orphaned
+  by crashed/killed saves (these can be hundreds of MB) are swept on the next
+  save once they are over an hour old — the age guard protects concurrent
+  live savers. The same scratch+sweep helper (`utils::scratch`) backs the
+  metric-trends and baseline writes.
+- **`pmat tdg baseline create --name` is honored**: the flag was accepted by
+  clap but silently discarded. Baselines now carry an optional `name` label
+  (round-trips through save/load, shown in `tdg baseline list --format json`,
+  preserved by `tdg baseline update`; pre-3.18.1 baselines without the field
+  still load).
+- **Spec/code drift in `pmat verify`**: the spec's example JSON showed a
+  `fixable` field on clippy violations that the shipped `Violation` struct
+  does not have; the spec now matches the code.
+
 ## [3.18.0] - 2026-06-11
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6325,7 +6325,7 @@ dependencies = [
 
 [[package]]
 name = "pmat"
-version = "3.18.0"
+version = "3.18.1"
 dependencies = [
  "actix",
  "actix-rt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pmat"
-version = "3.18.0"
+version = "3.18.1"
 edition = "2021"
 rust-version = "1.80.0"
 authors = ["Pragmatic AI Labs"]

--- a/docs/specifications/pmat-verify-autonomous-preflight.md
+++ b/docs/specifications/pmat-verify-autonomous-preflight.md
@@ -74,7 +74,7 @@ agent's signal to fix before committing.
     {"name": "clippy",     "ok": false, "duration_ms": 49000,
      "violations": [
        {"file": "src/x.rs", "line": 230, "rule": "clippy::nonminimal_bool",
-        "message": "...", "fixable": true}
+        "message": "..."}
      ]},
     {"name": "tests",      "ok": null, "skipped": "fail-fast"}
   ]

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -11,7 +11,7 @@ pmat is installed from crates.io — this is the single supported install method
 cargo install pmat
 
 # Specific version
-cargo install pmat --version 3.18.0
+cargo install pmat --version 3.18.1
 ```
 
 ## Testing

--- a/src/cli/handlers/tdg_handlers/baseline.rs
+++ b/src/cli/handlers/tdg_handlers/baseline.rs
@@ -23,8 +23,8 @@ pub(super) async fn handle_baseline_command(
             path,
             output,
             with_git_context,
-            name: _name,
-        } => create_baseline(_analyzer, &path, &output, with_git_context).await,
+            name,
+        } => create_baseline(_analyzer, &path, &output, with_git_context, name).await,
 
         BaselineCommand::Compare {
             baseline,
@@ -71,12 +71,26 @@ fn extract_git_context(
     }
 }
 
+/// Build a process-unique scratch path for an ephemeral baseline file.
+///
+/// Fixed names like `/tmp/pmat-current-baseline.json` are machine-global:
+/// two concurrent pmat invocations would overwrite each other's scratch
+/// baseline mid-comparison. PID plus a per-process counter makes the path
+/// unique across processes and across sequential calls within one process.
+pub(super) fn ephemeral_temp_json(prefix: &str) -> PathBuf {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    std::env::temp_dir().join(format!("{prefix}-{}-{n}.json", std::process::id()))
+}
+
 /// Create a new TDG baseline for the project (Sprint 66 Phase 1)
 pub(super) async fn create_baseline(
     analyzer: &TdgAnalyzer,
     path: &Path,
     output: &Path,
     with_git_context: bool,
+    name: Option<String>,
 ) -> Result<()> {
     use crate::tdg::TdgBaseline;
 
@@ -99,6 +113,10 @@ pub(super) async fn create_baseline(
 
     let git_context = extract_git_context(path, with_git_context);
     let mut baseline = TdgBaseline::new(git_context);
+    if let Some(label) = name {
+        println!("   {} {}", c::label("Name:"), c::path(&label));
+        baseline.name = Some(label);
+    }
     let (files_analyzed, files_skipped) =
         analyze_baseline_files(analyzer, path, &mut baseline).await?;
 
@@ -243,8 +261,8 @@ pub(super) async fn compare_baseline(
 
     // Create new baseline for current state
     println!("\n{}", c::dim("Analyzing current state..."));
-    let temp_output = std::env::temp_dir().join("pmat-current-baseline.json");
-    create_baseline(analyzer, current_path, &temp_output, false).await?;
+    let temp_output = ephemeral_temp_json("pmat-current-baseline");
+    create_baseline(analyzer, current_path, &temp_output, false, None).await?;
     let new_baseline = TdgBaseline::load(&temp_output)?;
 
     // Clean up ephemeral baseline file
@@ -277,6 +295,13 @@ pub(super) async fn compare_baseline(
     }
 
     Ok(())
+}
+
+/// Read the name label of an existing baseline file, if any
+fn existing_baseline_name(path: &Path) -> Option<String> {
+    crate::tdg::TdgBaseline::load(path)
+        .ok()
+        .and_then(|b| b.name)
 }
 
 /// Find all baseline files in a directory
@@ -337,6 +362,7 @@ async fn list_baselines(path: &Path, format: crate::cli::TdgOutputFormat) -> Res
                     serde_json::json!({
                         "path": path.display().to_string(),
                         "version": baseline.version,
+                        "name": baseline.name,
                         "created_at": baseline.created_at,
                         "total_files": baseline.summary.total_files,
                         "avg_score": baseline.summary.avg_score,
@@ -382,8 +408,16 @@ async fn update_baseline(
         c::path(&project_path.display().to_string())
     );
 
-    // Simply re-create the baseline (overwrites the file)
-    create_baseline(analyzer, project_path, baseline_path, with_git_context).await?;
+    // Simply re-create the baseline (overwrites the file), preserving any
+    // existing name label
+    create_baseline(
+        analyzer,
+        project_path,
+        baseline_path,
+        with_git_context,
+        existing_baseline_name(baseline_path),
+    )
+    .await?;
 
     println!("\n{}", c::pass("Baseline updated successfully"));
 
@@ -395,6 +429,44 @@ async fn update_baseline(
 mod baseline_tests {
     use super::*;
     use crate::tdg::TdgBaseline;
+
+    /// Ephemeral scratch paths must be unique per call and per process so
+    /// concurrent pmat invocations can't clobber each other's scratch files
+    /// (regression for fixed /tmp/pmat-*-baseline.json names).
+    #[test]
+    fn test_ephemeral_temp_json_unique_per_call() {
+        let a = ephemeral_temp_json("pmat-test-scratch");
+        let b = ephemeral_temp_json("pmat-test-scratch");
+        assert_ne!(a, b, "two calls must yield distinct paths");
+
+        let pid = std::process::id().to_string();
+        let name = a.file_name().unwrap().to_string_lossy().to_string();
+        assert!(name.contains(&pid), "path must embed the PID: {name}");
+        assert_eq!(a.extension().unwrap(), "json");
+    }
+
+    /// existing_baseline_name reads the name label back from a saved
+    /// baseline, returns None for unnamed baselines and missing files —
+    /// this is what lets `tdg baseline update` preserve the label.
+    #[test]
+    fn test_existing_baseline_name() {
+        let tmp = tempfile::tempdir().unwrap();
+
+        let mut named = TdgBaseline::new(None);
+        named.name = Some("sprint-66".to_string());
+        let named_path = tmp.path().join("named-baseline.json");
+        named.save(&named_path).unwrap();
+        assert_eq!(
+            existing_baseline_name(&named_path).as_deref(),
+            Some("sprint-66")
+        );
+
+        let unnamed_path = tmp.path().join("unnamed-baseline.json");
+        TdgBaseline::new(None).save(&unnamed_path).unwrap();
+        assert!(existing_baseline_name(&unnamed_path).is_none());
+
+        assert!(existing_baseline_name(&tmp.path().join("missing.json")).is_none());
+    }
 
     /// extract_git_context returns None immediately when with_git_context=false,
     /// skipping the GitContext::try_from_current_dir path.

--- a/src/cli/handlers/tdg_handlers/quality_gates.rs
+++ b/src/cli/handlers/tdg_handlers/quality_gates.rs
@@ -3,7 +3,7 @@
 //!
 //! Sprint 66 Phase 2: Quality gate enforcement for CI/CD pipelines.
 
-use super::baseline::create_baseline;
+use super::baseline::{create_baseline, ephemeral_temp_json};
 use super::display::{display_gate_result, display_gate_result_table};
 use super::parse_grade;
 use super::TdgCommandConfig;
@@ -67,8 +67,8 @@ pub(super) async fn handle_check_regression(
     );
 
     // Create current baseline
-    let temp_output = std::env::temp_dir().join("pmat-regression-check.json");
-    create_baseline(analyzer, current_path, &temp_output, false).await?;
+    let temp_output = ephemeral_temp_json("pmat-regression-check");
+    create_baseline(analyzer, current_path, &temp_output, false, None).await?;
     let current = TdgBaseline::load(&temp_output)?;
     std::fs::remove_file(&temp_output).ok();
 
@@ -147,8 +147,8 @@ pub(super) async fn handle_check_quality(
 
     println!("🔍 Checking quality thresholds...");
 
-    let temp_output = std::env::temp_dir().join("pmat-quality-check.json");
-    create_baseline(analyzer, path, &temp_output, false).await?;
+    let temp_output = ephemeral_temp_json("pmat-quality-check");
+    create_baseline(analyzer, path, &temp_output, false, None).await?;
     let current = TdgBaseline::load(&temp_output)?;
     std::fs::remove_file(&temp_output).ok();
 

--- a/src/services/agent_context/function_index/sqlite_backend/save.rs
+++ b/src/services/agent_context/function_index/sqlite_backend/save.rs
@@ -27,9 +27,14 @@ pub(crate) fn save_to_sqlite(
     manifest: &IndexManifest,
     coverage_off_files: &HashSet<String>,
 ) -> Result<(), String> {
-    let tmp_path = db_path.with_extension("db.tmp");
+    // Process-unique scratch path: a fixed shared name (`.db.tmp`) lets two
+    // concurrent savers build into the same scratch file and rename each
+    // other's half-built DB into place.
+    let tmp_path = crate::utils::scratch::scratch_path(db_path);
 
-    // Remove stale scratch file from a previous interrupted save
+    // Reclaim scratch DBs orphaned by crashed/killed saves (they can be
+    // hundreds of MB); the 1h age guard protects concurrent live savers
+    crate::utils::scratch::sweep_stale_scratch(db_path, std::time::Duration::from_secs(3600));
     let _ = std::fs::remove_file(&tmp_path);
 
     let conn = open_db(&tmp_path)?;

--- a/src/services/metric_trends.rs
+++ b/src/services/metric_trends.rs
@@ -63,7 +63,8 @@ mod tests {
 
     #[test]
     fn test_record_and_trend() {
-        let mut store = MetricTrendStore::from_path("/tmp/pmat-test-trends").unwrap();
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let mut store = MetricTrendStore::from_path(temp_dir.path().join("trends")).unwrap();
 
         let now = chrono::Utc::now().timestamp();
 
@@ -82,7 +83,8 @@ mod tests {
 
     #[test]
     fn test_trend_regressing() {
-        let mut store = MetricTrendStore::from_path("/tmp/pmat-test-trends-2").unwrap();
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let mut store = MetricTrendStore::from_path(temp_dir.path().join("trends")).unwrap();
 
         let now = chrono::Utc::now().timestamp();
 
@@ -101,7 +103,8 @@ mod tests {
     #[test]
     fn test_csr_graph_storage() {
         // Phase 3.2: Verify CSR graph is populated
-        let mut store = MetricTrendStore::from_path("/tmp/pmat-test-csr").unwrap();
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let mut store = MetricTrendStore::from_path(temp_dir.path().join("trends")).unwrap();
 
         let now = chrono::Utc::now().timestamp();
 
@@ -134,7 +137,8 @@ mod tests {
     #[test]
     fn test_pagerank_hotness() {
         // Phase 3.2: Verify PageRank computation
-        let mut store = MetricTrendStore::from_path("/tmp/pmat-test-pagerank").unwrap();
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let mut store = MetricTrendStore::from_path(temp_dir.path().join("trends")).unwrap();
 
         let now = chrono::Utc::now().timestamp();
 
@@ -186,7 +190,8 @@ mod tests {
     #[test]
     fn test_dual_write_consistency() {
         // Phase 3.2: Verify JSON and CSR storage are consistent
-        let mut store = MetricTrendStore::from_path("/tmp/pmat-test-dual-write").unwrap();
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let mut store = MetricTrendStore::from_path(temp_dir.path().join("trends")).unwrap();
 
         let now = chrono::Utc::now().timestamp();
 
@@ -220,7 +225,8 @@ mod tests {
     #[test]
     fn test_linear_model_training() {
         // Phase 4: Test linear regression training
-        let mut store = MetricTrendStore::from_path("/tmp/pmat-test-linear-model").unwrap();
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let mut store = MetricTrendStore::from_path(temp_dir.path().join("trends")).unwrap();
         let now = chrono::Utc::now().timestamp();
 
         // Record observations with linear trend (increasing by 100ms/day)
@@ -252,7 +258,8 @@ mod tests {
     #[test]
     fn test_threshold_breach_prediction() {
         // Phase 4: Test breach prediction
-        let mut store = MetricTrendStore::from_path("/tmp/pmat-test-breach-pred").unwrap();
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let mut store = MetricTrendStore::from_path(temp_dir.path().join("trends")).unwrap();
         let now = chrono::Utc::now().timestamp();
 
         // Current: ~25000ms, increasing 200ms/day
@@ -295,7 +302,8 @@ mod tests {
     #[test]
     fn test_no_breach_prediction() {
         // Phase 4: Test no-breach case (improving trend)
-        let mut store = MetricTrendStore::from_path("/tmp/pmat-test-no-breach-pred").unwrap();
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let mut store = MetricTrendStore::from_path(temp_dir.path().join("trends")).unwrap();
         let now = chrono::Utc::now().timestamp();
 
         // Decreasing trend (improving) - should never breach
@@ -327,7 +335,8 @@ mod tests {
     #[test]
     fn test_forecast_generation() {
         // Phase 4: Test forecast generation with confidence intervals
-        let mut store = MetricTrendStore::from_path("/tmp/pmat-test-forecast").unwrap();
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let mut store = MetricTrendStore::from_path(temp_dir.path().join("trends")).unwrap();
         let now = chrono::Utc::now().timestamp();
 
         // Record steady upward trend
@@ -371,7 +380,8 @@ mod tests {
     #[test]
     fn test_recommendations_urgency() {
         // Phase 4: Test urgency-based recommendations
-        let mut store = MetricTrendStore::from_path("/tmp/pmat-test-urgency").unwrap();
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let mut store = MetricTrendStore::from_path(temp_dir.path().join("trends")).unwrap();
         let now = chrono::Utc::now().timestamp();
 
         // Fast-increasing trend (breach in ~5 days)
@@ -408,7 +418,8 @@ mod tests {
     /// Tests guard at line 440-442
     #[test]
     fn test_predict_breach_insufficient_observations() {
-        let mut store = MetricTrendStore::from_path("/tmp/pmat-test-insufficient").unwrap();
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let mut store = MetricTrendStore::from_path(temp_dir.path().join("trends")).unwrap();
 
         // Record only 5 observations (< 7 minimum)
         let now = chrono::Utc::now().timestamp();
@@ -432,7 +443,8 @@ mod tests {
     /// Tests guard at line 454-456 (last 90 days)
     #[test]
     fn test_predict_breach_insufficient_recent_observations() {
-        let mut store = MetricTrendStore::from_path("/tmp/pmat-test-insufficient-recent").unwrap();
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let mut store = MetricTrendStore::from_path(temp_dir.path().join("trends")).unwrap();
 
         // Record 10 observations, but all > 90 days old
         let now = chrono::Utc::now().timestamp();
@@ -457,7 +469,8 @@ mod tests {
     /// Tests boundary condition for guards at lines 440-442 and 454-456
     #[test]
     fn test_predict_breach_exactly_7_observations() {
-        let mut store = MetricTrendStore::from_path("/tmp/pmat-test-exactly-7").unwrap();
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let mut store = MetricTrendStore::from_path(temp_dir.path().join("trends")).unwrap();
 
         // Record exactly 7 observations (minimum required)
         let now = chrono::Utc::now().timestamp();
@@ -478,6 +491,107 @@ mod tests {
         assert!(
             prediction.current_value > 0.0,
             "Should have valid current value"
+        );
+    }
+
+    #[test]
+    fn test_record_appends_across_store_instances() {
+        // Regression: record() used to overwrite <metric>.json with only its
+        // own observation because a fresh store instance (one per
+        // `pmat record-metric` invocation) never loaded existing history
+        // before persisting.
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let trends = temp_dir.path().join("trends");
+        let now = chrono::Utc::now().timestamp();
+
+        MetricTrendStore::from_path(&trends)
+            .unwrap()
+            .record("lint", 1.0, now - 10)
+            .unwrap();
+        MetricTrendStore::from_path(&trends)
+            .unwrap()
+            .record("lint", 2.0, now - 5)
+            .unwrap();
+        MetricTrendStore::from_path(&trends)
+            .unwrap()
+            .record("lint", 3.0, now)
+            .unwrap();
+
+        let json = std::fs::read_to_string(trends.join("lint.json")).unwrap();
+        let obs: Vec<MetricObservation> = serde_json::from_str(&json).unwrap();
+        assert_eq!(obs.len(), 3, "each invocation must append, not overwrite");
+    }
+
+    #[test]
+    fn test_record_concurrent_stores_lose_no_observations() {
+        // Concurrent recorders (separate store instances on one trends dir)
+        // must serialize their read-modify-write via the per-metric advisory
+        // lock.
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let trends = temp_dir.path().join("trends");
+        std::fs::create_dir_all(&trends).unwrap();
+        let base = chrono::Utc::now().timestamp();
+
+        let handles: Vec<_> = (0..8i64)
+            .map(|i| {
+                let trends = trends.clone();
+                std::thread::spawn(move || {
+                    let mut store = MetricTrendStore::from_path(&trends).unwrap();
+                    store.record("lint", i as f64, base + i).unwrap();
+                })
+            })
+            .collect();
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        let json = std::fs::read_to_string(trends.join("lint.json")).unwrap();
+        let obs: Vec<MetricObservation> = serde_json::from_str(&json).unwrap();
+        assert_eq!(obs.len(), 8, "advisory lock must prevent lost updates");
+    }
+
+    #[test]
+    fn test_metrics_listing_ignores_lock_and_scratch_files() {
+        // The trends dir now contains <metric>.lock files; metrics() must
+        // list only observation JSON files.
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let trends = temp_dir.path().join("trends");
+        let mut store = MetricTrendStore::from_path(&trends).unwrap();
+        store
+            .record("lint", 1.0, chrono::Utc::now().timestamp())
+            .unwrap();
+
+        // Plant the other file kinds that can live in the trends dir:
+        // a crash-orphaned scratch file and unrelated junk
+        std::fs::write(trends.join("lint.json.tmp.12345"), "[]").unwrap();
+        std::fs::write(trends.join("README.txt"), "junk").unwrap();
+        assert!(trends.join("lint.lock").exists(), "record() creates a lock");
+
+        let metrics = store.metrics().unwrap();
+        assert_eq!(metrics, vec!["lint".to_string()]);
+    }
+
+    #[test]
+    fn test_record_self_heals_corrupt_history() {
+        // Pre-3.18.1 record() wrote without a lock or atomic rename, so a
+        // killed process could leave torn JSON. record() must move such a
+        // file aside and keep recording, not fail forever.
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let trends = temp_dir.path().join("trends");
+        std::fs::create_dir_all(&trends).unwrap();
+        std::fs::write(trends.join("lint.json"), "{ torn mid-write").unwrap();
+
+        let mut store = MetricTrendStore::from_path(&trends).unwrap();
+        store
+            .record("lint", 1.0, chrono::Utc::now().timestamp())
+            .unwrap();
+
+        let json = std::fs::read_to_string(trends.join("lint.json")).unwrap();
+        let obs: Vec<MetricObservation> = serde_json::from_str(&json).unwrap();
+        assert_eq!(obs.len(), 1, "recording must succeed after self-heal");
+        assert!(
+            trends.join("lint.json.corrupt").exists(),
+            "corrupt history must be preserved aside, not destroyed"
         );
     }
 }

--- a/src/services/metric_trends_core.rs
+++ b/src/services/metric_trends_core.rs
@@ -34,8 +34,63 @@ impl MetricTrendStore {
     }
 
     /// Record new metric observation
+    ///
+    /// Holds an exclusive advisory lock on `<metric>.lock` and reloads the
+    /// metric's observations from disk before appending, so a fresh store
+    /// instance (each `pmat record-metric` invocation creates one) appends
+    /// to history instead of overwriting it, and concurrent recorders
+    /// cannot lose each other's updates.
     #[provable_contracts_macros::contract("pmat-core.yaml", equation = "check_compliance")]
     pub fn record(&mut self, metric: &str, value: f64, timestamp: i64) -> Result<()> {
+        use fs2::FileExt;
+
+        let lock_path = self.storage_path.join(format!("{metric}.lock"));
+        let lock_file = std::fs::OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .write(true)
+            .open(&lock_path)
+            .context("Failed to open metric lock file")?;
+
+        // Bounded wait: a stuck holder must not hang recording forever
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        loop {
+            match lock_file.try_lock_exclusive() {
+                Ok(()) => break,
+                Err(_) if std::time::Instant::now() < deadline => {
+                    std::thread::sleep(std::time::Duration::from_millis(50));
+                }
+                Err(e) => {
+                    anyhow::bail!(
+                        "Timed out waiting for metric lock {}: {e}",
+                        lock_path.display()
+                    );
+                }
+            }
+        }
+
+        let result = self.record_locked(metric, value, timestamp);
+        let _ = FileExt::unlock(&lock_file);
+        result
+    }
+
+    /// Append one observation while the metric lock is held
+    fn record_locked(&mut self, metric: &str, value: f64, timestamp: i64) -> Result<()> {
+        // Merge observations persisted by other invocations since this
+        // store instance was created. Pre-3.18.1 record() wrote without a
+        // lock or atomic rename and could leave a torn/corrupt history file;
+        // preserve such a file aside and continue with what we have, rather
+        // than failing every future record for this metric.
+        if let Err(e) = self.load(metric) {
+            let path = self.storage_path.join(format!("{metric}.json"));
+            let corrupt_path = self.storage_path.join(format!("{metric}.json.corrupt"));
+            let _ = std::fs::rename(&path, &corrupt_path);
+            eprintln!(
+                "warning: unreadable metric history for '{metric}' ({e}); moved aside to {}",
+                corrupt_path.display()
+            );
+        }
+
         let obs = MetricObservation {
             metric: metric.to_string(),
             value,

--- a/src/services/metric_trends_io.rs
+++ b/src/services/metric_trends_io.rs
@@ -64,11 +64,23 @@ impl MetricTrendStore {
     }
 
     /// Persist cache to disk (JSON for simplicity, trueno-graph in Phase 3.1)
+    ///
+    /// Writes to a process-unique scratch file then renames into place so
+    /// concurrent readers never observe a torn write.
     fn persist(&self, metric: &str) -> Result<()> {
         if let Some(observations) = self.cache.get(metric) {
             let path = self.storage_path.join(format!("{}.json", metric));
+            let tmp_path = crate::utils::scratch::scratch_path(&path);
+            crate::utils::scratch::sweep_stale_scratch(
+                &path,
+                std::time::Duration::from_secs(3600),
+            );
             let json = serde_json::to_string_pretty(observations)?;
-            std::fs::write(&path, json).context("Failed to write metric observations")?;
+            std::fs::write(&tmp_path, json).context("Failed to write metric observations")?;
+            if let Err(e) = std::fs::rename(&tmp_path, &path) {
+                let _ = std::fs::remove_file(&tmp_path);
+                return Err(e).context("Failed to rename metric observations into place");
+            }
         }
         Ok(())
     }
@@ -117,7 +129,12 @@ impl MetricTrendStore {
         let mut metrics = Vec::new();
         for entry in std::fs::read_dir(&self.storage_path)? {
             let entry = entry?;
-            if let Some(name) = entry.path().file_stem() {
+            let path = entry.path();
+            // Only observation files count; skip .lock and scratch files
+            if path.extension().and_then(|e| e.to_str()) != Some("json") {
+                continue;
+            }
+            if let Some(name) = path.file_stem() {
                 metrics.push(name.to_string_lossy().to_string());
             }
         }

--- a/src/tdg/baseline.rs
+++ b/src/tdg/baseline.rs
@@ -9,7 +9,7 @@ use anyhow::Result;
 use blake3::Hash as Blake3Hash;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 include!("baseline_types.rs");

--- a/src/tdg/baseline_impl.rs
+++ b/src/tdg/baseline_impl.rs
@@ -4,14 +4,15 @@ impl TdgBaseline {
     pub fn new(git_context: Option<GitContext>) -> Self {
         Self {
             version: env!("CARGO_PKG_VERSION").to_string(),
+            name: None,
             created_at: Utc::now(),
             git_context,
-            files: HashMap::new(),
+            files: BTreeMap::new(),
             summary: BaselineSummary {
                 total_files: 0,
                 avg_score: 0.0,
-                grade_distribution: HashMap::new(),
-                languages: HashMap::new(),
+                grade_distribution: BTreeMap::new(),
+                languages: BTreeMap::new(),
             },
         }
     }
@@ -117,10 +118,20 @@ impl TdgBaseline {
     }
 
     /// Save baseline to JSON file
+    ///
+    /// Writes to a process-unique scratch file in the same directory, then
+    /// renames into place so concurrent readers never observe a partial file.
     #[provable_contracts_macros::contract("pmat-core.yaml", equation = "path_exists")]
     pub fn save(&self, path: impl AsRef<Path>) -> Result<()> {
+        let path = path.as_ref();
         let json = serde_json::to_string_pretty(self)?;
-        std::fs::write(path, json)?;
+        let tmp_path = crate::utils::scratch::scratch_path(path);
+        crate::utils::scratch::sweep_stale_scratch(path, std::time::Duration::from_secs(3600));
+        std::fs::write(&tmp_path, json)?;
+        if let Err(e) = std::fs::rename(&tmp_path, path) {
+            let _ = std::fs::remove_file(&tmp_path);
+            return Err(e.into());
+        }
         Ok(())
     }
 

--- a/src/tdg/baseline_tests_serialization.rs
+++ b/src/tdg/baseline_tests_serialization.rs
@@ -28,6 +28,78 @@
     }
 
     #[test]
+    fn test_baseline_serialization_deterministic_across_insert_order() {
+        // Regression: `files`, `grade_distribution`, and `languages` were
+        // HashMaps, so two identical baselines could serialize with
+        // different key orders, breaking byte-level comparison across runs.
+        let mut a = TdgBaseline::new(None);
+        let mut b = TdgBaseline::new(None);
+        let entries = [
+            ("zeta.rs", 95.0, Grade::APLus),
+            ("alpha.rs", 85.0, Grade::AMinus),
+            ("mid.rs", 75.0, Grade::B),
+        ];
+        for (p, s, g) in &entries {
+            a.add_entry(PathBuf::from(p), create_test_entry(*s, *g));
+        }
+        for (p, s, g) in entries.iter().rev() {
+            b.add_entry(PathBuf::from(p), create_test_entry(*s, *g));
+        }
+        b.created_at = a.created_at;
+
+        let ja = serde_json::to_string_pretty(&a).expect("serialize a");
+        let jb = serde_json::to_string_pretty(&b).expect("serialize b");
+        assert_eq!(
+            ja, jb,
+            "serialized baseline must not depend on insertion order"
+        );
+
+        // Equality alone would pass ~3% of the time under HashMap iteration;
+        // sorted key order fails a HashMap revert deterministically
+        let ia = ja.find("alpha.rs").expect("alpha.rs present");
+        let im = ja.find("mid.rs").expect("mid.rs present");
+        let iz = ja.find("zeta.rs").expect("zeta.rs present");
+        assert!(
+            ia < im && im < iz,
+            "files keys must serialize in sorted order"
+        );
+    }
+
+    #[test]
+    fn test_baseline_name_roundtrip_and_legacy_load() {
+        let mut baseline = TdgBaseline::new(None);
+        baseline.name = Some("pre-refactor".to_string());
+        let temp_file = std::env::temp_dir().join(format!(
+            "test_baseline_name_{}.json",
+            std::process::id()
+        ));
+        baseline.save(&temp_file).expect("save named baseline");
+        let loaded = TdgBaseline::load(&temp_file).expect("load named baseline");
+        assert_eq!(loaded.name.as_deref(), Some("pre-refactor"));
+        std::fs::remove_file(&temp_file).ok();
+
+        // Baselines written before the `name` field existed must still load:
+        // a populated baseline serialized without a name key is exactly the
+        // shape 3.18.0 produced (modulo map key order, which serde accepts
+        // in any order)
+        let mut populated = TdgBaseline::new(None);
+        populated.add_entry(
+            PathBuf::from("a.rs"),
+            create_test_entry(95.0, Grade::APLus),
+        );
+        populated.add_entry(PathBuf::from("b.rs"), create_test_entry(70.0, Grade::B));
+        let json = serde_json::to_string(&populated).expect("serialize");
+        assert!(
+            !json.contains("\"name\""),
+            "None name must not be serialized"
+        );
+        let legacy: TdgBaseline = serde_json::from_str(&json).expect("legacy load");
+        assert!(legacy.name.is_none());
+        assert_eq!(legacy.files.len(), 2);
+        assert_eq!(legacy.summary.total_files, 2);
+    }
+
+    #[test]
     fn test_baseline_load_invalid_path() {
         let result = TdgBaseline::load("/nonexistent/path/baseline.json");
         assert!(result.is_err());

--- a/src/tdg/baseline_types.rs
+++ b/src/tdg/baseline_types.rs
@@ -7,14 +7,18 @@ pub struct TdgBaseline {
     /// PMAT version that created this baseline
     pub version: String,
 
+    /// Optional user-supplied label for this baseline
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+
     /// When this baseline was created
     pub created_at: DateTime<Utc>,
 
     /// Git context (commit, branch, author) when baseline was created
     pub git_context: Option<GitContext>,
 
-    /// Per-file TDG scores indexed by file path
-    pub files: HashMap<PathBuf, BaselineEntry>,
+    /// Per-file TDG scores indexed by file path (sorted for deterministic serialization)
+    pub files: BTreeMap<PathBuf, BaselineEntry>,
 
     /// Aggregate statistics across all files
     pub summary: BaselineSummary,
@@ -46,10 +50,10 @@ pub struct BaselineSummary {
     pub avg_score: f32,
 
     /// Distribution of grades (A+, A, B+, etc.)
-    pub grade_distribution: HashMap<Grade, usize>,
+    pub grade_distribution: BTreeMap<Grade, usize>,
 
     /// Count by programming language
-    pub languages: HashMap<String, usize>,
+    pub languages: BTreeMap<String, usize>,
 }
 
 /// Comparison result between two baselines

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -26,6 +26,7 @@ pub mod file_filter;
 pub mod helpers;
 pub mod path_validator;
 pub mod pattern_helpers;
+pub mod scratch;
 pub mod sovereign_compression;
 pub mod string_truncate;
 

--- a/src/utils/scratch.rs
+++ b/src/utils/scratch.rs
@@ -1,0 +1,105 @@
+//! Process-unique scratch files for atomic write-then-rename persistence.
+//!
+//! A fixed scratch name (e.g. `<db>.db.tmp`) lets two concurrent writers
+//! build into the same scratch file and rename each other's half-built
+//! output into place. Embedding the PID makes the scratch unique per
+//! process — but scratch files orphaned by a crashed process then need
+//! explicit sweeping, since no later invocation reuses their name.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+/// Build the process-unique scratch path for `target`:
+/// `<target_file_name>.tmp.<pid>` in the target's directory.
+pub fn scratch_path(target: &Path) -> PathBuf {
+    let file_name = target
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "scratch".to_string());
+    target.with_file_name(format!("{file_name}.tmp.{}", std::process::id()))
+}
+
+/// Remove scratch siblings of `target` (files named `<file_name>.tmp.*`)
+/// whose mtime is at least `max_age` old.
+///
+/// Crash-orphaned scratch files are never reclaimed by their owning
+/// process; callers sweep before (or after) each save. The age guard
+/// protects a concurrent live writer, whose scratch is by definition
+/// fresh. Best-effort: IO errors are ignored.
+pub fn sweep_stale_scratch(target: &Path, max_age: Duration) {
+    let Some(file_name) = target.file_name().map(|n| n.to_string_lossy().into_owned()) else {
+        return;
+    };
+    let prefix = format!("{file_name}.tmp.");
+    let Some(parent) = target.parent() else {
+        return;
+    };
+    let dir = if parent.as_os_str().is_empty() {
+        Path::new(".")
+    } else {
+        parent
+    };
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        if !name.to_string_lossy().starts_with(&prefix) {
+            continue;
+        }
+        let is_stale = entry
+            .metadata()
+            .and_then(|m| m.modified())
+            .ok()
+            .and_then(|t| t.elapsed().ok())
+            .is_some_and(|age| age >= max_age);
+        if is_stale {
+            let _ = std::fs::remove_file(entry.path());
+        }
+    }
+}
+
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_scratch_path_embeds_pid_and_target_name() {
+        let p = scratch_path(Path::new("/some/dir/context.db"));
+        let name = p.file_name().unwrap().to_string_lossy().to_string();
+        assert!(name.starts_with("context.db.tmp."));
+        assert!(name.ends_with(&std::process::id().to_string()));
+        assert_eq!(p.parent().unwrap(), Path::new("/some/dir"));
+    }
+
+    #[test]
+    fn test_sweep_removes_stale_scratch_but_not_target_or_unrelated() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let target = dir.path().join("data.json");
+        std::fs::write(&target, "{}").unwrap();
+        let orphan = dir.path().join("data.json.tmp.99999");
+        std::fs::write(&orphan, "half-written").unwrap();
+        let unrelated = dir.path().join("other.json.tmp.99999");
+        std::fs::write(&unrelated, "x").unwrap();
+
+        // max_age zero treats every matching scratch as stale
+        sweep_stale_scratch(&target, Duration::ZERO);
+
+        assert!(!orphan.exists(), "stale scratch must be swept");
+        assert!(target.exists(), "target itself must survive");
+        assert!(unrelated.exists(), "other targets' scratch must survive");
+    }
+
+    #[test]
+    fn test_sweep_spares_fresh_scratch() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let target = dir.path().join("data.json");
+        let fresh = dir.path().join("data.json.tmp.12345");
+        std::fs::write(&fresh, "live writer").unwrap();
+
+        sweep_stale_scratch(&target, Duration::from_secs(3600));
+
+        assert!(fresh.exists(), "fresh scratch (live writer) must be spared");
+    }
+}


### PR DESCRIPTION
## Summary

Concurrency and determinism fixes for multi-agent / parallel-invocation use, found by an adversarially-verified 21-agent audit of the 3.18.0 capability surface. Each fix ships with regression tests.

| Bug | Fix |
|---|---|
| `pmat record-metric` overwrote `<metric>.json` with only its own observation (fresh store per CLI invocation never loaded history) | `record()` reloads under an exclusive fs2 advisory lock (bounded 5s wait), appends, persists via scratch+rename; torn pre-3.18.1 files self-heal (moved aside to `.json.corrupt`) |
| `tdg check-regression` / `baseline compare` / `check-quality` wrote ephemeral baselines to fixed machine-global `/tmp` paths — concurrent invocations clobbered each other | PID + per-process-counter unique paths (`ephemeral_temp_json`) |
| `TdgBaseline` JSON key order was nondeterministic (`files`/`grade_distribution`/`languages` HashMaps) | BTreeMaps — sorted, byte-stable; legacy baselines load unchanged; `save()` now atomic |
| `tdg baseline create --name` silently discarded (`name: _name`) | Persisted, listed (`baseline list --format json`), preserved by `baseline update` |
| SQLite index save built into fixed shared `.db.tmp` — concurrent savers could rename each other's half-built DB into place | PID-unique scratch via new `utils::scratch`; crash-orphaned scratch (50–275 MB) swept after 1h |
| `pmat verify` spec example showed a `fixable` field the shipped struct lacks | Spec matches code |

Also: 13 pre-existing MetricTrendStore tests used fixed `/tmp` paths and passed **only because** the data-loss bug truncated history each run — all converted to per-test `TempDir`s.

## Validation

- `pmat verify --format json` → `ok: true` (format, complexity, satd, clippy `-D warnings`, full test suite)
- 111-command full-CLI dogfood with the freshly built 3.18.1 binary: 95 pass, 9 graceful degradations, 7 pre-existing issues, **0 regressions, 0 release blockers** (every blocker claim adversarially adjudicated)
- End-to-end fix validation: 2 sequential + 4 concurrent `record-metric` → exactly 6 observations; corrupt-file self-heal; `--name` round-trip; byte-identical baseline re-creation; parallel `check-regression` with PID-unique scratch and zero leftovers
- Fix diff itself went through a 4-lens adversarial review (23 agents); 2 regressions it introduced (corrupt-file brick, orphan scratch leak) were caught and fixed pre-merge
- pmat-book updated and pushed first per policy (ch73 + ch04-02), `make validate-book` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)