### PR TITLE
feat(deps): modernize dependency tree to latest + bincode→rmp-serde (v3.19.0)

### DIFF
--- a/.claude/skills/dogfood/SKILL.md
+++ b/.claude/skills/dogfood/SKILL.md
@@ -1,0 +1,214 @@
+---
+allowed-tools: Bash(cargo:*), Bash(pmat:*), Bash(gh:*), Bash(git:*), Bash(make:*), Bash(find:*), Bash(head:*), Bash(tail:*), Bash(wc:*), Bash(grep:*), Bash(diff:*), Bash(timeout:*), Bash(jq:*), Bash(python3:*), Bash(echo:*), Bash(cat:*), Bash(ls:*), Bash(rm:*), Read, Glob, Grep, Agent
+description: Dogfood pmat — rebuild, install, exercise every CLI command against pmat's own repo, check output integrity + self-quality, find next work. Read-only audit; files issues for bugs.
+---
+
+# PMAT Exhaustive Dogfood — Run pmat On Itself
+
+Rebuild and install the local `pmat`, then exercise its **entire command surface
+against this repository** (pmat analyzing pmat), check output integrity and
+self-quality, and surface the next work. This is the canonical "does the binary
+actually work end-to-end" audit — complementary to `pmat verify` (which runs the
+CI gate) and `make dogfood` (which only touches a few analyze commands).
+
+**Lineage**: modeled on `../aprender/.claude/skills/dogfood/SKILL.md` (apr-cli
+exhaustive QA), adapted to pmat's command surface and bug history.
+
+## Context
+
+- pmat local version: !`grep '^version' Cargo.toml | head -1`
+- Current git commit: !`git rev-parse --short HEAD` on !`git branch --show-current`
+- Installed pmat version: !`pmat --version 2>/dev/null || echo "not installed"`
+- Subcommand count: !`pmat --help 2>/dev/null | sed -n '/Commands:/,/Options:/p' | grep -cE '^  [a-z]'`
+- Lib test count: !`grep -roE '#\[test\]|#\[tokio::test\]' src/ 2>/dev/null | wc -l` test attrs
+
+## Arguments
+
+$ARGUMENTS
+
+If arguments name a target directory, dogfood against it. Otherwise dogfood
+against this repo (the canonical pmat-on-pmat case).
+
+## Your Task
+
+Run ALL gates below. For each: run the check, report **PASS / FAIL / SKIP** with
+one line of evidence. Run independent gates in parallel (use Agent for fan-out).
+At the end, give a single **GO / WARN / FAIL** verdict.
+
+**Do NOT modify source files.** This is a read-only audit. If bugs are found,
+file GitHub issues (`gh issue create --repo paiml/paiml-mcp-agent-toolkit`).
+
+### CRITICAL: exit-code capture (the gotcha that fakes bugs)
+
+`$?` after a pipe reports the LAST stage's status, not your command's. NEVER do
+`pmat foo | tail; echo $?` — `tail` always exits 0, so you'll report false
+passes/fails. Always:
+
+```bash
+OUT=$(timeout 60 pmat <cmd> 2>&1); EC=$?
+echo "$OUT" | tail -3; echo "exit=$EC"
+```
+
+This bug has been filed-then-retracted multiple times in this repo's history.
+Every gate below uses the `OUT=$(...); EC=$?` pattern.
+
+---
+
+## Gate 1: Build & Install
+
+```bash
+cargo install --path . --force 2>&1 | tail -5
+pmat --version
+```
+
+PASS if the installed `pmat --version` matches `Cargo.toml`'s `[package] version`.
+(pmat does not embed the git SHA in `--version`, so match on the semver.)
+FAIL on any build error or version mismatch.
+
+## Gate 2: Full Command Grid
+
+Exercise every subcommand category against this repo. `--help` for mutating/slow
+commands; real invocation for read-only analysis. SKIP (not FAIL) a command that
+needs an arg/network it doesn't have; FAIL only on panic / `thread 'main'
+panicked` / non-zero exit where success is expected.
+
+### 2a. Templates & scaffold
+```bash
+for c in "list" "search rust" "generate --help" "scaffold --help" "validate --help"; do
+  OUT=$(timeout 30 pmat $c 2>&1); EC=$?; echo "pmat $c -> exit=$EC :: $(echo "$OUT"|head -1)"
+done
+```
+
+### 2b. Context (AST analysis)
+```bash
+for f in markdown json llm-optimized; do
+  OUT=$(timeout 150 pmat context --format $f -o /tmp/df-ctx.$f 2>&1); EC=$?
+  echo "context --format $f -> exit=$EC :: $(wc -c </tmp/df-ctx.$f 2>/dev/null) bytes"
+done
+```
+
+### 2c. Query & semantic search
+```bash
+OUT=$(timeout 150 pmat query "error handling" --limit 5 2>&1); EC=$?; echo "query semantic -> exit=$EC :: $(echo "$OUT"|grep -c .) lines"
+OUT=$(timeout 150 pmat query --regex 'fn\s+handle_\w+' --limit 5 2>&1); EC=$?; echo "query regex -> exit=$EC"
+OUT=$(timeout 150 pmat query --literal 'unwrap()' --limit 5 --exclude-tests 2>&1); EC=$?; echo "query literal -> exit=$EC"
+OUT=$(timeout 150 pmat query --coverage-gaps --limit 10 --exclude-tests 2>&1); EC=$?; echo "coverage-gaps -> exit=$EC"
+```
+
+### 2d. Analyze family
+```bash
+# NOTE valid flags (drift killed make dogfood before): complexity/churn --format = summary|full|json|sarif / summary|json|markdown|csv (NOT table); dag uses --target-nodes (NOT --top-files).
+OUT=$(timeout 150 pmat analyze complexity --top-files 5 --format json 2>&1); EC=$?; echo "complexity json -> exit=$EC :: $(echo "$OUT"|jq -e 'keys' >/dev/null 2>&1 && echo OK || echo BAD-JSON)"
+OUT=$(timeout 150 pmat analyze complexity --top-files 5 --format full 2>&1); EC=$?; echo "complexity full(render) -> exit=$EC"
+OUT=$(timeout 150 pmat analyze churn --days 30 --top-files 5 --format json 2>&1); EC=$?; echo "churn json -> exit=$EC"
+OUT=$(timeout 150 pmat analyze dag --enhanced --target-nodes 15 -o /tmp/df-dag.mmd 2>&1); EC=$?; echo "dag mermaid -> exit=$EC :: $(grep -cE 'graph|flowchart' /tmp/df-dag.mmd 2>/dev/null) header, $(wc -l </tmp/df-dag.mmd 2>/dev/null) lines"
+OUT=$(timeout 150 pmat analyze satd --format json 2>&1); EC=$?; echo "satd -> exit=$EC"
+OUT=$(timeout 150 pmat analyze dead-code --top-files 5 --format json 2>&1); EC=$?; echo "dead-code -> exit=$EC"
+```
+
+### 2e. Scoring family (use fast/default modes; do NOT trigger mutation or rust-score --full)
+```bash
+for c in "score --format json" "tdg . --format json" "repo-score --format json" "quality-gate --format json"; do
+  OUT=$(timeout 150 pmat $c 2>&1); EC=$?; echo "pmat $c -> exit=$EC"
+done
+```
+
+### 2f. The rest (help-smoke — confirms dispatch, no panic)
+```bash
+for c in refactor qdd five-whys localize work qa-work falsify kaizen roadmap comply enforce spec ci-local maintain hooks memory cache telemetry config explain diagnose serve; do
+  OUT=$(timeout 20 pmat $c --help 2>&1); EC=$?; echo "$c --help -> exit=$EC :: $([ $EC -eq 0 ] && echo OK || echo FAIL)"
+done
+```
+
+FAIL the gate if any command panics or a real-invocation command exits non-zero unexpectedly.
+
+## Gate 3: Self-Quality (pmat on pmat) — the CI-faithful gate
+
+```bash
+OUT=$(pmat verify --format json 2>&1); EC=$?
+echo "$OUT" | jq '{ok, stages: [.stages[]|{name,ok}]}' 2>/dev/null || echo "$OUT" | tail -5
+echo "verify exit=$EC"
+```
+
+PASS iff `ok:true` (format, complexity, satd, clippy, tests all green).
+This is the strongest single signal — green here ⇒ green in CI.
+
+## Gate 4: Output Integrity Protocols (pmat's recurring bug classes)
+
+### P1. JSON stdout purity (v3.18.2 regression class)
+`--format json` stdout must be exactly ONE jq-parseable document; decoration on
+stderr only.
+```bash
+OUT=$(pmat analyze complexity --top-files 3 --format json 2>/dev/null); echo "$OUT" | jq -e . >/dev/null 2>&1 && echo "P1 PASS" || echo "P1 FAIL (impure json stdout)"
+```
+
+### P2. Count/rows consistency (the "Found N results" ghost bug)
+A printed count must match the rows actually rendered (semantic search printed
+"Found 3 results" with 0 rows in v3.18.1).
+```bash
+OUT=$(pmat query "zzz_nonexistent_symbol_xyz" --limit 5 2>&1); echo "$OUT" | tail -3   # count must agree with rows (0 = 0)
+```
+
+### P3. Score bounds (the perfection-score 184% bug)
+Every score must sit inside its declared range; no category exceeds its max.
+```bash
+S=$(pmat score --format json 2>/dev/null | jq -r '.score // .value // empty' 2>/dev/null); echo "score=$S (must be 0..=100)"
+```
+
+### P4. Flag validity / no drift
+Spot-check that documented flags still exist (make dogfood rotted on removed
+flags). `analyze dag --help` must list `--target-nodes`; `analyze complexity
+--help` must NOT accept `table`.
+```bash
+pmat analyze dag --help 2>&1 | grep -q -- '--target-nodes' && echo "P4a PASS" || echo "P4a FAIL"
+OUT=$(pmat analyze complexity --format table 2>&1); EC=$?; [ $EC -ne 0 ] && echo "P4b PASS (table correctly rejected)" || echo "P4b NOTE (table now accepted?)"
+```
+
+### P5. Phantom subcommand
+Unknown subcommand → clean error + non-zero exit (no panic, no silent success).
+```bash
+OUT=$(pmat definitely-not-a-real-command 2>&1); EC=$?; echo "phantom exit=$EC (expect !=0) :: $(echo "$OUT"|head -1)"
+```
+
+### P6. Cross-format consistency
+`--format json` and the human format must describe the SAME data (same file
+count, same top entries).
+```bash
+J=$(pmat analyze complexity --top-files 3 --format json 2>/dev/null | jq '.files? // .summary?'); echo "json summary: $J"
+```
+
+## Gate 5: Find Next Work
+
+```bash
+pmat query --coverage-gaps --rank-by impact --limit 15 --exclude-tests 2>&1 | head -20
+gh issue list --repo paiml/paiml-mcp-agent-toolkit --state open --limit 20 2>/dev/null
+```
+
+Report the top coverage gaps and open issues as candidate next work (do not fix
+them in this read-only audit).
+
+---
+
+## Verdict
+
+After all gates, provide:
+
+1. **Summary table**: Gate 1–5 | PASS/FAIL/SKIP | evidence
+2. **Command grid**: N commands | PASS / SKIP / FAIL counts
+3. **Protocols**: P1–P6 | PASS/FAIL
+4. **GO** iff Gate 1 (build), Gate 3 (`pmat verify` ok:true), and all protocols pass, and the command grid has zero FAIL.
+5. **WARN** for soft issues only (SKIPs, cosmetic output, pre-existing latent findings) — no panics, no integrity violations.
+6. **FAIL** on: build/install failure, `pmat verify` red, any command panic, JSON-impurity (P1), count/rows contradiction (P2), out-of-range score (P3), phantom-subcommand silent success (P5), or exit-code lies.
+
+If bugs found, file them:
+```bash
+gh issue create --repo paiml/paiml-mcp-agent-toolkit \
+  --title "pmat <cmd>: <one-line defect>" \
+  --body "Repro + expected vs actual + exit code (captured via OUT=\$(...); EC=\$?)."
+```
+
+## Cleanup
+
+```bash
+rm -f /tmp/df-ctx.* /tmp/df-dag.mmd
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,60 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.19.0] - 2026-06-13
+
+Major dependency modernization — the whole tree upgraded to latest
+semver-incompatible versions, with the API breakage fixed and the full CI gate
+green. No change to pmat's own CLI/MCP surface.
+
+### Changed
+- **Dependencies → latest** (breaking-version bumps): `aprender` and the
+  sovereign stack 0.30 → **0.41** (aprender, aprender-graph, aprender-viz,
+  aprender-rag, aprender-compute, aprender-db, aprender-zram-core,
+  aprender-orchestrate); `swc_ecma_*` 24/15 → **41/25**; `tree-sitter`
+  0.23 → **0.26** (+ grammars); `wgpu` 24 → **29**; `warp` 0.3 → **0.4**;
+  `gimli` 0.32 → **0.33**; `wasmparser` 0.239 → **0.252**; `git2` 0.20 →
+  **0.21**; `rusqlite`, `roaring`, `lru`, `sha2`, `toml`, `octocrab`, `which`,
+  and ~30 more. `pmcp` was already latest (2.9).
+- **`bincode` removed → `rmp-serde`**: `bincode` 3.0.0 is a non-functional
+  placeholder release and 2.x is a breaking rewrite, so all binary
+  serialization (messaging payloads, coverage/mutation caches, function-index
+  persistence) now uses `rmp-serde` (MessagePack), which pmat already shipped.
+  **Note**: this changes the on-disk format of regenerable caches and the
+  `.pmat` function index — they rebuild automatically on next run.
+- **Pinned by the sovereign stack** (cannot move without upstream): `arrow`
+  held at **57** to match `aprender-db` (lib `trueno_db`); `rusqlite` held at
+  **0.32** (aprender-rag links the native `sqlite3`).
+
+### Fixed
+- **swc 41 parser setup** (`simple_deep_context`): the JS/TS analyzer passed
+  `StringInput::new(content, default, default)`, leaving the lexer's byte span
+  at `BytePos(0)` while the `SourceMap` based the file at 1. swc 41's lexer now
+  asserts span bounds, panicking on every JS/TS file. Switched to
+  `StringInput::from(&*source_file)` (matching every other swc call site).
+- **`build.rs` / SHA digests**: `sha2` 0.11's `finalize()` returns an `Array`
+  that no longer implements `LowerHex`; replaced `format!("{:x}", …)` with an
+  explicit lowercase-hex encode across build.rs and ~12 source files.
+- API migrations for the new majors: swc atoms (`Wtf8Atom`), tree-sitter
+  `QueryMatches` streaming iteration, `wasmparser` new enum variants, `wgpu` 29
+  device/poll API, `gimli` 0.33, and several Option↔Result return-type changes.
+- **`docs.rs` badge**: the docs build exceeded docs.rs's build limit on the full
+  feature set; `[package.metadata.docs.rs]` now documents a lean feature set
+  (core + `rust-ast`), which compiles and fits the limit. pmat's own docs were
+  already clean.
+
+### Removed
+- **`pmat org analyze`** (organizational intelligence): the upstream
+  `aprender-orchestrate` 0.41 dropped the OIP analyzer/report/summarizer API
+  with no replacement, and 0.30 is incompatible with `aprender` 0.41, so the
+  command now returns a clear "feature unavailable" error pending an upstream
+  port.
+
+### Added
+- **`dogfood` Claude Code skill** (`.claude/skills/dogfood/`): rebuild, install,
+  and exercise pmat's full CLI surface against its own repo, with output-integrity
+  protocols and a GO/WARN/FAIL verdict.
+
 ## [3.18.4] - 2026-06-13
 
 Tooling and CI-hygiene patch. **No changes to the shipped binary or library** —

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,7 +65,7 @@ version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
 dependencies = [
- "gimli",
+ "gimli 0.32.3",
 ]
 
 [[package]]
@@ -125,10 +125,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab619ace811f204d8147d11ef71907a44ef98ba8d4ada2d3b1ea5306d5fd7a30"
 dependencies = [
  "arrow 57.3.1",
- "arrow-csv 57.3.1",
- "arrow-json 57.3.1",
+ "arrow-csv",
+ "arrow-json",
  "bytes",
- "lz4_flex",
+ "lz4_flex 0.11.6",
  "parquet 57.3.1",
  "rand 0.8.6",
  "rmp-serde",
@@ -136,7 +136,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "thiserror 2.0.18",
- "unicode-width 0.2.0",
+ "unicode-width 0.2.2",
  "zstd",
 ]
 
