### PR TITLE
fix(kaizen): dogfood sweep — 9 CLI + 6 MCP fixes, pmcp 2.9 (v3.18.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,89 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.18.2] - 2026-06-12
+
+Kaizen sweep: fixes for all 8 pre-existing issues catalogued by the v3.18.1
+full-CLI dogfood (111 commands). None were regressions; all predate 3.18.1.
+
+### Fixed
+- **`pmat perfection-score` math**: the Rust Project Quality category divided
+  RPS raw points by a stale hardcoded scale (134.0, the v1 maximum), so raw
+  246.6/289 became a "184%" score and the total clamped to 200/200 A+
+  regardless of actual quality. Normalization now uses the
+  orchestrator-reported `total_possible`, and `CategoryScore::new` clamps
+  earned points to `[0, max]` so no category can ever exceed its maximum.
+- **`pmat semantic search` ghost results**: with an empty embeddings store the
+  command printed "Found 3 results" (the pre-filter keyword-candidate count)
+  while rendering zero rows. Count and rows now derive from the same result
+  set; an empty store in vector/hybrid mode yields explicit guidance to run
+  `pmat embed sync` instead of a nonzero count with no output. JSON mode now
+  emits a structured `{query, mode, count, results[]}` document instead of a
+  plain string.
+- **JSON stdout purity** (`--format json` stdout is now exactly one
+  jq-parseable document, with decoration suppressed or routed to stderr):
+  - `pmat tdg baseline list` / `baseline compare` / `check-regression` /
+    `check-quality` — including all progress output from the ephemeral
+    baseline creation those commands run internally
+  - `pmat oracle status` / `fix` / `single`
+  - `pmat qdd validate`
+- **`pmat falsify --format json` implemented**: the flag was accepted and
+  silently ignored. Dry runs emit one `{dry_run, total_claims, specs[]}`
+  document; full runs emit a single report document (array for multi-spec,
+  which previously concatenated N documents); `--failures-only` is honored.
+- **TDG penalty ordering was nondeterministic**: `PenaltyTracker` stored
+  attributions in a HashMap, so `penalties_applied` in serialized TDG scores
+  (and therefore baselines) could reorder between identical runs — found by
+  the v3.18.2 re-dogfood when a byte-identical baseline check flaked. Now a
+  BTreeMap keyed by issue id; verified byte-identical across 4 consecutive
+  baseline creations.
+- **`pmat enforce extreme --file` is actually file-scoped**: single-file mode
+  previously ran every phase project-wide (2,717 files analyzed for a
+  one-file dry run). A new `AnalysisScope` threads the target file through
+  the complexity/TDG/SATD/dead-code/duplicate phases.
+
+### Fixed (MCP)
+All 20 live MCP tools were validated end-to-end over stdio JSON-RPC for
+multi-agent use (per-tool calls, 8-way concurrent sessions, framing purity);
+five confirmed defects fixed:
+- **Index source-wipe**: incremental index saves persisted empty `source` for
+  every checksum-reused function (lightweight loads omit the source column;
+  `maybe_save_incremental` rewrote the full DB from them), converging the
+  index to all-empty and killing `pmat_get_function` / `pmat_query_code
+  include_source` / `pmat query --include-source`. Additionally
+  `finalize_incremental_index` dropped `db_path`, disabling source backfill
+  even on healthy DBs. Incremental saves now bulk-restore source before
+  rewriting (empty-only fill, location-keyed); `db_path` propagates; wiped
+  DBs self-heal on the next save. Regression tests pin every row non-empty
+  across an incremental save.
+- **`quality_gate` MCP tool returned an inverted `passed` verdict** (three
+  sites compared `Grade` with the wrong direction — the derived Ord makes
+  better grades smaller). New `Grade::meets_threshold()` is the single
+  semantic comparison; the same inversion in CLI `pmat tdg --min-grade`
+  (rejected grades better than the minimum) is fixed too.
+- **`analyze_dag`, `analyze_big_o`, `analyze_deep_context` advertised no
+  description and an empty input schema** while requiring a `paths` field —
+  schema-conforming calls could never succeed. All three now publish accurate
+  descriptions and schemas; a test pins all 20 tools to non-empty metadata.
+- **`pdmt_deterministic_todos` was nondeterministic** (`Uuid::new_v4` ids):
+  ids are now deterministic UUIDv8s derived from seed/index/requirement;
+  byte-identical output for identical input is pinned by tests.
+- **MCP stdio server never exited on stdin EOF**, leaking one process per
+  scripted session; it now shuts down cleanly when the client closes stdin.
+- `refactor.*` tool descriptions now disclose the analysis engine is
+  currently simulated (violations synthesized from filename patterns).
+
+### Changed
+- **MCP SDK updated**: `pmcp` 2.3.0 → 2.9.0 (latest), pulling jsonschema
+  0.45 → 0.46.5 and fancy-regex 0.17 → 0.18. MCP stdio protocol re-validated
+  end-to-end against the updated SDK (initialize, tools/list, all 20 tool
+  calls, 8-way concurrent sessions, framing purity).
+- `tdg baseline list --format json` with zero baselines now prints `[]`
+  (previously human text only, no JSON document).
+- Two `pub` enforce-handler signatures gained a `specific_file` parameter
+  (`run_complexity_analysis`, `handle_special_modes`); all in-repo callers
+  updated.
+
 ## [3.18.1] - 2026-06-12
 
 Concurrency and determinism fixes for multi-agent / parallel-invocation use.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3197,9 +3197,9 @@ dependencies = [
 
 [[package]]
 name = "fancy-regex"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
+checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
 dependencies = [
  "bit-set 0.8.0",
  "regex-automata",
@@ -4704,15 +4704,15 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.45.0"
+version = "0.46.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f29616f6e19415398eb186964fb7cbbeef572c79bede3622a8277667924bbe3"
+checksum = "6a5fe5206f06e589caf25e79fc05ccdf91fca745685fe9fe1a13bbdfb479a631"
 dependencies = [
  "ahash",
  "bytecount",
  "data-encoding",
  "email_address",
- "fancy-regex 0.17.0",
+ "fancy-regex 0.18.0",
  "fraction",
  "getrandom 0.3.4",
  "idna",
@@ -4720,7 +4720,7 @@ dependencies = [
  "num-cmp",
  "num-traits",
  "percent-encoding",
- "referencing 0.45.0",
+ "referencing 0.46.5",
  "regex",
  "regex-syntax",
  "serde",
@@ -5249,6 +5249,12 @@ dependencies = [
  "objc",
  "paste",
 ]
+
+[[package]]
+name = "micromap"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
 
 [[package]]
 name = "mime"
@@ -6325,7 +6331,7 @@ dependencies = [
 
 [[package]]
 name = "pmat"
-version = "3.18.1"
+version = "3.18.2"
 dependencies = [
  "actix",
  "actix-rt",
@@ -6475,9 +6481,9 @@ dependencies = [
 
 [[package]]
 name = "pmcp"
-version = "2.3.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55682be7f9bc2e1603f560279c83551b5ae3bf614a3c39042b8b4f156ffaa9fd"
+checksum = "88c9cf51f3ce3953091a5f58e4de10d11a739705058dc9d9a5c66103c7c1cba6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6497,7 +6503,7 @@ dependencies = [
  "hyper-util",
  "indexmap",
  "js-sys",
- "jsonschema 0.45.0",
+ "jsonschema 0.46.5",
  "parking_lot",
  "pmcp-widget-utils",
  "regex",
@@ -7309,14 +7315,16 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.45.0"
+version = "0.46.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8a618c14f8ba29d8193bb55e2bf13e4fb2b1115313ecb7ae94b43100c7ac7d5"
+checksum = "69e4e17ef386c5383591d07623d3de49cbc601156e7582973e6db98d66a57de2"
 dependencies = [
  "ahash",
  "fluent-uri 0.4.1",
  "getrandom 0.3.4",
  "hashbrown 0.16.1",
+ "itoa",
+ "micromap",
  "parking_lot",
  "percent-encoding",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pmat"
-version = "3.18.1"
+version = "3.18.2"
 edition = "2021"
 rust-version = "1.80.0"
 authors = ["Pragmatic AI Labs"]
@@ -97,7 +97,7 @@ minijinja = { version = "2.16", default-features = false, optional = true }
 
 # MCP SDK - now core dependency for MCP server functionality
 # Sprint 46 Phase 4: Switched from "full" to explicit features (saves 150-250 KB)
-pmcp = { version = "2.3", features = ["websocket", "http", "sse", "validation"] }
+pmcp = { version = "2.9", features = ["websocket", "http", "sse", "validation"] }
 
 # Caching
 lru = { version = "0.16", features = ["hashbrown"], optional = true }

--- a/src/cli/command_dispatcher/semantic_commands.rs
+++ b/src/cli/command_dispatcher/semantic_commands.rs
@@ -153,15 +153,16 @@ impl CommandDispatcher {
                     SearchMode::Hybrid => "hybrid",
                 };
 
-                let result = semantic_cli
-                    .semantic_search(&query, mode_str, limit, language)
+                let output = semantic_cli
+                    .semantic_search_results(&query, mode_str, limit, language)
                     .await
                     .map_err(|e| anyhow::anyhow!(e))?;
                 match format {
+                    // JSON purity: stdout carries only the payload
                     OutputFormat::Json => {
-                        println!("{}", result); // Result is already JSON
+                        println!("{}", serde_json::to_string_pretty(&output.to_json())?)
                     }
-                    _ => println!("{}", result),
+                    _ => println!("{}", output.render_text()),
                 }
                 Ok(())
             }

--- a/src/cli/handlers/enforce_coverage_part2_checks.rs
+++ b/src/cli/handlers/enforce_coverage_part2_checks.rs
@@ -155,7 +155,7 @@
             let temp_dir = create_test_project();
             let profile = make_test_profile();
 
-            let violations = run_complexity_analysis(temp_dir.path(), &profile)
+            let violations = run_complexity_analysis(temp_dir.path(), &profile, None)
                 .await
                 .unwrap();
 

--- a/src/cli/handlers/enforce_coverage_part4.rs
+++ b/src/cli/handlers/enforce_coverage_part4.rs
@@ -152,6 +152,7 @@
                 &profile,
                 EnforceOutputFormat::Summary,
                 false, // ci_mode
+                None,  // specific_file
             )
             .await
             .unwrap();

--- a/src/cli/handlers/enforce_handlers/analysis.rs
+++ b/src/cli/handlers/enforce_handlers/analysis.rs
@@ -3,13 +3,82 @@
 
 use super::types::{QualityProfile, QualityViolation};
 use anyhow::Result;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+
+/// Per-phase analysis scope for enforcement.
+///
+/// When `--file` is given, phases with native single-file support
+/// (complexity, TDG) analyze exactly that file, while phases that must walk
+/// a directory tree (SATD, dead code, duplication) fall back to the file's
+/// parent module directory instead of scanning the whole project.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AnalysisScope {
+    /// Analyze the whole project rooted at this path
+    Project { root: PathBuf },
+    /// Analyze a single file; `module_dir` is the containing directory used
+    /// by phases that cannot operate on a lone file
+    SingleFile { file: PathBuf, module_dir: PathBuf },
+}
+
+impl AnalysisScope {
+    /// Resolve scope from the project root and the optional `--file` argument.
+    /// Relative file paths are resolved against the project root.
+    #[must_use]
+    pub fn resolve(project_path: &Path, specific_file: Option<&Path>) -> Self {
+        match specific_file {
+            None => Self::Project {
+                root: project_path.to_path_buf(),
+            },
+            Some(f) => {
+                let file = if f.is_absolute() {
+                    f.to_path_buf()
+                } else {
+                    project_path.join(f)
+                };
+                let module_dir = file
+                    .parent()
+                    .filter(|p| !p.as_os_str().is_empty())
+                    .map_or_else(|| project_path.to_path_buf(), Path::to_path_buf);
+                Self::SingleFile { file, module_dir }
+            }
+        }
+    }
+
+    /// Exact file under analysis, when scoped to a single file
+    #[must_use]
+    pub fn single_file(&self) -> Option<&Path> {
+        match self {
+            Self::Project { .. } => None,
+            Self::SingleFile { file, .. } => Some(file),
+        }
+    }
+
+    /// Root for phases that must walk a directory (SATD, dead code,
+    /// duplication): the project root, or the file's parent module dir
+    #[must_use]
+    pub fn walk_root(&self) -> &Path {
+        match self {
+            Self::Project { root } => root,
+            Self::SingleFile { module_dir, .. } => module_dir,
+        }
+    }
+
+    /// Path for phases that accept either a file or a directory (TDG)
+    #[must_use]
+    pub fn file_or_root(&self) -> &Path {
+        match self {
+            Self::Project { root } => root,
+            Self::SingleFile { file, .. } => file,
+        }
+    }
+}
 
 /// Run complexity analysis - extracted from `list_all_violations` (complexity: ≤10)
 #[provable_contracts_macros::contract("pmat-core.yaml", equation = "path_exists")]
 pub async fn run_complexity_analysis(
     project_path: &Path,
     profile: &QualityProfile,
+    specific_file: Option<&Path>,
 ) -> Result<Vec<QualityViolation>> {
     use crate::cli::handlers::complexity_handlers::handle_analyze_complexity;
     use crate::cli::ComplexityOutputFormat;
@@ -18,9 +87,9 @@ pub async fn run_complexity_analysis(
 
     match handle_analyze_complexity(
         project_path.to_path_buf(),
-        None,   // file
-        vec![], // files
-        None,   // toolchain
+        specific_file.map(Path::to_path_buf), // file: restricts analysis to one file
+        vec![],                               // files
+        None,                                 // toolchain
         ComplexityOutputFormat::Json,
         None,                         // output
         Some(profile.complexity_max), // max_cyclomatic
@@ -253,4 +322,62 @@ pub async fn run_coverage_analysis(
     }
 
     Ok(violations)
+}
+
+#[cfg(test)]
+mod scope_tests {
+    use super::AnalysisScope;
+    use std::path::{Path, PathBuf};
+
+    #[test]
+    fn test_resolve_without_file_is_project_scope() {
+        let scope = AnalysisScope::resolve(Path::new("/proj"), None);
+        assert_eq!(
+            scope,
+            AnalysisScope::Project {
+                root: PathBuf::from("/proj")
+            }
+        );
+        assert_eq!(scope.single_file(), None);
+        assert_eq!(scope.walk_root(), Path::new("/proj"));
+        assert_eq!(scope.file_or_root(), Path::new("/proj"));
+    }
+
+    #[test]
+    fn test_resolve_relative_file_joins_project_root() {
+        let scope =
+            AnalysisScope::resolve(Path::new("/proj"), Some(Path::new("src/utils/scratch.rs")));
+        assert_eq!(
+            scope.single_file(),
+            Some(Path::new("/proj/src/utils/scratch.rs"))
+        );
+        // Directory-walk phases are scoped to the parent module, not the project root
+        assert_eq!(scope.walk_root(), Path::new("/proj/src/utils"));
+        assert_eq!(
+            scope.file_or_root(),
+            Path::new("/proj/src/utils/scratch.rs")
+        );
+    }
+
+    #[test]
+    fn test_resolve_absolute_file_kept_as_is() {
+        let scope = AnalysisScope::resolve(Path::new("/proj"), Some(Path::new("/other/lib.rs")));
+        assert_eq!(scope.single_file(), Some(Path::new("/other/lib.rs")));
+        assert_eq!(scope.walk_root(), Path::new("/other"));
+    }
+
+    #[test]
+    fn test_resolve_bare_filename_uses_project_root_as_module_dir() {
+        let scope = AnalysisScope::resolve(Path::new("/proj"), Some(Path::new("main.rs")));
+        assert_eq!(scope.single_file(), Some(Path::new("/proj/main.rs")));
+        assert_eq!(scope.walk_root(), Path::new("/proj"));
+    }
+
+    #[test]
+    fn test_resolve_empty_parent_falls_back_to_project_root() {
+        // Empty project root + bare filename → joined path has an empty parent
+        let scope = AnalysisScope::resolve(Path::new(""), Some(Path::new("scratch.rs")));
+        assert_eq!(scope.walk_root(), Path::new(""));
+        assert_eq!(scope.single_file(), Some(Path::new("scratch.rs")));
+    }
 }

--- a/src/cli/handlers/enforce_handlers/enforcement.rs
+++ b/src/cli/handlers/enforce_handlers/enforcement.rs
@@ -3,7 +3,7 @@
 
 use super::analysis::{
     run_complexity_analysis, run_coverage_analysis, run_dead_code_analysis,
-    run_duplication_analysis, run_satd_analysis, run_tdg_analysis,
+    run_duplication_analysis, run_satd_analysis, run_tdg_analysis, AnalysisScope,
 };
 use super::config::EnforcementConfig;
 use super::output::{
@@ -32,16 +32,17 @@ pub async fn handle_special_modes(
     profile: &QualityProfile,
     format: EnforceOutputFormat,
     ci_mode: bool,
+    specific_file: Option<&PathBuf>,
 ) -> Result<Option<Result<()>>> {
     if list_violations {
         return Ok(Some(
-            list_all_violations(project_path, profile, format).await,
+            list_all_violations(project_path, profile, format, specific_file).await,
         ));
     }
 
     if validate_only {
         return Ok(Some(
-            validate_current_state(project_path, profile, format, ci_mode).await,
+            validate_current_state(project_path, profile, format, ci_mode, specific_file).await,
         ));
     }
 
@@ -288,36 +289,46 @@ async fn list_all_violations(
     project_path: &Path,
     profile: &QualityProfile,
     format: EnforceOutputFormat,
+    specific_file: Option<&PathBuf>,
 ) -> Result<()> {
     eprintln!("{}", c::header("Listing all quality violations..."));
 
-    let project_path_buf = project_path.to_path_buf();
+    let scope = AnalysisScope::resolve(project_path, specific_file.map(PathBuf::as_path));
+    if let AnalysisScope::SingleFile { module_dir, .. } = &scope {
+        // Directory-walk phases cannot target a lone file
+        eprintln!(
+            "  {} Single-file mode: SATD/dead-code/duplication scoped to parent module {}",
+            c::dim(">>"),
+            module_dir.display()
+        );
+    }
+
     let mut all_violations: Vec<QualityViolation> = Vec::new();
 
     // Run all analyses using extracted functions - COMPLEXITY REDUCED FROM 48 TO ≤10
     eprintln!("  {} Analyzing complexity...", c::dim(">>"));
-    let complexity_violations = run_complexity_analysis(&project_path_buf, profile).await?;
+    let complexity_violations =
+        run_complexity_analysis(scope.walk_root(), profile, scope.single_file()).await?;
     all_violations.extend(complexity_violations);
 
     eprintln!("  {} Analyzing technical debt (SATD)...", c::dim(">>"));
-    let satd_violations = run_satd_analysis(&project_path_buf, profile).await?;
+    let satd_violations = run_satd_analysis(scope.walk_root(), profile).await?;
     all_violations.extend(satd_violations);
 
     eprintln!("  {} Analyzing technical debt gradient...", c::dim(">>"));
-    let tdg_violations = run_tdg_analysis(project_path_buf.as_path(), profile).await?;
+    let tdg_violations = run_tdg_analysis(scope.file_or_root(), profile).await?;
     all_violations.extend(tdg_violations);
 
     eprintln!("  {} Analyzing dead code...", c::dim(">>"));
-    let dead_code_violations = run_dead_code_analysis(project_path_buf.as_path(), profile).await?;
+    let dead_code_violations = run_dead_code_analysis(scope.walk_root(), profile).await?;
     all_violations.extend(dead_code_violations);
 
     eprintln!("  {} Analyzing code duplication...", c::dim(">>"));
-    let duplication_violations =
-        run_duplication_analysis(project_path_buf.as_path(), profile).await?;
+    let duplication_violations = run_duplication_analysis(scope.walk_root(), profile).await?;
     all_violations.extend(duplication_violations);
 
     eprintln!("  {} Checking test coverage...", c::dim(">>"));
-    let coverage_violations = run_coverage_analysis(project_path_buf.as_path(), profile).await?;
+    let coverage_violations = run_coverage_analysis(scope.walk_root(), profile).await?;
     all_violations.extend(coverage_violations);
 
     eprintln!(
@@ -339,6 +350,7 @@ async fn validate_current_state(
     profile: &QualityProfile,
     format: EnforceOutputFormat,
     ci_mode: bool,
+    specific_file: Option<&PathBuf>,
 ) -> Result<()> {
     eprintln!("{}", c::label("Validating current quality state..."));
 
@@ -347,12 +359,12 @@ async fn validate_current_state(
         project_path,
         profile,
         EnforcementState::Analyzing,
-        false, // single_file_mode
-        true,  // dry_run
-        false, // apply_suggestions
-        None,  // specific_file
-        None,  // include_pattern
-        None,  // exclude_pattern
+        specific_file.is_some(), // single_file_mode
+        true,                    // dry_run
+        false,                   // apply_suggestions
+        specific_file,
+        None, // include_pattern
+        None, // exclude_pattern
     )
     .await?;
 

--- a/src/cli/handlers/enforce_handlers/handler.rs
+++ b/src/cli/handlers/enforce_handlers/handler.rs
@@ -101,6 +101,7 @@ async fn handle_enforce_extreme(
         &profile,
         format,
         ci_mode,
+        specific_file.as_ref(),
     )
     .await?
     {

--- a/src/cli/handlers/enforce_handlers/mod.rs
+++ b/src/cli/handlers/enforce_handlers/mod.rs
@@ -18,7 +18,7 @@ mod tests;
 // Re-export public API
 pub use analysis::{
     run_complexity_analysis, run_coverage_analysis, run_dead_code_analysis,
-    run_duplication_analysis, run_satd_analysis, run_tdg_analysis,
+    run_duplication_analysis, run_satd_analysis, run_tdg_analysis, AnalysisScope,
 };
 pub use config::{
     clear_enforcement_cache, initialize_enforcement_environment, load_quality_profile,

--- a/src/cli/handlers/enforce_handlers/states.rs
+++ b/src/cli/handlers/enforce_handlers/states.rs
@@ -4,7 +4,9 @@
 //! Contains the handlers for each enforcement state:
 //! Analyzing, Violating, Refactoring, Validating, Complete
 
-use super::analysis::{run_complexity_analysis, run_satd_analysis, run_tdg_analysis};
+use super::analysis::{
+    run_complexity_analysis, run_satd_analysis, run_tdg_analysis, AnalysisScope,
+};
 use super::types::{
     EnforcementProgress, EnforcementResult, EnforcementState, QualityProfile, QualityViolation,
 };
@@ -19,15 +21,29 @@ pub async fn handle_analyzing_state(
     project_path: &Path,
     profile: &QualityProfile,
     single_file_mode: bool,
-    _dry_run: bool,
+    dry_run: bool,
     specific_file: Option<&PathBuf>,
 ) -> Result<EnforcementResult> {
+    let scope = AnalysisScope::resolve(project_path, specific_file.map(PathBuf::as_path));
+
+    // SATD walks a directory tree and cannot target a lone file; surface the
+    // parent-module fallback so --dry-run output is honest about scope
+    if dry_run {
+        if let AnalysisScope::SingleFile { module_dir, .. } = &scope {
+            eprintln!(
+                "📍 Single-file mode: SATD scoped to parent module {}",
+                module_dir.display()
+            );
+        }
+    }
+
     let mut violations = Vec::new();
 
-    // Run all analyses in sequence
-    let complexity_violations = run_complexity_analysis(project_path, profile).await?;
-    let satd_violations = run_satd_analysis(project_path, profile).await?;
-    let tdg_violations = run_tdg_analysis(project_path, profile).await?;
+    // Run all analyses in sequence, each scoped per-phase when --file is given
+    let complexity_violations =
+        run_complexity_analysis(scope.walk_root(), profile, scope.single_file()).await?;
+    let satd_violations = run_satd_analysis(scope.walk_root(), profile).await?;
+    let tdg_violations = run_tdg_analysis(scope.file_or_root(), profile).await?;
 
     violations.extend(complexity_violations);
     violations.extend(satd_violations);

--- a/src/cli/handlers/oracle_handlers_commands.rs
+++ b/src/cli/handlers/oracle_handlers_commands.rs
@@ -1,3 +1,21 @@
+/// Whether decorative banners/progress lines may be printed to stdout.
+///
+/// In JSON mode stdout must contain ONLY the JSON payload (jq-parseable),
+/// so banners are suppressed.
+fn banner_enabled(format: OracleOutputFormat) -> bool {
+    format != OracleOutputFormat::Json
+}
+
+/// Print the "results written" confirmation; stderr in JSON mode to keep
+/// stdout reserved for the payload.
+fn notify_results_written(output_path: &Path, format: OracleOutputFormat) {
+    if banner_enabled(format) {
+        println!("✅ Results written to: {}", output_path.display());
+    } else {
+        eprintln!("✅ Results written to: {}", output_path.display());
+    }
+}
+
 /// Handle `pmat oracle fix` - Run PDCA fix loop
 async fn handle_oracle_fix(
     path: &Path,
@@ -8,17 +26,19 @@ async fn handle_oracle_fix(
     format: OracleOutputFormat,
     output: Option<&Path>,
 ) -> Result<()> {
-    println!("🔮 PMAT Oracle - PDCA Quality Improvement Loop");
-    println!("   Path: {}", path.display());
-    println!("   Max iterations: {}", max_iterations);
-    println!(
-        "   Thresholds: auto={:.2}, review={:.2}",
-        auto_apply_threshold, review_threshold
-    );
-    if dry_run {
-        println!("   Mode: DRY RUN (no changes will be applied)");
+    if banner_enabled(format) {
+        println!("🔮 PMAT Oracle - PDCA Quality Improvement Loop");
+        println!("   Path: {}", path.display());
+        println!("   Max iterations: {}", max_iterations);
+        println!(
+            "   Thresholds: auto={:.2}, review={:.2}",
+            auto_apply_threshold, review_threshold
+        );
+        if dry_run {
+            println!("   Mode: DRY RUN (no changes will be applied)");
+        }
+        println!();
     }
-    println!();
 
     // Validate path
     if !path.exists() {
@@ -38,14 +58,18 @@ async fn handle_oracle_fix(
     let pdca = PdcaLoop::with_config(config, targets.clone());
 
     if dry_run {
-        println!("🔍 Dry run: Collecting signals only...\n");
+        if banner_enabled(format) {
+            println!("🔍 Dry run: Collecting signals only...\n");
+        }
         // Just run one iteration without applying fixes
         let results = pdca.run_iterations(path, 1).await?;
         if let Some(result) = results.first() {
             format_iteration_result(result, &format, output)?;
         }
     } else {
-        println!("🚀 Starting PDCA loop...\n");
+        if banner_enabled(format) {
+            println!("🚀 Starting PDCA loop...\n");
+        }
         let results = pdca.run(path).await?;
 
         // Format and output results
@@ -53,7 +77,7 @@ async fn handle_oracle_fix(
 
         if let Some(output_path) = output {
             std::fs::write(output_path, &formatted)?;
-            println!("✅ Results written to: {}", output_path.display());
+            notify_results_written(output_path, format);
         } else {
             println!("{}", formatted);
         }
@@ -64,9 +88,11 @@ async fn handle_oracle_fix(
 
 /// Handle `pmat oracle status` - Show current quality status
 async fn handle_oracle_status(path: &Path, format: OracleOutputFormat) -> Result<()> {
-    println!("📊 PMAT Oracle - Project Quality Status");
-    println!("   Path: {}", path.display());
-    println!();
+    if banner_enabled(format) {
+        println!("📊 PMAT Oracle - Project Quality Status");
+        println!("   Path: {}", path.display());
+        println!();
+    }
 
     // Validate path
     if !path.exists() {
@@ -91,9 +117,11 @@ async fn handle_oracle_single(
     format: OracleOutputFormat,
     output: Option<&Path>,
 ) -> Result<()> {
-    println!("⚡ PMAT Oracle - Single PDCA Iteration");
-    println!("   Path: {}", path.display());
-    println!();
+    if banner_enabled(format) {
+        println!("⚡ PMAT Oracle - Single PDCA Iteration");
+        println!("   Path: {}", path.display());
+        println!();
+    }
 
     // Validate path
     if !path.exists() {
@@ -107,7 +135,7 @@ async fn handle_oracle_single(
 
     if let Some(output_path) = output {
         std::fs::write(output_path, &formatted)?;
-        println!("✅ Results written to: {}", output_path.display());
+        notify_results_written(output_path, format);
     } else {
         println!("{}", formatted);
     }

--- a/src/cli/handlers/oracle_handlers_tests.rs
+++ b/src/cli/handlers/oracle_handlers_tests.rs
@@ -25,6 +25,19 @@ mod tests {
         assert!(result.is_err());
     }
 
+    // ── banner_enabled: JSON mode must keep stdout jq-parseable ──
+
+    #[test]
+    fn test_banner_enabled_suppressed_for_json() {
+        assert!(!banner_enabled(OracleOutputFormat::Json));
+    }
+
+    #[test]
+    fn test_banner_enabled_for_human_formats() {
+        assert!(banner_enabled(OracleOutputFormat::Text));
+        assert!(banner_enabled(OracleOutputFormat::Markdown));
+    }
+
     #[test]
     fn test_format_pdca_json() {
         let results = vec![];

--- a/src/cli/handlers/qdd_handlers.rs
+++ b/src/cli/handlers/qdd_handlers.rs
@@ -7,7 +7,7 @@ use crate::cli::commands::{QddCodeType, QddCommands, QddOutputFormat, QddQuality
 use crate::qdd::{
     CodeType, CreateSpec, Parameter, QddOperation, QddResult, QddTool, QualityProfile, RefactorSpec,
 };
-use anyhow::Result;
+use anyhow::{Context, Result};
 use std::path::{Path, PathBuf};
 
 /// Handle QDD CLI commands
@@ -395,9 +395,92 @@ async fn handle_qdd_validate(
         QddQualityProfile::Standard => QualityProfile::standard(),
         QddQualityProfile::Relaxed => QualityProfile::relaxed(),
     };
+    let is_json = matches!(format, QddOutputFormat::Json);
 
-    // For now, implement as a simple quality check
-    // In a full implementation, this would use the QDD validation engine
+    // JSON mode must keep stdout pure (jq-parseable): header goes to humans only
+    if !is_json {
+        print_validation_header(&path, profile, &quality_profile);
+    }
+
+    // Simple validation placeholder
+    let validation_passed = true; // Would implement actual validation
+
+    match format {
+        QddOutputFormat::Summary => {
+            println!("\n{}", c::subheader("Validation Summary:"));
+            println!(
+                "{}",
+                if validation_passed {
+                    c::pass("PASSED")
+                } else {
+                    c::fail("FAILED")
+                }
+            );
+        }
+        QddOutputFormat::Detailed => {
+            println!("\n{}", c::subheader("Detailed Validation Results:"));
+            println!("{}", c::pass("Quality checks: PASSED"));
+            println!("{}", c::pass("Complexity check: PASSED"));
+            println!("{}", c::pass("Coverage check: PASSED"));
+            println!("{}", c::pass("Technical debt: PASSED"));
+        }
+        QddOutputFormat::Json => {
+            let json_result = build_validation_json(validation_passed, profile, &path);
+            println!("{}", serde_json::to_string_pretty(&json_result)?);
+        }
+        QddOutputFormat::Markdown => {
+            println!("# QDD Validation Report");
+            println!();
+            println!(
+                "**Status:** {}",
+                if validation_passed {
+                    "✅ PASSED"
+                } else {
+                    "❌ FAILED"
+                }
+            );
+            println!("**Profile:** {profile:?}");
+            println!("**Path:** {}", path.display());
+            println!(
+                "**Date:** {}",
+                chrono::Utc::now().format("%Y-%m-%d %H:%M:%S UTC")
+            );
+        }
+    }
+
+    if let Some(output_path) = output {
+        // Write the report before claiming it was written
+        let report = serde_json::to_string_pretty(&build_validation_json(
+            validation_passed,
+            profile,
+            &path,
+        ))?;
+        std::fs::write(&output_path, report)
+            .with_context(|| format!("Failed to write report: {}", output_path.display()))?;
+        let message = c::pass(&format!(
+            "Validation report written to: {}",
+            c::path(&output_path.display().to_string())
+        ));
+        if is_json {
+            eprintln!("{message}");
+        } else {
+            println!("\n{message}");
+        }
+    }
+
+    if strict && !validation_passed {
+        return Err(anyhow::anyhow!("Quality validation failed (strict mode)"));
+    }
+
+    Ok(())
+}
+
+/// Print the validation header and thresholds (human formats only)
+fn print_validation_header(
+    path: &Path,
+    profile: QddQualityProfile,
+    quality_profile: &QualityProfile,
+) {
     println!("{}", c::header("QDD Quality Validation"));
     println!(
         "  {} {}",
@@ -426,73 +509,20 @@ async fn handle_qdd_validate(
         c::label("Zero SATD:"),
         c::number(&format!("{}", quality_profile.thresholds.zero_satd))
     );
+}
 
-    // Simple validation placeholder
-    let validation_passed = true; // Would implement actual validation
-
-    match format {
-        QddOutputFormat::Summary => {
-            println!("\n{}", c::subheader("Validation Summary:"));
-            println!(
-                "{}",
-                if validation_passed {
-                    c::pass("PASSED")
-                } else {
-                    c::fail("FAILED")
-                }
-            );
-        }
-        QddOutputFormat::Detailed => {
-            println!("\n{}", c::subheader("Detailed Validation Results:"));
-            println!("{}", c::pass("Quality checks: PASSED"));
-            println!("{}", c::pass("Complexity check: PASSED"));
-            println!("{}", c::pass("Coverage check: PASSED"));
-            println!("{}", c::pass("Technical debt: PASSED"));
-        }
-        QddOutputFormat::Json => {
-            let json_result = serde_json::json!({
-                "status": if validation_passed { "passed" } else { "failed" },
-                "profile": format!("{profile:?}").to_lowercase(),
-                "path": path.display().to_string(),
-                "validation_time": chrono::Utc::now().to_rfc3339()
-            });
-            println!("{}", serde_json::to_string_pretty(&json_result)?);
-        }
-        QddOutputFormat::Markdown => {
-            println!("# QDD Validation Report");
-            println!();
-            println!(
-                "**Status:** {}",
-                if validation_passed {
-                    "✅ PASSED"
-                } else {
-                    "❌ FAILED"
-                }
-            );
-            println!("**Profile:** {profile:?}");
-            println!("**Path:** {}", path.display());
-            println!(
-                "**Date:** {}",
-                chrono::Utc::now().format("%Y-%m-%d %H:%M:%S UTC")
-            );
-        }
-    }
-
-    if let Some(output_path) = output {
-        println!(
-            "\n{}",
-            c::pass(&format!(
-                "Validation report written to: {}",
-                c::path(&output_path.display().to_string())
-            ))
-        );
-    }
-
-    if strict && !validation_passed {
-        return Err(anyhow::anyhow!("Quality validation failed (strict mode)"));
-    }
-
-    Ok(())
+/// Build the JSON payload for validation results (stdout in JSON mode is this payload only)
+fn build_validation_json(
+    validation_passed: bool,
+    profile: QddQualityProfile,
+    path: &Path,
+) -> serde_json::Value {
+    serde_json::json!({
+        "status": if validation_passed { "passed" } else { "failed" },
+        "profile": format!("{profile:?}").to_lowercase(),
+        "path": path.display().to_string(),
+        "validation_time": chrono::Utc::now().to_rfc3339()
+    })
 }
 
 // Tests extracted to qdd_handlers_tests.rs for file health (CB-040).

--- a/src/cli/handlers/qdd_handlers_tests.rs
+++ b/src/cli/handlers/qdd_handlers_tests.rs
@@ -1173,6 +1173,46 @@ mod coverage_tests {
         }
     }
 
+    // ===============================================================
+    // Tests for build_validation_json (JSON purity)
+    // ===============================================================
+
+    #[test]
+    fn test_build_validation_json_passed() {
+        let path = PathBuf::from("src/utils/scratch.rs");
+        let json = build_validation_json(true, QddQualityProfile::Standard, &path);
+
+        assert_eq!(json["status"], "passed");
+        assert_eq!(json["profile"], "standard");
+        assert_eq!(json["path"], "src/utils/scratch.rs");
+        assert!(json["validation_time"].is_string());
+    }
+
+    #[test]
+    fn test_build_validation_json_failed() {
+        let path = PathBuf::from("/some/dir");
+        let json = build_validation_json(false, QddQualityProfile::Extreme, &path);
+
+        assert_eq!(json["status"], "failed");
+        assert_eq!(json["profile"], "extreme");
+        assert_eq!(json["path"], "/some/dir");
+    }
+
+    #[test]
+    fn test_build_validation_json_pretty_output_is_pure_json() {
+        // Stdout in JSON mode is exactly this pretty-printed payload: it must
+        // start with '{' (no ANSI header) and round-trip through a JSON parser.
+        let path = PathBuf::from(".");
+        let json = build_validation_json(true, QddQualityProfile::Relaxed, &path);
+        let pretty = serde_json::to_string_pretty(&json).unwrap();
+
+        assert!(pretty.starts_with('{'));
+        assert!(!pretty.contains('\x1b'));
+        let reparsed: serde_json::Value = serde_json::from_str(&pretty).unwrap();
+        assert_eq!(reparsed["profile"], "relaxed");
+    }
+
+
     #[tokio::test]
     async fn test_handle_qdd_validate_all_formats() {
         let temp_dir = TempDir::new().unwrap();

--- a/src/cli/handlers/query_handler/indexing.rs
+++ b/src/cli/handlers/query_handler/indexing.rs
@@ -19,23 +19,59 @@ pub(super) fn load_query_index(
     // Fast path: if no --include-project, check if workspace cache is fresh
     // and load it, otherwise load local-only (skip expensive sibling discovery)
     if include_project.is_empty() && !rebuild_index {
-        // Try cached workspace first (O(1) mtime check)
         let siblings = AgentContextIndex::discover_sibling_indexes(project_path);
-        if !siblings.is_empty() && is_workspace_cache_fresh(&workspace_idx, &siblings, &index_path)
+        if let Some(cached) =
+            try_load_fresh_workspace_cache(&workspace_idx, &siblings, &index_path, quiet)
         {
-            if !quiet {
-                eprintln!("Loading cached workspace index...");
-            }
-            if let Ok(cached) = AgentContextIndex::load(&workspace_idx) {
-                return Ok(cached);
-            }
+            return Ok(cached);
         }
         // No fresh cache — load local only for speed, merge lazily
         return load_or_build_index(project_path, &index_path, false, quiet);
     }
 
     let mut siblings = AgentContextIndex::discover_sibling_indexes(project_path);
+    extend_siblings_with_includes(&mut siblings, include_project, quiet);
 
+    if !rebuild_index {
+        if let Some(cached) =
+            try_load_fresh_workspace_cache(&workspace_idx, &siblings, &index_path, quiet)
+        {
+            return Ok(cached);
+        }
+    }
+
+    load_and_merge_index(
+        project_path,
+        &index_path,
+        &workspace_idx,
+        &siblings,
+        rebuild_index,
+        quiet,
+    )
+}
+
+/// Load the cached workspace index if it exists and is fresh (O(1) mtime check)
+fn try_load_fresh_workspace_cache(
+    workspace_idx: &std::path::Path,
+    siblings: &[(PathBuf, String)],
+    index_path: &std::path::Path,
+    quiet: bool,
+) -> Option<AgentContextIndex> {
+    if siblings.is_empty() || !is_workspace_cache_fresh(workspace_idx, siblings, index_path) {
+        return None;
+    }
+    if !quiet {
+        eprintln!("Loading cached workspace index...");
+    }
+    AgentContextIndex::load(workspace_idx).ok()
+}
+
+/// Add explicitly-included projects to the sibling list (deduplicated)
+fn extend_siblings_with_includes(
+    siblings: &mut Vec<(PathBuf, String)>,
+    include_project: &[PathBuf],
+    quiet: bool,
+) {
     for project in include_project {
         let idx_path = project.join(".pmat/context.idx");
         if idx_path.exists() {
@@ -53,27 +89,6 @@ pub(super) fn load_query_index(
             );
         }
     }
-
-    if !siblings.is_empty()
-        && !rebuild_index
-        && is_workspace_cache_fresh(&workspace_idx, &siblings, &index_path)
-    {
-        if !quiet {
-            eprintln!("Loading cached workspace index...");
-        }
-        if let Ok(cached) = AgentContextIndex::load(&workspace_idx) {
-            return Ok(cached);
-        }
-    }
-
-    load_and_merge_index(
-        project_path,
-        &index_path,
-        &workspace_idx,
-        &siblings,
-        rebuild_index,
-        quiet,
-    )
 }
 
 /// Pre-load source and call graph into the index based on the query mode.
@@ -130,13 +145,15 @@ pub(super) fn collect_siblings(
 /// In deferred-source mode, `QueryResult.source` is `Some("")` (empty) for
 /// semantic queries. This fetches source on-demand for the top N results
 /// that need it for display (--include-source, --code, context lines).
+///
+/// No db_path guard here: `load_source_for()` already falls back from
+/// in-memory to SQLite to filesystem, and an early return on a missing
+/// db_path silently broke `--include-source` after incremental updates
+/// (which used to drop the db_path).
 pub(super) fn backfill_results_source(
     results: &mut [crate::services::agent_context::QueryResult],
     index: &AgentContextIndex,
 ) {
-    if index.db_path().is_none() {
-        return; // Blob-loaded index already has source
-    }
     for r in results.iter_mut() {
         // Skip results that already have non-empty source
         if r.source.as_ref().is_some_and(|s| !s.is_empty()) {
@@ -173,8 +190,8 @@ fn try_incremental_update(
         eprintln!("Checking for incremental updates...");
     }
     match AgentContextIndex::build_incremental(project_path, &existing) {
-        Ok(updated) => {
-            maybe_save_incremental(&updated, index_path, quiet);
+        Ok(mut updated) => {
+            maybe_save_incremental(&mut updated, index_path, quiet);
             updated
         }
         Err(_) => existing,
@@ -183,7 +200,14 @@ fn try_incremental_update(
 
 /// Save the index only when changes exceed 50 files or 5% of index size.
 /// Avoids rewriting 660MB SQLite for a handful of changes (#212).
-fn maybe_save_incremental(index: &AgentContextIndex, index_path: &PathBuf, quiet: bool) {
+///
+/// Before saving, backfills deferred (empty) source for checksum-reused
+/// entries: they were cloned from a lightweight SQLite load, and rewriting
+/// the DB without their source would persist `source=''` for every reused
+/// row, converging the index to all-empty source (the source-wipe bug).
+/// The backfill is guarded by the save threshold so pure-read queries keep
+/// their lazy-load performance.
+fn maybe_save_incremental(index: &mut AgentContextIndex, index_path: &PathBuf, quiet: bool) {
     let changes = index.manifest().last_incremental_changes;
     if changes == 0 {
         return;
@@ -198,6 +222,8 @@ fn maybe_save_incremental(index: &AgentContextIndex, index_path: &PathBuf, quiet
         if !quiet {
             eprintln!("Saving index ({} changes)...", changes);
         }
+        // Must run before save(): it reads the old DB this save overwrites.
+        index.load_all_source();
         let _ = index.save(index_path);
     } else if !quiet {
         eprintln!("Skipping save ({} minor changes)", changes);
@@ -370,4 +396,100 @@ fn build_and_save_index(
     }
 
     Ok(index)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::agent_context::function_index::sqlite_backend;
+
+    fn write_file(root: &std::path::Path, rel: &str, content: &str) {
+        let path = root.join(rel);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, content).unwrap();
+    }
+
+    fn build_and_save(project: &std::path::Path) -> PathBuf {
+        let index_path = project.join(".pmat/context.idx");
+        std::fs::create_dir_all(index_path.parent().unwrap()).unwrap();
+        let built = AgentContextIndex::build(project).unwrap();
+        built.save(&index_path).unwrap();
+        index_path
+    }
+
+    /// Regression (source wipe): an incremental update that crosses the save
+    /// threshold must not rewrite the database with empty source for
+    /// checksum-reused entries. Before the fix, every reused row persisted
+    /// with source='' and repeated saves converged the DB to all-empty.
+    #[test]
+    fn test_incremental_save_keeps_source_in_db() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let project = temp.path().to_path_buf();
+        write_file(&project, "src/a.rs", "fn alpha() { let a = 1; }\n");
+        write_file(&project, "src/b.rs", "fn beta() { let b = 2; }\n");
+        write_file(&project, "src/c.rs", "fn gamma() { let c = 3; }\n");
+        let index_path = build_and_save(&project);
+
+        let loaded = AgentContextIndex::load(&index_path).unwrap();
+
+        // Change 1/3 files: 1 reparse out of 4 functions (25% > 5% threshold)
+        write_file(
+            &project,
+            "src/c.rs",
+            "fn gamma() { let c = 30; }\nfn delta() { let d = 4; }\n",
+        );
+
+        let updated = try_incremental_update(&project, &index_path, loaded, true);
+        assert!(
+            updated.db_path().is_some(),
+            "incremental index must keep the db_path it loaded from"
+        );
+
+        let conn = sqlite_backend::open_db(&index_path.with_extension("db")).unwrap();
+        let rows = sqlite_backend::load_functions(&conn).unwrap();
+        assert_eq!(rows.len(), 4);
+        for row in &rows {
+            assert!(
+                !row.source.is_empty(),
+                "incremental save wiped source for '{}'",
+                row.function_name
+            );
+        }
+    }
+
+    /// Regression (Bug B): queries served right after an incremental update
+    /// must return non-empty source. The incremental build used to reset
+    /// db_path to None, so backfill_results_source early-returned and
+    /// --include-source / pmat_get_function returned source:"" even with a
+    /// healthy database on disk.
+    #[test]
+    fn test_backfill_results_source_after_incremental_update() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let project = temp.path().to_path_buf();
+        write_file(&project, "src/a.rs", "fn alpha() { let a = 1; }\n");
+        let index_path = build_and_save(&project);
+
+        let loaded = AgentContextIndex::load(&index_path).unwrap();
+
+        // No file changes: pure reuse pass, below save threshold, so the
+        // in-memory entries keep deferred (empty) source.
+        let updated = try_incremental_update(&project, &index_path, loaded, true);
+
+        let result = updated
+            .get_function("src/a.rs", "alpha")
+            .expect("alpha should be indexed");
+        let mut results = [result];
+        assert_eq!(
+            results[0].source.as_deref(),
+            Some(""),
+            "precondition: source is deferred after incremental update"
+        );
+
+        backfill_results_source(&mut results, &updated);
+        let source = results[0].source.as_deref().unwrap_or("");
+        assert!(
+            source.contains("alpha"),
+            "expected backfilled source, got {source:?}"
+        );
+    }
 }

--- a/src/cli/handlers/spec_falsify_handler.rs
+++ b/src/cli/handlers/spec_falsify_handler.rs
@@ -63,6 +63,7 @@ async fn handle_spec_falsification(
     failures_only: bool,
     dry_run: bool,
 ) -> Result<()> {
+    let json_output = matches!(format, Some("json"));
     let engine = crate::services::spec_falsification::FalsificationEngine::new(project_path);
 
     // Collect spec files
@@ -79,32 +80,11 @@ async fn handle_spec_falsification(
     let mut total_claims = 0usize;
     let mut total_falsified = 0usize;
     let mut all_reports = Vec::new();
+    let mut dry_run_claims = Vec::new();
 
     for spec_file in &spec_files {
         if dry_run {
-            // Dry run: extract claims only
-            let extractor = crate::services::spec_falsification::SpecClaimExtractor::new();
-            let content = std::fs::read_to_string(spec_file)
-                .with_context(|| format!("Failed to read: {}", spec_file.display()))?;
-            let claims = extractor.extract(&content, spec_file);
-            println!(
-                "{} {} -- {} claims extracted {}",
-                c::label("Spec:"),
-                c::path(&spec_file.display().to_string()),
-                c::number(&claims.len().to_string()),
-                c::dim("(dry run)")
-            );
-            for claim in &claims {
-                println!(
-                    "  [{}] {} {} (line {}): {}",
-                    c::label(&claim.id),
-                    claim.priority,
-                    claim.category,
-                    c::number(&claim.source_line.to_string()),
-                    c::dim(&truncate(&claim.original_text, 80)),
-                );
-            }
-            total_claims += claims.len();
+            total_claims += process_dry_run_spec(spec_file, json_output, &mut dry_run_claims)?;
             continue;
         }
 
@@ -112,63 +92,32 @@ async fn handle_spec_falsification(
         total_claims += report.summary.total_claims;
         total_falsified += report.summary.falsified;
 
-        match format {
-            Some("json") => {
-                let json = report.to_json()?;
-                println!("{}", json);
-            }
-            _ => {
-                if failures_only {
-                    print_failures_only(&report);
-                } else {
-                    report.display();
-                }
+        if !json_output {
+            if failures_only {
+                print_failures_only(&report);
+            } else {
+                report.display();
             }
         }
 
         all_reports.push(report);
     }
 
-    // Multi-spec summary
-    if spec_files.len() > 1 && !dry_run {
-        println!();
-        println!("{}", c::header("Multi-Spec Summary"));
-        println!(
-            "  {} {}",
-            c::label("Specs analyzed:"),
-            c::number(&spec_files.len().to_string())
-        );
-        println!(
-            "  {} {}",
-            c::label("Total claims:  "),
-            c::number(&total_claims.to_string())
-        );
-        println!(
-            "  {} {}",
-            c::label("Falsified:     "),
-            c::number(&total_falsified.to_string())
-        );
-        let health = if total_claims > 0 {
-            (total_claims - total_falsified) as f64 / total_claims as f64
+    // JSON mode: stdout carries exactly one jq-parseable document, no decoration
+    if json_output {
+        let doc = if dry_run {
+            dry_run_claims_to_json(&dry_run_claims)?
         } else {
-            1.0
+            reports_to_json(&all_reports, failures_only)?
         };
-        println!(
-            "  {} {}",
-            c::label("Health:        "),
-            c::pct(health * 100.0, 90.0, 70.0)
-        );
-    }
-
-    if dry_run {
-        println!();
-        println!(
-            "{} {} claims extracted across {} specs",
-            c::dim("Dry run complete:"),
-            c::number(&total_claims.to_string()),
-            c::number(&spec_files.len().to_string())
-        );
-        println!("Run without --dry-run to falsify claims against the codebase.");
+        println!("{doc}");
+    } else {
+        if spec_files.len() > 1 && !dry_run {
+            print_multi_spec_summary(spec_files.len(), total_claims, total_falsified);
+        }
+        if dry_run {
+            print_dry_run_footer(total_claims, spec_files.len());
+        }
     }
 
     // Exit with non-zero if any claims were falsified
@@ -181,6 +130,87 @@ async fn handle_spec_falsification(
     }
 
     Ok(())
+}
+
+/// Extract claims from one spec in dry-run mode; print them in human mode,
+/// collect them for the single JSON document otherwise. Returns claim count.
+fn process_dry_run_spec(
+    spec_file: &Path,
+    json_output: bool,
+    dry_run_claims: &mut Vec<(PathBuf, Vec<crate::services::spec_falsification::SpecClaim>)>,
+) -> Result<usize> {
+    let extractor = crate::services::spec_falsification::SpecClaimExtractor::new();
+    let content = std::fs::read_to_string(spec_file)
+        .with_context(|| format!("Failed to read: {}", spec_file.display()))?;
+    let claims = extractor.extract(&content, spec_file);
+    let count = claims.len();
+
+    if json_output {
+        dry_run_claims.push((spec_file.to_path_buf(), claims));
+        return Ok(count);
+    }
+
+    println!(
+        "{} {} -- {} claims extracted {}",
+        c::label("Spec:"),
+        c::path(&spec_file.display().to_string()),
+        c::number(&count.to_string()),
+        c::dim("(dry run)")
+    );
+    for claim in &claims {
+        println!(
+            "  [{}] {} {} (line {}): {}",
+            c::label(&claim.id),
+            claim.priority,
+            claim.category,
+            c::number(&claim.source_line.to_string()),
+            c::dim(&truncate(&claim.original_text, 80)),
+        );
+    }
+    Ok(count)
+}
+
+/// Human-format summary block for multi-spec full runs
+fn print_multi_spec_summary(spec_count: usize, total_claims: usize, total_falsified: usize) {
+    println!();
+    println!("{}", c::header("Multi-Spec Summary"));
+    println!(
+        "  {} {}",
+        c::label("Specs analyzed:"),
+        c::number(&spec_count.to_string())
+    );
+    println!(
+        "  {} {}",
+        c::label("Total claims:  "),
+        c::number(&total_claims.to_string())
+    );
+    println!(
+        "  {} {}",
+        c::label("Falsified:     "),
+        c::number(&total_falsified.to_string())
+    );
+    let health = if total_claims > 0 {
+        (total_claims - total_falsified) as f64 / total_claims as f64
+    } else {
+        1.0
+    };
+    println!(
+        "  {} {}",
+        c::label("Health:        "),
+        c::pct(health * 100.0, 90.0, 70.0)
+    );
+}
+
+/// Human-format trailer for dry runs
+fn print_dry_run_footer(total_claims: usize, spec_count: usize) {
+    println!();
+    println!(
+        "{} {} claims extracted across {} specs",
+        c::dim("Dry run complete:"),
+        c::number(&total_claims.to_string()),
+        c::number(&spec_count.to_string())
+    );
+    println!("Run without --dry-run to falsify claims against the codebase.");
 }
 
 /// Collect markdown spec files from a directory
@@ -239,6 +269,66 @@ fn print_failures_only(report: &crate::services::spec_falsification::SpecFalsifi
             if ev.contradiction_score >= 0.8 {
                 println!("    {} {} -> {}", c::fail(&ev.check), c::DIM, ev.finding);
             }
+        }
+    }
+}
+
+/// Serialize dry-run claim extraction to a single pretty-JSON document
+fn dry_run_claims_to_json(
+    specs: &[(PathBuf, Vec<crate::services::spec_falsification::SpecClaim>)],
+) -> Result<String> {
+    #[derive(serde::Serialize)]
+    struct SpecClaims<'a> {
+        spec: &'a Path,
+        claims: &'a [crate::services::spec_falsification::SpecClaim],
+    }
+    #[derive(serde::Serialize)]
+    struct DryRunOutput<'a> {
+        dry_run: bool,
+        total_claims: usize,
+        specs: Vec<SpecClaims<'a>>,
+    }
+    let output = DryRunOutput {
+        dry_run: true,
+        total_claims: specs.iter().map(|(_, claims)| claims.len()).sum(),
+        specs: specs
+            .iter()
+            .map(|(spec, claims)| SpecClaims { spec, claims })
+            .collect(),
+    };
+    serde_json::to_string_pretty(&output).context("Failed to serialize dry-run claims")
+}
+
+/// Serialize falsification reports to a single pretty-JSON document.
+///
+/// Single spec emits one report object (back-compat with prior JSON output);
+/// multiple specs emit an array. With `failures_only`, only Falsified verdicts
+/// are retained — summary counts still reflect the full run.
+fn reports_to_json(
+    reports: &[crate::services::spec_falsification::SpecFalsificationReport],
+    failures_only: bool,
+) -> Result<String> {
+    use crate::services::spec_falsification::VerdictStatus;
+
+    let filtered: Vec<_> = reports
+        .iter()
+        .map(|report| {
+            let mut report = report.clone();
+            if failures_only {
+                report
+                    .verdicts
+                    .retain(|v| v.status == VerdictStatus::Falsified);
+            }
+            report
+        })
+        .collect();
+
+    match filtered.as_slice() {
+        // Delegate so the single-report shape has exactly one serialization
+        // path (SpecFalsificationReport::to_json)
+        [single] => single.to_json(),
+        many => {
+            serde_json::to_string_pretty(many).context("Failed to serialize falsification reports")
         }
     }
 }
@@ -356,5 +446,111 @@ mod spec_falsify_helper_tests {
         let nonexistent = std::path::PathBuf::from("/nonexistent/path/that/should/not/exist");
         let result = collect_spec_files(&nonexistent);
         assert!(result.is_err());
+    }
+
+    // ── JSON output (--format json) ─────────────────────────────────────────
+
+    use crate::services::spec_falsification::{
+        ClaimPriority, SpecClaim, SpecClaimCategory, SpecFalsificationReport,
+        SpecFalsificationSummary, SpecVerdict, VerdictStatus,
+    };
+
+    fn sample_claim(id: &str) -> SpecClaim {
+        SpecClaim {
+            id: id.to_string(),
+            original_text: "The parser MUST handle UTF-8".to_string(),
+            source_line: 10,
+            category: SpecClaimCategory::CodeEntity,
+            priority: ClaimPriority::P0Critical,
+            is_absolute: false,
+            path_refs: vec![],
+            entity_refs: vec![],
+            numeric_value: None,
+            numeric_comparator: None,
+        }
+    }
+
+    fn sample_report() -> SpecFalsificationReport {
+        SpecFalsificationReport {
+            target_file: PathBuf::from("spec.md"),
+            timestamp: "2026-06-12T00:00:00Z".to_string(),
+            verdicts: vec![
+                SpecVerdict {
+                    claim: sample_claim("SPEC-001"),
+                    status: VerdictStatus::Survived,
+                    evidence: vec![],
+                    contradiction_score: 0.0,
+                },
+                SpecVerdict {
+                    claim: sample_claim("SPEC-002"),
+                    status: VerdictStatus::Falsified,
+                    evidence: vec![],
+                    contradiction_score: 1.0,
+                },
+            ],
+            summary: SpecFalsificationSummary {
+                total_claims: 2,
+                survived: 1,
+                falsified: 1,
+                unfalsifiable: 0,
+                inconclusive: 0,
+                health_score: 0.5,
+            },
+        }
+    }
+
+    #[test]
+    fn test_dry_run_claims_to_json_is_parseable_with_totals() {
+        let specs = vec![
+            (PathBuf::from("a.md"), vec![sample_claim("SPEC-001")]),
+            (
+                PathBuf::from("b.md"),
+                vec![sample_claim("SPEC-002"), sample_claim("SPEC-003")],
+            ),
+        ];
+        let json = dry_run_claims_to_json(&specs).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["dry_run"], true);
+        assert_eq!(parsed["total_claims"], 3);
+        assert_eq!(parsed["specs"].as_array().unwrap().len(), 2);
+        assert_eq!(parsed["specs"][1]["claims"][0]["id"], "SPEC-002");
+        assert_eq!(parsed["specs"][1]["claims"][0]["source_line"], 10);
+    }
+
+    #[test]
+    fn test_dry_run_claims_to_json_empty_specs() {
+        let json = dry_run_claims_to_json(&[]).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["total_claims"], 0);
+        assert!(parsed["specs"].as_array().unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_reports_to_json_single_report_emits_object() {
+        // PIN: single spec emits one report object, not a 1-element array (back-compat).
+        let json = reports_to_json(&[sample_report()], false).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert!(parsed.is_object());
+        assert_eq!(parsed["summary"]["total_claims"], 2);
+        assert_eq!(parsed["verdicts"].as_array().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn test_reports_to_json_multiple_reports_emit_array() {
+        let json = reports_to_json(&[sample_report(), sample_report()], false).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert!(parsed.is_array());
+        assert_eq!(parsed.as_array().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn test_reports_to_json_failures_only_filters_verdicts() {
+        let json = reports_to_json(&[sample_report()], true).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let verdicts = parsed["verdicts"].as_array().unwrap();
+        assert_eq!(verdicts.len(), 1);
+        assert_eq!(verdicts[0]["status"], "Falsified");
+        // PIN: summary still reflects the full run, not the filtered view.
+        assert_eq!(parsed["summary"]["total_claims"], 2);
     }
 }

--- a/src/cli/handlers/tdg_handlers/baseline.rs
+++ b/src/cli/handlers/tdg_handlers/baseline.rs
@@ -10,6 +10,32 @@ use crate::tdg::TdgAnalyzer;
 use anyhow::Result;
 use std::path::{Path, PathBuf};
 
+/// True when the format owns stdout exclusively: JSON output must stay
+/// jq-parseable, so decorative/progress lines are diverted to stderr.
+pub(super) fn json_exclusive_stdout(format: &crate::cli::TdgOutputFormat) -> bool {
+    matches!(format, crate::cli::TdgOutputFormat::Json)
+}
+
+/// Print a decorative/progress line: stdout for human formats, stderr when
+/// `quiet` (JSON mode) so the JSON payload on stdout stays jq-parseable.
+macro_rules! decor {
+    ($quiet:expr) => {
+        if $quiet {
+            eprintln!();
+        } else {
+            println!();
+        }
+    };
+    ($quiet:expr, $($arg:tt)*) => {
+        if $quiet {
+            eprintln!($($arg)*);
+        } else {
+            println!($($arg)*);
+        }
+    };
+}
+pub(super) use decor;
+
 /// Handle TDG baseline subcommand (Sprint 66 Phase 1)
 pub(super) async fn handle_baseline_command(
     command: crate::cli::commands::BaselineCommand,
@@ -24,7 +50,10 @@ pub(super) async fn handle_baseline_command(
             output,
             with_git_context,
             name,
-        } => create_baseline(_analyzer, &path, &output, with_git_context, name).await,
+        } => {
+            // Create has no --format flag; always human-mode output
+            create_baseline(_analyzer, &path, &output, with_git_context, name, false).await
+        }
 
         BaselineCommand::Compare {
             baseline,
@@ -47,13 +76,15 @@ pub(super) async fn handle_baseline_command(
 fn extract_git_context(
     path: &Path,
     with_git_context: bool,
+    quiet: bool,
 ) -> Option<crate::models::git_context::GitContext> {
     if !with_git_context {
         return None;
     }
     match crate::models::git_context::GitContext::try_from_current_dir(path) {
         Some(ctx) => {
-            println!(
+            decor!(
+                quiet,
                 "   {} {} on {}",
                 c::label("Git:"),
                 c::number(&ctx.commit_sha_short),
@@ -62,7 +93,8 @@ fn extract_git_context(
             Some(ctx)
         }
         None => {
-            println!(
+            decor!(
+                quiet,
                 "   {}",
                 c::warn("Not in a git repository, git context unavailable")
             );
@@ -85,63 +117,76 @@ pub(super) fn ephemeral_temp_json(prefix: &str) -> PathBuf {
 }
 
 /// Create a new TDG baseline for the project (Sprint 66 Phase 1)
+///
+/// `quiet` diverts all progress output to stderr so JSON-mode callers
+/// (compare/check-regression/check-quality) keep stdout jq-parseable.
 pub(super) async fn create_baseline(
     analyzer: &TdgAnalyzer,
     path: &Path,
     output: &Path,
     with_git_context: bool,
     name: Option<String>,
+    quiet: bool,
 ) -> Result<()> {
     use crate::tdg::TdgBaseline;
 
-    println!("{}", c::header("Creating TDG baseline..."));
-    println!(
+    decor!(quiet, "{}", c::header("Creating TDG baseline..."));
+    decor!(
+        quiet,
         "   {} {}",
         c::label("Path:"),
         c::path(&path.display().to_string())
     );
-    println!(
+    decor!(
+        quiet,
         "   {} {}",
         c::label("Output:"),
         c::path(&output.display().to_string())
     );
-    println!(
+    decor!(
+        quiet,
         "   {} {}",
         c::label("Git context:"),
         if with_git_context { "yes" } else { "no" }
     );
 
-    let git_context = extract_git_context(path, with_git_context);
+    let git_context = extract_git_context(path, with_git_context, quiet);
     let mut baseline = TdgBaseline::new(git_context);
     if let Some(label) = name {
-        println!("   {} {}", c::label("Name:"), c::path(&label));
+        decor!(quiet, "   {} {}", c::label("Name:"), c::path(&label));
         baseline.name = Some(label);
     }
     let (files_analyzed, files_skipped) =
-        analyze_baseline_files(analyzer, path, &mut baseline).await?;
+        analyze_baseline_files(analyzer, path, &mut baseline, quiet).await?;
 
-    println!();
-    println!("\n{}", c::pass("Analysis complete:"));
-    println!(
+    decor!(quiet);
+    decor!(quiet, "\n{}", c::pass("Analysis complete:"));
+    decor!(
+        quiet,
         "   {} {}",
         c::label("Files analyzed:"),
         c::number(&format!("{}", files_analyzed))
     );
-    println!(
+    decor!(
+        quiet,
         "   {} {}",
         c::label("Files skipped:"),
         c::number(&format!("{}", files_skipped))
     );
-    println!(
+    decor!(
+        quiet,
         "   {} {}",
         c::label("Average score:"),
         c::number(&format!("{:.1}", baseline.summary.avg_score))
     );
 
-    display_grade_distribution(&baseline);
+    if !quiet {
+        display_grade_distribution(&baseline);
+    }
 
     baseline.save(output)?;
-    println!(
+    decor!(
+        quiet,
         "\n{}",
         c::pass(&format!(
             "Baseline saved to: {}",
@@ -157,6 +202,7 @@ async fn analyze_baseline_files(
     analyzer: &TdgAnalyzer,
     path: &Path,
     baseline: &mut crate::tdg::TdgBaseline,
+    quiet: bool,
 ) -> Result<(usize, usize)> {
     use crate::tdg::BaselineEntry;
     use std::fs;
@@ -165,7 +211,7 @@ async fn analyze_baseline_files(
     let mut files_analyzed = 0;
     let mut files_skipped = 0;
 
-    println!("\n{}", c::dim("Analyzing files..."));
+    decor!(quiet, "\n{}", c::dim("Analyzing files..."));
 
     for entry in WalkDir::new(path)
         .follow_links(false)
@@ -204,28 +250,45 @@ async fn analyze_baseline_files(
                 baseline.add_entry(file_path.to_path_buf(), entry);
                 files_analyzed += 1;
                 if files_analyzed % 10 == 0 {
-                    print!(".");
-                    use std::io::Write;
-                    std::io::stdout().flush().ok();
+                    print_progress_dot(quiet);
                 }
             }
             Err(e) => {
                 files_skipped += 1;
                 if files_skipped <= 5 {
-                    println!(
-                        "   {}",
-                        c::warn(&format!(
-                            "Skipped {}: {}",
-                            c::path(&file_path.display().to_string()),
-                            e
-                        ))
-                    );
+                    print_skipped_file(quiet, file_path, &e);
                 }
             }
         }
     }
 
     Ok((files_analyzed, files_skipped))
+}
+
+/// Emit one progress dot — to stderr in quiet (JSON) mode so it never lands
+/// on a JSON stdout
+fn print_progress_dot(quiet: bool) {
+    use std::io::Write;
+    if quiet {
+        eprint!(".");
+        std::io::stderr().flush().ok();
+    } else {
+        print!(".");
+        std::io::stdout().flush().ok();
+    }
+}
+
+/// Report a file the analyzer skipped (human formats only)
+fn print_skipped_file(quiet: bool, file_path: &Path, e: &anyhow::Error) {
+    decor!(
+        quiet,
+        "   {}",
+        c::warn(&format!(
+            "Skipped {}: {}",
+            c::path(&file_path.display().to_string()),
+            e
+        ))
+    );
 }
 
 /// Compare current state against a baseline (Sprint 66 Phase 1)
@@ -238,13 +301,17 @@ pub(super) async fn compare_baseline(
 ) -> Result<()> {
     use crate::tdg::TdgBaseline;
 
-    println!("{}", c::header("Comparing against baseline..."));
-    println!(
+    let quiet = json_exclusive_stdout(&format);
+
+    decor!(quiet, "{}", c::header("Comparing against baseline..."));
+    decor!(
+        quiet,
         "   {} {}",
         c::label("Baseline:"),
         c::path(&baseline_path.display().to_string())
     );
-    println!(
+    decor!(
+        quiet,
         "   {} {}",
         c::label("Current path:"),
         c::path(&current_path.display().to_string())
@@ -252,7 +319,8 @@ pub(super) async fn compare_baseline(
 
     // Load baseline
     let old_baseline = TdgBaseline::load(baseline_path)?;
-    println!(
+    decor!(
+        quiet,
         "   {} {} files, avg score {}",
         c::label("Loaded baseline:"),
         c::number(&format!("{}", old_baseline.summary.total_files)),
@@ -260,16 +328,16 @@ pub(super) async fn compare_baseline(
     );
 
     // Create new baseline for current state
-    println!("\n{}", c::dim("Analyzing current state..."));
+    decor!(quiet, "\n{}", c::dim("Analyzing current state..."));
     let temp_output = ephemeral_temp_json("pmat-current-baseline");
-    create_baseline(analyzer, current_path, &temp_output, false, None).await?;
+    create_baseline(analyzer, current_path, &temp_output, false, None, quiet).await?;
     let new_baseline = TdgBaseline::load(&temp_output)?;
 
     // Clean up ephemeral baseline file
     std::fs::remove_file(&temp_output).ok();
 
     // Compare
-    println!("\n{}", c::dim("Computing comparison..."));
+    decor!(quiet, "\n{}", c::dim("Computing comparison..."));
     let comparison = old_baseline.compare(&new_baseline);
 
     // Format output
@@ -284,7 +352,12 @@ pub(super) async fn compare_baseline(
         }
     };
 
-    println!("\n{}", output_str);
+    if quiet {
+        // JSON mode: payload only, no leading blank line
+        println!("{output_str}");
+    } else {
+        println!("\n{}", output_str);
+    }
 
     // Check for regressions
     if fail_on_regression && comparison.has_regressions() {
@@ -330,7 +403,10 @@ fn find_baseline_files(path: &Path) -> Vec<(PathBuf, crate::tdg::TdgBaseline)> {
 
 /// List all baselines in a directory (Sprint 66 Phase 1)
 async fn list_baselines(path: &Path, format: crate::cli::TdgOutputFormat) -> Result<()> {
-    println!(
+    let quiet = json_exclusive_stdout(&format);
+
+    decor!(
+        quiet,
         "{} {}",
         c::header("Listing baselines in:"),
         c::path(&path.display().to_string())
@@ -339,11 +415,16 @@ async fn list_baselines(path: &Path, format: crate::cli::TdgOutputFormat) -> Res
     let baselines = find_baseline_files(path);
 
     if baselines.is_empty() {
-        println!("   {}", c::dim("No baselines found"));
+        decor!(quiet, "   {}", c::dim("No baselines found"));
+        if quiet {
+            // JSON consumers always get a parseable payload on stdout
+            println!("[]");
+        }
         return Ok(());
     }
 
-    println!(
+    decor!(
+        quiet,
         "\n{} {}:\n",
         c::label("Found"),
         c::number(&format!("{} baseline(s)", baselines.len()))
@@ -416,6 +497,7 @@ async fn update_baseline(
         baseline_path,
         with_git_context,
         existing_baseline_name(baseline_path),
+        false,
     )
     .await?;
 
@@ -473,7 +555,7 @@ mod baseline_tests {
     #[test]
     fn test_extract_git_context_disabled_returns_none() {
         let tmp = tempfile::tempdir().unwrap();
-        let result = extract_git_context(tmp.path(), false);
+        let result = extract_git_context(tmp.path(), false, false);
         assert!(result.is_none());
     }
 
@@ -484,8 +566,20 @@ mod baseline_tests {
         let tmp = tempfile::tempdir().unwrap();
         // Tempdir is not a git repo → try_from_current_dir returns None →
         // the warning-log arm fires and returns None.
-        let result = extract_git_context(tmp.path(), true);
+        let result = extract_git_context(tmp.path(), true, false);
         assert!(result.is_none());
+    }
+
+    /// Only JSON owns stdout exclusively: decorative output must be diverted
+    /// to stderr for Json so stdout stays jq-parseable, while human formats
+    /// (Table/Markdown) and Sarif keep their current stdout output.
+    #[test]
+    fn test_json_exclusive_stdout_predicate() {
+        use crate::cli::TdgOutputFormat;
+        assert!(json_exclusive_stdout(&TdgOutputFormat::Json));
+        assert!(!json_exclusive_stdout(&TdgOutputFormat::Table));
+        assert!(!json_exclusive_stdout(&TdgOutputFormat::Markdown));
+        assert!(!json_exclusive_stdout(&TdgOutputFormat::Sarif));
     }
 
     /// find_baseline_files returns empty for a dir with no baseline files.

--- a/src/cli/handlers/tdg_handlers/quality_gates.rs
+++ b/src/cli/handlers/tdg_handlers/quality_gates.rs
@@ -3,7 +3,7 @@
 //!
 //! Sprint 66 Phase 2: Quality gate enforcement for CI/CD pipelines.
 
-use super::baseline::{create_baseline, ephemeral_temp_json};
+use super::baseline::{create_baseline, decor, ephemeral_temp_json, json_exclusive_stdout};
 use super::display::{display_gate_result, display_gate_result_table};
 use super::parse_grade;
 use super::TdgCommandConfig;
@@ -34,7 +34,10 @@ pub(crate) fn validate_minimum_grade(
 ) -> Result<()> {
     if let Some(min_grade_str) = &config.min_grade {
         let min_grade = parse_grade(min_grade_str)?;
-        if score.grade < min_grade {
+        // Grade ordering is APLus < A < ... < F (smaller = better), so the
+        // old `score.grade < min_grade` rejected grades BETTER than the
+        // minimum and accepted worse ones
+        if !score.grade.meets_threshold(min_grade) {
             return Err(anyhow::anyhow!(
                 "Grade {} is below minimum required grade {}",
                 super::format_grade(score.grade),
@@ -57,18 +60,21 @@ pub(super) async fn handle_check_regression(
 ) -> Result<()> {
     use crate::tdg::{GateConfig, QualityGate, RegressionGate, TdgBaseline};
 
-    println!("🔍 Checking for quality regressions...");
+    let quiet = json_exclusive_stdout(&format);
+
+    decor!(quiet, "🔍 Checking for quality regressions...");
 
     // Load baseline
     let baseline = TdgBaseline::load(baseline_path)?;
-    println!(
+    decor!(
+        quiet,
         "   ✅ Loaded baseline: {} files",
         baseline.summary.total_files
     );
 
     // Create current baseline
     let temp_output = ephemeral_temp_json("pmat-regression-check");
-    create_baseline(analyzer, current_path, &temp_output, false, None).await?;
+    create_baseline(analyzer, current_path, &temp_output, false, None, quiet).await?;
     let current = TdgBaseline::load(&temp_output)?;
     std::fs::remove_file(&temp_output).ok();
 
@@ -145,28 +151,52 @@ pub(super) async fn handle_check_quality(
 ) -> Result<()> {
     use crate::tdg::{FGradeGate, QualityGate, TdgBaseline};
 
-    println!("🔍 Checking quality thresholds...");
+    let quiet = json_exclusive_stdout(&format);
+
+    decor!(quiet, "🔍 Checking quality thresholds...");
 
     let temp_output = ephemeral_temp_json("pmat-quality-check");
-    create_baseline(analyzer, path, &temp_output, false, None).await?;
+    create_baseline(analyzer, path, &temp_output, false, None, quiet).await?;
     let current = TdgBaseline::load(&temp_output)?;
     std::fs::remove_file(&temp_output).ok();
 
     let f_grade_result = FGradeGate::with_defaults().check(&TdgBaseline::new(None), &current)?;
     let result = run_primary_gate(new_files_only, min_grade_str, baseline_path, &current)?;
 
-    if !f_grade_result.violations.is_empty() {
-        println!("\n⚠️  F-Grade Warning: {}", f_grade_result.message);
-        println!("   F-grades cap project score at B regardless of average.");
-        display_gate_result(&f_grade_result, &format)?;
-        println!();
-    }
+    if quiet {
+        // JSON mode: one combined document — two display_gate_result calls
+        // would concatenate two JSON docs on stdout when F-grades exist
+        println!("{}", check_quality_json(&result, &f_grade_result)?);
+    } else {
+        if !f_grade_result.violations.is_empty() {
+            decor!(quiet, "\n⚠️  F-Grade Warning: {}", f_grade_result.message);
+            decor!(
+                quiet,
+                "   F-grades cap project score at B regardless of average."
+            );
+            display_gate_result(&f_grade_result, &format)?;
+            decor!(quiet);
+        }
 
-    display_gate_result(&result, &format)?;
+        display_gate_result(&result, &format)?;
+    }
 
     if fail_on_violation && (!result.passed || !f_grade_result.passed) {
         return Err(anyhow::anyhow!("Quality violations detected"));
     }
 
     Ok(())
+}
+
+/// Single JSON document for check-quality: primary gate plus the F-grade
+/// gate, so JSON consumers see both verdicts in one parseable payload
+pub(super) fn check_quality_json(
+    primary: &crate::tdg::GateResult,
+    f_grade: &crate::tdg::GateResult,
+) -> Result<String> {
+    Ok(serde_json::to_string_pretty(&serde_json::json!({
+        "gate": primary,
+        "f_grade_gate": f_grade,
+        "passed": primary.passed && f_grade.passed,
+    }))?)
 }

--- a/src/cli/handlers/tdg_handlers_tests.rs
+++ b/src/cli/handlers/tdg_handlers_tests.rs
@@ -513,6 +513,32 @@ mod unit_tests {
             let result = validate_minimum_grade(&score, &config);
             assert!(result.is_ok());
         }
+
+        /// Direction pins — the old `score.grade < min_grade` comparison was
+        /// inverted (Grade ordering is APLus < ... < F, smaller = better):
+        /// it rejected grades better than the minimum and accepted worse
+        /// ones. Equal-grade tests alone cannot catch that.
+        #[test]
+        fn test_grade_better_than_minimum_passes() {
+            let mut config = make_test_config(PathBuf::from("."));
+            config.min_grade = Some("B".to_string());
+            let score = make_test_score(95.0, Grade::APLus);
+            assert!(
+                validate_minimum_grade(&score, &config).is_ok(),
+                "A+ must satisfy a B minimum"
+            );
+        }
+
+        #[test]
+        fn test_grade_worse_than_minimum_fails() {
+            let mut config = make_test_config(PathBuf::from("."));
+            config.min_grade = Some("B".to_string());
+            let score = make_test_score(40.0, Grade::D);
+            assert!(
+                validate_minimum_grade(&score, &config).is_err(),
+                "D must NOT satisfy a B minimum"
+            );
+        }
     }
 
     // ========== format_tdg_output tests ==========
@@ -921,6 +947,48 @@ mod unit_tests {
     mod display_gate_result_tests {
         use super::*;
         use crate::tdg::{GateResult, Severity, Violation, ViolationType};
+
+        /// check-quality JSON mode must emit ONE combined document even when
+        /// the F-grade gate has violations — previously two concatenated
+        /// JSON docs landed on stdout on exactly that path.
+        #[test]
+        fn test_check_quality_json_single_document_with_f_grades() {
+            let primary = GateResult {
+                passed: true,
+                gate_name: "MinimumGradeGate".to_string(),
+                violations: vec![],
+                message: "ok".to_string(),
+            };
+            let f_grade = GateResult {
+                passed: false,
+                gate_name: "FGradeGate".to_string(),
+                violations: vec![Violation {
+                    path: PathBuf::from("bad.rs"),
+                    violation_type: ViolationType::BelowMinimum,
+                    severity: Severity::Error,
+                    message: "F grade".to_string(),
+                    old_score: None,
+                    new_score: 35.0,
+                    old_grade: None,
+                    new_grade: crate::tdg::Grade::F,
+                }],
+                message: "1 F-grade file".to_string(),
+            };
+
+            let doc = crate::cli::handlers::tdg_handlers::quality_gates::check_quality_json(
+                &primary, &f_grade,
+            )
+            .unwrap();
+
+            // Exactly one parseable document carrying both gate verdicts
+            let parsed: serde_json::Value = serde_json::from_str(&doc).unwrap();
+            assert_eq!(parsed["gate"]["gate_name"], "MinimumGradeGate");
+            assert_eq!(parsed["f_grade_gate"]["gate_name"], "FGradeGate");
+            assert_eq!(
+                parsed["passed"], false,
+                "combined verdict must AND both gates"
+            );
+        }
 
         #[test]
         fn test_display_passed_result() {

--- a/src/cli/semantic_commands.rs
+++ b/src/cli/semantic_commands.rs
@@ -6,10 +6,82 @@
 
 use crate::services::semantic::{
     ClusterFilters, ClusteringEngine, ClusteringMethod, HybridSearchEngine, HybridSearchMode,
-    HybridSearchQuery, Linkage, SemanticSearchEngine, TopicEngine, TopicFilters, TursoVectorDB,
+    HybridSearchQuery, HybridSearchResult, Linkage, SemanticSearchEngine, TopicEngine,
+    TopicFilters, TursoVectorDB,
 };
 use std::path::PathBuf;
 use std::sync::Arc;
+
+/// Guidance shown when vector/hybrid search runs against an empty embeddings store.
+const EMPTY_STORE_HINT: &str =
+    "No embeddings indexed — run `pmat embed sync <path>` to build the embeddings database first";
+
+/// Assembled semantic search output.
+///
+/// The reported count and the rendered rows are both derived from the same
+/// `results` vec, so they can never disagree (ghost-results fix: the old code
+/// printed `Found N results` from the engine's candidate count but rendered
+/// zero rows).
+pub struct SemanticSearchOutput {
+    pub query: String,
+    pub mode: String,
+    pub results: Vec<HybridSearchResult>,
+    /// Set when the embeddings store is empty and the mode needs vectors.
+    pub empty_store_hint: Option<String>,
+}
+
+impl SemanticSearchOutput {
+    /// Render human-readable output. One numbered row per result.
+    pub fn render_text(&self) -> String {
+        if let Some(hint) = &self.empty_store_hint {
+            return hint.clone();
+        }
+        if self.results.is_empty() {
+            return format!("No results found for query: {}", self.query);
+        }
+
+        let mut output = format!(
+            "Found {} results for query: {}\n",
+            self.results.len(),
+            self.query
+        );
+        for (i, r) in self.results.iter().enumerate() {
+            output.push_str(&format!(
+                "\n{}. {}:{}-{} [{}] (score: {:.4})\n   {}\n",
+                i + 1,
+                r.file_path,
+                r.start_line,
+                r.end_line,
+                r.language,
+                r.hybrid_score,
+                r.snippet
+            ));
+        }
+        output
+    }
+
+    /// Render JSON output. `count` always equals `results.len()`.
+    pub fn to_json(&self) -> serde_json::Value {
+        serde_json::json!({
+            "query": self.query,
+            "mode": self.mode,
+            "count": self.results.len(),
+            "results": self.results.iter().map(|r| serde_json::json!({
+                "file_path": r.file_path,
+                "chunk_name": r.chunk_name,
+                "chunk_type": r.chunk_type,
+                "language": r.language,
+                "start_line": r.start_line,
+                "end_line": r.end_line,
+                "keyword_score": r.keyword_score,
+                "vector_score": r.vector_score,
+                "hybrid_score": r.hybrid_score,
+                "snippet": r.snippet,
+            })).collect::<Vec<_>>(),
+            "message": self.empty_store_hint,
+        })
+    }
+}
 
 /// Semantic search CLI handler
 pub struct SemanticCli {
@@ -95,15 +167,19 @@ impl SemanticCli {
         Ok("All embeddings cleared".to_string())
     }
 
-    /// Semantic search
+    /// Semantic search returning structured results
+    ///
+    /// Vector/hybrid modes are guarded against an empty embeddings store:
+    /// previously the keyword (ripgrep) side could report `Found N results`
+    /// while zero rows rendered, which misrepresented unindexed workspaces.
     #[provable_contracts_macros::contract("pmat-core.yaml", equation = "check_compliance")]
-    pub async fn semantic_search(
+    pub async fn semantic_search_results(
         &self,
         query: &str,
         mode: &str,
         limit: usize,
         language: Option<String>,
-    ) -> Result<String, String> {
+    ) -> Result<SemanticSearchOutput, String> {
         if query.trim().is_empty() {
             return Err("Query cannot be empty".to_string());
         }
@@ -114,6 +190,18 @@ impl SemanticCli {
             "hybrid" => HybridSearchMode::Hybrid,
             _ => return Err(format!("Invalid mode: {}", mode)),
         };
+
+        // Keyword mode greps the workspace directly; vector/hybrid need embeddings.
+        if search_mode != HybridSearchMode::KeywordOnly
+            && self.search_engine.entry_count().await? == 0
+        {
+            return Ok(SemanticSearchOutput {
+                query: query.to_string(),
+                mode: mode.to_string(),
+                results: Vec::new(),
+                empty_store_hint: Some(EMPTY_STORE_HINT.to_string()),
+            });
+        }
 
         let search_query = HybridSearchQuery {
             query: query.to_string(),
@@ -127,11 +215,27 @@ impl SemanticCli {
 
         let results = self.hybrid_engine.search(&search_query).await?;
 
-        Ok(format!(
-            "Found {} results for query: {}",
-            results.len(),
-            query
-        ))
+        Ok(SemanticSearchOutput {
+            query: query.to_string(),
+            mode: mode.to_string(),
+            results,
+            empty_store_hint: None,
+        })
+    }
+
+    /// Semantic search (human-readable rendering)
+    #[provable_contracts_macros::contract("pmat-core.yaml", equation = "check_compliance")]
+    pub async fn semantic_search(
+        &self,
+        query: &str,
+        mode: &str,
+        limit: usize,
+        language: Option<String>,
+    ) -> Result<String, String> {
+        let output = self
+            .semantic_search_results(query, mode, limit, language)
+            .await?;
+        Ok(output.render_text())
     }
 
     /// Find similar code
@@ -310,6 +414,136 @@ mod tests {
 
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("Invalid mode"));
+    }
+
+    #[tokio::test]
+    async fn test_semantic_search_empty_store_reports_hint_not_ghost_count() {
+        let (cli, _temp) = setup_cli().await;
+
+        // Empty embeddings DB: vector/hybrid must show guidance, never `Found N`.
+        for mode in ["hybrid", "vector"] {
+            let result = cli
+                .semantic_search("advisory lock", mode, 10, None)
+                .await
+                .unwrap();
+            assert!(
+                result.contains("No embeddings indexed"),
+                "mode {mode}: {result}"
+            );
+            assert!(result.contains("pmat embed sync"), "mode {mode}: {result}");
+            assert!(!result.contains("Found"), "mode {mode}: {result}");
+        }
+    }
+
+    // Render/count consistency tests (ghost-results fix)
+
+    fn sample_result(n: usize) -> crate::services::semantic::HybridSearchResult {
+        crate::services::semantic::HybridSearchResult {
+            file_path: format!("src/file{n}.rs"),
+            chunk_name: format!("chunk{n}"),
+            chunk_type: "function".to_string(),
+            language: "rust".to_string(),
+            start_line: n * 10,
+            end_line: n * 10 + 5,
+            keyword_score: 0.1,
+            vector_score: 0.2,
+            hybrid_score: 0.3,
+            snippet: format!("fn chunk{n}()"),
+        }
+    }
+
+    fn count_rendered_rows(text: &str) -> usize {
+        text.lines()
+            .filter(|l| {
+                l.split_once(". ")
+                    .is_some_and(|(n, _)| n.parse::<usize>().is_ok())
+            })
+            .count()
+    }
+
+    #[test]
+    fn test_render_text_count_matches_rendered_rows() {
+        let output = SemanticSearchOutput {
+            query: "advisory lock".to_string(),
+            mode: "hybrid".to_string(),
+            results: (1..=3).map(sample_result).collect(),
+            empty_store_hint: None,
+        };
+
+        let text = output.render_text();
+
+        assert!(text.contains("Found 3 results for query: advisory lock"));
+        assert_eq!(
+            count_rendered_rows(&text),
+            3,
+            "rendered rows must match reported count: {text}"
+        );
+    }
+
+    #[test]
+    fn test_render_text_empty_results_no_found_line() {
+        let output = SemanticSearchOutput {
+            query: "advisory lock".to_string(),
+            mode: "hybrid".to_string(),
+            results: Vec::new(),
+            empty_store_hint: None,
+        };
+
+        let text = output.render_text();
+
+        assert!(text.contains("No results found for query: advisory lock"));
+        assert!(!text.contains("Found"));
+    }
+
+    #[test]
+    fn test_render_text_empty_store_hint() {
+        let output = SemanticSearchOutput {
+            query: "advisory lock".to_string(),
+            mode: "hybrid".to_string(),
+            results: Vec::new(),
+            empty_store_hint: Some(EMPTY_STORE_HINT.to_string()),
+        };
+
+        let text = output.render_text();
+
+        assert!(text.contains("No embeddings indexed"));
+        assert!(text.contains("pmat embed sync"));
+        assert!(!text.contains("Found"));
+    }
+
+    #[test]
+    fn test_to_json_count_matches_results_len() {
+        let output = SemanticSearchOutput {
+            query: "advisory lock".to_string(),
+            mode: "hybrid".to_string(),
+            results: (1..=3).map(sample_result).collect(),
+            empty_store_hint: None,
+        };
+
+        let json = output.to_json();
+
+        assert_eq!(json["count"], 3);
+        assert_eq!(json["results"].as_array().unwrap().len(), 3);
+        assert!(json["message"].is_null());
+    }
+
+    #[test]
+    fn test_to_json_empty_store() {
+        let output = SemanticSearchOutput {
+            query: "advisory lock".to_string(),
+            mode: "vector".to_string(),
+            results: Vec::new(),
+            empty_store_hint: Some(EMPTY_STORE_HINT.to_string()),
+        };
+
+        let json = output.to_json();
+
+        assert_eq!(json["count"], 0);
+        assert!(json["results"].as_array().unwrap().is_empty());
+        assert!(json["message"]
+            .as_str()
+            .unwrap()
+            .contains("pmat embed sync"));
     }
 
     #[tokio::test]

--- a/src/mcp/tools/agent_context_tools_index_manager.rs
+++ b/src/mcp/tools/agent_context_tools_index_manager.rs
@@ -29,7 +29,11 @@ impl IndexManager {
             // Try incremental update if checksums are available
             if !existing.manifest().file_checksums.is_empty() {
                 match AgentContextIndex::build_incremental(&self.project_path, &existing) {
-                    Ok(updated) => {
+                    Ok(mut updated) => {
+                        // Backfill deferred (empty) source for reused entries
+                        // before save() rewrites the DB, or every reused row
+                        // would persist with source='' (source-wipe bug).
+                        updated.load_all_source();
                         let _ = updated.save(&index_path);
                         updated
                     }

--- a/src/mcp_pmcp/analyze_metrics_handlers.rs
+++ b/src/mcp_pmcp/analyze_metrics_handlers.rs
@@ -47,10 +47,11 @@ impl ToolHandler for LintHotspotTool {
         let extra = json!({
             "top_files": { "type": "integer", "description": "Return only the top N files with the most lint violations" }
         });
-        // Registered as `analyze_dag` in server.rs; keep the registered name for consistency.
+        // R17-1: this tool was formerly (mis)registered as `analyze_dag`. It is
+        // no longer registered in any live server; advertise its real identity.
         Some(build_tool_info(
-            "analyze_dag",
-            "Generate a dependency graph (DAG) / lint hotspot report highlighting files with the most violations.",
+            "analyze_lint_hotspot",
+            "Lint hotspot report highlighting the files with the most lint violations.",
             paths_object_schema(extra, vec!["paths"]),
         ))
     }
@@ -108,10 +109,11 @@ impl ToolHandler for ChurnTool {
             "days":      { "type": "integer", "description": "Git history window in days (default: 90)" },
             "top_files": { "type": "integer", "description": "Return only the top N files by churn" }
         });
-        // Registered as `analyze_deep_context` in server.rs.
+        // R17-1: this tool was formerly (mis)registered as `analyze_deep_context`.
+        // It is no longer registered in any live server; advertise its real identity.
         Some(build_tool_info(
-            "analyze_deep_context",
-            "Comprehensive code analysis combining git churn history with code metrics.",
+            "analyze_churn",
+            "Git churn analysis: file change frequency over a configurable history window.",
             paths_object_schema(extra, vec!["paths"]),
         ))
     }
@@ -166,10 +168,11 @@ impl ToolHandler for CouplingTool {
         let extra = json!({
             "threshold": { "type": "number", "description": "Minimum similarity threshold for reporting coupled modules (0.0-1.0)" }
         });
-        // Registered as `analyze_big_o` in server.rs.
+        // R17-1: this tool was formerly (mis)registered as `analyze_big_o`. It is
+        // no longer registered in any live server; advertise its real identity.
         Some(build_tool_info(
-            "analyze_big_o",
-            "Big-O complexity / module coupling analysis.",
+            "analyze_coupling",
+            "Module coupling analysis based on cross-module similarity.",
             paths_object_schema(extra, vec!["paths"]),
         ))
     }
@@ -227,6 +230,21 @@ impl ToolHandler for AnalyzeDagTool {
 
         Ok(results)
     }
+
+    fn metadata(&self) -> Option<ToolInfo> {
+        let extra = json!({
+            "dag_type": {
+                "type": "string",
+                "enum": ["call-graph", "import-graph", "inheritance", "full-dependency"],
+                "description": "Dependency graph type to generate (default: full-dependency)"
+            }
+        });
+        Some(build_tool_info(
+            "analyze_dag",
+            "Generate a project dependency graph (call graph, import graph, inheritance, or full dependency DAG).",
+            paths_object_schema(extra, vec!["paths"]),
+        ))
+    }
 }
 
 // --- Big-O analysis tool ---
@@ -273,6 +291,17 @@ impl ToolHandler for AnalyzeBigOTool {
 
         Ok(results)
     }
+
+    fn metadata(&self) -> Option<ToolInfo> {
+        let extra = json!({
+            "top_files": { "type": "integer", "description": "Return only the top N files by algorithmic complexity" }
+        });
+        Some(build_tool_info(
+            "analyze_big_o",
+            "Classify the Big-O time complexity of functions in the given paths.",
+            paths_object_schema(extra, vec!["paths"]),
+        ))
+    }
 }
 
 // --- Deep context analysis tool ---
@@ -318,5 +347,20 @@ impl ToolHandler for AnalyzeDeepContextTool {
             .map_err(|e| Error::internal(format!("Deep context analysis failed: {e}")))?;
 
         Ok(results)
+    }
+
+    fn metadata(&self) -> Option<ToolInfo> {
+        let extra = json!({
+            "include_patterns": {
+                "type": "array",
+                "items": { "type": "string" },
+                "description": "Optional file glob patterns (accepted but not yet applied as a filter)"
+            }
+        });
+        Some(build_tool_info(
+            "analyze_deep_context",
+            "Run the full deep-context analysis pipeline (AST, complexity, churn, dead code) over the given paths.",
+            paths_object_schema(extra, vec!["paths"]),
+        ))
     }
 }

--- a/src/mcp_pmcp/handlers_tool_impls.rs
+++ b/src/mcp_pmcp/handlers_tool_impls.rs
@@ -50,7 +50,9 @@ impl ToolHandler for RefactorStartTool {
         });
         Some(build_tool_info(
             "refactor.start",
-            "Start a new refactoring session against the given target paths.",
+            "Start a new refactoring session against the given target paths \
+             (experimental: simulated analysis engine — violations are synthesized \
+             from filename patterns, not real analysis).",
             schema,
         ))
     }
@@ -77,7 +79,8 @@ impl ToolHandler for RefactorNextIterationTool {
     fn metadata(&self) -> Option<ToolInfo> {
         Some(build_tool_info(
             "refactor.nextIteration",
-            "Advance the active refactoring session by one iteration.",
+            "Advance the active refactoring session by one iteration \
+             (experimental: simulated analysis engine).",
             json!({ "type": "object", "properties": {}, "additionalProperties": false }),
         ))
     }
@@ -100,7 +103,8 @@ impl ToolHandler for RefactorGetStateTool {
     fn metadata(&self) -> Option<ToolInfo> {
         Some(build_tool_info(
             "refactor.getState",
-            "Return the current state of the active refactoring session.",
+            "Return the current state of the active refactoring session \
+             (experimental: simulated analysis engine).",
             json!({ "type": "object", "properties": {}, "additionalProperties": false }),
         ))
     }
@@ -125,7 +129,8 @@ impl ToolHandler for RefactorStopTool {
     fn metadata(&self) -> Option<ToolInfo> {
         Some(build_tool_info(
             "refactor.stop",
-            "Stop the active refactoring session and release resources.",
+            "Stop the active refactoring session and release resources \
+             (experimental: simulated analysis engine).",
             json!({ "type": "object", "properties": {}, "additionalProperties": false }),
         ))
     }

--- a/src/mcp_pmcp/simple_unified_server.rs
+++ b/src/mcp_pmcp/simple_unified_server.rs
@@ -14,11 +14,82 @@ use crate::mcp_pmcp::pdmt_handler::PdmtTool;
 use crate::mcp_pmcp::quality_handlers::QualityGateTool;
 use crate::mcp_pmcp::quality_proxy_handler::QualityProxyTool;
 use crate::mcp_server::state_manager::StateManager;
+use async_trait::async_trait;
+use pmcp::shared::{StdioTransport, Transport, TransportMessage};
 use pmcp::{Server, ServerCapabilities};
 use std::path::PathBuf;
 use std::sync::Arc;
-use tokio::sync::Mutex;
+use tokio::sync::{oneshot, Mutex};
 use tracing::info;
+
+/// Stdio transport wrapper that signals session end when the read side fails.
+///
+/// pmcp's `Server::run` spawns the stdio reader task and then awaits an
+/// infinite keep-alive loop. When the client closes stdin (EOF surfaces from
+/// `StdioTransport::receive` as `TransportError::ConnectionClosed`), the
+/// reader task breaks out of its loop but the keep-alive future never
+/// completes — so a one-shot piped session (`printf '...' | MCP_VERSION=1
+/// pmat`) answered in milliseconds yet the process lived until externally
+/// killed (exit=124 under `timeout`). This wrapper forwards the first
+/// `receive()` error to a oneshot channel so [`SimpleUnifiedServer::run`] can
+/// race the server future against session end and exit cleanly.
+///
+/// Long-lived hosts (e.g. Claude Code) hold stdin open: the blocking read
+/// never errors, the channel never fires, and behavior is unchanged. Any
+/// other receive error also signals shutdown, because pmcp's reader task
+/// breaks on every receive error and would otherwise leave the server
+/// permanently deaf.
+#[derive(Debug)]
+struct EofSignalingTransport<T: Transport> {
+    inner: T,
+    session_end_tx: Option<oneshot::Sender<String>>,
+}
+
+impl<T: Transport> EofSignalingTransport<T> {
+    /// Wrap `inner`, returning the transport and the session-end receiver.
+    ///
+    /// The receiver resolves with a human-readable reason once `receive()`
+    /// on the wrapped transport returns an error (EOF or otherwise).
+    fn new(inner: T) -> (Self, oneshot::Receiver<String>) {
+        let (tx, rx) = oneshot::channel();
+        (
+            Self {
+                inner,
+                session_end_tx: Some(tx),
+            },
+            rx,
+        )
+    }
+}
+
+#[async_trait]
+impl<T: Transport> Transport for EofSignalingTransport<T> {
+    async fn send(&mut self, message: TransportMessage) -> pmcp::Result<()> {
+        self.inner.send(message).await
+    }
+
+    async fn receive(&mut self) -> pmcp::Result<TransportMessage> {
+        let result = self.inner.receive().await;
+        if let Err(e) = &result {
+            if let Some(tx) = self.session_end_tx.take() {
+                let _ = tx.send(e.to_string());
+            }
+        }
+        result
+    }
+
+    async fn close(&mut self) -> pmcp::Result<()> {
+        self.inner.close().await
+    }
+
+    fn is_connected(&self) -> bool {
+        self.inner.is_connected()
+    }
+
+    fn transport_type(&self) -> &'static str {
+        self.inner.transport_type()
+    }
+}
 
 /// Simple unified MCP server that uses only existing, working handlers.
 ///
@@ -105,8 +176,25 @@ impl SimpleUnifiedServer {
 
         info!("PMAT Simple Unified MCP server ready with 20 tools (16 core + 4 agent_context), listening on stdio");
 
-        // Run server with stdio transport
-        server.run_stdio().await?;
+        // Run server with stdio transport, racing against stdin EOF. pmcp's
+        // `Server::run` keep-alive future never completes (even after the
+        // reader task exits on EOF), so without this the process leaks after
+        // one-shot piped sessions. See `EofSignalingTransport`.
+        let (transport, session_end) = EofSignalingTransport::new(StdioTransport::new());
+        tokio::select! {
+            result = server.run(transport) => {
+                result?;
+            }
+            reason = session_end => {
+                // All responses for consumed requests were already written and
+                // flushed (pmcp handles messages sequentially and flushes per
+                // send); flush once more defensively before exiting.
+                use std::io::Write;
+                let _ = std::io::stdout().flush();
+                let reason = reason.unwrap_or_else(|_| "transport dropped".to_string());
+                info!("MCP stdio session ended ({reason}); exiting");
+            }
+        }
 
         info!("PMAT Simple Unified MCP server shutting down");
         Ok(())
@@ -203,6 +291,290 @@ mod active_tests {
         {
             let _state2 = state_clone.lock().await;
         }
+    }
+
+    /// v3.18.2: every tool registered on the live SimpleUnifiedServer must
+    /// advertise a non-empty description and a real inputSchema, otherwise
+    /// `tools/list` shows "no description, empty schema" and agents cannot
+    /// call it (pmcp's default `metadata()` is `None`, which the builder
+    /// silently turns into `ToolInfo { description: None, input_schema: {} }`).
+    ///
+    /// Regression: analyze_dag / analyze_big_o / analyze_deep_context shipped
+    /// with no `metadata()` after R17-1 replaced the aliased handlers with
+    /// new structs.
+    #[test]
+    fn test_all_20_live_tools_advertise_description_and_schema() {
+        use pmcp::ToolHandler;
+
+        let state_manager = Arc::new(Mutex::new(StateManager::new()));
+        let index_manager = Arc::new(IndexManager::new(PathBuf::from(".")));
+
+        // (registered name, metadata, takes_arguments) — mirrors the
+        // `.tool(...)` registrations in `run()` above. Tools with
+        // `takes_arguments = false` are genuinely no-arg (empty `properties`
+        // plus `additionalProperties: false` is their correct schema).
+        let tools: Vec<(&str, Option<pmcp::types::ToolInfo>, bool)> = vec![
+            ("analyze_complexity", AnalyzeComplexityTool.metadata(), true),
+            ("analyze_satd", AnalyzeSatdTool.metadata(), true),
+            ("analyze_dead_code", AnalyzeDeadCodeTool.metadata(), true),
+            ("analyze_dag", AnalyzeDagTool.metadata(), true),
+            (
+                "analyze_deep_context",
+                AnalyzeDeepContextTool.metadata(),
+                true,
+            ),
+            ("analyze_big_o", AnalyzeBigOTool.metadata(), true),
+            (
+                "refactor.start",
+                RefactorStartTool::new(state_manager.clone()).metadata(),
+                true,
+            ),
+            (
+                "refactor.nextIteration",
+                RefactorNextIterationTool::new(state_manager.clone()).metadata(),
+                false,
+            ),
+            (
+                "refactor.getState",
+                RefactorGetStateTool::new(state_manager.clone()).metadata(),
+                false,
+            ),
+            (
+                "refactor.stop",
+                RefactorStopTool::new(state_manager).metadata(),
+                false,
+            ),
+            ("quality_gate", QualityGateTool.metadata(), true),
+            ("quality_proxy", QualityProxyTool.metadata(), true),
+            ("pdmt_deterministic_todos", PdmtTool::new().metadata(), true),
+            ("git_operation", GitTool.metadata(), true),
+            ("generate_context", GenerateContextTool.metadata(), true),
+            ("scaffold_project", ScaffoldProjectTool.metadata(), true),
+            (
+                "pmat_query_code",
+                PmatQueryCodeHandler::new(index_manager.clone()).metadata(),
+                true,
+            ),
+            (
+                "pmat_get_function",
+                PmatGetFunctionHandler::new(index_manager.clone()).metadata(),
+                true,
+            ),
+            (
+                "pmat_find_similar",
+                PmatFindSimilarHandler::new(index_manager.clone()).metadata(),
+                true,
+            ),
+            (
+                "pmat_index_stats",
+                PmatIndexStatsHandler::new(index_manager).metadata(),
+                true,
+            ),
+        ];
+
+        assert_eq!(
+            tools.len(),
+            20,
+            "registry drift: update this test when tools are added or removed"
+        );
+
+        for (name, metadata, takes_arguments) in tools {
+            let info = metadata.unwrap_or_else(|| {
+                panic!(
+                    "{name}: metadata() is None — tools/list would advertise \
+                     an empty description and empty inputSchema"
+                )
+            });
+            assert_eq!(
+                info.name, name,
+                "{name}: metadata name must match the registered tool name"
+            );
+            assert!(
+                info.description
+                    .as_deref()
+                    .is_some_and(|d| !d.trim().is_empty()),
+                "{name}: description must be non-empty"
+            );
+            let schema = info
+                .input_schema
+                .as_object()
+                .unwrap_or_else(|| panic!("{name}: inputSchema must be a JSON object"));
+            assert_eq!(
+                schema.get("type").and_then(|t| t.as_str()),
+                Some("object"),
+                "{name}: inputSchema must declare type: object"
+            );
+            let properties = schema
+                .get("properties")
+                .and_then(|p| p.as_object())
+                .unwrap_or_else(|| panic!("{name}: inputSchema must have a properties map"));
+            if takes_arguments {
+                assert!(
+                    !properties.is_empty(),
+                    "{name}: inputSchema.properties must be non-empty for a \
+                     tool that takes arguments"
+                );
+            }
+        }
+    }
+
+    /// v3.18.2: the refactor.* tools run a simulated analysis engine
+    /// (violations are synthesized from filename patterns in
+    /// `src/models/refactor_impls.rs`); their descriptions must disclose
+    /// this so agents are not misled.
+    #[test]
+    fn test_refactor_tool_descriptions_disclose_simulation() {
+        use pmcp::ToolHandler;
+
+        let state_manager = Arc::new(Mutex::new(StateManager::new()));
+        let descriptions = [
+            (
+                "refactor.start",
+                RefactorStartTool::new(state_manager.clone()).metadata(),
+            ),
+            (
+                "refactor.nextIteration",
+                RefactorNextIterationTool::new(state_manager.clone()).metadata(),
+            ),
+            (
+                "refactor.getState",
+                RefactorGetStateTool::new(state_manager.clone()).metadata(),
+            ),
+            (
+                "refactor.stop",
+                RefactorStopTool::new(state_manager).metadata(),
+            ),
+        ];
+
+        for (name, metadata) in descriptions {
+            let description = metadata
+                .and_then(|info| info.description)
+                .unwrap_or_default();
+            assert!(
+                description.contains("simulated analysis engine"),
+                "{name}: description must disclose the simulated analysis \
+                 engine, got: {description}"
+            );
+        }
+    }
+}
+
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg(test)]
+mod eof_shutdown_tests {
+    //! Regression tests for the stdio EOF process leak: when the client
+    //! closes stdin, `EofSignalingTransport` must fire the session-end
+    //! channel so `SimpleUnifiedServer::run` exits instead of hanging on
+    //! pmcp's never-completing keep-alive loop.
+    //!
+    //! Manual end-to-end repro (must answer fast and exit 0, NOT 124):
+    //! ```text
+    //! printf '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"t","version":"0"}}}\n' \
+    //!   | MCP_VERSION=2024-11-05 timeout 10 pmat; echo exit=$?
+    //! ```
+    use super::*;
+    use pmcp::error::TransportError;
+    use pmcp::types::{Notification, ProgressNotification, ProgressToken};
+
+    /// Scripted inner transport: pops pre-canned receive results, then EOF.
+    #[derive(Debug)]
+    struct ScriptedTransport {
+        receives: Vec<pmcp::Result<TransportMessage>>,
+    }
+
+    #[async_trait]
+    impl Transport for ScriptedTransport {
+        async fn send(&mut self, _message: TransportMessage) -> pmcp::Result<()> {
+            Ok(())
+        }
+
+        async fn receive(&mut self) -> pmcp::Result<TransportMessage> {
+            self.receives
+                .pop()
+                .unwrap_or_else(|| Err(TransportError::ConnectionClosed.into()))
+        }
+
+        async fn close(&mut self) -> pmcp::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn progress_message() -> TransportMessage {
+        TransportMessage::Notification(Notification::Progress(ProgressNotification::new(
+            ProgressToken::String("test".to_string()),
+            50.0,
+            None,
+        )))
+    }
+
+    #[tokio::test]
+    async fn eof_on_receive_signals_session_end_and_propagates_error() {
+        let inner = ScriptedTransport { receives: vec![] };
+        let (mut transport, session_end) = EofSignalingTransport::new(inner);
+
+        let result = transport.receive().await;
+        assert!(result.is_err(), "EOF error must propagate to pmcp's reader");
+
+        let reason = session_end
+            .await
+            .expect("session-end signal must fire on EOF");
+        assert!(
+            reason.contains("Connection closed"),
+            "expected ConnectionClosed reason, got: {reason}"
+        );
+    }
+
+    #[tokio::test]
+    async fn successful_receive_does_not_signal_session_end() {
+        // Long-lived hosts (Claude Code) hold stdin open; a successful read
+        // must NOT trigger shutdown.
+        let inner = ScriptedTransport {
+            receives: vec![Ok(progress_message())],
+        };
+        let (mut transport, mut session_end) = EofSignalingTransport::new(inner);
+
+        let result = transport.receive().await;
+        assert!(result.is_ok());
+        assert!(
+            session_end.try_recv().is_err(),
+            "session-end must not fire on a successful receive"
+        );
+    }
+
+    #[tokio::test]
+    async fn send_does_not_signal_session_end() {
+        let inner = ScriptedTransport { receives: vec![] };
+        let (mut transport, mut session_end) = EofSignalingTransport::new(inner);
+
+        transport
+            .send(progress_message())
+            .await
+            .expect("scripted send always succeeds");
+        assert!(
+            session_end.try_recv().is_err(),
+            "session-end must not fire on send"
+        );
+    }
+
+    #[tokio::test]
+    async fn session_end_signal_fires_at_most_once() {
+        let inner = ScriptedTransport { receives: vec![] };
+        let (mut transport, session_end) = EofSignalingTransport::new(inner);
+
+        let _ = transport.receive().await; // first error: fires the signal
+        let _ = transport.receive().await; // second error: sender consumed, must not panic
+        assert!(session_end.await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn wrapper_delegates_transport_metadata_to_inner() {
+        let inner = ScriptedTransport { receives: vec![] };
+        let (transport, _session_end) = EofSignalingTransport::new(inner);
+
+        // ScriptedTransport uses the trait defaults; the wrapper must
+        // delegate rather than override.
+        assert!(transport.is_connected());
+        assert_eq!(transport.transport_type(), "unknown");
     }
 }
 

--- a/src/mcp_pmcp/tool_functions/quality_tools.rs
+++ b/src/mcp_pmcp/tool_functions/quality_tools.rs
@@ -29,8 +29,10 @@ pub async fn check_quality_gates(paths: &[PathBuf], strict: bool) -> Result<Valu
         crate::tdg::Grade::D
     };
 
+    // Grade's derived Ord is inverted (better grades compare as smaller),
+    // so use the semantic helper instead of a raw `>=` comparison.
     let passed = project_score.average_score >= threshold_score
-        && project_score.average_grade >= threshold_grade;
+        && project_score.average_grade.meets_threshold(threshold_grade);
 
     // Collect violations (files below threshold)
     let violations: Vec<Value> = project_score
@@ -87,7 +89,10 @@ pub async fn check_quality_gate_file(file_path: &Path, strict: bool) -> Result<V
         crate::tdg::Grade::D
     };
 
-    let passed = file_score.total >= threshold_score && file_score.grade >= threshold_grade;
+    // Grade's derived Ord is inverted (better grades compare as smaller),
+    // so use the semantic helper instead of a raw `>=` comparison.
+    let passed =
+        file_score.total >= threshold_score && file_score.grade.meets_threshold(threshold_grade);
 
     // Collect violations (penalty details)
     let violations: Vec<Value> = file_score
@@ -156,7 +161,7 @@ pub async fn quality_gate_summary(paths: &[PathBuf]) -> Result<Value> {
     let passed_files = project_score
         .files
         .iter()
-        .filter(|s| s.total >= threshold_score && s.grade >= threshold_grade)
+        .filter(|s| s.total >= threshold_score && s.grade.meets_threshold(threshold_grade))
         .count();
     let failed_files = project_score.total_files - passed_files;
 

--- a/src/mcp_pmcp/tool_functions_tests.rs
+++ b/src/mcp_pmcp/tool_functions_tests.rs
@@ -214,6 +214,132 @@ mod coverage_tests {
         assert!(result.unwrap_err().to_string().contains("does not exist"));
     }
 
+    // ============ QUALITY GATE VERDICT DIRECTION TESTS (v3.18.2) ============
+    // Regression tests for the inverted `passed` verdict: Grade's derived Ord
+    // makes BETTER grades compare as SMALLER (APLus < ... < F), so the old
+    // `grade >= threshold_grade` was true only for grades AT OR WORSE than
+    // the threshold. Reproduced as: paths=[src/utils] -> passed:false despite
+    // score 88.99 / grade AMinus and zero violations.
+
+    #[test]
+    fn test_quality_gate_grade_threshold_direction() {
+        use crate::tdg::Grade;
+        // An A- grade must pass a B+ threshold (better than required)
+        assert!(Grade::AMinus.meets_threshold(Grade::BPlus));
+        // A C grade must fail a B+ threshold (worse than required)
+        assert!(!Grade::C.meets_threshold(Grade::BPlus));
+        // Equal grade meets the threshold
+        assert!(Grade::BPlus.meets_threshold(Grade::BPlus));
+        // The thresholds actually used by the quality gate tools:
+        // strict = B, standard = D
+        assert!(Grade::AMinus.meets_threshold(Grade::B));
+        assert!(!Grade::C.meets_threshold(Grade::B));
+        assert!(Grade::C.meets_threshold(Grade::D));
+        assert!(!Grade::F.meets_threshold(Grade::D));
+    }
+
+    /// Helper: a clean, documented Rust source that grades well.
+    fn write_clean_rust_file(dir: &Path) -> PathBuf {
+        let file_path = dir.join("clean.rs");
+        fs::write(
+            &file_path,
+            "/// Adds two numbers.\n\
+             pub fn add(a: i32, b: i32) -> i32 {\n    a + b\n}\n\n\
+             /// Subtracts two numbers.\n\
+             pub fn sub(a: i32, b: i32) -> i32 {\n    a - b\n}\n",
+        )
+        .unwrap();
+        file_path
+    }
+
+    #[tokio::test]
+    async fn test_check_quality_gate_file_verdict_not_inverted() {
+        let temp_dir = TempDir::new().unwrap();
+        let file_path = write_clean_rust_file(temp_dir.path());
+
+        // Standard mode: threshold is score >= 50 and grade at least D.
+        let result = check_quality_gate_file(&file_path, false).await.unwrap();
+        let passed = result["passed"].as_bool().unwrap();
+        let score = result["score"].as_f64().unwrap();
+        let grade = result["grade"].as_str().unwrap();
+
+        // Only an F grade fails the grade leg in standard mode, so the
+        // verdict must satisfy this invariant regardless of exact score.
+        assert_eq!(
+            passed,
+            score >= 50.0 && grade != "F",
+            "inverted verdict: score={score} grade={grade} passed={passed}"
+        );
+        // A clean documented file must pass the standard gate outright.
+        assert!(
+            passed,
+            "clean file should pass standard quality gate (score={score}, grade={grade})"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_check_quality_gate_file_strict_verdict_not_inverted() {
+        let temp_dir = TempDir::new().unwrap();
+        let file_path = write_clean_rust_file(temp_dir.path());
+
+        // Strict mode: threshold is score >= 70 and grade at least B.
+        let result = check_quality_gate_file(&file_path, true).await.unwrap();
+        let passed = result["passed"].as_bool().unwrap();
+        let score = result["score"].as_f64().unwrap();
+        let grade = result["grade"].as_str().unwrap();
+
+        let grade_meets_b = matches!(grade, "APLus" | "A" | "AMinus" | "BPlus" | "B");
+        assert_eq!(
+            passed,
+            score >= 70.0 && grade_meets_b,
+            "inverted strict verdict: score={score} grade={grade} passed={passed}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_check_quality_gates_project_verdict_not_inverted() {
+        let temp_dir = TempDir::new().unwrap();
+        write_clean_rust_file(temp_dir.path());
+
+        let paths = vec![temp_dir.path().to_path_buf()];
+        let result = check_quality_gates(&paths, false).await.unwrap();
+        let passed = result["passed"].as_bool().unwrap();
+        let score = result["score"].as_f64().unwrap();
+        let grade = result["grade"].as_str().unwrap();
+
+        assert_eq!(
+            passed,
+            score >= 50.0 && grade != "F",
+            "inverted project verdict: score={score} grade={grade} passed={passed}"
+        );
+        assert!(
+            passed,
+            "clean project should pass standard quality gate (score={score}, grade={grade})"
+        );
+        // The original repro: passing grade reported with zero violations
+        // yet passed:false. Pin that violations stay consistent too.
+        assert!(result["violations"].as_array().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_quality_gate_summary_counts_passing_files() {
+        let temp_dir = TempDir::new().unwrap();
+        write_clean_rust_file(temp_dir.path());
+
+        let paths = vec![temp_dir.path().to_path_buf()];
+        let result = quality_gate_summary(&paths).await.unwrap();
+        let summary = &result["summary"];
+
+        assert_eq!(summary["total_files"].as_u64().unwrap(), 1);
+        // With the inverted comparison a passing file was counted as failed.
+        assert_eq!(
+            summary["passed_files"].as_u64().unwrap(),
+            1,
+            "clean file must count as passed: {summary}"
+        );
+        assert_eq!(summary["failed_files"].as_u64().unwrap(), 0);
+    }
+
     #[tokio::test]
     async fn test_generate_context_empty_paths() {
         let result = generate_context(&[], None, false).await;

--- a/src/services/agent_context/function_index/build_accessors.rs
+++ b/src/services/agent_context/function_index/build_accessors.rs
@@ -117,12 +117,24 @@ impl AgentContextIndex {
         0
     }
 
-    /// Load all source code from SQLite into the functions vec.
+    /// Load source code for all entries that are missing it (deferred-source mode).
     ///
-    /// Used when regex/literal search mode needs full source for pattern matching.
-    /// No-op if db_path is not set (blob-loaded indexes already have source).
+    /// Fills from SQLite first (matched by `(file_path, start_line)`, not row
+    /// id — incremental rebuilds reorder functions relative to the persisted
+    /// DB), then falls back to reading project files. Only entries with empty
+    /// source are filled: re-parsed entries already carry fresh source and
+    /// must never be overwritten with stale DB rows.
+    ///
+    /// Used when regex/literal search mode needs full source for pattern
+    /// matching, and by the incremental save path: checksum-reused entries
+    /// are cloned from a lightweight SQLite load with `source == ""`, and
+    /// saving them unfilled would rewrite every reused row with empty source
+    /// (the source-wipe bug breaking `--include-source` / `pmat_get_function`).
     #[provable_contracts_macros::contract("pmat-core.yaml", equation = "check_compliance")]
     pub fn load_all_source(&mut self) {
+        if !self.functions.iter().any(|f| f.source.is_empty()) {
+            return; // Nothing deferred — keep pure-read paths cheap
+        }
         self.load_source_from_db();
         self.load_source_from_filesystem();
     }
@@ -136,7 +148,21 @@ impl AgentContextIndex {
             Ok(c) => c,
             Err(_) => return,
         };
-        let _ = super::sqlite_backend::load_source_into(&conn, &mut self.functions);
+        let source_map = match super::sqlite_backend::load_source_map(&conn) {
+            Ok(m) => m,
+            Err(_) => return,
+        };
+        for func in &mut self.functions {
+            if !func.source.is_empty() {
+                continue;
+            }
+            if let Some(src) = source_map
+                .get(&func.file_path)
+                .and_then(|by_line| by_line.get(&func.start_line))
+            {
+                func.source = src.clone();
+            }
+        }
     }
 
     fn load_source_from_filesystem(&mut self) {
@@ -147,7 +173,11 @@ impl AgentContextIndex {
             }
         }
         for (file_path, indices) in &files_to_read {
-            let content = match std::fs::read_to_string(file_path) {
+            // Prefer the project_root-anchored path (correct regardless of
+            // cwd); fall back to cwd-relative for workspace-prefixed paths.
+            let content = match std::fs::read_to_string(self.project_root.join(file_path))
+                .or_else(|_| std::fs::read_to_string(file_path))
+            {
                 Ok(c) => c,
                 Err(_) => continue,
             };

--- a/src/services/agent_context/function_index/build_incremental.rs
+++ b/src/services/agent_context/function_index/build_incremental.rs
@@ -70,6 +70,7 @@ fn finalize_incremental_index(
     mut languages_seen: HashMap<String, usize>,
     file_checksums: HashMap<String, String>,
     coverage_off_files: HashSet<String>,
+    db_path: Option<PathBuf>,
 ) -> AgentContextIndex {
     let indices = build_indices(&functions);
     let (calls, called_by) = build_call_graph(&functions, &indices.name_index);
@@ -111,7 +112,11 @@ fn finalize_incremental_index(
         graph_metrics,
         project_root,
         manifest,
-        db_path: None,
+        // Keep the db_path the existing index loaded from: reused entries have
+        // deferred (empty) source that is backfilled on-demand from this DB.
+        // Dropping it here broke source retrieval after every incremental
+        // update (backfill assumed a blob-loaded index already had source).
+        db_path,
         coverage_off_files,
     }
 }
@@ -208,6 +213,7 @@ impl AgentContextIndex {
         Ok(finalize_incremental_index(
             functions, project_root, file_count, files_reparsed,
             languages_seen, file_checksums, coverage_off_files,
+            existing.db_path.clone(),
         ))
     }
 }

--- a/src/services/agent_context/function_index/sqlite_backend/load.rs
+++ b/src/services/agent_context/function_index/sqlite_backend/load.rs
@@ -88,7 +88,7 @@ pub(crate) fn load_functions(conn: &Connection) -> Result<Vec<FunctionEntry>, St
 /// Load all functions from SQLite without the `source` column (lightweight).
 ///
 /// Saves ~200ms by skipping deserialization of 70K source strings (~35MB).
-/// Source is loaded on-demand via `load_source_by_location()` or `load_source_into()`.
+/// Source is loaded on-demand via `load_source_by_location()` or `load_source_map()`.
 #[allow(clippy::cast_possible_truncation)]
 #[provable_contracts_macros::contract("pmat-core.yaml", equation = "check_compliance")]
 pub(crate) fn load_functions_lightweight(conn: &Connection) -> Result<Vec<FunctionEntry>, String> {
@@ -148,36 +148,45 @@ pub(crate) fn load_functions_lightweight(conn: &Connection) -> Result<Vec<Functi
         .map_err(|e| format!("Failed to collect functions (lightweight): {e}"))
 }
 
-/// Bulk-load source code into an existing functions slice.
+/// Bulk-load all non-empty sources keyed by location.
 ///
-/// Reads `(id, source)` from SQLite and updates `functions[id-1].source`.
-/// Used when regex/literal mode needs full source for pattern matching.
+/// Returns `file_path -> start_line -> source`. Location-keyed (not row-id
+/// keyed) because an incremental rebuild can reorder functions relative to
+/// the persisted database, so positional matching would attach the wrong
+/// source. Empty rows are skipped so callers only fill what the DB can
+/// actually supply. Used when regex/literal mode needs full source and to
+/// backfill checksum-reused entries before an incremental save.
+#[allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::type_complexity
+)]
 #[provable_contracts_macros::contract("pmat-core.yaml", equation = "check_compliance")]
-pub(crate) fn load_source_into(
+pub(crate) fn load_source_map(
     conn: &Connection,
-    functions: &mut [FunctionEntry],
-) -> Result<(), String> {
+) -> Result<HashMap<String, HashMap<usize, String>>, String> {
     let mut stmt = conn
-        .prepare("SELECT id, source FROM functions ORDER BY id")
-        .map_err(|e| format!("Failed to prepare source load: {e}"))?;
+        .prepare("SELECT file_path, start_line, source FROM functions WHERE source != ''")
+        .map_err(|e| format!("Failed to prepare source map load: {e}"))?;
 
     let rows = stmt
         .query_map([], |row| {
-            let id: i64 = row.get(0)?;
-            let source: String = row.get(1)?;
-            Ok((id, source))
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, i64>(1)? as usize,
+                row.get::<_, String>(2)?,
+            ))
         })
-        .map_err(|e| format!("Failed to query source: {e}"))?;
+        .map_err(|e| format!("Failed to query source map: {e}"))?;
 
+    let mut map: HashMap<String, HashMap<usize, String>> = HashMap::new();
     for row in rows {
-        let (id, source) = row.map_err(|e| format!("Bad source row: {e}"))?;
-        let idx = (id - 1) as usize;
-        if idx < functions.len() {
-            functions[idx].source = source;
-        }
+        let (file_path, start_line, source) =
+            row.map_err(|e| format!("Bad source map row: {e}"))?;
+        map.entry(file_path).or_default().insert(start_line, source);
     }
 
-    Ok(())
+    Ok(map)
 }
 
 /// Load source code for a single function by file path and start line.

--- a/src/services/agent_context/function_index/sqlite_backend/mod.rs
+++ b/src/services/agent_context/function_index/sqlite_backend/mod.rs
@@ -35,7 +35,7 @@ pub(crate) use query::{fts5_search, query_callees, query_callers};
 // From load (used by build.rs and query engine)
 pub(crate) use load::{
     load_call_graph, load_functions_lightweight, load_graph_metrics, load_metadata,
-    load_source_by_location, load_source_into,
+    load_source_by_location, load_source_map,
 };
 
 // From persist (used by quality gate handlers)

--- a/src/services/agent_context/function_index/tests_persistence.rs
+++ b/src/services/agent_context/function_index/tests_persistence.rs
@@ -142,6 +142,102 @@ fn test_incremental_build_with_change() {
 }
 
 #[test]
+fn test_incremental_build_propagates_db_path() {
+    // Regression: build_incremental used to reset db_path to None, so
+    // deferred-source backfill was skipped and every query after an
+    // incremental update returned empty source (Bug B of the source wipe).
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let project_path = temp_dir.path();
+
+    std::fs::create_dir_all(project_path.join("src")).unwrap();
+    std::fs::write(
+        project_path.join("src/lib.rs"),
+        "fn alpha() { let a = 1; }\n",
+    )
+    .unwrap();
+
+    let index = AgentContextIndex::build(project_path).unwrap();
+    let index_path = project_path.join("idx");
+    index.save(&index_path).unwrap();
+
+    let loaded = AgentContextIndex::load(&index_path).unwrap();
+    let db_path = loaded.db_path.clone().expect("SQLite load sets db_path");
+
+    let updated = AgentContextIndex::build_incremental(project_path, &loaded).unwrap();
+    assert_eq!(
+        updated.db_path.as_deref(),
+        Some(db_path.as_path()),
+        "incremental index must keep the db_path it loaded from"
+    );
+
+    // Deferred source must remain retrievable through the incremental index
+    let (file_path, start_line) = {
+        let entry = &updated.functions[0];
+        (entry.file_path.clone(), entry.start_line)
+    };
+    let src = updated.load_source_for(&file_path, start_line);
+    assert!(
+        src.contains("alpha"),
+        "expected source via DB backfill, got {src:?}"
+    );
+}
+
+#[test]
+fn test_incremental_save_preserves_source_for_reused_entries() {
+    // Regression (source wipe, Bug A): lightweight SQLite loads defer source
+    // (entries carry ""). build_incremental clones those entries for
+    // checksum-reused files, and saving used to rewrite the full DB with
+    // source='' for every reused row — repeated incremental saves converged
+    // the index to all-empty source, breaking --include-source,
+    // pmat_query_code, and pmat_get_function.
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let project_path = temp_dir.path();
+
+    std::fs::create_dir_all(project_path.join("src")).unwrap();
+    std::fs::write(project_path.join("src/a.rs"), "fn alpha() { let a = 1; }\n").unwrap();
+    std::fs::write(project_path.join("src/b.rs"), "fn beta() { let b = 2; }\n").unwrap();
+    std::fs::write(project_path.join("src/c.rs"), "fn gamma() { let c = 3; }\n").unwrap();
+
+    let index = AgentContextIndex::build(project_path).unwrap();
+    let index_path = project_path.join("idx");
+    index.save(&index_path).unwrap();
+
+    // Lightweight SQLite load: source is deferred (empty) for every entry
+    let loaded = AgentContextIndex::load(&index_path).unwrap();
+    assert!(loaded.functions.iter().all(|f| f.source.is_empty()));
+
+    // Change one of three files; a.rs and b.rs entries are checksum-reused
+    std::fs::write(
+        project_path.join("src/c.rs"),
+        "fn gamma() { let c = 30; }\nfn delta() { let d = 4; }\n",
+    )
+    .unwrap();
+
+    let mut updated = AgentContextIndex::build_incremental(project_path, &loaded).unwrap();
+    assert_eq!(updated.functions.len(), 4);
+
+    // The save path backfills deferred source before rewriting the DB
+    updated.load_all_source();
+    assert!(
+        updated.functions.iter().all(|f| !f.source.is_empty()),
+        "backfill must restore source for reused entries"
+    );
+    updated.save(&index_path).unwrap();
+
+    // Reload raw rows: EVERY row must still have non-empty source
+    let conn = super::sqlite_backend::open_db(&index_path.with_extension("db")).unwrap();
+    let rows = super::sqlite_backend::load_functions(&conn).unwrap();
+    assert_eq!(rows.len(), 4);
+    for row in &rows {
+        assert!(
+            !row.source.is_empty(),
+            "row '{}' persisted with empty source after incremental save",
+            row.function_name
+        );
+    }
+}
+
+#[test]
 fn test_parse_workspace_siblings() {
     let toml = r#"siblings = ["../aprender", "../trueno", "../realizar"]"#;
     let result = parse_workspace_siblings(toml);

--- a/src/services/pdmt_service.rs
+++ b/src/services/pdmt_service.rs
@@ -4,10 +4,29 @@ use crate::models::pdmt::{
     TodoStatus, ValidationCommands,
 };
 use anyhow::Result;
-use chrono::Utc;
 use std::collections::HashMap;
 use tracing::{debug, info};
 use uuid::Uuid;
+
+/// Fixed RFC 3339 timestamp used instead of wall-clock time.
+///
+/// `pdmt_deterministic_todos` guarantees byte-identical output for identical
+/// input, so `generated_at` must not depend on when the tool runs.
+const DETERMINISTIC_GENERATED_AT: &str = "1970-01-01T00:00:00+00:00";
+
+/// FNV-1a 128-bit offset basis.
+const FNV128_OFFSET_BASIS: u128 = 0x6c62_272e_07bb_0142_62b8_2175_6295_c58d;
+/// FNV-1a 128-bit prime.
+const FNV128_PRIME: u128 = 0x0000_0000_0100_0000_0000_0000_0000_013b;
+
+/// Hash `bytes` with FNV-1a (128-bit). Used to derive deterministic todo ids;
+/// unlike `DefaultHasher`, the result is stable across platforms and Rust
+/// versions, so identical inputs always yield identical ids.
+fn fnv1a_128(bytes: &[u8]) -> u128 {
+    bytes.iter().fold(FNV128_OFFSET_BASIS, |hash, &byte| {
+        (hash ^ u128::from(byte)).wrapping_mul(FNV128_PRIME)
+    })
+}
 
 /// Service for generating deterministic, quality-enforced todo lists
 pub struct PdmtService {
@@ -61,7 +80,7 @@ impl PdmtService {
             project_name,
             todos,
             quality_config,
-            generated_at: Utc::now().to_rfc3339(),
+            generated_at: DETERMINISTIC_GENERATED_AT.to_string(),
             deterministic_seed: self.deterministic_seed,
         };
 

--- a/src/services/pdmt_service_generation.rs
+++ b/src/services/pdmt_service_generation.rs
@@ -2,13 +2,35 @@
 // Included by pdmt_service.rs — shares parent module scope (no `use` imports here)
 
 impl PdmtService {
+    /// Derive a stable, uuid-formatted todo id from the deterministic seed,
+    /// the requirement text, its index, and the todo role (base/test/doc).
+    ///
+    /// Identical inputs always produce the same id (RFC 9562 UUIDv8 over an
+    /// FNV-1a 128-bit hash), which keeps `pdmt_deterministic_todos` honest:
+    /// no `Uuid::new_v4()` randomness in the output.
+    fn deterministic_todo_id(
+        &self,
+        requirement: &str,
+        requirement_idx: usize,
+        role: &str,
+    ) -> String {
+        let input = format!(
+            "pdmt:{seed}:{requirement_idx}:{role}:{requirement}",
+            seed = self.deterministic_seed
+        );
+        let mut bytes = fnv1a_128(input.as_bytes()).to_be_bytes();
+        bytes[6] = (bytes[6] & 0x0f) | 0x80; // version 8 (custom, RFC 9562)
+        bytes[8] = (bytes[8] & 0x3f) | 0x80; // RFC 4122 variant
+        Uuid::from_bytes(bytes).to_string()
+    }
+
     /// Convert a single requirement into detailed todos
     fn requirement_to_todos(
         &self,
         requirement: &str,
         granularity: &str,
         quality_config: &PdmtQualityConfig,
-        _requirement_idx: usize,
+        requirement_idx: usize,
         dependency_map: &mut HashMap<String, Vec<String>>,
     ) -> Result<Vec<PdmtTodo>> {
         let mut todos = Vec::new();
@@ -33,7 +55,7 @@ impl PdmtService {
         let needs_tests = !requirement_lower.contains("test");
 
         // Create base implementation task
-        let base_id = Uuid::new_v4().to_string();
+        let base_id = self.deterministic_todo_id(requirement, requirement_idx, "base");
         let base_todo = PdmtTodo {
             id: base_id.clone(),
             content: self.generate_action_content(requirement, is_feature, is_fix, is_refactor),
@@ -58,7 +80,7 @@ impl PdmtService {
 
         // Include test task when granularity permits
         if needs_tests && task_count >= 2 {
-            let test_id = Uuid::new_v4().to_string();
+            let test_id = self.deterministic_todo_id(requirement, requirement_idx, "test");
             dependency_map
                 .entry(test_id.clone())
                 .or_default()
@@ -103,7 +125,7 @@ impl PdmtService {
 
         // Include documentation task for detailed granularity
         if task_count >= 3 {
-            let doc_id = Uuid::new_v4().to_string();
+            let doc_id = self.deterministic_todo_id(requirement, requirement_idx, "doc");
             dependency_map
                 .entry(doc_id.clone())
                 .or_default()

--- a/src/services/pdmt_service_tests.rs
+++ b/src/services/pdmt_service_tests.rs
@@ -33,9 +33,88 @@ mod tests {
             )
             .unwrap();
 
-        // Verify deterministic generation (same seed produces similar structure)
+        // Verify deterministic generation: byte-identical serialized output
+        let json1 = serde_json::to_string(&result1).unwrap();
+        let json2 = serde_json::to_string(&result2).unwrap();
+        assert_eq!(
+            json1, json2,
+            "identical inputs must produce byte-identical output"
+        );
+
+        // Ids must be stable across calls (no Uuid::new_v4 randomness)
+        let ids1: Vec<&str> = result1.todos.iter().map(|t| t.id.as_str()).collect();
+        let ids2: Vec<&str> = result2.todos.iter().map(|t| t.id.as_str()).collect();
+        assert_eq!(ids1, ids2);
         assert_eq!(result1.todos.len(), result2.todos.len());
         assert_eq!(result1.deterministic_seed, result2.deterministic_seed);
+    }
+
+    #[test]
+    fn test_todo_ids_stable_across_service_instances() {
+        let requirements = vec!["implement user authentication".to_string()];
+        let make = || {
+            PdmtService::new()
+                .generate_todos(
+                    requirements.clone(),
+                    Some("test".to_string()),
+                    "high",
+                    PdmtQualityConfig::default(),
+                )
+                .unwrap()
+        };
+
+        let first = make();
+        let second = make();
+        assert_eq!(
+            serde_json::to_string(&first).unwrap(),
+            serde_json::to_string(&second).unwrap(),
+            "fresh service instances must produce byte-identical output"
+        );
+    }
+
+    #[test]
+    fn test_todo_ids_are_valid_uuids_and_unique() {
+        let service = PdmtService::new();
+        // Duplicate requirement text: index must disambiguate ids
+        let requirements = vec![
+            "implement caching".to_string(),
+            "implement caching".to_string(),
+        ];
+        let result = service
+            .generate_todos(requirements, None, "high", PdmtQualityConfig::default())
+            .unwrap();
+
+        let mut seen = std::collections::HashSet::new();
+        for todo in &result.todos {
+            let parsed = Uuid::parse_str(&todo.id).expect("todo id must be uuid-formatted");
+            assert_eq!(parsed.get_version_num(), 8, "deterministic ids use UUIDv8");
+            assert!(seen.insert(todo.id.clone()), "todo ids must be unique");
+        }
+    }
+
+    #[test]
+    fn test_generated_at_is_deterministic() {
+        let service = PdmtService::new();
+        let result = service
+            .generate_todos(
+                vec!["add logging".to_string()],
+                None,
+                "medium",
+                PdmtQualityConfig::default(),
+            )
+            .unwrap();
+
+        // Wall-clock time is excluded from the output by contract
+        assert_eq!(result.generated_at, DETERMINISTIC_GENERATED_AT);
+    }
+
+    #[test]
+    fn test_fnv1a_128_stable_known_values() {
+        // Empty input hashes to the offset basis by definition
+        assert_eq!(fnv1a_128(b""), FNV128_OFFSET_BASIS);
+        // Stable across calls, sensitive to input
+        assert_eq!(fnv1a_128(b"pdmt"), fnv1a_128(b"pdmt"));
+        assert_ne!(fnv1a_128(b"pdmt"), fnv1a_128(b"pdmt2"));
     }
 
     #[test]

--- a/src/services/perfection_score/calculator.rs
+++ b/src/services/perfection_score/calculator.rs
@@ -185,7 +185,9 @@ impl PerfectionScoreCalculator {
     }
 
     pub(super) async fn get_rust_project_score(&self, project_path: &Path) -> f64 {
-        // Rust Project Score: 0-134 scale, normalize to 0-100
+        // Rust Project Score: raw points, normalize to 0-100 using the
+        // orchestrator-reported max (289 in v3.0). Never hardcode the scale —
+        // it grows as scorers are added (was 134, now 289).
         let orchestrator = RustProjectScoreOrchestrator::new();
         let mode = if self.fast_mode {
             ScoringMode::Quick
@@ -194,10 +196,7 @@ impl PerfectionScoreCalculator {
         };
 
         match orchestrator.score_with_mode(project_path, mode) {
-            Ok(score) => {
-                // Normalize 134-point scale to 100-point scale
-                (score.total_earned / 134.0) * 100.0
-            }
+            Ok(score) => normalize_rps_percentage(score.total_earned, score.total_possible),
             Err(e) => {
                 eprintln!("⚠️  Rust project score failed: {}", e);
                 50.0 // Default on error
@@ -359,5 +358,19 @@ impl PerfectionScoreCalculator {
         }
 
         score.min(100.0)
+    }
+}
+
+/// Convert raw rust-project-score points to a 0-100 percentage.
+///
+/// `total_earned` is raw points out of `total_possible` (289 in RPS v3.0).
+/// Feeding raw points directly into `CategoryScore::new` (which expects a
+/// 0-100 percentage) inflated the category past its max — e.g. raw 184
+/// scaled to 55.2/30 and clamped the total at 200/200 A+.
+pub(super) fn normalize_rps_percentage(total_earned: f64, total_possible: f64) -> f64 {
+    if total_possible > 0.0 {
+        ((total_earned / total_possible) * 100.0).clamp(0.0, 100.0)
+    } else {
+        0.0
     }
 }

--- a/src/services/perfection_score/calculator_tests.rs
+++ b/src/services/perfection_score/calculator_tests.rs
@@ -2,7 +2,7 @@
 /// Calculator unit tests for perfection_score module
 #[cfg(test)]
 mod calculator_tests {
-    use super::super::calculator::PerfectionScoreCalculator;
+    use super::super::calculator::{normalize_rps_percentage, PerfectionScoreCalculator};
     use super::super::types::CategoryScore;
     use std::fs;
     use tempfile::TempDir;
@@ -223,5 +223,63 @@ edition = "2021"
         let score = CategoryScore::new("Technical Debt Grade", 75.0, 40);
         assert_eq!(score.earned_points, 30.0);
         assert_eq!(score.grade, "C");
+    }
+
+    // ============================================================================
+    // RPS Normalization Tests (raw points → percentage, not raw → category)
+    // ============================================================================
+
+    #[test]
+    fn test_rps_raw_points_normalize_to_category_fraction() {
+        // RPS raw 246.6/289 = 85.3% → 0.853 * 30 ≈ 25.6/30, NOT 246.6 treated
+        // as a percentage (which earned 55.2/30 and clamped total at 200 A+)
+        let pct = normalize_rps_percentage(246.6, 289.0);
+        assert!((pct - 85.328).abs() < 0.01, "pct was {}", pct);
+
+        let score = CategoryScore::new("Rust Project Quality", pct, 30);
+        assert!(
+            (score.earned_points - 25.6).abs() < 0.01,
+            "earned was {}",
+            score.earned_points
+        );
+    }
+
+    #[test]
+    fn test_rps_perfect_input_earns_exactly_max() {
+        let pct = normalize_rps_percentage(289.0, 289.0);
+        assert_eq!(pct, 100.0);
+
+        let score = CategoryScore::new("Rust Project Quality", pct, 30);
+        assert_eq!(score.earned_points, 30.0);
+    }
+
+    #[test]
+    fn test_rps_normalize_degenerate_inputs() {
+        // Zero/negative max must not divide by zero or go negative
+        assert_eq!(normalize_rps_percentage(100.0, 0.0), 0.0);
+        assert_eq!(normalize_rps_percentage(-5.0, 289.0), 0.0);
+        // Earned above max (should not happen) clamps to 100%
+        assert_eq!(normalize_rps_percentage(300.0, 289.0), 100.0);
+    }
+
+    #[test]
+    fn test_category_never_exceeds_max_points() {
+        // Regression: raw 184.03 fed as a percentage must clamp at the
+        // category max instead of earning 55.2/30
+        let score = CategoryScore::new("Rust Project Quality", 184.03, 30);
+        assert_eq!(score.earned_points, 30.0);
+        let perfect = CategoryScore::new("Rust Project Quality", 100.0, 30);
+        assert_eq!(
+            score.grade, perfect.grade,
+            "over-max raw must grade as the clamped 100%, not via overflow"
+        );
+
+        let negative = CategoryScore::new("Rust Project Quality", -10.0, 30);
+        assert_eq!(negative.earned_points, 0.0);
+        let zero = CategoryScore::new("Rust Project Quality", 0.0, 30);
+        assert_eq!(
+            negative.grade, zero.grade,
+            "negative raw must grade as the clamped 0%"
+        );
     }
 }

--- a/src/services/perfection_score/types.rs
+++ b/src/services/perfection_score/types.rs
@@ -51,8 +51,12 @@ impl CategoryScore {
     #[provable_contracts_macros::contract("pmat-core.yaml", equation = "check_compliance")]
     /// Create a new instance.
     pub fn new(name: &str, raw_score: f64, max_points: u16) -> Self {
-        let earned_points = (raw_score / 100.0) * f64::from(max_points);
-        let grade = Self::calculate_grade(raw_score);
+        let max = f64::from(max_points);
+        // raw_score is a 0-100 percentage; clamp so a mis-scaled upstream
+        // score (e.g. raw points instead of a percentage) can never earn
+        // more than the category max or go negative.
+        let earned_points = ((raw_score / 100.0) * max).clamp(0.0, max);
+        let grade = Self::calculate_grade(raw_score.clamp(0.0, 100.0));
         Self {
             name: name.to_string(),
             raw_score,

--- a/src/tdg/core_tests.rs
+++ b/src/tdg/core_tests.rs
@@ -882,6 +882,50 @@ fn test_penalty_tracker_default() {
     assert!(tracker.get_attributions().is_empty());
 }
 
+/// Penalties land in serialized TDG scores and baselines; their order must
+/// not depend on insertion order or hash seeds (regression: two duplication
+/// penalties swapped positions between identical runs, breaking the
+/// byte-identical-baseline guarantee).
+#[test]
+fn test_penalty_tracker_attribution_order_deterministic() {
+    let issues = [
+        ("dup_ratio_0.11", "Code duplication: 10.6%", 2.11),
+        ("dup_lines_16", "Found 16 duplicate code patterns", 5.0),
+        ("complexity_a", "High cyclomatic complexity", 3.0),
+    ];
+
+    let mut forward = PenaltyTracker::new();
+    for (id, issue, amt) in &issues {
+        forward.apply(
+            (*id).to_string(),
+            MetricCategory::Duplication,
+            *amt,
+            (*issue).to_string(),
+        );
+    }
+    let mut reverse = PenaltyTracker::new();
+    for (id, issue, amt) in issues.iter().rev() {
+        reverse.apply(
+            (*id).to_string(),
+            MetricCategory::Duplication,
+            *amt,
+            (*issue).to_string(),
+        );
+    }
+
+    let f: Vec<_> = forward
+        .get_attributions()
+        .into_iter()
+        .map(|a| a.issue)
+        .collect();
+    let r: Vec<_> = reverse
+        .get_attributions()
+        .into_iter()
+        .map(|a| a.issue)
+        .collect();
+    assert_eq!(f, r, "attribution order must not depend on insertion order");
+}
+
 #[test]
 fn test_penalty_tracker_multiple_issues() {
     let mut tracker = PenaltyTracker::new();

--- a/src/tdg/grade.rs
+++ b/src/tdg/grade.rs
@@ -23,6 +23,19 @@ pub enum Grade {
 }
 
 impl Grade {
+    /// Returns `true` if this grade is at least as good as `threshold`.
+    ///
+    /// `Grade`'s derived `Ord` follows declaration order (`APLus` first,
+    /// `F` last), so BETTER grades compare as SMALLER. Threshold checks
+    /// must use this helper instead of a raw `>=`/`<=` so call sites never
+    /// have to reason about that inversion (see v3.18.2 quality_gate fix).
+    #[must_use]
+    #[provable_contracts_macros::contract("pmat-core.yaml", equation = "tdg_grade_monotonic")]
+    pub fn meets_threshold(self, threshold: Grade) -> bool {
+        // Smaller discriminant == better grade, so "at least as good" is `<=`.
+        self <= threshold
+    }
+
     #[must_use]
     #[provable_contracts_macros::contract("pmat-core.yaml", equation = "score_range")]
     /// From score.
@@ -79,4 +92,68 @@ pub struct PenaltyAttribution {
     pub amount: f32,
     pub applied_to: HashSet<MetricCategory>,
     pub issue: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// All grades from best to worst (declaration order).
+    const BEST_TO_WORST: [Grade; 11] = [
+        Grade::APLus,
+        Grade::A,
+        Grade::AMinus,
+        Grade::BPlus,
+        Grade::B,
+        Grade::BMinus,
+        Grade::CPlus,
+        Grade::C,
+        Grade::CMinus,
+        Grade::D,
+        Grade::F,
+    ];
+
+    #[test]
+    fn test_derived_ord_makes_better_grades_smaller() {
+        // Documents the inversion that meets_threshold exists to hide:
+        // declaration order means APLus < F under the derived Ord.
+        assert!(Grade::APLus < Grade::F);
+        assert!(Grade::AMinus < Grade::BPlus);
+    }
+
+    #[test]
+    fn test_meets_threshold_better_grade_passes() {
+        // A- is better than B+, so it must meet a B+ threshold
+        assert!(Grade::AMinus.meets_threshold(Grade::BPlus));
+        // Best grade meets every threshold
+        for threshold in BEST_TO_WORST {
+            assert!(Grade::APLus.meets_threshold(threshold));
+        }
+    }
+
+    #[test]
+    fn test_meets_threshold_worse_grade_fails() {
+        // C is worse than B+, so it must NOT meet a B+ threshold
+        assert!(!Grade::C.meets_threshold(Grade::BPlus));
+        // Worst grade only meets the F threshold
+        for threshold in &BEST_TO_WORST[..BEST_TO_WORST.len() - 1] {
+            assert!(!Grade::F.meets_threshold(*threshold));
+        }
+        assert!(Grade::F.meets_threshold(Grade::F));
+    }
+
+    #[test]
+    fn test_meets_threshold_exhaustive_direction() {
+        // For every pair: grade meets threshold iff it sits at or before
+        // the threshold in best-to-worst order.
+        for (gi, grade) in BEST_TO_WORST.iter().enumerate() {
+            for (ti, threshold) in BEST_TO_WORST.iter().enumerate() {
+                assert_eq!(
+                    grade.meets_threshold(*threshold),
+                    gi <= ti,
+                    "{grade} vs threshold {threshold}"
+                );
+            }
+        }
+    }
 }

--- a/src/tdg/penalty_tracker.rs
+++ b/src/tdg/penalty_tracker.rs
@@ -1,12 +1,16 @@
 #![cfg_attr(coverage_nightly, coverage(off))]
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashSet};
 
 use super::grade::{MetricCategory, PenaltyAttribution};
 
 /// Penalty tracker.
+///
+/// Keyed by issue id in a BTreeMap so `get_attributions()` returns a
+/// deterministic order — penalties land in serialized TDG scores (and
+/// baselines), where HashMap iteration order made output byte-unstable.
 pub struct PenaltyTracker {
-    applied: HashMap<String, PenaltyAttribution>,
+    applied: BTreeMap<String, PenaltyAttribution>,
 }
 
 impl Default for PenaltyTracker {
@@ -21,7 +25,7 @@ impl PenaltyTracker {
     /// Create a new instance.
     pub fn new() -> Self {
         Self {
-            applied: HashMap::new(),
+            applied: BTreeMap::new(),
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes every issue catalogued by the v3.18.1 full-CLI dogfood (111 commands) plus everything found by a dedicated 20-tool MCP validation pass (per-tool stdio calls, 8-way concurrent sessions, framing purity, schema audit). All fixes adversarially reviewed and re-validated end-to-end on the release binary.

### CLI fixes
| Issue | Fix |
|---|---|
| `perfection-score` divided RPS raw points by a stale 134.0 scale → always 200/200 A+ | Normalize by orchestrator-reported `total_possible`; categories clamp to `[0,max]` (now 180.4/200 A, matching the real 84.5%) |
| `semantic search` printed "Found 3 results" with zero rows on an empty store | Count derives from rendered set; empty store → `pmat embed sync` guidance; structured JSON |
| JSON stdout polluted on `tdg baseline list/compare`, `check-regression`, `check-quality`, `oracle`, `qdd validate` | JSON-mode stdout is exactly one jq-parseable document; `check-quality` merges both gates into `{gate, f_grade_gate, passed}` (review caught the F-grade double-document path) |
| `falsify --format json` silently ignored | Implemented (dry-run + full, honors `--failures-only`) |
| `qdd validate --output` claimed to write a report it never wrote | Report written before the notice |
| `enforce extreme --file` analyzed all 2,717 files | `AnalysisScope` threads the file through every phase (10.5s vs 120s+ timeout) |
| TDG penalty order nondeterministic (flaked the byte-identical baseline check) | `PenaltyTracker` HashMap → BTreeMap; 4/4 runs byte-identical |

### MCP fixes
| Issue | Fix |
|---|---|
| **Index source-wipe**: every incremental save persisted empty `source` for reused functions until all 21k rows were empty; `db_path: None` killed the backfill — `pmat_get_function` / `--include-source` dead for 4 months | Bulk source restore before rewrite (empty-only, location-keyed); `db_path` propagated; wiped DBs self-heal; regression tests pin all rows non-empty across incremental saves |
| `quality_gate` returned inverted `passed` (Grade derived Ord: smaller = better) | `Grade::meets_threshold()` at all 3 sites + the same inversion in CLI `pmat tdg --min-grade` |
| `analyze_dag`/`analyze_big_o`/`analyze_deep_context` shipped empty descriptions + empty schemas | Real metadata; test pins all 20 tools to non-empty descriptions/schemas |
| `pdmt_deterministic_todos` used `Uuid::new_v4` | Deterministic UUIDv8 from seed/index/requirement; byte-identical output pinned |
| stdio server never exited on stdin EOF (leaked process per scripted session) | `EofSignalingTransport`; one-shot sessions exit 0 in ms (was 124 after full timeout) |
| `refactor.*` engine is simulated, undisclosed | Descriptions now disclose it |

### Deps
- pmcp 2.3.0 → **2.9.0** (latest); jsonschema 0.45 → 0.46.5; 695 MCP tests green; protocol re-validated against the new SDK

## Validation
- `pmat verify --format json` → `ok: true` (format, complexity, satd, clippy `-D warnings`, full test suite — run 5×, green on final tree)
- Every fix re-validated on the release binary: 20/20 tool metadata, `passed:true` verdicts, pdmt determinism, EOF exit, 21,043/21,043 sources surviving incremental saves, 8-way MCP concurrency clean
- pmat-book updated and pushed first (ch73 ×3 sections, ch04-02)

🤖 Generated with [Claude Code](https://claude.com/claude-code)