@@ -252,16 +252,25 @@ dependencies = [
 
 [[package]]
 name = "apr-cli"
-version = "0.30.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b40010fa734b68ba244bb2e9683c0e7ba52459b62c2525f5cf3a7045557c102"
+checksum = "f8f22bf34813b363089b78ed37049afa219374c66b650000e07a7434c2b637dd"
 dependencies = [
  "alimentar",
- "aprender-core 0.30.0",
- "aprender-present-core 0.30.0",
+ "anyhow",
+ "aprender-compute 0.41.0",
+ "aprender-core 0.41.0",
+ "aprender-mcp",
+ "aprender-orchestrate",
+ "aprender-present-core 0.41.0",
  "aprender-present-terminal",
+ "aprender-profile",
  "aprender-serve",
  "aprender-train",
+ "aprender-train-common",
+ "aprender-train-distill",
+ "aprender-train-lora",
+ "arrow-array 57.3.1",
  "async-stream",
  "axum 0.7.9",
  "batuta-common",
@@ -271,7 +280,6 @@ dependencies = [
  "colored 2.2.0",
  "crossterm 0.28.1",
  "dirs 5.0.1",
- "entrenar-lora",
  "futures-util",
  "gag",
  "glob",
@@ -279,19 +287,23 @@ dependencies = [
  "humansize",
  "libc",
  "pacha",
+ "parquet 57.3.1",
  "provable-contracts-macros 0.3.1",
- "renacer",
+ "rayon",
  "rmp-serde",
+ "safetensors 0.4.5",
  "serde",
  "serde_json",
  "serde_yaml_ng",
+ "sha2 0.10.9",
+ "subtle",
  "tabled",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
- "trueno 0.19.1",
  "trueno-viz 0.3.0",
  "trueno-zram-core",
+ "unicode-normalization",
  "ureq 2.12.1",
  "which 7.0.3",
 ]
@@ -319,33 +331,9 @@ dependencies = [
 
 [[package]]
 name = "aprender"
-version = "0.27.8"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df954f1095e9717ef2e19bdcc3f6ffa1975eba2a93d0f6a5a6ae0a2231e414b"
-dependencies = [
- "batuta-common",
- "bincode",
- "getrandom 0.2.17",
- "memmap2",
- "minijinja",
- "provable-contracts-macros 0.2.2",
- "rand 0.9.4",
- "rand_chacha 0.9.0",
- "rayon",
- "rmp-serde",
- "serde",
- "serde_json",
- "serde_yaml_ng",
- "tempfile",
- "trueno 0.17.5",
- "trueno-quant",
-]
-
-[[package]]
-name = "aprender"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a8b66b44e8f05dee829f5a9bd2140b58c73fe7d32099b9312fb116144ba5ab"
+checksum = "dbb32eccbde3b6e54a32cbcf859b268383f5ec242622f9944c9d7e5c1fb9fa2f"
 dependencies = [
  "apr-cli",
  "aprender-core 0.49.0",
@@ -380,12 +368,32 @@ dependencies = [
  "anyhow",
  "aprender-gemm-codegen 0.30.0",
  "aprender-quant 0.30.0",
+ "chrono",
+ "hostname",
+ "num_cpus",
+ "provable-contracts-macros 0.3.1",
+ "serde",
+ "serde_json",
+ "serde_yaml_ng",
+ "thiserror 2.0.18",
+ "toml 0.8.23",
+]
+
+[[package]]
+name = "aprender-compute"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512dfc0f5cf2b98be207e3615b5049d5c4e57d6134196a70354142b60b10e0b5"
+dependencies = [
+ "anyhow",
+ "aprender-gemm-codegen 0.41.0",
+ "aprender-quant 0.41.0",
  "bytemuck",
  "chrono",
  "futures-intrusive",
  "hostname",
  "num_cpus",
- "pollster 0.4.0",
+ "pollster",
  "provable-contracts-macros 0.3.1",
  "serde",
  "serde_json",
@@ -397,9 +405,9 @@ dependencies = [
 
 [[package]]
 name = "aprender-contracts"
-version = "0.30.0"
+version = "0.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73aa39a632f343e37763c2cfc53caed1b44a7728fce511e3c376ea28fdfef892"
+checksum = "a1e6b0270a70f94bb1f63d8206f355dde607fe52893538cf4fe64d0690d0fd66"
 dependencies = [
  "aprender-contracts-macros",
  "regex",
@@ -411,9 +419,9 @@ dependencies = [
 
 [[package]]
 name = "aprender-contracts-macros"
-version = "0.30.0"
+version = "0.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d70bf07543fd13d63cca281c28e48dc62a50c46fbc3c1fd13cb0be50884f4da"
+checksum = "63a7fb6ec42581eb862c52627d4248fb7e50ced670cd0d884a72fa5d2e49e1b6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -422,33 +430,9 @@ dependencies = [
 
 [[package]]
 name = "aprender-core"
-version = "0.29.3"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c509dd37bf29b0c0b07d38318d0b9149c50cd69b7c9276235d9c0cdc7f20ea"
-dependencies = [
- "batuta-common",
- "bincode",
- "getrandom 0.2.17",
- "memmap2",
- "minijinja",
- "provable-contracts-macros 0.3.1",
- "rand 0.9.4",
- "rand_chacha 0.9.0",
- "rayon",
- "rmp-serde",
- "serde",
- "serde_json",
- "serde_yaml_ng",
- "tempfile",
- "trueno 0.17.5",
- "trueno-quant",
-]
-
-[[package]]
-name = "aprender-core"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "831fb398548a3e5db753e98d142d1fd2477cfd8502a8e9dfd4b0cab5dc09a1ed"
+checksum = "fcdde33d3e349c9778176ed57b9d26740a9fdb10df00c25c2703f6302b9569fd"
 dependencies = [
  "batuta-common",
  "bincode",
@@ -456,7 +440,7 @@ dependencies = [
  "getrandom 0.2.17",
  "half",
  "hf-hub",
- "lz4_flex",
+ "lz4_flex 0.11.6",
  "memmap2",
  "minijinja",
  "provable-contracts-macros 0.3.1",
@@ -502,9 +486,9 @@ dependencies = [
 
 [[package]]
 name = "aprender-db"
-version = "0.30.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9ef4f7a256fb76a8bb63209818c7511bb92091ac653b2a15ebc73c94820b44d"
+checksum = "ffc19e9579fa8b4c8e620134ac901325d8bd2084c11628244f65a2b47077ea3f"
 dependencies = [
  "anyhow",
  "arrow 57.3.1",
@@ -515,6 +499,7 @@ dependencies = [
  "dashmap",
  "futures-intrusive",
  "js-sys",
+ "parquet 57.3.1",
  "rustc-hash 2.1.2",
  "serde",
  "serde-wasm-bindgen",
@@ -554,13 +539,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "aprender-graph"
-version = "0.30.0"
+name = "aprender-gemm-codegen"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55aa80b86f1c2b06bd536914b0274af827c378a1843bf0a351d9f5b406488b7b"
+checksum = "f5386c18da51266425e52e092b3126a8b5a1d0ced7a28825bab7202fd7c23c3b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "aprender-graph"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a01b4a18811a5bfb72316d3fee311fd632058b455932fa55712c5ba00aa6eb0"
 dependencies = [
  "anyhow",
- "aprender-core 0.30.0",
+ "aprender-core 0.41.0",
+ "arrow 57.3.1",
+ "parquet 57.3.1",
  "thiserror 2.0.18",
  "tokio",
  "trueno 0.17.5",
@@ -568,12 +566,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "aprender-orchestrate"
-version = "0.30.0"
+name = "aprender-mcp"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e98dcf63a1e1cf122bf3a43ec06f10039de5827adffc3e07f9d016e4399ff9e"
+checksum = "8dd858553348b95cc224ab1ed4ddd2f081d2e90c9e4101943299610d1264e9fd"
 dependencies = [
  "anyhow",
+ "inventory",
+ "nix 0.29.0",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+]
+
+[[package]]
+name = "aprender-orchestrate"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f1b0292422b702ba95a80841729ec79e8c7b5dbf5c66106972d04553152f937"
+dependencies = [
+ "anyhow",
+ "aprender-graph",
  "async-trait",
  "batuta-common",
  "blake3",
@@ -584,7 +597,9 @@ dependencies = [
  "futures-util",
  "glob",
  "indexmap",
+ "libc",
  "pacha",
+ "pmcp",
  "quick-xml 0.37.5",
  "realizar",
  "reqwest 0.12.28",
@@ -598,7 +613,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "trueno-db",
- "trueno-graph",
  "trueno-rag",
  "walkdir",
  "which 6.0.3",
@@ -631,6 +645,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "aprender-present-core"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4450ae9f598d70f4ae16769d4e3d7b7aff74dcd6e0e64242e3fb549aac3f87a1"
+dependencies = [
+ "aprender-compute 0.41.0",
+ "provable-contracts-macros 0.3.1",
+ "serde",
+ "serde_json",
+ "serde_yaml_ng",
+]
+
+[[package]]
 name = "aprender-present-layout"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -642,17 +669,17 @@ dependencies = [
 
 [[package]]
 name = "aprender-present-terminal"
-version = "0.30.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3fc20b6c57008a8004587c94ced11c84bf33a5d16efbf4887150061c152116"
+checksum = "fc0d4490a462adfb7db6bfa92606c18b6747b1b8cc71e646a64f58693a9261cf"
 dependencies = [
- "aprender-present-core 0.30.0",
+ "aprender-present-core 0.41.0",
  "bitvec",
  "compact_str 0.8.2",
  "crossterm 0.28.1",
  "thiserror 2.0.18",
  "unicode-segmentation",
- "unicode-width 0.2.0",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -679,20 +706,21 @@ dependencies = [
 
 [[package]]
 name = "aprender-profile"
-version = "0.29.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e2a5b315ef18a25276fc566d88154d26368ff0340aebe1bdd6b88062cd1d663"
+checksum = "27db58442b13020023c2e94e6b2a0a22548ab51ad7b95b4b42d68de7cc482649"
 dependencies = [
  "addr2line",
  "anyhow",
- "aprender-core 0.29.3",
+ "aprender-core 0.41.0",
+ "aprender-graph",
  "backtrace",
  "clap",
  "crossbeam",
  "crossterm 0.28.1",
  "dashmap",
  "fnv",
- "gimli",
+ "gimli 0.32.3",
  "hex",
  "libc",
  "memmap2",
@@ -702,7 +730,6 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "rand 0.8.6",
- "ratatui 0.29.0",
  "regex",
  "renacer-core",
  "rmp-serde",
@@ -717,7 +744,6 @@ dependencies = [
  "tracing-subscriber",
  "trueno 0.17.5",
  "trueno-db",
- "trueno-graph",
  "trueno-viz 0.2.4",
 ]
 
@@ -735,6 +761,15 @@ name = "aprender-quant"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16bcc2e820648b2c94b67139e3db39fa07ba4622070cea7f3c6232bd0cff92a3"
+dependencies = [
+ "half",
+]
+
+[[package]]
+name = "aprender-quant"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d37ac37c1923f1fc2103e1f1da9ad9222e3ba1872b80ef8ad00630686bf65292"
 dependencies = [
  "half",
 ]
@@ -760,9 +795,9 @@ dependencies = [
 
 [[package]]
 name = "aprender-serve"
-version = "0.30.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c3c12daed7d71af295852c9a6e3b4c702c431c3a6f33b54f80f38ee966297f"
+checksum = "00b4ec19e4f9cc9e8bcd0987e5ab2535044bad3576db5e859e6712689d15727e"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -798,11 +833,11 @@ dependencies = [
 
 [[package]]
 name = "aprender-train"
-version = "0.30.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "701d348166d652213e7b3f86301ea52a2cc42daab72cbf451944befcd1a89ea1"
+checksum = "1d02c086e2956178f7bad8ef4286d3c9ef67a6d5dce03f6fa4fcdc33091a8d16"
 dependencies = [
- "aprender-core 0.30.0",
+ "aprender-core 0.41.0",
  "bytemuck",
  "chrono",
  "clap",
@@ -833,8 +868,55 @@ dependencies = [
  "toml 0.8.23",
  "trueno 0.17.5",
  "trueno-viz 0.2.4",
+ "unicode-normalization",
  "validator",
  "zip",
+]
+
+[[package]]
+name = "aprender-train-common"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e86414e0ff1ff800d923ba54800d974dc97a2752635e8d4150ad808f02f2e60"
+dependencies = [
+ "clap",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "trueno-viz 0.1.27",
+]
+
+[[package]]
+name = "aprender-train-distill"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "770be15564fc25654e2f0e38314b8884066f2ef3c1593fce167d3b819a1b381d"
+dependencies = [
+ "aprender-train",
+ "aprender-train-common",
+ "bytemuck",
+ "clap",
+ "half",
+ "ndarray",
+ "safetensors 0.7.0",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "aprender-train-lora"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca2d16eb64bb6eebc98a5142a2803cf8b4d5d5c5be43bbcd85c1e5ef60b18d2"
+dependencies = [
+ "aprender-train",
+ "aprender-train-common",
+ "clap",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -843,7 +925,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bee1676e591f34905ffa1039c890cb48fc78afbe9ef742429ae76c58da22132d"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "batuta-common",
  "libc",
  "png",
@@ -853,24 +935,24 @@ dependencies = [
 
 [[package]]
 name = "aprender-viz"
-version = "0.30.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb3898e1669ef87a082a5ed8bbc13405f5cef1a27dad8e4ea96310d5a8b6662"
+checksum = "d485ceca9983b7517618bccdbe6c4ae69913b73489fb95526b994576629599dd"
 dependencies = [
- "base64 0.22.1",
+ "aprender-graph",
+ "base64",
  "batuta-common",
  "libc",
  "png",
  "thiserror 2.0.18",
  "trueno 0.17.5",
- "trueno-graph",
 ]
 
 [[package]]
 name = "aprender-zram-core"
-version = "0.30.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9d9949306b6ea5aa88c0554a09ca544e7bfdc697ce9f1be510012e6d1fd392"
+checksum = "9d00111f3ba970d7af4c5f41b8d5dd9648c50414aa83a36e51be0901db0628d4"
 dependencies = [
  "thiserror 2.0.18",
 ]
@@ -924,10 +1006,7 @@ dependencies = [
  "arrow-array 54.3.1",
  "arrow-buffer 54.3.1",
  "arrow-cast 54.3.1",
- "arrow-csv 54.3.1",
  "arrow-data 54.3.1",
- "arrow-ipc 54.3.1",
- "arrow-json 54.3.1",
  "arrow-ord 54.3.1",
  "arrow-row 54.3.1",
  "arrow-schema 54.3.1",
@@ -945,8 +1024,10 @@ dependencies = [
  "arrow-array 57.3.1",
  "arrow-buffer 57.3.1",
  "arrow-cast 57.3.1",
+ "arrow-csv",
  "arrow-data 57.3.1",
  "arrow-ipc 57.3.1",
+ "arrow-json",
  "arrow-ord 57.3.1",
  "arrow-row 57.3.1",
  "arrow-schema 57.3.1",
@@ -1051,7 +1132,7 @@ dependencies = [
  "arrow-schema 54.3.1",
  "arrow-select 54.3.1",
  "atoi",
- "base64 0.22.1",
+ "base64",
  "chrono",
  "half",
  "lexical-core",
@@ -1072,29 +1153,13 @@ dependencies = [
  "arrow-schema 57.3.1",
  "arrow-select 57.3.1",
  "atoi",
- "base64 0.22.1",
+ "base64",
  "chrono",
  "comfy-table",
  "half",
  "lexical-core",
  "num-traits",
  "ryu",
-]
-
-[[package]]
-name = "arrow-csv"
-version = "54.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1644877d8bc9a0ef022d9153dc29375c2bda244c39aec05a91d0e87ccf77995f"
-dependencies = [
- "arrow-array 54.3.1",
- "arrow-cast 54.3.1",
- "arrow-schema 54.3.1",
- "chrono",
- "csv",
- "csv-core",
- "lazy_static",
- "regex",
 ]
 
 [[package]]
@@ -1162,28 +1227,6 @@ dependencies = [
  "arrow-schema 57.3.1",
  "arrow-select 57.3.1",
  "flatbuffers 25.12.19",
-]
-
-[[package]]
-name = "arrow-json"
-version = "54.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee5b4ca98a7fb2efb9ab3309a5d1c88b5116997ff93f3147efdc1062a6158e9"
-dependencies = [
- "arrow-array 54.3.1",
- "arrow-buffer 54.3.1",
- "arrow-cast 54.3.1",
- "arrow-data 54.3.1",
- "arrow-schema 54.3.1",
- "chrono",
- "half",
- "indexmap",
- "lexical-core",
- "memchr",
- "num",
- "serde",
- "serde_json",
- "simdutf8",
 ]
 
 [[package]]
@@ -1362,9 +1405,9 @@ dependencies = [
 
 [[package]]
 name = "ast_node"
-version = "3.0.4"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a184645bcc6f52d69d8e7639720699c6a99efb711f886e251ed1d16db8dd90e"
+checksum = "2eb025ef00a6da925cf40870b9c8d008526b6004ece399cb0974209720f0b194"
 dependencies = [
  "quote",
  "swc_macros_common",
@@ -1498,10 +1541,10 @@ dependencies = [
  "axum-core 0.4.5",
  "bytes",
  "futures-util",
- "http 1.4.2",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.10.1",
+ "hyper",
  "hyper-util",
  "itoa",
  "matchit 0.7.3",
@@ -1532,10 +1575,10 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http 1.4.2",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.10.1",
+ "hyper",
  "hyper-util",
  "itoa",
  "matchit 0.8.4",
@@ -1563,8 +1606,8 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 1.4.2",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -1583,8 +1626,8 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.2",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -1605,7 +1648,7 @@ dependencies = [
  "miniz_oxide",
  "object 0.37.3",
  "rustc-demangle",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -1613,12 +1656,6 @@ name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
-
-[[package]]
-name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
@@ -1648,7 +1685,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97eb4c76189d694d880ab9affaf6087fb88bc7afe2de7c7e9c9452745788f478"
 dependencies = [
- "lz4_flex",
+ "lz4_flex 0.11.6",
  "zstd",
 ]
 
@@ -1704,6 +1741,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34ddef2995421ab6a5c779542c81ee77c115206f4ad9d5a8e05f4ff49716a3dd"
+dependencies = [
+ "bit-vec 0.9.1",
+]
+
+[[package]]
 name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1722,6 +1768,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1732,9 +1784,6 @@ name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
-dependencies = [
- "serde_core",
-]
 
 [[package]]
 name = "bitvec"
@@ -1788,6 +1837,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1804,9 +1862,9 @@ checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
 
 [[package]]
 name = "brotli"
-version = "7.0.0"
+version = "8.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc97b8f16f944bba54f0433f07e30be199b6dc2bd25937444bbad560bcea29bd"
+checksum = "8119e4516436f5708bbc474a9d395bf12f1b5395e93a92a56e647ac3388c8610"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -1815,9 +1873,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "4.0.3"
+version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a334ef7c9e23abf0ce748e8cd309037da93e606ad52eb372e4ce327a0dcfbdfd"
+checksum = "5962523e1b92ce1b5e793d9169b9943eece10d39f62550bc04bb605d75b94924"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -1970,12 +2028,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cassowary"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
-
-[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1991,6 +2043,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2001,6 +2062,18 @@ dependencies = [
  "libc",
  "shlex",
 ]
+
+[[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
+name = "cff-parser"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31f5b6e9141c036f3ff4ce7b2f7e432b0f00dee416ddcd4f17741d189ddc2e9d"
 
 [[package]]
 name = "cfg-if"
@@ -2031,7 +2104,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -2067,7 +2140,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common 0.1.6",
+ "crypto-common 0.1.7",
  "inout",
 ]
 
@@ -2157,7 +2230,18 @@ checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
 dependencies = [
  "serde",
  "termcolor",
- "unicode-width 0.2.0",
+ "unicode-width 0.2.2",
+]
+
+[[package]]
+name = "codespan-reporting"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
+dependencies = [
+ "serde",
+ "termcolor",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -2233,7 +2317,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
 dependencies = [
  "unicode-segmentation",
- "unicode-width 0.2.0",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -2290,7 +2374,7 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "unicode-width 0.2.0",
+ "unicode-width 0.2.2",
  "windows-sys 0.59.0",
 ]
 
@@ -2407,9 +2491,9 @@ dependencies = [
 
 [[package]]
 name = "cpp_demangle"
-version = "0.4.5"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2bb79cb74d735044c972aae58ed0aaa9a837e85b01106a54c39e42e97f62253"
+checksum = "0667304c32ea56cb4cd6d2d7c0cfe9a2f8041229db8c033af7f8d69492429def"
 dependencies = [
  "cfg-if",
 ]
@@ -2616,9 +2700,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
@@ -2955,7 +3039,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "const-oid 0.9.6",
- "crypto-common 0.1.6",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -3036,6 +3120,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dlib"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
 name = "document-features"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3055,6 +3148,15 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "ecb"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a8bfa975b1aec2145850fcaa1c6fe269a16578c44705a532ae3edc92b8881c7"
+dependencies = [
+ "cipher",
+]
 
 [[package]]
 name = "ecdsa"
@@ -3151,74 +3253,6 @@ name = "endian-type"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
-
-[[package]]
-name = "entrenar"
-version = "0.7.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "717fad455e8ba5435bcfcea2200cf5f70b1672981afd909ed407693f5d4a136e"
-dependencies = [
- "aprender 0.27.8",
- "bytemuck",
- "chrono",
- "clap",
- "clap_complete",
- "ctrlc",
- "dirs 5.0.1",
- "ed25519-dalek",
- "fs4",
- "half",
- "hex",
- "hostname",
- "jsonschema 0.28.3",
- "ndarray",
- "presentar-core",
- "presentar-terminal",
- "provable-contracts-macros 0.2.2",
- "rand 0.9.4",
- "regex",
- "rusqlite",
- "safetensors 0.7.0",
- "schemars",
- "serde",
- "serde_json",
- "serde_yaml",
- "serde_yaml_ng",
- "sha2 0.10.9",
- "thiserror 2.0.18",
- "toml 0.8.23",
- "trueno 0.17.5",
- "trueno-viz 0.2.4",
- "validator",
- "zip",
-]
-
-[[package]]
-name = "entrenar-common"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8558b7437f5b1eb77bdc2d43c6a3ace5cc418effac4cbf1e395bf4f0f670e61a"
-dependencies = [
- "clap",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "trueno-viz 0.1.27",
-]
-
-[[package]]
-name = "entrenar-lora"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d768472539adac6d7ec1954eb9cefc77d5f61df93a11c5d2697cf9775cb0de"
-dependencies = [
- "clap",
- "entrenar",
- "entrenar-common",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
-]
 
 [[package]]
 name = "env_filter"
@@ -3455,6 +3489,7 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -3554,9 +3589,9 @@ dependencies = [
 
 [[package]]
 name = "from_variant"
-version = "2.0.2"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308530a56b099da144ebc5d8e179f343ad928fa2b3558d1eb3db9af18d6eff43"
+checksum = "e5ff35a391aef949120a0340d690269b3d9f63460a6106e99bd07b961f345ea9"
 dependencies = [
  "swc_macros_common",
  "syn 2.0.117",
@@ -3760,9 +3795,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.9"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
@@ -3775,7 +3810,7 @@ version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
 dependencies = [
- "unicode-width 0.2.0",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -3849,15 +3884,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 dependencies = [
  "fallible-iterator",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "gimli"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf7f043f89559805f8c7cacc432749b2fa0d0a0a9ee46ce47164ed5ba7f126c"
+dependencies = [
+ "fnv",
+ "hashbrown 0.16.1",
  "indexmap",
  "stable_deref_trait",
 ]
 
 [[package]]
 name = "git2"
-version = "0.20.4"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
+checksum = "ddddbf932745a6be37109b6112d3ee09696106f848449069d3a57bba937ab82e"
 dependencies = [
  "bitflags 2.13.0",
  "libc",
@@ -3915,6 +3961,18 @@ name = "glow"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5e5ea60d70410161c8bf5da3fdfeaa1c72ed2c15f8bbb9d19fe3a4fad085f08"
+dependencies = [
+ "js-sys",
+ "slotmap",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "glow"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29038e1c483364cc6bb3cf78feee1816002e127c331a1eec55a4d202b9e1adb5"
 dependencies = [
  "js-sys",
  "slotmap",
@@ -3987,6 +4045,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "gpu-allocator"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51255ea7cfaadb6c5f1528d43e92a82acb2b96c43365989a28b2d44ee38f8795"
+dependencies = [
+ "ash",
+ "hashbrown 0.16.1",
+ "log",
+ "presser",
+ "thiserror 2.0.18",
+ "windows 0.62.2",
+]
+
+[[package]]
 name = "gpu-descriptor"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4019,25 +4091,6 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "h2"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
@@ -4047,7 +4100,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.2",
+ "http",
  "indexmap",
  "slab",
  "tokio",
@@ -4083,10 +4136,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "allocator-api2",
- "equivalent",
  "foldhash 0.1.5",
- "serde",
 ]
 
 [[package]]
@@ -4111,6 +4161,8 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -4139,14 +4191,14 @@ dependencies = [
 
 [[package]]
 name = "headers"
-version = "0.3.9"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06683b93020a07e3dbcf5f8c0f6d40080d725bea7936fc01ad345c01b97dc270"
+checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
 dependencies = [
- "base64 0.21.7",
+ "base64",
  "bytes",
  "headers-core",
- "http 0.2.12",
+ "http",
  "httpdate",
  "mime",
  "sha1",
@@ -4154,11 +4206,11 @@ dependencies = [
 
 [[package]]
 name = "headers-core"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
+checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
 dependencies = [
- "http 0.2.12",
+ "http",
 ]
 
 [[package]]
@@ -4198,7 +4250,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "629d8f3bbeda9d148036d6b0de0a3ab947abd08ce90626327fc3547a49d59d97"
 dependencies = [
  "dirs 6.0.0",
- "http 1.4.2",
+ "http",
  "indicatif",
  "libc",
  "log",
@@ -4245,19 +4297,20 @@ checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
 dependencies = [
  "cfg-if",
  "libc",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
 name = "hstr"
-version = "2.1.0"
+version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f11d91d7befd2ffd9d216e9e5ea1fae6174b20a2a1b67a688138003d2f4122"
+checksum = "83bb87e4b300d73412f6dcc7022ee7741452b51b155c2b06e5994d0770c2dbe2"
 dependencies = [
  "hashbrown 0.14.5",
  "new_debug_unreachable",
  "once_cell",
  "rustc-hash 2.1.2",
+ "serde",
  "triomphe",
 ]
 
@@ -4277,17 +4330,6 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
@@ -4298,23 +4340,12 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.12",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.4.2",
+ "http",
 ]
 
 [[package]]
@@ -4325,9 +4356,19 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.2",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "pin-project-lite",
+]
+
+[[package]]
+name = "http-serde"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f056c8559e3757392c8d091e796416e4649d8e49e88b8d76df6c002f05027fd"
+dependencies = [
+ "http",
+ "serde",
 ]
 
 [[package]]
@@ -4362,30 +4403,6 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2 0.5.10",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
@@ -4394,9 +4411,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.14",
- "http 1.4.2",
- "http-body 1.0.1",
+ "h2",
+ "http",
+ "http-body",
  "httparse",
  "httpdate",
  "itoa",
@@ -4412,8 +4429,8 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http 1.4.2",
- "hyper 1.10.1",
+ "http",
+ "hyper",
  "hyper-util",
  "log",
  "rustls",
@@ -4430,7 +4447,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 1.10.1",
+ "hyper",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -4443,18 +4460,18 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.4.2",
- "http-body 1.0.1",
- "hyper 1.10.1",
+ "http",
+ "http-body",
+ "hyper",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -4642,7 +4659,7 @@ dependencies = [
  "console",
  "number_prefix",
  "portable-atomic",
- "unicode-width 0.2.0",
+ "unicode-width 0.2.2",
  "web-time",
 ]
 
@@ -4681,6 +4698,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
+ "block-padding",
  "generic-array",
 ]
 
@@ -4702,6 +4720,15 @@ name = "integer-encoding"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
+
+[[package]]
+name = "inventory"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "ipnet"
@@ -4777,32 +4804,18 @@ dependencies = [
 
 [[package]]
 name = "jni"
-version = "0.22.4"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
 dependencies = [
+ "cesu8",
  "cfg-if",
  "combine",
- "jni-macros",
- "jni-sys 0.4.1",
+ "jni-sys 0.3.1",
  "log",
- "simd_cesu8",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
  "walkdir",
- "windows-link 0.2.1",
-]
-
-[[package]]
-name = "jni-macros"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
-dependencies = [
- "proc-macro2",
- "quote",
- "rustc_version",
- "simd_cesu8",
- "syn 2.0.117",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -4861,7 +4874,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b8f66fe41fa46a5c83ed1c717b7e0b4635988f427083108c8cf0a882cc13441"
 dependencies = [
  "ahash",
- "base64 0.22.1",
+ "base64",
  "bytecount",
  "email_address",
  "fancy-regex 0.14.0",
@@ -4912,7 +4925,7 @@ version = "10.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "ed25519-dalek",
  "getrandom 0.2.17",
  "hmac",
@@ -5088,7 +5101,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -5230,38 +5243,30 @@ dependencies = [
 
 [[package]]
 name = "lopdf"
-version = "0.34.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5c8ecfc6c72051981c0459f75ccc585e7ff67c70829560cda8e647882a9abff"
+checksum = "c7184fdea2bc3cd272a1acec4030c321a8f9875e877b3f92a53f2f6033fdc289"
 dependencies = [
+ "aes",
+ "bitflags 2.13.0",
+ "cbc",
+ "ecb",
  "encoding_rs",
  "flate2",
+ "getrandom 0.3.4",
  "indexmap",
  "itoa",
  "log",
  "md-5",
- "nom",
+ "nom 8.0.0",
+ "nom_locate",
+ "rand 0.9.4",
  "rangemap",
- "time",
+ "sha2 0.10.9",
+ "stringprep",
+ "thiserror 2.0.18",
+ "ttf-parser",
  "weezl",
-]
-
-[[package]]
-name = "lru"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
-dependencies = [
- "hashbrown 0.15.5",
-]
-
-[[package]]
-name = "lru"
-version = "0.16.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
-dependencies = [
- "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -5284,6 +5289,24 @@ name = "lz4_flex"
 version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
+dependencies = [
+ "twox-hash 2.1.2",
+]
+
+[[package]]
+name = "lz4_flex"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90071f8077f8e40adfc4b7fe9cd495ce316263f19e75c2211eeff3fdf475a3d9"
+dependencies = [
+ "twox-hash 2.1.2",
+]
+
+[[package]]
+name = "lz4_flex"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e"
 dependencies = [
  "twox-hash 2.1.2",
 ]
@@ -5460,21 +5483,6 @@ dependencies = [
 
 [[package]]
 name = "metal"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f569fb946490b5743ad69813cb19629130ce9374034abe31614a36402d18f99e"
-dependencies = [
- "bitflags 2.13.0",
- "block",
- "core-graphics-types 0.1.3",
- "foreign-types",
- "log",
- "objc",
- "paste",
-]
-
-[[package]]
-name = "metal"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00c15a6f673ff72ddcc22394663290f870fb224c1bfce55734a75c414150e605"
@@ -5565,24 +5573,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "multer"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01acbdc23469fd8fe07ab135923371d5f5a422fbf9c522158677c8eb15bc51c2"
-dependencies = [
- "bytes",
- "encoding_rs",
- "futures-util",
- "http 0.2.12",
- "httparse",
- "log",
- "memchr",
- "mime",
- "spin",
- "version_check",
-]
-
-[[package]]
 name = "naga"
 version = "22.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5597,31 +5587,9 @@ dependencies = [
  "indexmap",
  "log",
  "rustc-hash 1.1.0",
- "spirv",
+ "spirv 0.3.0+sdk-1.3.268.0",
  "termcolor",
  "thiserror 1.0.69",
- "unicode-xid",
-]
-
-[[package]]
-name = "naga"
-version = "24.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e380993072e52eef724eddfcde0ed013b0c023c3f0417336ed041aa9f076994e"
-dependencies = [
- "arrayvec",
- "bit-set 0.8.0",
- "bitflags 2.13.0",
- "cfg_aliases 0.2.1",
- "codespan-reporting 0.11.1",
- "hexf-parse",
- "indexmap",
- "log",
- "rustc-hash 1.1.0",
- "spirv",
- "strum 0.26.3",
- "termcolor",
- "thiserror 2.0.18",
  "unicode-xid",
 ]
 
@@ -5646,7 +5614,33 @@ dependencies = [
  "num-traits",
  "once_cell",
  "rustc-hash 1.1.0",
- "spirv",
+ "spirv 0.3.0+sdk-1.3.268.0",
+ "thiserror 2.0.18",
+ "unicode-ident",
+]
+
+[[package]]
+name = "naga"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd91265cc2454558f659b3b4b9640f0ddb8cc6521277f166b8a8c181c898079"
+dependencies = [
+ "arrayvec",
+ "bit-set 0.9.1",
+ "bitflags 2.13.0",
+ "cfg-if",
+ "cfg_aliases 0.2.1",
+ "codespan-reporting 0.13.1",
+ "half",
+ "hashbrown 0.16.1",
+ "hexf-parse",
+ "indexmap",
+ "libm",
+ "log",
+ "num-traits",
+ "once_cell",
+ "rustc-hash 1.1.0",
+ "spirv 0.4.0+sdk-1.4.341.0",
  "thiserror 2.0.18",
  "unicode-ident",
 ]
@@ -5773,6 +5767,26 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "nom_locate"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b577e2d69827c4740cba2b52efaad1c4cc7c73042860b199710b3575c68438d"
+dependencies = [
+ "bytecount",
+ "memchr",
+ "nom 8.0.0",
 ]
 
 [[package]]
@@ -5990,6 +6004,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.13.0",
+ "dispatch2",
+ "objc2",
 ]
 
 [[package]]
@@ -5999,6 +6015,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "objc2-io-kit"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6006,6 +6033,42 @@ checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
 dependencies = [
  "libc",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
+dependencies = [
+ "bitflags 2.13.0",
+ "block2",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-open-directory"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb82bed227edf5201dfedf072bba4015a33d3d4a98519837295a90f0a23f676d"
+dependencies = [
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "objc2-metal",
 ]
 
 [[package]]
@@ -6028,30 +6091,29 @@ dependencies = [
 
 [[package]]
 name = "octocrab"
-version = "0.48.1"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5930b376c98c438a4f4259a760cda2c198efea3b82de8f8a2aff0c00a8b7c1c"
+checksum = "fe45bd53ce50c9e85e8a27259675f65d772165fe5eef3e278c1b6168c3f97623"
 dependencies = [
  "arc-swap",
  "async-trait",
- "base64 0.22.1",
+ "base64",
  "bytes",
  "cargo_metadata 0.23.1",
  "cfg-if",
  "chrono",
- "either",
  "futures",
  "futures-util",
  "getrandom 0.2.17",
- "http 1.4.2",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.10.1",
+ "http-serde",
+ "hyper",
  "hyper-rustls",
  "hyper-timeout",
  "hyper-util",
  "jsonwebtoken",
- "once_cell",
  "percent-encoding",
  "pin-project",
  "secrecy",
@@ -6132,7 +6194,7 @@ checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
 dependencies = [
  "async-trait",
  "bytes",
- "http 1.4.2",
+ "http",
  "opentelemetry",
  "reqwest 0.12.28",
 ]
@@ -6143,7 +6205,7 @@ version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
 dependencies = [
- "http 1.4.2",
+ "http",
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-proto",
@@ -6338,7 +6400,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -6355,23 +6417,17 @@ dependencies = [
  "arrow-ipc 54.3.1",
  "arrow-schema 54.3.1",
  "arrow-select 54.3.1",
- "base64 0.22.1",
- "brotli",
+ "base64",
  "bytes",
  "chrono",
- "flate2",
  "half",
  "hashbrown 0.15.5",
- "lz4_flex",
  "num",
  "num-bigint",
  "paste",
  "seq-macro",
- "simdutf8",
- "snap",
  "thrift",
  "twox-hash 1.6.3",
- "zstd",
 ]
 
 [[package]]
@@ -6388,16 +6444,20 @@ dependencies = [
  "arrow-ipc 57.3.1",
  "arrow-schema 57.3.1",
  "arrow-select 57.3.1",
- "base64 0.22.1",
+ "base64",
+ "brotli",
  "bytes",
  "chrono",
+ "flate2",
  "half",
  "hashbrown 0.16.1",
+ "lz4_flex 0.12.2",
  "num-bigint",
  "num-integer",
  "num-traits",
  "paste",
  "seq-macro",
+ "simdutf8",
  "snap",
  "thrift",
  "twox-hash 2.1.2",
@@ -6422,13 +6482,15 @@ dependencies = [
 
 [[package]]
 name = "pdf-extract"
-version = "0.7.12"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbb3a5387b94b9053c1e69d8abfd4dd6dae7afda65a5c5279bc1f42ab39df575"
+checksum = "1e28ba1758a3d3f361459645780e09570b573fc3c82637449e9963174c813a98"
 dependencies = [
  "adobe-cmap-parser",
+ "cff-parser",
  "encoding_rs",
  "euclid 0.20.14",
+ "log",
  "lopdf",
  "postscript",
  "type1-encoding-parser",
@@ -6441,7 +6503,7 @@ version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "serde_core",
 ]
 
@@ -6620,7 +6682,7 @@ version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "indexmap",
  "quick-xml 0.39.4",
  "serde",
@@ -6657,29 +6719,28 @@ dependencies = [
 
 [[package]]
 name = "pmat"
-version = "3.18.4"
+version = "3.19.0"
 dependencies = [
  "actix",
  "actix-rt",
  "anyhow",
- "aprender 0.30.0",
- "aprender-compute 0.30.0",
+ "aprender 0.41.0",
+ "aprender-compute 0.41.0",
  "aprender-contracts",
  "aprender-contracts-macros",
  "aprender-db",
  "aprender-graph",
  "aprender-orchestrate",
- "aprender-present-core 0.30.0",
+ "aprender-present-core 0.41.0",
  "aprender-rag",
- "aprender-viz 0.30.0",
+ "aprender-viz 0.41.0",
  "aprender-zram-core",
- "arrow 54.3.1",
+ "arrow 57.3.1",
  "assert_cmd",
  "async-raft",
  "async-trait",
  "axum 0.8.9",
  "batuta-common",
- "bincode",
  "blake3",
  "bytemuck",
  "bytes",
@@ -6690,7 +6751,7 @@ dependencies = [
  "criterion",
  "crossbeam",
  "crossbeam-channel",
- "crossterm 0.28.1",
+ "crossterm 0.29.0",
  "csv",
  "dashmap",
  "dhat",
@@ -6701,20 +6762,20 @@ dependencies = [
  "fs2",
  "futures",
  "futures-test",
- "gimli",
+ "gimli 0.33.0",
  "git2",
  "glob",
  "globset",
  "goblin",
- "http 1.4.2",
+ "http",
  "http-body-util",
- "hyper 1.10.1",
+ "hyper",
  "hyper-util",
  "ignore",
  "lazy_static",
  "libc",
- "lru 0.16.4",
- "lz4_flex",
+ "lru",
+ "lz4_flex 0.13.1",
  "minijinja",
  "notify",
  "num_cpus",
@@ -6722,7 +6783,7 @@ dependencies = [
  "parking_lot",
  "pdf-extract",
  "pmcp",
- "pollster 0.3.0",
+ "pollster",
  "predicates",
  "pretty_assertions",
  "prettyplease",
@@ -6734,7 +6795,7 @@ dependencies = [
  "rand 0.9.4",
  "rayon",
  "regex",
- "reqwest 0.12.28",
+ "reqwest 0.13.1",
  "rmp-serde",
  "roaring",
  "ruchy",
@@ -6745,7 +6806,7 @@ dependencies = [
  "serde_json",
  "serde_yaml_ng",
  "serial_test",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "shell-words",
  "sourcemap",
  "swc_common",
@@ -6761,7 +6822,7 @@ dependencies = [
  "tokio",
  "tokio-test",
  "tokio-util",
- "toml 0.8.23",
+ "toml 1.1.2+spec-1.1.0",
  "tower 0.5.3",
  "tower-http",
  "tracing",
@@ -6781,9 +6842,9 @@ dependencies = [
  "uuid",
  "walkdir",
  "warp",
- "wasmparser 0.239.0",
- "wgpu 24.0.5",
- "which 6.0.3",
+ "wasmparser 0.252.0",
+ "wgpu 29.0.3",
+ "which 8.0.3",
  "xxhash-rust",
 ]
 
@@ -6813,7 +6874,7 @@ checksum = "88c9cf51f3ce3953091a5f58e4de10d11a739705058dc9d9a5c66103c7c1cba6"
 dependencies = [
  "anyhow",
  "async-trait",
- "base64 0.22.1",
+ "base64",
  "bytes",
  "chrono",
  "dashmap",
@@ -6823,9 +6884,9 @@ dependencies = [
  "garde",
  "getrandom 0.4.2",
  "glob",
- "http 1.4.2",
+ "http",
  "http-body-util",
- "hyper 1.10.1",
+ "hyper",
  "hyper-util",
  "indexmap",
  "js-sys",
@@ -6833,7 +6894,7 @@ dependencies = [
  "parking_lot",
  "pmcp-widget-utils",
  "regex",
- "reqwest 0.13.4",
+ "reqwest 0.13.1",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -6841,7 +6902,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
- "tokio-tungstenite 0.29.0",
+ "tokio-tungstenite",
  "tokio-util",
  "toml 1.1.2+spec-1.1.0",
  "tracing",
@@ -6872,12 +6933,6 @@ dependencies = [
  "flate2",
  "miniz_oxide",
 ]
-
-[[package]]
-name = "pollster"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22686f4785f02a4fcc856d3b3bb19bf6c8160d103f7a99cc258bddd0251dc7f2"
 
 [[package]]
 name = "pollster"
@@ -6995,7 +7050,7 @@ dependencies = [
  "presentar-core",
  "thiserror 2.0.18",
  "unicode-segmentation",
- "unicode-width 0.2.0",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -7271,7 +7326,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.6.4",
+ "socket2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -7309,7 +7364,7 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2 0.6.4",
+ "socket2",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -7474,27 +7529,6 @@ checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
 
 [[package]]
 name = "ratatui"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
-dependencies = [
- "bitflags 2.13.0",
- "cassowary",
- "compact_str 0.8.2",
- "crossterm 0.28.1",
- "indoc",
- "instability",
- "itertools 0.13.0",
- "lru 0.12.5",
- "paste",
- "strum 0.26.3",
- "unicode-segmentation",
- "unicode-truncate 1.1.0",
- "unicode-width 0.2.0",
-]
-
-[[package]]
-name = "ratatui"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1695748e3a735b34968c887ceea5a380b43545903868ae8f5b666593100f6b68"
@@ -7521,14 +7555,14 @@ dependencies = [
  "indoc",
  "itertools 0.14.0",
  "kasuari",
- "lru 0.18.0",
+ "lru",
  "palette",
  "serde",
- "strum 0.28.0",
+ "strum",
  "thiserror 2.0.18",
  "unicode-segmentation",
- "unicode-truncate 2.0.1",
- "unicode-width 0.2.0",
+ "unicode-truncate",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -7577,10 +7611,10 @@ dependencies = [
  "line-clipping",
  "ratatui-core",
  "serde",
- "strum 0.28.0",
+ "strum",
  "time",
  "unicode-segmentation",
- "unicode-width 0.2.0",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -7588,6 +7622,18 @@ name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "raw-window-metal"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40d213455a5f1dc59214213c7330e074ddf8114c9a42411eb890c767357ce135"
+dependencies = [
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "objc2-quartz-core",
+]
 
 [[package]]
 name = "rawpointer"
@@ -7765,15 +7811,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
-name = "renacer"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf14117858798c5cba59ec7f797ac8f365553c8333859ae4923298a2246bfc64"
-dependencies = [
- "aprender-profile",
-]
-
-[[package]]
 name = "renacer-core"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7797,15 +7834,15 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
- "http 1.4.2",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.10.1",
+ "hyper",
  "hyper-rustls",
  "hyper-util",
  "js-sys",
@@ -7835,17 +7872,17 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.13.4"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+checksum = "04e9018c9d814e5f30cc16a0f03271aeab3571e609612d9fe78c1aa8d11c2f62"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-core",
- "http 1.4.2",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.10.1",
+ "hyper",
  "hyper-rustls",
  "hyper-util",
  "js-sys",
@@ -7854,6 +7891,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "serde",
@@ -7916,9 +7954,9 @@ dependencies = [
 
 [[package]]
 name = "roaring"
-version = "0.10.12"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e8d2cfa184d94d0726d650a9f4a1be7f9b76ac9fdb954219878dc00c1c1e7b"
+checksum = "1dedc5658c6ecb3bdb5ef5f3295bb9253f42dcf3fd1402c03f6b1f7659c3c4a9"
 dependencies = [
  "bytemuck",
  "byteorder",
@@ -8106,9 +8144,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.7.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
@@ -8178,7 +8216,7 @@ dependencies = [
  "nix 0.30.1",
  "radix_trie",
  "unicode-segmentation",
- "unicode-width 0.2.0",
+ "unicode-width 0.2.2",
  "utf8parse",
  "windows-sys 0.60.2",
 ]
@@ -8606,16 +8644,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
-name = "simd_cesu8"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
-dependencies = [
- "rustc_version",
- "simdutf8",
-]
-
-[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8709,16 +8737,6 @@ checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
@@ -8772,6 +8790,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spirv"
+version = "0.4.0+sdk-1.4.341.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9571ea910ebd84c86af4b3ed27f9dbdc6ad06f17c5f96146b2b671e2976744f"
+dependencies = [
+ "bitflags 2.13.0",
+]
+
+[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8816,6 +8843,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
+
+[[package]]
 name = "string_cache"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8852,6 +8885,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8859,33 +8903,11 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.26.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
-dependencies = [
- "strum_macros 0.26.4",
-]
-
-[[package]]
-name = "strum"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
- "strum_macros 0.28.0",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
-dependencies = [
- "heck 0.5.0",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 2.0.117",
+ "strum_macros",
 ]
 
 [[package]]
@@ -8908,9 +8930,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swc_atoms"
-version = "7.0.0"
+version = "9.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3500dcf04c84606b38464561edc5e46f5132201cb3e23cf9613ed4033d6b1bb2"
+checksum = "845f31910b5236db42dba106e8277681098d183b9b65b8dfa88ca8abe464aeff"
 dependencies = [
  "hstr",
  "once_cell",
@@ -8919,9 +8941,9 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "14.0.4"
+version = "23.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2bb772b3a26b8b71d4e8c112ced5b5867be2266364b58517407a270328a2696"
+checksum = "353daaf5e6c2ad90efd4ff52270173074ded88fdba5a40f302c7c3a9b1c037fb"
 dependencies = [
  "anyhow",
  "ast_node",
@@ -8929,7 +8951,6 @@ dependencies = [
  "bytes-str",
  "either",
  "from_variant",
- "new_debug_unreachable",
  "num-bigint",
  "once_cell",
  "rustc-hash 2.1.2",
@@ -8939,15 +8960,15 @@ dependencies = [
  "swc_eq_ignore_macros",
  "swc_visit",
  "tracing",
- "unicode-width 0.1.11",
+ "unicode-width 0.2.2",
  "url",
 ]
 
 [[package]]
 name = "swc_ecma_ast"
-version = "15.0.0"
+version = "25.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65c25af97d53cf8aab66a6c68f3418663313fc969ad267fc2a4d19402c329be1"
+checksum = "a207e09f23885ff1f4354ebfdd4e715ccd4a68fca2e7e0df09baafbca850762e"
 dependencies = [
  "bitflags 2.13.0",
  "is-macro",
@@ -8963,12 +8984,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "swc_ecma_lexer"
-version = "23.0.2"
+name = "swc_ecma_parser"
+version = "41.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "017d06ea85008234aa9fb34d805c7dc563f2ea6e03869ed5ac5a2dc27d561e4d"
+checksum = "c309c89bf8f08cd064e67dda821009673895a85144417f811dfc1dc4ee71458c"
 dependencies = [
- "arrayvec",
  "bitflags 2.13.0",
  "either",
  "num-bigint",
@@ -8976,7 +8996,6 @@ dependencies = [
  "rustc-hash 2.1.2",
  "seq-macro",
  "serde",
- "smallvec",
  "smartstring",
  "stacker",
  "swc_atoms",
@@ -8986,26 +9005,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "swc_ecma_parser"
-version = "24.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e9011783c975ba592ffc09cd208ced92b1dfabb2e5e0ef453559e2e25286127"
-dependencies = [
- "either",
- "num-bigint",
- "serde",
- "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
- "swc_ecma_lexer",
- "tracing",
-]
-
-[[package]]
 name = "swc_ecma_visit"
-version = "15.0.0"
+version = "25.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a579aa8f9e212af521588df720ccead079c09fe5c8f61007cf724324aed3a0"
+checksum = "1f9cb1e958e57fa6427c106674a12190c4578684beee783e3a0508f048d1b372"
 dependencies = [
  "new_debug_unreachable",
  "num-bigint",
@@ -9123,16 +9126,17 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.37.2"
+version = "0.39.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16607d5caffd1c07ce073528f9ed972d88db15dd44023fa57142963be3feb11f"
+checksum = "21d0d938c10fcda3e897e28aaddf4ab462375d411f4378cd63b1c945f69aba96"
 dependencies = [
  "libc",
  "memchr",
  "ntapi",
  "objc2-core-foundation",
  "objc2-io-kit",
- "windows 0.61.3",
+ "objc2-open-directory",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -9214,7 +9218,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
 dependencies = [
  "fnv",
- "nom",
+ "nom 7.1.3",
  "phf",
  "phf_codegen",
 ]
@@ -9241,7 +9245,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
 dependencies = [
  "anyhow",
- "base64 0.22.1",
+ "base64",
  "bitflags 2.13.0",
  "fancy-regex 0.11.0",
  "filedescriptor",
@@ -9431,7 +9435,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.4",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -9481,18 +9485,6 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
-dependencies = [
- "futures-util",
- "log",
- "tokio",
- "tungstenite 0.21.0",
-]
-
-[[package]]
-name = "tokio-tungstenite"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
@@ -9500,7 +9492,7 @@ dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite 0.29.0",
+ "tungstenite",
 ]
 
 [[package]]
@@ -9628,12 +9620,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
- "base64 0.22.1",
+ "base64",
  "bytes",
- "http 1.4.2",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.10.1",
+ "hyper",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
@@ -9703,8 +9695,8 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http 1.4.2",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "pin-project-lite",
  "tokio",
  "tokio-util",
@@ -9801,21 +9793,23 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.23.2"
+version = "0.26.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0203df02a3b6dd63575cc1d6e609edc2181c9a11867a271b25cfd2abff3ec5ca"
+checksum = "4dab76d0b724ba557954125188cf0633a1ca43199ced82d95c7b9c32cc3de1f3"
 dependencies = [
  "cc",
  "regex",
  "regex-syntax",
+ "serde_json",
+ "streaming-iterator",
  "tree-sitter-language",
 ]
 
 [[package]]
 name = "tree-sitter-c"
-version = "0.23.4"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afd2b1bf1585dc2ef6d69e87d01db8adb059006649dd5f96f31aa789ee6e9c71"
+checksum = "a9b2eb57a55fed6b00812912e730b7a275cf4fe98bfd6a5d76263d4438371728"
 dependencies = [
  "cc",
  "tree-sitter-language",
@@ -9833,9 +9827,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-go"
-version = "0.23.4"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b13d476345220dbe600147dd444165c5791bf85ef53e28acbedd46112ee18431"
+checksum = "c8560a4d2f835cc0d4d2c2e03cbd0dde2f6114b43bc491164238d333e28b16ea"
 dependencies = [
  "cc",
  "tree-sitter-language",
@@ -9843,9 +9837,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-javascript"
-version = "0.23.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf40bf599e0416c16c125c3cec10ee5ddc7d1bb8b0c60fa5c4de249ad34dc1b1"
+checksum = "68204f2abc0627a90bdf06e605f5c470aa26fdcb2081ea553a04bdad756693f5"
 dependencies = [
  "cc",
  "tree-sitter-language",
@@ -9869,9 +9863,9 @@ checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
 
 [[package]]
 name = "tree-sitter-lua"
-version = "0.2.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cdb9adf0965fec58e7660cbb3a059dbb12ebeec9459e6dcbae3db004739641e"
+checksum = "8daaf5f4235188a58603c39760d5fa5d4b920d36a299c934adddae757f32a10c"
 dependencies = [
  "cc",
  "tree-sitter-language",
@@ -9879,9 +9873,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-python"
-version = "0.23.6"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d065aaa27f3aaceaf60c1f0e0ac09e1cb9eb8ed28e7bcdaa52129cffc7f4b04"
+checksum = "6bf85fd39652e740bf60f46f4cda9492c3a9ad75880575bf14960f775cb74a1c"
 dependencies = [
  "cc",
  "tree-sitter-language",
@@ -9889,9 +9883,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-rust"
-version = "0.23.3"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8ccb3e3a3495c8a943f6c3fd24c3804c471fd7f4f16087623c7fa4c0068e8a"
+checksum = "439e577dbe07423ec2582ac62c7531120dbfccfa6e5f92406f93dd271a120e45"
 dependencies = [
  "cc",
  "tree-sitter-language",
@@ -9962,7 +9956,7 @@ dependencies = [
  "futures-intrusive",
  "hostname",
  "num_cpus",
- "pollster 0.4.0",
+ "pollster",
  "provable-contracts-macros 0.2.2",
  "rayon",
  "serde",
@@ -9973,15 +9967,6 @@ dependencies = [
  "trueno-gemm-codegen",
  "trueno-quant",
  "wgpu 27.0.1",
-]
-
-[[package]]
-name = "trueno"
-version = "0.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4345857bde03e293203b222b8040cadee91c4cc957c31996f1df424a524a2234"
-dependencies = [
- "aprender-compute 0.29.0",
 ]
 
 [[package]]
@@ -10040,22 +10025,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "trueno-graph"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fb66018c97b3a2296df80bdaedcc8d47879e61cd43b466609e9d1a24ce4a0d3"
-dependencies = [
- "anyhow",
- "aprender 0.27.8",
- "arrow 54.3.1",
- "parquet 54.3.1",
- "thiserror 2.0.18",
- "tokio",
- "trueno 0.17.5",
- "trueno-db",
-]
-
-[[package]]
 name = "trueno-quant"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10089,7 +10058,7 @@ version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "882ffd53613bef43526c08f0a87d6058a10c276a599c7055caa985103475faf9"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "batuta-common",
  "libc",
  "png",
@@ -10103,13 +10072,13 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90f068401a9878ba9a5874e4b69e3eec75aae215f73aab966e99c9529f7943c4"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "batuta-common",
  "crossterm 0.29.0",
  "dirs 5.0.1",
  "libc",
  "png",
- "ratatui 0.30.1",
+ "ratatui",
  "serde",
  "serde_yaml_ng",
  "thiserror 2.0.18",
@@ -10141,23 +10110,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
-name = "tungstenite"
-version = "0.21.0"
+name = "ttf-parser"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
-dependencies = [
- "byteorder",
- "bytes",
- "data-encoding",
- "http 1.4.2",
- "httparse",
- "log",
- "rand 0.8.6",
- "sha1",
- "thiserror 1.0.69",
- "url",
- "utf-8",
-]
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
 
 [[package]]
 name = "tungstenite"
@@ -10167,7 +10123,7 @@ checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
 dependencies = [
  "bytes",
  "data-encoding",
- "http 1.4.2",
+ "http",
  "httparse",
  "log",
  "rand 0.9.4",
@@ -10225,6 +10181,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-general-category"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10252,21 +10214,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
-
-[[package]]
-name = "unicode-truncate"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
-dependencies = [
- "itertools 0.13.0",
- "unicode-segmentation",
- "unicode-width 0.1.11",
-]
 
 [[package]]
 name = "unicode-truncate"
@@ -10276,7 +10233,7 @@ checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
  "itertools 0.14.0",
  "unicode-segmentation",
- "unicode-width 0.2.0",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -10287,9 +10244,9 @@ checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
 name = "unicode-width"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"
@@ -10315,7 +10272,7 @@ version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "flate2",
  "log",
  "once_cell",
@@ -10334,7 +10291,7 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "flate2",
  "log",
  "percent-encoding",
@@ -10351,8 +10308,8 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
 dependencies = [
- "base64 0.22.1",
- "http 1.4.2",
+ "base64",
+ "http",
  "httparse",
  "log",
 ]
@@ -10517,20 +10474,21 @@ dependencies = [
 
 [[package]]
 name = "warp"
-version = "0.3.7"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4378d202ff965b011c64817db11d5829506d3404edeadb61f190d111da3f231c"
+checksum = "c0a808122a8a77eecdabaefd88ddb1913c4be5ea1465399f63ba64c7aa705fea"
 dependencies = [
  "bytes",
- "futures-channel",
  "futures-util",
  "headers",
- "http 0.2.12",
- "hyper 0.14.32",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
  "log",
  "mime",
  "mime_guess",
- "multer",
  "percent-encoding",
  "pin-project",
  "scoped-tls",
@@ -10538,7 +10496,6 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "tokio",
- "tokio-tungstenite 0.21.0",
  "tokio-util",
  "tower-service",
  "tracing",
@@ -10714,19 +10671,6 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.239.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9d90bb93e764f6beabf1d02028c70a2156a6583e63ac4218dd07ef733368b0"
-dependencies = [
- "bitflags 2.13.0",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
- "serde",
-]
-
-[[package]]
-name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
@@ -10735,6 +10679,31 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.252.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3eb099dcadcde5be9eef55e3a337128efd4e44b4c93122487e4d2e4e1c6627c"
+dependencies = [
+ "bitflags 2.13.0",
+ "hashbrown 0.17.1",
+ "indexmap",
+ "semver",
+ "serde",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "dlib",
+ "log",
+ "once_cell",
+ "pkg-config",
 ]
 
 [[package]]
@@ -10890,32 +10859,6 @@ dependencies = [
 
 [[package]]
 name = "wgpu"
-version = "24.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b0b3436f0729f6cdf2e6e9201f3d39dc95813fad61d826c1ed07918b4539353"
-dependencies = [
- "arrayvec",
- "bitflags 2.13.0",
- "cfg_aliases 0.2.1",
- "document-features",
- "js-sys",
- "log",
- "naga 24.0.0",
- "parking_lot",
- "profiling",
- "raw-window-handle",
- "smallvec",
- "static_assertions",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "wgpu-core 24.0.5",
- "wgpu-hal 24.0.4",
- "wgpu-types 24.0.0",
-]
-
-[[package]]
-name = "wgpu"
 version = "27.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfe68bac7cde125de7a731c3400723cadaaf1703795ad3f4805f187459cd7a77"
@@ -10941,6 +10884,36 @@ dependencies = [
  "wgpu-core 27.0.3",
  "wgpu-hal 27.0.4",
  "wgpu-types 27.0.1",
+]
+
+[[package]]
+name = "wgpu"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb3feacc458f7bee8bc1737149b42b6c731aa461039a4264a67bb6681646b250"
+dependencies = [
+ "arrayvec",
+ "bitflags 2.13.0",
+ "bytemuck",
+ "cfg-if",
+ "cfg_aliases 0.2.1",
+ "document-features",
+ "hashbrown 0.16.1",
+ "js-sys",
+ "log",
+ "naga 29.0.3",
+ "parking_lot",
+ "portable-atomic",
+ "profiling",
+ "raw-window-handle",
+ "smallvec",
+ "static_assertions",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "wgpu-core 29.0.3",
+ "wgpu-hal 29.0.3",
+ "wgpu-types 29.0.3",
 ]
 
 [[package]]
@@ -10970,31 +10943,6 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "24.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f0aa306497a238d169b9dc70659105b4a096859a34894544ca81719242e1499"
-dependencies = [
- "arrayvec",
- "bit-vec 0.8.0",
- "bitflags 2.13.0",
- "cfg_aliases 0.2.1",
- "document-features",
- "indexmap",
- "log",
- "naga 24.0.0",
- "once_cell",
- "parking_lot",
- "profiling",
- "raw-window-handle",
- "rustc-hash 1.1.0",
- "smallvec",
- "thiserror 2.0.18",
- "wgpu-hal 24.0.4",
- "wgpu-types 24.0.0",
-]
-
-[[package]]
-name = "wgpu-core"
 version = "27.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27a75de515543b1897b26119f93731b385a19aea165a1ec5f0e3acecc229cae7"
@@ -11018,11 +10966,44 @@ dependencies = [
  "rustc-hash 1.1.0",
  "smallvec",
  "thiserror 2.0.18",
- "wgpu-core-deps-apple",
- "wgpu-core-deps-emscripten",
- "wgpu-core-deps-windows-linux-android",
+ "wgpu-core-deps-apple 27.0.0",
+ "wgpu-core-deps-emscripten 27.0.0",
+ "wgpu-core-deps-windows-linux-android 27.0.0",
  "wgpu-hal 27.0.4",
  "wgpu-types 27.0.1",
+]
+
+[[package]]
+name = "wgpu-core"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02da3ad1b568337f25513b317870960ef87073ea0945502e44b864b67a8c77b7"
+dependencies = [
+ "arrayvec",
+ "bit-set 0.9.1",
+ "bit-vec 0.9.1",
+ "bitflags 2.13.0",
+ "bytemuck",
+ "cfg_aliases 0.2.1",
+ "document-features",
+ "hashbrown 0.16.1",
+ "indexmap",
+ "log",
+ "naga 29.0.3",
+ "once_cell",
+ "parking_lot",
+ "portable-atomic",
+ "profiling",
+ "raw-window-handle",
+ "rustc-hash 1.1.0",
+ "smallvec",
+ "thiserror 2.0.18",
+ "wgpu-core-deps-apple 29.0.3",
+ "wgpu-core-deps-emscripten 29.0.3",
+ "wgpu-core-deps-windows-linux-android 29.0.3",
+ "wgpu-hal 29.0.3",
+ "wgpu-naga-bridge",
+ "wgpu-types 29.0.3",
 ]
 
 [[package]]
@@ -11035,6 +11016,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wgpu-core-deps-apple"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62e51b5447e144b3dbba4feb01f80f4fa21696fa0cd99afb2c3df1affd6fdb28"
+dependencies = [
+ "wgpu-hal 29.0.3",
+]
+
+[[package]]
 name = "wgpu-core-deps-emscripten"
 version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11044,12 +11034,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "wgpu-core-deps-emscripten"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3487cd6293a963bc5c0c0396f6a2192043c50003c07f4efdccbad3d90ec9d819"
+dependencies = [
+ "wgpu-hal 29.0.3",
+]
+
+[[package]]
 name = "wgpu-core-deps-windows-linux-android"
 version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71197027d61a71748e4120f05a9242b2ad142e3c01f8c1b47707945a879a03c3"
 dependencies = [
  "wgpu-hal 27.0.4",
+]
+
+[[package]]
+name = "wgpu-core-deps-windows-linux-android"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb01076d0aa08b0ba9bd741e178b5cc440f5abe99d9581323a4c8b5d1a1916"
+dependencies = [
+ "wgpu-hal 29.0.3",
 ]
 
 [[package]]
@@ -11095,52 +11103,6 @@ dependencies = [
  "web-sys",
  "wgpu-types 22.0.0",
  "winapi",
-]
-
-[[package]]
-name = "wgpu-hal"
-version = "24.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f112f464674ca69f3533248508ee30cb84c67cf06c25ff6800685f5e0294e259"
-dependencies = [
- "android_system_properties",
- "arrayvec",
- "ash",
- "bit-set 0.8.0",
- "bitflags 2.13.0",
- "block",
- "bytemuck",
- "cfg_aliases 0.2.1",
- "core-graphics-types 0.1.3",
- "glow 0.16.0",
- "glutin_wgl_sys",
- "gpu-alloc",
- "gpu-allocator 0.27.0",
- "gpu-descriptor",
- "js-sys",
- "khronos-egl",
- "libc",
- "libloading",
- "log",
- "metal 0.31.0",
- "naga 24.0.0",
- "ndk-sys 0.5.0+25.2.9519653",
- "objc",
- "once_cell",
- "ordered-float 4.6.0",
- "parking_lot",
- "profiling",
- "range-alloc",
- "raw-window-handle",
- "renderdoc-sys",
- "rustc-hash 1.1.0",
- "smallvec",
- "thiserror 2.0.18",
- "wasm-bindgen",
- "web-sys",
- "wgpu-types 24.0.0",
- "windows 0.58.0",
- "windows-core 0.58.0",
 ]
 
 [[package]]
@@ -11193,6 +11155,70 @@ dependencies = [
 ]
 
 [[package]]
+name = "wgpu-hal"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31f8e1a9e7a8512f276f7c62e018c7fa8d60954303fed2e5750114332049193f"
+dependencies = [
+ "android_system_properties",
+ "arrayvec",
+ "ash",
+ "bit-set 0.9.1",
+ "bitflags 2.13.0",
+ "block2",
+ "bytemuck",
+ "cfg-if",
+ "cfg_aliases 0.2.1",
+ "glow 0.17.0",
+ "glutin_wgl_sys",
+ "gpu-allocator 0.28.0",
+ "gpu-descriptor",
+ "hashbrown 0.16.1",
+ "js-sys",
+ "khronos-egl",
+ "libc",
+ "libloading",
+ "log",
+ "naga 29.0.3",
+ "ndk-sys 0.6.0+11769913",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "objc2-metal",
+ "objc2-quartz-core",
+ "once_cell",
+ "ordered-float 5.3.0",
+ "parking_lot",
+ "portable-atomic",
+ "portable-atomic-util",
+ "profiling",
+ "range-alloc",
+ "raw-window-handle",
+ "raw-window-metal",
+ "renderdoc-sys",
+ "smallvec",
+ "thiserror 2.0.18",
+ "wasm-bindgen",
+ "wayland-sys",
+ "web-sys",
+ "wgpu-naga-bridge",
+ "wgpu-types 29.0.3",
+ "windows 0.62.2",
+ "windows-core 0.62.2",
+ "windows-result 0.4.1",
+]
+
+[[package]]
+name = "wgpu-naga-bridge"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59c654c483f058800972c3645e95388a7eca31bf9fe1933bc20e036588a0be02"
+dependencies = [
+ "naga 29.0.3",
+ "wgpu-types 29.0.3",
+]
+
+[[package]]
 name = "wgpu-types"
 version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11200,18 +11226,6 @@ checksum = "bc9d91f0e2c4b51434dfa6db77846f2793149d8e73f800fa2e41f52b8eac3c5d"
 dependencies = [
  "bitflags 2.13.0",
  "js-sys",
- "web-sys",
-]
-
-[[package]]
-name = "wgpu-types"
-version = "24.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50ac044c0e76c03a0378e7786ac505d010a873665e2d51383dcff8dd227dc69c"
-dependencies = [
- "bitflags 2.13.0",
- "js-sys",
- "log",
  "web-sys",
 ]
 
@@ -11226,6 +11240,20 @@ dependencies = [
  "js-sys",
  "log",
  "thiserror 2.0.18",
+ "web-sys",
+]
+
+[[package]]
+name = "wgpu-types"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9bcc31518a0e9735aefebedb5f7a9ef3ed1c42549c9f4c882fa9060ceaac639"
+dependencies = [
+ "bitflags 2.13.0",
+ "bytemuck",
+ "js-sys",
+ "log",
+ "raw-window-handle",
  "web-sys",
 ]
 
@@ -11251,6 +11279,15 @@ dependencies = [
  "env_home",
  "rustix 1.1.4",
  "winsafe",
+]
+
+[[package]]
+name = "which"
+version = "8.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c789537cf2f7f55be8e6192f92e464174ee55f91af622777f7f1ceb0dbccd03e"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -11312,24 +11349,23 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.61.3"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
  "windows-collections",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
  "windows-future",
- "windows-link 0.1.3",
  "windows-numerics",
 ]
 
 [[package]]
 name = "windows-collections"
-version = "0.2.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -11356,38 +11392,25 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
-dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
-]
-
-[[package]]
-name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement 0.60.2",
  "windows-interface 0.59.3",
- "windows-link 0.2.1",
+ "windows-link",
  "windows-result 0.4.1",
  "windows-strings 0.5.1",
 ]
 
 [[package]]
 name = "windows-future"
-version = "0.2.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
+ "windows-core 0.62.2",
+ "windows-link",
  "windows-threading",
 ]
 
@@ -11437,24 +11460,18 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-numerics"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
+ "windows-core 0.62.2",
+ "windows-link",
 ]
 
 [[package]]
@@ -11468,20 +11485,11 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
-dependencies = [
- "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -11496,20 +11504,20 @@ dependencies = [
 
 [[package]]
 name = "windows-strings"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
-dependencies = [
- "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-strings"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
 ]
 
 [[package]]
@@ -11554,7 +11562,22 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -11594,7 +11617,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
@@ -11607,12 +11630,18 @@ dependencies = [
 
 [[package]]
 name = "windows-threading"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -11634,6 +11663,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -11649,6 +11684,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -11682,6 +11723,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -11697,6 +11744,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -11718,6 +11771,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -11733,6 +11792,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -12075,6 +12140,12 @@ dependencies = [
  "zopfli",
  "zstd",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pmat"
-version = "3.18.4"
+version = "3.19.0"
 edition = "2021"
 rust-version = "1.80.0"
 authors = ["Pragmatic AI Labs"]
@@ -31,7 +31,7 @@ required-features = ["mcp-integration"]
 batuta-common = "0.1"
 
 # Organizational Intelligence Plugin - Phase 4 integration
-organizational-intelligence-plugin = { package = "aprender-orchestrate", version = "0.30", optional = true }
+organizational-intelligence-plugin = { package = "aprender-orchestrate", version = "0.41", optional = true }  # 0.41 removed the OIP analyzer/report/summarizer API; `pmat org analyze` is stubbed (see org_handlers.rs)
 
 # Async runtime
 # Sprint 46 Phase 4: Removed "io-std", "signal", "process" features (saves 180-280 KB)
@@ -54,7 +54,7 @@ async-raft = { version = "0.6", optional = true }
 crossbeam = { version = "0.8", optional = true }
 
 # Resource management (only used by mcp-integration feature: resources/)
-sysinfo = { version = "0.37", optional = true }  # Updated for reduced duplicates
+sysinfo = { version = "0.39", optional = true }  # Updated for reduced duplicates
 libc = { version = "0.2", optional = true }
 
 # Text similarity - Now using aprender::text::similarity (edit_distance_similarity)
@@ -64,28 +64,28 @@ libc = { version = "0.2", optional = true }
 # Migration to aprender complete (Sprint 45)
 # Graph algorithms enhanced (Sprint 46) - added 8 new centrality & structural stats
 # See: docs/specifications/aprender-ml-integration.md
-aprender = "0.30"  # Aprender monorepo: ML, stats, text similarity, sovereign stack foundation
+aprender = "0.41"  # Aprender monorepo: ML, stats, text similarity, sovereign stack foundation
 
 # High-Performance Compute (SIMD/GPU)
-aprender-compute = { version = "0.30", optional = true }
-aprender-db = { version = "0.30", optional = true, default-features = false }
+aprender-compute = { version = "0.41", optional = true }
+aprender-db = { version = "0.41", optional = true, default-features = false }
 
 # Semantic Search Stack (Pure Rust - Zero API Keys)
 # See: docs/specifications/semantic-search-feature.md
-aprender-graph = { version = "0.30", default-features = false }  # CSR graph, PageRank, Louvain
+aprender-graph = { version = "0.41", default-features = false }  # CSR graph, PageRank, Louvain
 aprender-rag = { version = "0.41", optional = true }  # RAG pipeline
-aprender-viz = { version = "0.30", optional = true, features = ["terminal", "graph"] }
+aprender-viz = { version = "0.41", optional = true, features = ["terminal", "graph"] }
 
 # Analytics GPU dependencies (optional, gated by analytics-gpu feature)
 # Issue #79: Feature-gated architecture to prevent +3.8 MB binary bloat
-wgpu = { version = "24.0", optional = true, features = ["wgsl"] }
-pollster = { version = "0.3", optional = true }  # Async runtime for wgpu
+wgpu = { version = "29.0", optional = true, features = ["wgsl"] }
+pollster = { version = "0.4", optional = true }  # Async runtime for wgpu
 bytemuck = { version = "1.14", optional = true }  # Safe cast for GPU buffers
-arrow = { version = "54", optional = true }  # Arrow columnar format (required for direct arrow API usage)
+arrow = { version = "57", optional = true }  # Arrow columnar format. MUST match aprender-db's arrow (57) — pmat passes RecordBatch/arrays across the aprender-db (lib `trueno_db`) boundary, so arrow type identity is required.
 # Note: parquet is managed by trueno-db dependency
 
 # Document indexing (PDF text extraction for `pmat query --docs`)
-pdf-extract = { version = "0.7", optional = true }
+pdf-extract = { version = "0.10", optional = true }
 
 # Serialization (pinned to avoid swc_common issue with serde::__private)
 serde = { version = "1.0", default-features = false, features = ["derive", "std"] }
@@ -100,7 +100,7 @@ minijinja = { version = "2.16", default-features = false, optional = true }
 pmcp = { version = "2.9", features = ["websocket", "http", "sse", "validation"] }
 
 # Caching
-lru = { version = "0.16", features = ["hashbrown"], optional = true }
+lru = { version = "0.18", features = ["hashbrown"], optional = true }
 
 # Error handling
 thiserror = "2.0"
@@ -112,7 +112,7 @@ tracing = { version = "0.1", default-features = false, features = ["std"] }
 tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt", "std"], optional = true }
 
 # Utilities
-sha2 = { version = "0.10", optional = true }
+sha2 = { version = "0.11", optional = true }
 # once_cell removed: migrated to std::sync::LazyLock/OnceLock (Rust 1.80+)
 lazy_static = { version = "1.5", optional = true }
 semver = { version = "1.0", features = ["serde"], optional = true }
@@ -124,11 +124,11 @@ csv = { version = "1.3", optional = true }
 uuid = { version = "1.17", features = ["v4", "v7", "serde"], optional = true }
 parking_lot = { version = "0.12", optional = true }
 dirs = { version = "6.0", optional = true }
-roaring = { version = "0.10", optional = true }
+roaring = { version = "0.11", optional = true }
 rand = { version = "0.9", optional = true }
 rayon = { version = "1.10", optional = true }
 # Optional: saves 67 transitive deps when disabled - falls back to shell `git` commands
-git2 = { version = "0.20", default-features = false, features = ["https"], optional = true }
+git2 = { version = "0.21", default-features = false, features = ["https"], optional = true }
 
 # CLI utilities - REMOVED to save transitive deps
 # dialoguer = "0.12"  # REMOVED: Replaced with simple stdin (saves 14 transitive deps)
@@ -141,19 +141,20 @@ syntect = { version = "5.2", default-features = false, features = ["default-fanc
 
 # Storage
 # libsql = "0.9.24"  # REMOVED: Not used directly (migration to rusqlite complete)
-lz4_flex = { version = "0.11", optional = true }  # Legacy index format
-aprender-zram-core = { version = "0.30", optional = true }
+lz4_flex = { version = "0.13", optional = true }  # Legacy index format
+aprender-zram-core = { version = "0.41", optional = true }
 rusqlite = { version = "0.32", features = ["bundled"], optional = true }  # SQLite with bundled library
 # sled = REMOVED (unmaintained, migrated to libsql/trueno-db)
 # rocksdb = { version = "0.22", default-features = false, features = ["zstd"] }
-bincode = { version = "1.3", optional = true }
+# bincode REMOVED: 3.0.0 is a non-functional placeholder release (compile_error),
+# 2.x is a breaking rewrite. Replaced by rmp-serde (MessagePack), already in-tree.
 
 # Async utilities
 futures = { version = "0.3", optional = true }
 
 # GitHub API client (Issue #75: Unified GitHub/YAML workflow)
 # Optional: saves 255 transitive deps when disabled - falls back to `gh` CLI
-octocrab = { version = "0.48", optional = true }
+octocrab = { version = "0.53", optional = true }
 
 # File watching for configuration hot-reload (feature-gated: watch)
 notify = { version = "8.0", optional = true }
@@ -170,27 +171,27 @@ proc-macro2 = { version = "1.0", optional = true }
 walkdir = { version = "2.5", optional = true }
 ignore = { version = "0.4", optional = true }
 glob = { version = "0.3", optional = true }
-toml = { version = "0.8.23", optional = true }
+toml = { version = "1.1", optional = true }
 crossbeam-channel = { version = "0.5", optional = true }
-which = { version = "6.0", optional = true }  # Sprint 70: Find cargo-mutants in PATH
+which = { version = "8.0", optional = true }  # Sprint 70: Find cargo-mutants in PATH
 # For TypeScript/JavaScript parsing (conditional) - use compatible versions
-swc_ecma_parser = { version = "24.0", optional = true }
-swc_common = { version = "14.0", optional = true }
-swc_ecma_ast = { version = "15.0", optional = true }
-swc_ecma_visit = { version = "15.0", optional = true }
+swc_ecma_parser = { version = "41.0", optional = true }
+swc_common = { version = "23.0", optional = true }
+swc_ecma_ast = { version = "25.0", optional = true }
+swc_ecma_visit = { version = "25.0", optional = true }
 # For Python parsing (conditional) - REMOVED: Migrated to tree-sitter-python
 # rustpython-parser = { version = "0.4.0", optional = true }
 # For C/C++ parsing (conditional)
-tree-sitter = { version = "0.23", optional = true }
-tree-sitter-c = { version = "0.23", optional = true }
+tree-sitter = { version = "0.26", optional = true }
+tree-sitter-c = { version = "0.24", optional = true }
 tree-sitter-cpp = { version = "0.23", optional = true }
-tree-sitter-go = { version = "0.23", optional = true }
-tree-sitter-javascript = { version = "0.23", optional = true }
+tree-sitter-go = { version = "0.25", optional = true }
+tree-sitter-javascript = { version = "0.25", optional = true }
 tree-sitter-typescript = { version = "0.23", optional = true }
-tree-sitter-python = { version = "0.23", optional = true }
-tree-sitter-lua = { version = "0.2.0", optional = true }
+tree-sitter-python = { version = "0.25", optional = true }
+tree-sitter-lua = { version = "0.5", optional = true }
 tree-sitter-kotlin-ng = { version = "1.1", optional = true }
-tree-sitter-rust = { version = "0.23", optional = true }
+tree-sitter-rust = { version = "0.24", optional = true }
 # Sprint 46 Phase 6: Removed unused tree-sitter parsers (0 references - cargo-machete verified)
 # tree-sitter-c-sharp = { version = "0.23", optional = true }  # 0 references
 # tree-sitter-java = { version = "0.23", optional = true }      # 0 references
@@ -209,8 +210,8 @@ ruchy = { version = "4.2.1", optional = true }
 # tree-sitter-kotlin = { version = "0.3.8", optional = true }
 
 # Language-specific analysis
-cpp_demangle = { version = "0.4", optional = true }
-gimli = { version = "0.32", optional = true }
+cpp_demangle = { version = "0.5", optional = true }
+gimli = { version = "0.33", optional = true }
 goblin = { version = "0.10", optional = true }
 # Analysis infrastructure for C/C++
 fixedbitset = { version = "0.5", optional = true }
@@ -249,11 +250,11 @@ http-body-util = { version = "0.1", optional = true }
 pulldown-cmark = { version = "0.13", optional = true }
 
 # HTTP client for GitHub API (optional - feature-gated behind http-client)
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"], optional = true }
+reqwest = { version = "0.13", default-features = false, features = ["json", "rustls", "rustls-native-certs"], optional = true }
 
 # Prometheus metrics (optional - rarely used)
 prometheus = { version = "0.14", optional = true }
-warp = { version = "0.3", optional = true }
+warp = { version = "0.4", optional = true, features = ["server"] }  # 0.4 gates serve()/Server behind the `server` feature
 
 # Table formatting - REMOVED: Using simple println formatting (saves 16 transitive deps)
 # prettytable-rs = "0.10"
@@ -262,13 +263,13 @@ warp = { version = "0.3", optional = true }
 # presentar-terminal provides: TuiApp, DiffRenderer, BrailleGraph, Meter, Table
 # Benefits: Jidoka verification gates, zero-allocation rendering, 95% coverage
 # presentar-terminal = { version = "0.3.0", path = "../../presentar/crates/presentar-terminal", optional = true }  # Not yet on crates.io
-aprender-present-core = { version = "0.30", optional = true }
+aprender-present-core = { version = "0.41", optional = true }
 # crossterm 0.28 matches presentar-terminal's version (ratatui REMOVED)
-crossterm = { version = "0.28", optional = true }
+crossterm = { version = "0.29", optional = true }
 sys-info = { version = "0.9.1", optional = true }
 
 # Storage backends (sled/rocksdb REMOVED - migrated to libsql/trueno-db)
-wasmparser = { version = "0.239.0", optional = true }
+wasmparser = { version = "0.252", optional = true }
 shell-words = { version = "1.1.0", optional = true }
 crc32fast = { version = "1.5.0", optional = true }
 # pest = "2.8.2"  # REMOVED: WorkflowParser never instantiated, DslCompiler uses serde
@@ -282,14 +283,14 @@ sourcemap = { version = "9.0", optional = true }  # Only needed for deep-wasm so
 # ahash = "0.8"  # REMOVED: cargo-machete verified unused
 prettyplease = { version = "0.2.37", optional = true }
 fs2 = { version = "0.4.3", optional = true }
-aprender-contracts-macros = "0.30"
+aprender-contracts-macros = "0.49"
 
 
 [dev-dependencies]
-aprender-contracts = "0.30"
+aprender-contracts = "0.49"
 dhat = "0.3"
 tokio-test = "0.4"
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.13", default-features = false, features = ["json", "rustls", "rustls-native-certs"] }
 pretty_assertions = "1.4"
 tempfile = "3.20"
 assert_cmd = "2.0"      # CLI testing for PMAT-7001
@@ -308,7 +309,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml_ng = { version = "0.10", optional = true }
 # hex removed: generated code now uses inline hex_decode_templates() (CB-081)
-sha2 = { version = "0.10", optional = true }  # For O(1) build artifact hash caching
+sha2 = { version = "0.11", optional = true }  # For O(1) build artifact hash caching
 # capnpc = "0.20" # REMOVED: Unused Cap'n Proto compiler
 
 [features]
@@ -322,7 +323,7 @@ default = ["core-languages", "viz", "http-client", "standard-deps"]
 # Standard deps bundle — feature-gated for dep count reduction but enabled by default
 standard-deps = [
     "minijinja", "tracing-subscriber", "semver", "globset",
-    "roaring", "rand", "url", "lz4_flex", "bincode", "crossbeam-channel",
+    "roaring", "rand", "url", "lz4_flex", "rmp-serde", "crossbeam-channel",
     "lru", "lazy_static", "dirs", "ignore", "xxhash-rust",
     "flate2", "crc32fast", "fs2", "pulldown-cmark", "aprender-rag", "num_cpus",
     "sha2", "uuid", "futures", "serde_yaml_ng", "blake3", "dashmap",
@@ -478,7 +479,7 @@ sovereign-compression = ["aprender-zram-core"]
 
 # Analytics features (Issue #79: Feature-gated architecture)
 # Default: SIMD-only (7.8 MB, 18s compile, ≤30 transitive deps)
-analytics-simd = ["aprender-compute", "aprender-db", "aprender-db/simd", "arrow"]
+analytics-simd = ["aprender-compute", "aprender-db", "aprender-db/simd", "aprender-db/parquet-io", "arrow"]
 # GPU-enabled: +wgpu (11.6 MB, 63s compile, ≤95 transitive deps)
 analytics-gpu = ["analytics-simd", "aprender-db/gpu", "wgpu", "pollster", "bytemuck"]
 
@@ -724,8 +725,14 @@ required-features = ["lua-ast"]
 # Profile configuration moved to workspace root
 
 [package.metadata.docs.rs]
-# Use default features for documentation (which excludes python-ast due to malachite-bigint build issues)
-features = ["default"]
+# Lean doc build: the full default feature set (swc/typescript-ast, c/cpp-ast via
+# gimli+goblin, every tree-sitter grammar) pushes the docs.rs build past its
+# 15-minute / memory limit for this large crate, which is why the docs.rs badge
+# was failing. Document the core public API with the lightest parser (rust-ast)
+# plus the always-on core (standard-deps), viz, and http-client. The heavy
+# language-parser modules are feature-gated, so this still compiles cleanly.
+no-default-features = true
+features = ["standard-deps", "rust-ast", "viz", "http-client"]
 # Set DOCS_RS environment variable to skip network operations
 rustdoc-args = ["--cfg", "docsrs", "--generate-link-to-definition"]
 rustc-args = ["--cfg", "docsrs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -288,6 +288,7 @@ aprender-contracts-macros = "0.49"
 
 [dev-dependencies]
 aprender-contracts = "0.49"
+rmp-serde = "1.3"  # MessagePack codec for integration tests (replaces bincode after its removal)
 dhat = "0.3"
 tokio-test = "0.4"
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls", "rustls-native-certs"] }

--- a/build.rs
+++ b/build.rs
@@ -370,7 +370,15 @@ fn calculate_templates_hash(templates_dir: &Path) -> Option<String> {
         return None;
     }
 
-    Some(format!("{:x}", hasher.finalize()))
+    // sha2 0.11's finalize() returns an Array<u8> that no longer impls LowerHex;
+    // encode the digest bytes to lowercase hex explicitly.
+    Some(
+        hasher
+            .finalize()
+            .iter()
+            .map(|b| format!("{b:02x}"))
+            .collect(),
+    )
 }
 
 #[cfg(not(feature = "standard-deps"))]
@@ -733,7 +741,15 @@ fn calculate_file_hash(path: &Path) -> Option<String> {
     let content = fs::read(path).ok()?;
     let mut hasher = Sha256::new();
     hasher.update(&content);
-    Some(format!("{:x}", hasher.finalize()))
+    // sha2 0.11's finalize() returns an Array<u8> that no longer impls LowerHex;
+    // encode the digest bytes to lowercase hex explicitly.
+    Some(
+        hasher
+            .finalize()
+            .iter()
+            .map(|b| format!("{b:02x}"))
+            .collect(),
+    )
 }
 
 #[cfg(not(feature = "standard-deps"))]

--- a/src/agents/messaging/message_format_protocol.rs
+++ b/src/agents/messaging/message_format_protocol.rs
@@ -33,7 +33,7 @@ impl BinaryProtocol {
         buf.put_u8(1);
 
         // Header
-        let header_bytes = bincode::serialize(&msg.header)
+        let header_bytes = rmp_serde::to_vec(&msg.header)
             .map_err(|e| ProtocolError::EncodingError(e.to_string()))?;
         buf.put_u32(header_bytes.len() as u32);
         buf.put_slice(&header_bytes);
@@ -84,7 +84,7 @@ impl BinaryProtocol {
         // Decode header
         let header_len = data.get_u32() as usize;
         let header_bytes = data.copy_to_bytes(header_len);
-        let header: MessageHeader = bincode::deserialize(&header_bytes)
+        let header: MessageHeader = rmp_serde::from_slice(&header_bytes)
             .map_err(|e| ProtocolError::DecodingError(e.to_string()))?;
 
         // Decode payload

--- a/src/agents/messaging/messaging_agent.rs
+++ b/src/agents/messaging/messaging_agent.rs
@@ -3,8 +3,8 @@
 impl AgentMessage {
     #[provable_contracts_macros::contract("pmat-core.yaml", equation = "check_compliance")]
     /// Create a new instance.
-    pub fn new(from: Uuid, to: Uuid, payload: impl Serialize) -> Result<Self, bincode::Error> {
-        let payload_bytes = bincode::serialize(&payload)?;
+    pub fn new(from: Uuid, to: Uuid, payload: impl Serialize) -> Result<Self, rmp_serde::encode::Error> {
+        let payload_bytes = rmp_serde::to_vec(&payload)?;
 
         Ok(Self {
             header: MessageHeader {
@@ -58,7 +58,7 @@ impl AgentMessage {
 
     #[provable_contracts_macros::contract("pmat-core.yaml", equation = "check_compliance")]
     /// Deserialize payload.
-    pub fn deserialize_payload<T: for<'de> Deserialize<'de>>(&self) -> Result<T, bincode::Error> {
-        bincode::deserialize(&self.payload)
+    pub fn deserialize_payload<T: for<'de> Deserialize<'de>>(&self) -> Result<T, rmp_serde::decode::Error> {
+        rmp_serde::from_slice(&self.payload)
     }
 }

--- a/src/agents/messaging/pubsub.rs
+++ b/src/agents/messaging/pubsub.rs
@@ -41,7 +41,9 @@ pub struct TopicStats {
 /// Error variants for pub sub operations.
 pub enum PubSubError {
     #[error("Serialization error: {0}")]
-    Serialization(#[from] bincode::Error),
+    Serialization(#[from] rmp_serde::decode::Error),
+    #[error("Encode error: {0}")]
+    Encode(#[from] rmp_serde::encode::Error),
     #[error("No subscribers for topic")]
     NoSubscribers,
 }

--- a/src/agents/messaging/pubsub_tests.rs
+++ b/src/agents/messaging/pubsub_tests.rs
@@ -189,7 +189,7 @@ mod coverage_tests {
         // Create a serialization error by serializing a known-bad value
         // Use a size hint that will trigger a bincode error during deserialization
         let bad_data = vec![0xFFu8; 16]; // Invalid serialized data
-        let result: Result<String, _> = bincode::deserialize(&bad_data);
+        let result: Result<String, _> = rmp_serde::from_slice(&bad_data);
         if let Err(e) = result {
             let pubsub_err = PubSubError::Serialization(e);
             let display_str = format!("{}", pubsub_err);

--- a/src/agents/messaging/request_response.rs
+++ b/src/agents/messaging/request_response.rs
@@ -20,7 +20,9 @@ pub enum RequestError {
     #[error("Request cancelled")]
     Cancelled,
     #[error("Serialization error: {0}")]
-    Serialization(#[from] bincode::Error),
+    Serialization(#[from] rmp_serde::decode::Error),
+    #[error("Encode error: {0}")]
+    Encode(#[from] rmp_serde::encode::Error),
     #[error("Router error: {0}")]
     Router(#[from] RouterError),
 }

--- a/src/agents/messaging/request_response_tests.rs
+++ b/src/agents/messaging/request_response_tests.rs
@@ -337,7 +337,7 @@ mod coverage_tests {
     fn test_request_error_serialization() {
         // Create a bincode deserialization error with invalid data
         let bad_data = vec![0xFFu8; 16]; // Invalid serialized data
-        let bincode_result: Result<String, _> = bincode::deserialize(&bad_data);
+        let bincode_result: Result<String, _> = rmp_serde::from_slice(&bad_data);
 
         if let Err(e) = bincode_result {
             let request_err = RequestError::Serialization(e);

--- a/src/agents_md/discovery/core.rs
+++ b/src/agents_md/discovery/core.rs
@@ -283,7 +283,7 @@ impl AgentsMdDiscovery {
             return;
         };
         for entry in entries.flatten() {
-            if entry.file_type().is_some_and(|ft| ft.is_dir()) {
+            if entry.file_type().is_ok_and(|ft| ft.is_dir()) {
                 self.discover_recursive(&entry.path(), depth + 1, files);
             }
         }

--- a/src/cli/handlers/org_handlers.rs
+++ b/src/cli/handlers/org_handlers.rs
@@ -12,29 +12,17 @@ use crate::cli::colors as c;
 use crate::cli::commands::OrgCommands;
 #[cfg(feature = "org-intelligence")]
 use anyhow::{Context, Result};
-#[cfg(feature = "org-intelligence")]
-use chrono::{Duration, Utc};
-// NOTE: indicatif removed - using local progress types
-#[cfg(feature = "org-intelligence")]
-use crate::services::progress::{ProgressBar, ProgressStyle};
-#[cfg(feature = "org-intelligence")]
-use organizational_intelligence_plugin::analyzer::OrgAnalyzer;
-#[cfg(feature = "org-intelligence")]
-use organizational_intelligence_plugin::github::GitHubMiner;
-#[cfg(feature = "org-intelligence")]
-use organizational_intelligence_plugin::report::{
-    AnalysisMetadata, AnalysisReport, ReportGenerator,
-};
-#[cfg(feature = "org-intelligence")]
-use organizational_intelligence_plugin::summarizer::{ReportSummarizer, SummaryConfig};
-#[cfg(feature = "org-intelligence")]
-use std::env;
+// NOTE: The organizational-intelligence-plugin (aprender-orchestrate) crate was
+// repurposed in 0.41: the OIP API consumed by `handle_org_analyze`
+// (analyzer::OrgAnalyzer, github::GitHubMiner, report::{AnalysisMetadata,
+// AnalysisReport, ReportGenerator}, summarizer::{ReportSummarizer, SummaryConfig})
+// was removed upstream with no replacement. The `org analyze` path is therefore
+// no longer available; `org localize` (fault localization) is PMAT-native and
+// unaffected.
 #[cfg(feature = "org-intelligence")]
 use std::path::{Path, PathBuf};
 #[cfg(feature = "org-intelligence")]
-use tempfile::TempDir;
-#[cfg(feature = "org-intelligence")]
-use tracing::{info, warn};
+use tracing::info;
 
 /// Handle organizational intelligence commands
 #[cfg(feature = "org-intelligence")]
@@ -100,223 +88,36 @@ async fn handle_org_analyze(
     org: &str,
     output: &PathBuf,
     _max_concurrent: usize,
-    summarize: bool,
-    strip_pii: bool,
-    top_n: usize,
-    min_frequency: usize,
+    _summarize: bool,
+    _strip_pii: bool,
+    _top_n: usize,
+    _min_frequency: usize,
 ) -> Result<()> {
+    // The organizational-intelligence-plugin (aprender-orchestrate) crate was
+    // repurposed in 0.41 and the organizational-analysis API that powered this
+    // command (GitHub repo mining via GitHubMiner, OrgAnalyzer defect-pattern
+    // analysis, and the AnalysisReport/ReportSummarizer report pipeline) was
+    // removed upstream with no replacement. There is no longer any backing
+    // implementation for `pmat org analyze`, so surface a clear, actionable
+    // error instead of silently doing nothing.
     println!(
         "\n{}",
         c::header(&format!("Analyzing GitHub Organization: {}", org))
     );
     println!("   {} {:?}", c::label("Output:"), output);
 
-    // Initialize GitHub client
-    let github_token = env::var("GITHUB_TOKEN").ok();
-    if github_token.is_none() {
-        println!(
-            "{}",
-            c::warn("GITHUB_TOKEN not set - using unauthenticated requests (lower rate limits)")
-        );
-        println!("   Set GITHUB_TOKEN environment variable for higher rate limits");
-    }
-
-    let miner = GitHubMiner::new(github_token);
-
-    // Fetch organization repositories
-    info!("Fetching repositories for organization: {}", org);
-    let all_repos = miner
-        .fetch_organization_repos(org)
-        .await
-        .context("Failed to fetch organization repositories")?;
-
-    info!("✅ Successfully fetched {} repositories", all_repos.len());
-
-    // Filter repos updated in last 2 years
-    let two_years_ago = Utc::now() - Duration::days(730);
-    let repos = GitHubMiner::filter_by_date(all_repos.clone(), two_years_ago);
-
-    println!("\n{}", c::subheader("Organization Statistics:"));
-    println!(
-        "   {} {}",
-        c::label("Total repositories:"),
-        c::number(&all_repos.len().to_string())
-    );
-    println!(
-        "   {} {}",
-        c::label("Active (last 2 years):"),
-        c::number(&repos.len().to_string())
+    info!(
+        "org analyze requested for {} but the upstream OIP analysis API was removed in aprender-orchestrate 0.41",
+        org
     );
 
-    // Display top 5 repositories by stars
-    let mut sorted_repos = repos.clone();
-    sorted_repos.sort_by(|a, b| b.stars.cmp(&a.stars));
-
-    println!("\n{}", c::subheader("Top Repositories:"));
-    for (i, repo) in sorted_repos.iter().take(5).enumerate() {
-        println!(
-            "   {}. {} ({}) - {}",
-            c::number(&(i + 1).to_string()),
-            c::label(&repo.name),
-            c::number(&format!("{} stars", repo.stars)),
-            c::dim(repo.language.as_deref().unwrap_or("Unknown"))
-        );
-    }
-
-    // Analyze repositories
-    println!(
-        "\n{} Analyzing defect patterns in {} repositories...",
-        c::label(">>"),
-        c::number(&sorted_repos.len().to_string())
-    );
-
-    let temp_dir = TempDir::new()?;
-    let analyzer = OrgAnalyzer::new(temp_dir.path());
-
-    let mut all_patterns = vec![];
-    let mut total_commits = 0;
-    let mut repos_analyzed = 0;
-
-    // Create progress bar
-    let pb = ProgressBar::new(sorted_repos.len() as u64);
-    pb.set_style(
-        ProgressStyle::default_bar()
-            .template("{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] {pos}/{len} {msg}")
-            .expect("Failed to set progress bar template")
-            .progress_chars("#>-"),
-    );
-
-    for (i, repo) in sorted_repos.iter().enumerate() {
-        pb.set_message(format!("Analyzing: {}", repo.name));
-
-        let repo_url = format!("https://github.com/{}/{}", org, repo.name);
-
-        match analyzer
-            .analyze_repository(&repo_url, &repo.name, 100)
-            .await
-        {
-            Ok(patterns) => {
-                total_commits += 100;
-                let pattern_count = patterns.len();
-                all_patterns.extend(patterns);
-                repos_analyzed += 1;
-                pb.println(format!(
-                    "   ✅ [{}/{}] {} - {} patterns found",
-                    i + 1,
-                    sorted_repos.len(),
-                    repo.name,
-                    pattern_count
-                ));
-                info!("✅ Analyzed {}", repo.name);
-            }
-            Err(e) => {
-                warn!("Failed to analyze {}: {}", repo.name, e);
-                pb.println(format!(
-                    "   ⚠️  [{}/{}] {} - SKIPPED: {}",
-                    i + 1,
-                    sorted_repos.len(),
-                    repo.name,
-                    e
-                ));
-            }
-        }
-        pb.inc(1);
-    }
-
-    pb.finish_with_message("Analysis complete!");
-    println!();
-
-    // Generate YAML report
-    info!("Generating YAML report");
-    let report_generator = ReportGenerator::new();
-
-    let metadata = AnalysisMetadata {
-        organization: org.to_string(),
-        analysis_date: Utc::now().to_rfc3339(),
-        repositories_analyzed: repos_analyzed,
-        commits_analyzed: total_commits,
-        analyzer_version: env!("CARGO_PKG_VERSION").to_string(),
-    };
-
-    let report = AnalysisReport {
-        version: "1.0".to_string(),
-        metadata,
-        defect_patterns: all_patterns,
-    };
-
-    // Write report to file
-    report_generator.write_to_file(&report, output).await?;
-
-    println!("\n{}", c::subheader("Analysis Report:"));
-    println!(
-        "   {} {}",
-        c::label("Repositories:"),
-        c::number(&repos_analyzed.to_string())
-    );
-    println!(
-        "   {} {}",
-        c::label("Commits:"),
-        c::number(&total_commits.to_string())
-    );
-    println!("   {} {:?}", c::label("Output:"), output);
-
-    // Phase 2: Optionally summarize results
-    if summarize {
-        let summary_path = output.with_extension("summary.yaml");
-
-        println!("\n{}", c::subheader("Generating Summary..."));
-        println!("   {} {}", c::label("Strip PII:"), strip_pii);
-        println!(
-            "   {} {}",
-            c::label("Top N categories:"),
-            c::number(&top_n.to_string())
-        );
-        println!(
-            "   {} {}",
-            c::label("Min frequency:"),
-            c::number(&min_frequency.to_string())
-        );
-
-        let config = SummaryConfig {
-            strip_pii,
-            top_n_categories: top_n,
-            min_frequency,
-            include_examples: false, // No examples for PMAT prompts
-        };
-
-        let summary =
-            ReportSummarizer::summarize(output, config).context("Failed to generate summary")?;
-
-        ReportSummarizer::save_to_file(&summary, &summary_path)?;
-
-        println!("\n{}", c::pass("Summary Complete:"));
-        println!(
-            "   {} {}",
-            c::label("Defect patterns:"),
-            c::number(
-                &summary
-                    .organizational_insights
-                    .top_defect_categories
-                    .len()
-                    .to_string()
-            )
-        );
-        println!("   {} {:?}", c::label("Output:"), summary_path);
-        println!(
-            "\n{} Use with: pmat prompt generate --task \"<task>\" --context \"<context>\" --summary {:?}",
-            c::dim("Tip:"),
-            summary_path
-        );
-    } else {
-        println!(
-            "\n{} To generate summary: pmat org analyze --org {} --output {:?} --summarize --strip-pii",
-            c::dim("Tip:"),
-            org,
-            output
-        );
-    }
-
-    Ok(())
+    anyhow::bail!(
+        "`pmat org analyze` is no longer available: the upstream \
+organizational-intelligence-plugin (aprender-orchestrate) crate removed its \
+organizational-analysis API (GitHub mining, defect-pattern analysis, and report \
+generation) in 0.41 with no replacement. Use `pmat org localize` for native \
+Tarantula fault localization, which is unaffected."
+    )
 }
 
 /// Handle fault localization using native Tarantula implementation (Issue #103)

--- a/src/cli/handlers/work_contract_manifest.rs
+++ b/src/cli/handlers/work_contract_manifest.rs
@@ -58,7 +58,7 @@ impl FileManifest {
                 hasher.update(entry.content_hash.as_bytes());
             }
         }
-        let manifest_hash = format!("{:x}", hasher.finalize());
+        let manifest_hash = hasher.finalize().iter().map(|b| format!("{b:02x}")).collect::<String>();
 
         Ok(Self {
             files,
@@ -138,7 +138,7 @@ impl FileEntry {
         // Compute content hash
         let mut hasher = Sha256::new();
         hasher.update(content.as_bytes());
-        let content_hash = format!("{:x}", hasher.finalize());
+        let content_hash = hasher.finalize().iter().map(|b| format!("{b:02x}")).collect::<String>();
 
         // Approximate function count (simple heuristic)
         let functions = Self::count_functions(&content, &category);

--- a/src/cli/handlers/work_contract_stack.rs
+++ b/src/cli/handlers/work_contract_stack.rs
@@ -310,7 +310,7 @@ impl StackManifest {
     pub fn content_hash(content: &str) -> String {
         let mut hasher = Sha256::new();
         hasher.update(content.as_bytes());
-        format!("{:x}", hasher.finalize())
+        hasher.finalize().iter().map(|b| format!("{b:02x}")).collect::<String>()
     }
 }
 

--- a/src/cli/handlers/work_contract_violations.rs
+++ b/src/cli/handlers/work_contract_violations.rs
@@ -293,7 +293,7 @@ impl TrustChainEntry {
     #[provable_contracts_macros::contract("pmat-core.yaml", equation = "check_compliance")]
     pub fn new(manifest_path: &str, content_hash: &str, prev_hash: &str) -> Self {
         let chain_input = format!("{}{}", content_hash, prev_hash);
-        let chain_hash = format!("{:x}", Sha256::digest(chain_input.as_bytes()));
+        let chain_hash = Sha256::digest(chain_input.as_bytes()).iter().map(|b| format!("{b:02x}")).collect::<String>();
         Self {
             manifest_path: manifest_path.to_string(),
             content_hash: content_hash.to_string(),
@@ -307,7 +307,7 @@ impl TrustChainEntry {
     #[provable_contracts_macros::contract("pmat-core.yaml", equation = "check_compliance")]
     pub fn verify(&self) -> bool {
         let chain_input = format!("{}{}", self.content_hash, self.prev_hash);
-        let expected = format!("{:x}", Sha256::digest(chain_input.as_bytes()));
+        let expected = Sha256::digest(chain_input.as_bytes()).iter().map(|b| format!("{b:02x}")).collect::<String>();
         self.chain_hash == expected
     }
 }

--- a/src/cli/handlers/work_ledger_receipt.rs
+++ b/src/cli/handlers/work_ledger_receipt.rs
@@ -122,7 +122,7 @@ impl FalsificationReceipt {
             hasher.update(o.ticket.as_bytes());
         }
         hasher.update(format!("{}", self.summary.allows_completion).as_bytes());
-        format!("{:x}", hasher.finalize())
+        hasher.finalize().iter().map(|b| format!("{b:02x}")).collect::<String>()
     }
 
     /// Verify content hash integrity

--- a/src/models/git_context.rs
+++ b/src/models/git_context.rs
@@ -354,10 +354,15 @@ impl GitContext {
     #[cfg(feature = "git-lib")]
     fn get_remote_url_git2(repo: &git2::Repository) -> Result<String, GitContextError> {
         let remote = repo.find_remote("origin")?;
-        remote
-            .url()
-            .ok_or_else(|| GitContextError::GitCommandFailed("Remote URL not found".to_string()))
-            .map(String::from)
+        // git2 0.21 changed `Remote::url` from `Option<&str>` to `Result<&str, Error>`.
+        // A missing URL now surfaces either as an `Err` or as an empty string, so treat
+        // both as "not found" to preserve the original behavior.
+        match remote.url() {
+            Ok(url) if !url.is_empty() => Ok(url.to_string()),
+            _ => Err(GitContextError::GitCommandFailed(
+                "Remote URL not found".to_string(),
+            )),
+        }
     }
 
     #[cfg(feature = "git-lib")]

--- a/src/quality/git_hooks_validate.rs
+++ b/src/quality/git_hooks_validate.rs
@@ -89,7 +89,7 @@ impl IncrementalChecker {
         use sha2::{Digest, Sha256};
 
         let content = fs::read_to_string(file_path)?;
-        let hash = format!("{:x}", Sha256::digest(content.as_bytes()));
+        let hash = Sha256::digest(content.as_bytes()).iter().map(|b| format!("{b:02x}")).collect::<String>();
 
         self.cache.insert(
             file_path.to_str().unwrap_or("").to_string(),

--- a/src/services/agent_context/document_index/build.rs
+++ b/src/services/agent_context/document_index/build.rs
@@ -74,57 +74,7 @@ pub(crate) fn build_document_index(
         if !path.is_file() || !is_document_file(path) {
             continue;
         }
-
-        result.files_scanned += 1;
-
-        let relative_path = match path.strip_prefix(&project_root) {
-            Ok(rel) => rel.to_string_lossy().to_string(),
-            Err(_) => continue,
-        };
-
-        seen_files.insert(relative_path.clone());
-
-        // Compute checksum for incremental update detection
-        let checksum = match compute_document_checksum(path) {
-            Ok(cs) => cs,
-            Err(e) => {
-                result.errors.push(format!("{relative_path}: {e}"));
-                continue;
-            }
-        };
-
-        // Skip if file hasn't changed
-        if file_is_current(conn, &relative_path, &checksum) {
-            result.files_skipped += 1;
-            continue;
-        }
-
-        // Remove old chunks for this file (if any)
-        let _ = remove_file_documents(conn, &relative_path);
-
-        // Extract and insert
-        match extract_document(path, &relative_path, &checksum) {
-            Ok(chunks) => {
-                if !chunks.is_empty() {
-                    match insert_document_chunks(conn, &chunks) {
-                        Ok(count) => {
-                            result.chunks_inserted += count;
-                            result.files_indexed += 1;
-                        }
-                        Err(e) => {
-                            result
-                                .errors
-                                .push(format!("{relative_path}: insert failed: {e}"));
-                        }
-                    }
-                }
-            }
-            Err(e) => {
-                result
-                    .errors
-                    .push(format!("{relative_path}: extraction failed: {e}"));
-            }
-        }
+        index_one_document(conn, path, &project_root, &mut result, &mut seen_files);
     }
 
     // Remove stale entries (files that no longer exist on disk)
@@ -133,6 +83,69 @@ pub(crate) fn build_document_index(
     }
 
     Ok(result)
+}
+
+/// Index a single document file: checksum, staleness check, extract, insert.
+///
+/// Extracted from `build_document_index`'s walk loop so the per-file logic uses
+/// early returns instead of deep match/if nesting (keeps cognitive complexity low).
+fn index_one_document(
+    conn: &Connection,
+    path: &Path,
+    project_root: &Path,
+    result: &mut DocumentBuildResult,
+    seen_files: &mut HashSet<String>,
+) {
+    result.files_scanned += 1;
+
+    let relative_path = match path.strip_prefix(project_root) {
+        Ok(rel) => rel.to_string_lossy().to_string(),
+        Err(_) => return,
+    };
+    seen_files.insert(relative_path.clone());
+
+    // Compute checksum for incremental update detection
+    let checksum = match compute_document_checksum(path) {
+        Ok(cs) => cs,
+        Err(e) => {
+            result.errors.push(format!("{relative_path}: {e}"));
+            return;
+        }
+    };
+
+    // Skip if file hasn't changed
+    if file_is_current(conn, &relative_path, &checksum) {
+        result.files_skipped += 1;
+        return;
+    }
+
+    // Remove old chunks for this file (if any), then extract + insert
+    let _ = remove_file_documents(conn, &relative_path);
+
+    let chunks = match extract_document(path, &relative_path, &checksum) {
+        Ok(chunks) => chunks,
+        Err(e) => {
+            result
+                .errors
+                .push(format!("{relative_path}: extraction failed: {e}"));
+            return;
+        }
+    };
+    if chunks.is_empty() {
+        return;
+    }
+
+    match insert_document_chunks(conn, &chunks) {
+        Ok(count) => {
+            result.chunks_inserted += count;
+            result.files_indexed += 1;
+        }
+        Err(e) => {
+            result
+                .errors
+                .push(format!("{relative_path}: insert failed: {e}"));
+        }
+    }
 }
 
 /// Check if a directory should be skipped during document indexing.
@@ -171,7 +184,11 @@ fn compute_document_checksum(path: &Path) -> Result<String, String> {
         std::fs::read(path).map_err(|e| format!("Failed to read {}: {e}", path.display()))?;
     let mut hasher = Sha256::new();
     hasher.update(&bytes);
-    Ok(format!("{:x}", hasher.finalize()))
+    Ok(hasher
+        .finalize()
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect::<String>())
 }
 
 #[cfg(test)]

--- a/src/services/agent_context/function_index/build_persistence.rs
+++ b/src/services/agent_context/function_index/build_persistence.rs
@@ -146,7 +146,7 @@ impl AgentContextIndex {
             .map_err(|e| format!("Failed to decompress functions: {e}"))?;
 
         // Deserialize payload (v1.3.0+ has cached indices)
-        let payload: IndexPayload = bincode::deserialize(&decompressed)
+        let payload: IndexPayload = rmp_serde::from_slice(&decompressed)
             .map_err(|e| format!("Failed to parse payload: {e}"))?;
 
         let functions = payload.functions;

--- a/src/services/agent_context/function_index/helpers_index_building.rs
+++ b/src/services/agent_context/function_index/helpers_index_building.rs
@@ -110,5 +110,5 @@ fn build_indices_impl(functions: &[FunctionEntry], include_corpus: bool) -> Buil
 pub(super) fn compute_file_sha256(content: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(content.as_bytes());
-    format!("{:x}", hasher.finalize())
+    hasher.finalize().iter().map(|b| format!("{b:02x}")).collect::<String>()
 }

--- a/src/services/analytics_backend_gpu.rs
+++ b/src/services/analytics_backend_gpu.rs
@@ -35,9 +35,9 @@ impl GpuDevice {
     /// Initialize GPU device with PCIe calibration
     fn new() -> Result<Self> {
         // Create wgpu instance
-        let instance = wgpu::Instance::new(&wgpu::InstanceDescriptor {
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
             backends: wgpu::Backends::all(),
-            ..Default::default()
+            ..wgpu::InstanceDescriptor::new_without_display_handle()
         });
 
         // Request adapter (GPU device)
@@ -57,16 +57,16 @@ impl GpuDevice {
         );
 
         // Request device and queue
-        let (device, queue) = pollster::block_on(adapter.request_device(
-            &wgpu::DeviceDescriptor {
+        let (device, queue) =
+            pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
                 label: Some("PMAT Analytics GPU"),
                 required_features: wgpu::Features::empty(),
                 required_limits: wgpu::Limits::default(),
                 memory_hints: Default::default(),
-            },
-            None,
-        ))
-        .context("Failed to create GPU device")?;
+                experimental_features: Default::default(),
+                trace: Default::default(),
+            }))
+            .context("Failed to create GPU device")?;
 
         // Calibrate PCIe bandwidth
         let pcie_bandwidth_gbps = Self::calibrate_pcie_bandwidth(&device, &queue)?;
@@ -126,7 +126,9 @@ impl GpuDevice {
         buffer_slice.map_async(wgpu::MapMode::Read, move |result| {
             tx.send(result).ok();
         });
-        device.poll(wgpu::Maintain::Wait);
+        device
+            .poll(wgpu::PollType::wait_indefinitely())
+            .context("Failed to poll GPU device")?;
         rx.recv()
             .context("Failed to map buffer")?
             .context("Buffer mapping failed")?;

--- a/src/services/code_intelligence_types.rs
+++ b/src/services/code_intelligence_types.rs
@@ -67,7 +67,7 @@ impl AnalysisRequest {
         for t in &self.analysis_types {
             hasher.update(format!("{t:?}").as_bytes());
         }
-        format!("{:x}", hasher.finalize())
+        hasher.finalize().iter().map(|b| format!("{b:02x}")).collect::<String>()
     }
 }
 

--- a/src/services/deep_wasm/bytecode_analyzer_parsing.rs
+++ b/src/services/deep_wasm/bytecode_analyzer_parsing.rs
@@ -4,7 +4,7 @@ impl BytecodeAnalyzer {
     /// Convert ExternalKind to string
     fn external_kind_str(kind: wasmparser::ExternalKind) -> &'static str {
         match kind {
-            wasmparser::ExternalKind::Func => "function",
+            wasmparser::ExternalKind::Func | wasmparser::ExternalKind::FuncExact => "function",
             wasmparser::ExternalKind::Memory => "memory",
             wasmparser::ExternalKind::Table => "table",
             wasmparser::ExternalKind::Global => "global",
@@ -15,7 +15,7 @@ impl BytecodeAnalyzer {
     /// Convert TypeRef to kind string
     fn type_ref_kind_str(ty: &TypeRef) -> &'static str {
         match ty {
-            TypeRef::Func(_) => "function",
+            TypeRef::Func(_) | TypeRef::FuncExact(_) => "function",
             TypeRef::Memory(_) => "memory",
             TypeRef::Table(_) => "table",
             TypeRef::Global(_) => "global",
@@ -26,7 +26,7 @@ impl BytecodeAnalyzer {
     /// Parse a single import into ImportAnalysis
     fn parse_import(import: wasmparser::Import, type_section: &[FuncType]) -> ImportAnalysis {
         let kind = Self::type_ref_kind_str(&import.ty);
-        let signature = if let TypeRef::Func(type_idx) = import.ty {
+        let signature = if let TypeRef::Func(type_idx) | TypeRef::FuncExact(type_idx) = import.ty {
             type_section
                 .get(type_idx as usize)
                 .map(|func_type| FunctionSignature {
@@ -144,7 +144,7 @@ impl BytecodeAnalyzer {
                     }
                 }
                 Ok(Payload::ImportSection(reader)) => {
-                    for import in reader.into_iter().flatten() {
+                    for import in reader.into_imports().flatten() {
                         sections
                             .import_section
                             .push(Self::parse_import(import, &sections.type_section));

--- a/src/services/deep_wasm/dwarf_parser.rs
+++ b/src/services/deep_wasm/dwarf_parser.rs
@@ -110,7 +110,7 @@ impl DwarfParser {
 
         // Iterate through all DIEs in this unit
         // Handle errors gracefully for malformed/synthetic data
-        while let Some((_, entry)) = entries_cursor.next_dfs().ok().flatten() {
+        while let Some(entry) = entries_cursor.next_dfs().ok().flatten() {
             // Get offset - convert unit-relative offset to debug_info offset
             let die_offset = entry
                 .offset()
@@ -146,10 +146,7 @@ impl DwarfParser {
         entry: &gimli::DebuggingInformationEntry<R>,
         debug_str: &DebugStr<R>,
     ) -> DeepWasmResult<Option<String>> {
-        if let Some(attr) = entry
-            .attr(gimli::DW_AT_name)
-            .map_err(|e| DeepWasmError::Analysis(format!("Failed to read DW_AT_name: {}", e)))?
-        {
+        if let Some(attr) = entry.attr(gimli::DW_AT_name) {
             if let gimli::AttributeValue::DebugStrRef(offset) = attr.value() {
                 let name_slice = debug_str.get_str(offset).map_err(|e| {
                     DeepWasmError::Analysis(format!("Failed to resolve string: {}", e))

--- a/src/services/enhanced_typescript_visitor_methods.rs
+++ b/src/services/enhanced_typescript_visitor_methods.rs
@@ -93,7 +93,7 @@ impl EnhancedTypeScriptVisitor {
                     Prop::KeyValue(KeyValueProp { key, value }) => {
                         let method_name = match key {
                             PropName::Ident(ident) => ident.sym.to_string(),
-                            PropName::Str(s) => s.value.to_string(),
+                            PropName::Str(s) => s.value.to_string_lossy().into_owned(),
                             _ => continue,
                         };
 
@@ -117,7 +117,7 @@ impl EnhancedTypeScriptVisitor {
                     Prop::Method(method_prop) => {
                         let method_name = match &method_prop.key {
                             PropName::Ident(ident) => ident.sym.to_string(),
-                            PropName::Str(s) => s.value.to_string(),
+                            PropName::Str(s) => s.value.to_string_lossy().into_owned(),
                             _ => continue,
                         };
 

--- a/src/services/enhanced_typescript_visitor_visit.rs
+++ b/src/services/enhanced_typescript_visitor_visit.rs
@@ -71,7 +71,7 @@ impl Visit for EnhancedTypeScriptVisitor {
     fn visit_method_prop(&mut self, method: &MethodProp) {
         let method_name = match &method.key {
             PropName::Ident(ident) => ident.sym.to_string(),
-            PropName::Str(s) => s.value.to_string(),
+            PropName::Str(s) => s.value.to_string_lossy().into_owned(),
             PropName::Num(n) => n.value.to_string(),
             PropName::Computed(_) => "computed".to_string(),
             PropName::BigInt(b) => b.value.to_string(),
@@ -108,7 +108,7 @@ impl Visit for EnhancedTypeScriptVisitor {
     fn visit_class_method(&mut self, method: &ClassMethod) {
         let method_name = match &method.key {
             PropName::Ident(ident) => ident.sym.to_string(),
-            PropName::Str(s) => s.value.to_string(),
+            PropName::Str(s) => s.value.to_string_lossy().into_owned(),
             PropName::Num(n) => n.value.to_string(),
             PropName::Computed(_) => "computed".to_string(),
             PropName::BigInt(b) => b.value.to_string(),
@@ -158,7 +158,7 @@ impl Visit for EnhancedTypeScriptVisitor {
     }
 
     fn visit_import_decl(&mut self, import: &ImportDecl) {
-        let path = import.src.value.to_string();
+        let path = import.src.value.to_string_lossy().into_owned();
         let line = self.get_line(import.span());
 
         self.items.push(AstItem::Use { path, line });
@@ -168,7 +168,7 @@ impl Visit for EnhancedTypeScriptVisitor {
 
     fn visit_named_export(&mut self, export: &NamedExport) {
         if let Some(src) = &export.src {
-            let path = format!("export from {}", src.value);
+            let path = format!("export from {}", src.value.to_string_lossy());
             let line = self.get_line(export.span());
 
             self.items.push(AstItem::Use { path, line });
@@ -182,7 +182,7 @@ impl Visit for EnhancedTypeScriptVisitor {
             ModuleDecl::Import(import) => self.visit_import_decl(import),
             ModuleDecl::ExportNamed(export) => self.visit_named_export(export),
             ModuleDecl::ExportAll(export) => {
-                let path = format!("export * from {}", export.src.value);
+                let path = format!("export * from {}", export.src.value.to_string_lossy());
                 let line = self.get_line(export.span());
                 self.items.push(AstItem::Use { path, line });
             }

--- a/src/services/incremental_coverage_analyzer_cache.rs
+++ b/src/services/incremental_coverage_analyzer_cache.rs
@@ -4,7 +4,7 @@ impl IncrementalCoverageAnalyzer {
 
         match self.coverage_cache.get(&key) {
             Some(data) => {
-                let coverage: FileCoverage = bincode::deserialize(&data)?;
+                let coverage: FileCoverage = rmp_serde::from_slice(&data)?;
                 Ok(Some(coverage))
             }
             None => Ok(None),
@@ -13,7 +13,7 @@ impl IncrementalCoverageAnalyzer {
 
     fn store_coverage(&self, file_id: &FileId, coverage: &FileCoverage) -> Result<()> {
         let key = self.coverage_key(file_id);
-        let data = bincode::serialize(coverage)?;
+        let data = rmp_serde::to_vec(coverage)?;
         self.coverage_cache.insert(key, data);
         Ok(())
     }

--- a/src/services/mutation/cpp_mutation_generator.rs
+++ b/src/services/mutation/cpp_mutation_generator.rs
@@ -68,7 +68,10 @@ impl CppMutationGenerator {
             if operator.can_mutate(node, source) {
                 let mutations = operator.mutate(node, source);
                 for mutation in mutations {
-                    let hash = format!("{:x}", Sha256::digest(&mutation.source));
+                    let hash = Sha256::digest(&mutation.source)
+                        .iter()
+                        .map(|b| format!("{b:02x}"))
+                        .collect::<String>();
                     mutants.push(Mutant {
                         id: format!(
                             "{}_{}_{}:{}",

--- a/src/services/mutation/engine.rs
+++ b/src/services/mutation/engine.rs
@@ -277,7 +277,11 @@ impl<'a> Visit<'_> for MutationVisitor<'a> {
                     let mut hasher = Sha256::new();
                     let stmt_str = quote::quote!(# stmt).to_string();
                     hasher.update(&stmt_str);
-                    let hash = format!("{:x}", hasher.finalize());
+                    let hash = hasher
+                        .finalize()
+                        .iter()
+                        .map(|b| format!("{b:02x}"))
+                        .collect::<String>();
                     let location = SourceLocation {
                         line: 0,
                         column: 0,
@@ -318,7 +322,11 @@ impl<'a> Visit<'_> for MutationVisitor<'a> {
                         let mut hasher = Sha256::new();
                         let expr_str = quote::quote!(# mutated_expr).to_string();
                         hasher.update(&expr_str);
-                        let hash = format!("{:x}", hasher.finalize());
+                        let hash = hasher
+                            .finalize()
+                            .iter()
+                            .map(|b| format!("{b:02x}"))
+                            .collect::<String>();
                         let mutant = Mutant {
                             id: format!("{}_{}", operator.name(), hash.get(..8).unwrap_or(&hash)),
                             original_file: self.file_path.clone(),

--- a/src/services/mutation/equivalent_detector_core.rs
+++ b/src/services/mutation/equivalent_detector_core.rs
@@ -243,7 +243,7 @@ impl EquivalentMutantDetector {
     /// Save detector to file
     #[provable_contracts_macros::contract("pmat-core.yaml", equation = "path_exists")]
     pub fn save(&self, path: &Path) -> Result<()> {
-        let serialized = bincode::serialize(self)?;
+        let serialized = rmp_serde::to_vec(self)?;
         std::fs::write(path, serialized)?;
         Ok(())
     }
@@ -252,7 +252,7 @@ impl EquivalentMutantDetector {
     #[provable_contracts_macros::contract("pmat-core.yaml", equation = "path_exists")]
     pub fn load(path: &Path) -> Result<Self> {
         let data = std::fs::read(path)?;
-        let detector = bincode::deserialize(&data)?;
+        let detector = rmp_serde::from_slice(&data)?;
         Ok(detector)
     }
 }

--- a/src/services/mutation/go_mutation_generator.rs
+++ b/src/services/mutation/go_mutation_generator.rs
@@ -67,7 +67,10 @@ impl GoMutationGenerator {
             if operator.can_mutate(node, source) {
                 let mutations = operator.mutate(node, source);
                 for mutation in mutations {
-                    let hash = format!("{:x}", Sha256::digest(&mutation.source));
+                    let hash = Sha256::digest(&mutation.source)
+                        .iter()
+                        .map(|b| format!("{b:02x}"))
+                        .collect::<String>();
                     mutants.push(Mutant {
                         id: format!(
                             "{}_{}_{}:{}",

--- a/src/services/mutation/ml_predictor/predictor.rs
+++ b/src/services/mutation/ml_predictor/predictor.rs
@@ -425,7 +425,7 @@ impl SurvivabilityPredictor {
     /// For consistent ML predictions, retrain the model after loading.
     #[provable_contracts_macros::contract("pmat-core.yaml", equation = "path_exists")]
     pub fn save(&self, path: &Path) -> Result<()> {
-        let serialized = bincode::serialize(self)?;
+        let serialized = rmp_serde::to_vec(self)?;
         std::fs::write(path, serialized)?;
         Ok(())
     }
@@ -434,7 +434,7 @@ impl SurvivabilityPredictor {
     #[provable_contracts_macros::contract("pmat-core.yaml", equation = "path_exists")]
     pub fn load(path: &Path) -> Result<Self> {
         let data = std::fs::read(path)?;
-        let predictor = bincode::deserialize(&data)?;
+        let predictor = rmp_serde::from_slice(&data)?;
         Ok(predictor)
     }
 }

--- a/src/services/mutation/python_mutation_generator.rs
+++ b/src/services/mutation/python_mutation_generator.rs
@@ -66,7 +66,10 @@ impl PythonMutationGenerator {
             if operator.can_mutate(node, source) {
                 let mutations = operator.mutate(node, source);
                 for mutation in mutations {
-                    let hash = format!("{:x}", Sha256::digest(&mutation.source));
+                    let hash = Sha256::digest(&mutation.source)
+                        .iter()
+                        .map(|b| format!("{b:02x}"))
+                        .collect::<String>();
                     mutants.push(Mutant {
                         id: format!(
                             "{}_{}_{}:{}",

--- a/src/services/mutation/rust_mutation_generator.rs
+++ b/src/services/mutation/rust_mutation_generator.rs
@@ -74,7 +74,11 @@ impl RustMutationGenerator {
                     // Generate hash for deduplication
                     let mut hasher = Sha256::new();
                     hasher.update(mutation.source.as_bytes());
-                    let hash = format!("{:x}", hasher.finalize());
+                    let hash = hasher
+                        .finalize()
+                        .iter()
+                        .map(|b| format!("{b:02x}"))
+                        .collect::<String>();
 
                     let mutant = Mutant {
                         id: format!(

--- a/src/services/mutation/typescript_mutation_generator.rs
+++ b/src/services/mutation/typescript_mutation_generator.rs
@@ -84,7 +84,10 @@ impl TypeScriptMutationGenerator {
                     let mutated_source = mutation.source.clone();
                     // Simple hash using SHA256 (already in deps)
                     use sha2::{Digest, Sha256};
-                    let hash = format!("{:x}", Sha256::digest(&mutated_source));
+                    let hash = Sha256::digest(&mutated_source)
+                        .iter()
+                        .map(|b| format!("{b:02x}"))
+                        .collect::<String>();
 
                     mutants.push(Mutant {
                         id: format!(

--- a/src/services/semantic/chunker_helpers.rs
+++ b/src/services/semantic/chunker_helpers.rs
@@ -104,5 +104,5 @@ fn push_chunk(
 fn compute_checksum(content: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(content.as_bytes());
-    format!("{:x}", hasher.finalize())
+    hasher.finalize().iter().map(|b| format!("{b:02x}")).collect::<String>()
 }

--- a/src/services/simple_deep_context/language_complexity.rs
+++ b/src/services/simple_deep_context/language_complexity.rs
@@ -69,7 +69,7 @@ impl SimpleDeepContext {
         use swc_ecma_parser::{lexer::Lexer, Parser, StringInput, Syntax, TsSyntax};
 
         let source_map = Arc::new(SourceMap::default());
-        let _source_file = source_map.new_source_file(
+        let source_file = source_map.new_source_file(
             FileName::Custom(file_path.display().to_string()).into(),
             content.to_owned(),
         );
@@ -99,7 +99,7 @@ impl SimpleDeepContext {
         let lexer = Lexer::new(
             syntax,
             Default::default(),
-            StringInput::new(content, Default::default(), Default::default()),
+            StringInput::from(&*source_file),
             None,
         );
 

--- a/src/state/snapshot_store_lifecycle.rs
+++ b/src/state/snapshot_store_lifecycle.rs
@@ -85,7 +85,7 @@ impl SnapshotStore {
         // Calculate checksum
         let mut hasher = Sha256::new();
         hasher.update(&decompressed);
-        let checksum = format!("{:x}", hasher.finalize());
+        let checksum = hasher.finalize().iter().map(|b| format!("{b:02x}")).collect::<String>();
 
         if checksum != expected_checksum {
             return Err(SnapshotError::ChecksumMismatch {

--- a/src/state/snapshot_store_persistence.rs
+++ b/src/state/snapshot_store_persistence.rs
@@ -38,7 +38,7 @@ impl SnapshotStore {
         // Calculate checksum
         let mut hasher = Sha256::new();
         hasher.update(&serialized);
-        let checksum = format!("{:x}", hasher.finalize());
+        let checksum = hasher.finalize().iter().map(|b| format!("{b:02x}")).collect::<String>();
 
         // Compress data
         let mut encoder =
@@ -145,7 +145,7 @@ impl SnapshotStore {
         if self.config.verify_on_read {
             let mut hasher = Sha256::new();
             hasher.update(&decompressed);
-            let checksum = format!("{:x}", hasher.finalize());
+            let checksum = hasher.finalize().iter().map(|b| format!("{b:02x}")).collect::<String>();
 
             if checksum != metadata.checksum {
                 return Err(SnapshotError::ChecksumMismatch {

--- a/src/tdg/analyzer.rs
+++ b/src/tdg/analyzer.rs
@@ -218,7 +218,7 @@ impl TdgAnalyzer {
         hasher.update(&modified.to_le_bytes());
         hasher.update(&size.to_le_bytes());
         
-        Ok(format!("{:x}", hasher.finalize()))
+        Ok(hasher.finalize().iter().map(|b| format!("{b:02x}")).collect::<String>())
     }
 }
 

--- a/src/tdg/analyzer_ast/analyzer_impl1_language_extra.rs
+++ b/src/tdg/analyzer_ast/analyzer_impl1_language_extra.rs
@@ -240,7 +240,7 @@ impl TdgAnalyzerAst {
     ) -> Result<()> {
         #[cfg(feature = "c-ast")]
         {
-            use tree_sitter::{Parser, Query, QueryCursor};
+            use tree_sitter::{Parser, Query, QueryCursor, StreamingIterator};
 
             let mut parser = Parser::new();
             let language = if score.language == Language::Cpp {

--- a/src/tdg/olap_analytics_trueno.rs
+++ b/src/tdg/olap_analytics_trueno.rs
@@ -230,5 +230,8 @@ fn build_tdg_score_from_row(cols: &ArrowColumns<'_>, i: usize) -> TdgScore {
         penalties_applied: Vec::new(),
         critical_defects_count: 0,
         has_critical_defects: false,
+        // Not persisted in the OLAP arrow schema; default to false (matches
+        // TdgScore::default() and other non-test initializers).
+        has_contract_coverage: false,
     }
 }

--- a/src/unified_protocol/adapters/cli/cli_input_impl.rs
+++ b/src/unified_protocol/adapters/cli/cli_input_impl.rs
@@ -218,6 +218,27 @@ impl CliInput {
             Commands::Sql { .. } => {
                 CommandCategory::Analysis // SQL analytics
             }
+            Commands::Score { .. } => {
+                CommandCategory::Analysis // Unified quality score (sibling of RepoScore)
+            }
+            Commands::InfraScore { .. } => {
+                CommandCategory::Analysis // Infrastructure CI/CD quality score (sibling of RepoScore)
+            }
+            Commands::Verify(_) => {
+                CommandCategory::Analysis // CI-faithful pre-flight gate (sibling of QualityGate)
+            }
+            Commands::Explain { .. } => {
+                CommandCategory::System // Informational lookup of check/metric meaning
+            }
+            Commands::CiLocal { .. } => {
+                CommandCategory::Workflow // Local CI simulation (sibling of Test/Validate)
+            }
+            Commands::TestStability { .. } => {
+                CommandCategory::Workflow // Flaky/timeout test detection (sibling of Test)
+            }
+            Commands::Stack { .. } => {
+                CommandCategory::Workflow // Cross-repo dependency coordination (sibling of Maintain)
+            }
         }
     }
 
@@ -296,7 +317,8 @@ impl CliAdapter {
     fn get_analyze_command_category(analyze_cmd: &AnalyzeCommands) -> AnalyzeCommandCategory {
         match analyze_cmd {
             // Core analysis commands (basic metrics)
-            AnalyzeCommands::Churn { .. }
+            AnalyzeCommands::Bottleneck { .. }
+            | AnalyzeCommands::Churn { .. }
             | AnalyzeCommands::Complexity { .. }
             | AnalyzeCommands::DeadCode { .. }
             | AnalyzeCommands::Defects { .. }

--- a/src/unified_protocol/adapters/cli/decode_analyze_extended.rs
+++ b/src/unified_protocol/adapters/cli/decode_analyze_extended.rs
@@ -480,6 +480,12 @@ impl CliAdapter {
             OutputFormat::Json => "json",
             OutputFormat::Table => "table",
             OutputFormat::Yaml => "yaml",
+            OutputFormat::Markdown => "md",
+            OutputFormat::Csv => "csv",
+            OutputFormat::Summary => "txt",
+            OutputFormat::Text => "txt",
+            OutputFormat::Plain => "txt",
+            OutputFormat::Junit => "xml",
         }
     }
 }

--- a/src/unified_protocol/adapters/cli/decode_core.rs
+++ b/src/unified_protocol/adapters/cli/decode_core.rs
@@ -123,6 +123,13 @@ impl CliAdapter {
             | Commands::Extract { .. } // Extract refactoring (CLI-only)
             | Commands::Split { .. } // File splitting (CLI-only)
             | Commands::Sql { .. } // SQL analytics (CLI-only)
+            | Commands::Score { .. } // Unified quality score (CLI-only)
+            | Commands::InfraScore { .. } // Infrastructure CI/CD quality score (CLI-only)
+            | Commands::Verify(_) // CI-faithful pre-flight gate (CLI-only)
+            | Commands::Explain { .. } // Check/metric explanation lookup (CLI-only)
+            | Commands::CiLocal { .. } // Local CI simulation (CLI-only)
+            | Commands::TestStability { .. } // Flaky/timeout test detection (CLI-only)
+            | Commands::Stack { .. } // Cross-repo dependency coordination (CLI-only)
             => Self::cli_only_command_error(),
 
             #[cfg(feature = "mutation-testing")]
@@ -189,7 +196,7 @@ impl CliAdapter {
             Method::GET,
             format!("/api/v1/templates{query_string}"),
             json!({}),
-            Some(format.clone()),
+            Some(*format),
         ))
     }
 

--- a/tests/modules/storage_backend_tests.rs
+++ b/tests/modules/storage_backend_tests.rs
@@ -61,11 +61,11 @@ fn test_bincode_blake3hash_serialization() {
     let content = b"test data";
     let hash = blake3::hash(content);
 
-    let serialized = bincode::serialize(&hash).expect("Failed to serialize Blake3Hash");
+    let serialized = rmp_serde::to_vec(&hash).expect("Failed to serialize Blake3Hash");
     println!("DEBUG: Blake3Hash serialized to {} bytes", serialized.len());
 
     let deserialized: blake3::Hash =
-        bincode::deserialize(&serialized).expect("Failed to deserialize Blake3Hash");
+        rmp_serde::from_slice(&serialized).expect("Failed to deserialize Blake3Hash");
     assert_eq!(hash, deserialized);
 }
 
@@ -75,11 +75,11 @@ fn test_bincode_systemtime_serialization() {
     use std::time::SystemTime;
 
     let now = SystemTime::now();
-    let serialized = bincode::serialize(&now).expect("Failed to serialize SystemTime");
+    let serialized = rmp_serde::to_vec(&now).expect("Failed to serialize SystemTime");
     println!("DEBUG: SystemTime serialized to {} bytes", serialized.len());
 
     let deserialized: SystemTime =
-        bincode::deserialize(&serialized).expect("Failed to deserialize SystemTime");
+        rmp_serde::from_slice(&serialized).expect("Failed to deserialize SystemTime");
     // SystemTime may not implement Eq, so just check it doesn't panic
     println!(
         "DEBUG: SystemTime deserialized successfully: {:?}",
@@ -112,11 +112,11 @@ fn test_bincode_tdgscore_serialization() {
         has_contract_coverage: false,
     };
 
-    let serialized = bincode::serialize(&score).expect("Failed to serialize TdgScore");
+    let serialized = rmp_serde::to_vec(&score).expect("Failed to serialize TdgScore");
     println!("DEBUG: TdgScore serialized to {} bytes", serialized.len());
 
     let deserialized: TdgScore =
-        bincode::deserialize(&serialized).expect("Failed to deserialize TdgScore");
+        rmp_serde::from_slice(&serialized).expect("Failed to deserialize TdgScore");
     assert_eq!(deserialized.total, score.total);
     println!("DEBUG: TdgScore deserialized successfully");
 }
@@ -138,14 +138,14 @@ fn test_bincode_fileidentity_serialization() {
         modified_time: SystemTime::now(),
     };
 
-    let serialized = bincode::serialize(&identity).expect("Failed to serialize FileIdentity");
+    let serialized = rmp_serde::to_vec(&identity).expect("Failed to serialize FileIdentity");
     println!(
         "DEBUG: FileIdentity serialized to {} bytes",
         serialized.len()
     );
 
     let deserialized: FileIdentity =
-        bincode::deserialize(&serialized).expect("Failed to deserialize FileIdentity");
+        rmp_serde::from_slice(&serialized).expect("Failed to deserialize FileIdentity");
     assert_eq!(deserialized.size_bytes, identity.size_bytes);
     println!("DEBUG: FileIdentity deserialized successfully");
 }


### PR DESCRIPTION
## Summary

Breaking-version upgrade of the **entire dependency tree** to latest, with all API breakage fixed and the full local gate green. **No change to pmat's own CLI/MCP surface.**

- **Sovereign stack 0.30 → 0.41**: aprender + graph/viz/rag/compute/db/zram-core/orchestrate
- **Parsers**: swc_ecma_* 24/15 → 41/25, tree-sitter 0.23 → 0.26
- **wgpu** 24 → 29, **warp** 0.3 → 0.4, **gimli** 0.33, **wasmparser** 0.252, **git2** 0.21, + ~30 more. pmcp already latest (2.9).
- **bincode removed → rmp-serde** (MessagePack): bincode 3.0.0 is a non-functional placeholder; 2.x a breaking rewrite. Regenerable caches + `.pmat` index rebuild automatically.
- **Held by the sovereign stack**: arrow pinned 57 (matches `aprender-db` lib `trueno_db`); rusqlite 0.32 (aprender-rag links native `sqlite3`).

## Key fixes
- **swc 41**: `simple_deep_context` initialized the lexer with a zero-based `StringInput` while the `SourceMap` based the file at byte 1 → swc 41 asserts span bounds → panic on every JS/TS file. Now `StringInput::from(&*source_file)`.
- **sha2 0.11**: `finalize()` no longer impls `LowerHex` → explicit hex encode (build.rs + 12 files).
- API migrations: wgpu 29 device/poll, gimli 0.33, wasmparser variants, tree-sitter `QueryMatches` streaming iteration, swc atoms, Option↔Result changes.

## Removed
- **`pmat org analyze`**: `aprender-orchestrate` 0.41 dropped the OIP API with no replacement (0.30 conflicts with aprender 0.41); returns a clear "unavailable" error.

## Also
- **docs.rs badge**: leaned `[package.metadata.docs.rs]` so the doc build fits docs.rs's build limit (pmat's own docs were already clean).
- **`dogfood` skill** (`.claude/skills/dogfood/`): exercise pmat's full CLI against its own repo, GO/WARN/FAIL verdict.

## Validation
- `cargo check --all-features` — **0 errors**
- `pmat verify` — **all 5 gates green** (format, complexity, satd, clippy, full ~20k-test suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)