### PR TITLE
fix(analyze): dead-code worktree descent + --exclude-tests leak, with contracts (v3.19.2)

### DIFF
--- a/.claude/skills/dogfood/SKILL.md
+++ b/.claude/skills/dogfood/SKILL.md
@@ -177,6 +177,51 @@ count, same top entries).
 J=$(pmat analyze complexity --top-files 3 --format json 2>/dev/null | jq '.files? // .summary?'); echo "json summary: $J"
 ```
 
+### P7. Dead-code file-count sanity (v3.19.2 regression class)
+`analyze dead-code`'s `total_files_analyzed` must roughly match the real source
+file count (what `analyze complexity` reports) — NOT a multiple of it — and must
+NOT include hidden/ignored trees like `.claude/worktrees/`. (A raw `walkdir` once
+descended into git-worktree copies, inflating the count ~60×.) Clear the cache
+first so this measures live behavior.
+```bash
+rm -f .pmat/dead-code-cache.json
+DC=$(pmat analyze dead-code --format json 2>/dev/null | jq '.summary.total_files_analyzed // .total_files'); \
+CX=$(pmat analyze complexity --format json 2>/dev/null | jq '.summary.total_files // .total_files_analyzed // empty'); \
+echo "dead-code files=$DC vs complexity files=$CX (must be same order of magnitude; FAIL if DC ≫ CX or any result path contains .claude/worktrees)"
+pmat analyze dead-code --top-files 5 --format json 2>/dev/null | jq -r '.files[].path' | grep -q '.claude/worktrees' && echo "P7 FAIL (worktree paths in results)" || echo "P7 PASS"
+```
+
+### P8. `--exclude-tests` actually excludes test code (v3.19.2 regression class)
+With `--exclude-tests`, no result may come from a test file or test helper —
+including `include!()`-ed `*_tests_basic.rs` fragments, `setup_test*`/`create_test*`
+helpers, and `*fixtures*` support files — across semantic, `--literal`, and
+`--coverage-gaps` modes.
+```bash
+for q in "pmat query --literal unwrap() --limit 12 --exclude-tests" "pmat query --coverage-gaps --limit 15 --exclude-tests"; do
+  BAD=$($q 2>/dev/null | grep -ioE 'create_test[a-z_]*|setup_test[a-z_]*|_tests_[a-z]+\.rs|coverage_fixtures\.rs|/tests/' | sort -u)
+  [ -z "$BAD" ] && echo "P8 PASS ($q)" || echo "P8 FAIL ($q leaked: $BAD)"
+done
+```
+(Known limitation, not a P8 FAIL: functions inside `#[cfg(test)] mod` blocks in
+otherwise-production files with non-test-prefixed names still leak — needs
+AST-level attribute detection in the index.)
+
+## Gate 6: Provable-contract coverage (policy)
+
+**Every fix in this repo must carry a provable contract** —
+`#[provable_contracts_macros::contract("pmat-core.yaml", equation = "...")]` on
+the changed/added functions (`check_compliance` for the never-panics/valid-result
+invariant; `path_exists`, `score_range`, `non_empty_index`, etc. where apter).
+Spot-check that functions touched by the work-in-progress diff carry one:
+```bash
+# Functions changed on the branch that lack a contract attribute on the line above:
+git diff --name-only origin/master... | grep '\.rs$' | while read f; do
+  grep -nE '^\s*(pub(\([^)]*\))?\s+)?(async\s+)?fn ' "$f" 2>/dev/null
+done | head   # review: each fix fn should have a #[...contract(...)] directly above
+```
+PASS if the functions implementing the fixes are annotated; the CI gate
+(`pmat verify` / `pv`) validates the contracts themselves.
+
 ## Gate 5: Find Next Work
 
 ```bash
@@ -193,12 +238,12 @@ them in this read-only audit).
 
 After all gates, provide:
 
-1. **Summary table**: Gate 1–5 | PASS/FAIL/SKIP | evidence
+1. **Summary table**: Gate 1–6 | PASS/FAIL/SKIP | evidence
 2. **Command grid**: N commands | PASS / SKIP / FAIL counts
-3. **Protocols**: P1–P6 | PASS/FAIL
-4. **GO** iff Gate 1 (build), Gate 3 (`pmat verify` ok:true), and all protocols pass, and the command grid has zero FAIL.
+3. **Protocols**: P1–P8 | PASS/FAIL
+4. **GO** iff Gate 1 (build), Gate 3 (`pmat verify` ok:true), and all protocols pass, the command grid has zero FAIL, and fix functions carry provable contracts (Gate 6).
 5. **WARN** for soft issues only (SKIPs, cosmetic output, pre-existing latent findings) — no panics, no integrity violations.
-6. **FAIL** on: build/install failure, `pmat verify` red, any command panic, JSON-impurity (P1), count/rows contradiction (P2), out-of-range score (P3), phantom-subcommand silent success (P5), or exit-code lies.
+6. **FAIL** on: build/install failure, `pmat verify` red, any command panic, JSON-impurity (P1), count/rows contradiction (P2), out-of-range score (P3), phantom-subcommand silent success (P5), dead-code worktree inflation (P7), `--exclude-tests` leaking test files (P8), or exit-code lies.
 
 If bugs found, file them:
 ```bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.19.2] - 2026-06-13
+
+Fixes two defects surfaced by the v3.19.0 self-dogfood.
+
+### Fixed
+- **`analyze dead-code` file count**: the analyzer walked files with a raw
+  `walkdir` that only skipped `target/`, so it descended into the hidden
+  `.claude/worktrees/` git-worktree copies — inflating `total_files_analyzed`
+  ~60× (263,890 vs the real ~4,224) and surfacing worktree duplicates as dead
+  code. Both walks (`scan_for_suppression_attributes`, the line counter) now use
+  `ignore::WalkBuilder` (hidden + .gitignore aware), matching the
+  complexity/function-index analyzers. Also: `total_files_analyzed` is now the
+  actual count of `.rs` files walked, not the previous `total_lines / 100`
+  estimate, so it reads **4224** for this repo.
+- **`pmat query --exclude-tests`**: test code was leaking into results. Test
+  detection (`is_test_chunk` at index build, `is_test_function`/`is_test_path`
+  at query time) now also matches mid-filename variants like
+  `*_tests_basic.rs` / `*_test_helpers.rs` (commonly `include!()`-ed into a
+  `#[cfg(test)]` module, so they have no standalone test attribute),
+  `setup_test*`/`create_test*` helper names, and `*fixtures*` support files.
+  The raw (`--literal`/`--regex`) and coverage-gaps paths now apply this filter
+  too (previously only a file-glob that couldn't express nested test paths).
+  **Known limitation**: functions inside `#[cfg(test)] mod` blocks within
+  otherwise-production `.rs` files, with non-test-prefixed names, are not yet
+  excluded — reliably detecting those requires AST-level `#[cfg(test)]`/`#[test]`
+  attribute tracking in the index (tracked follow-up).
+
 ## [3.19.1] - 2026-06-13
 
 MSRV correction following the v3.19.0 dependency modernization.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6719,7 +6719,7 @@ dependencies = [
 
 [[package]]
 name = "pmat"
-version = "3.19.1"
+version = "3.19.2"
 dependencies = [
  "actix",
  "actix-rt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pmat"
-version = "3.19.1"
+version = "3.19.2"
 edition = "2021"
 rust-version = "1.95.0"
 authors = ["Pragmatic AI Labs"]

--- a/src/cli/handlers/complexity_tests_watch.rs
+++ b/src/cli/handlers/complexity_tests_watch.rs
@@ -116,6 +116,7 @@ mod dead_code_conversion_tests {
             total_dead_items: 12,
             dead_code_percentage: 10.5,
             total_lines: 1000,
+            total_files: 10,
             dead_lines: 105,
             dead_by_type,
         }

--- a/src/cli/handlers/dead_code_handlers_analysis.rs
+++ b/src/cli/handlers/dead_code_handlers_analysis.rs
@@ -237,7 +237,7 @@ fn create_dead_code_summary(
     use crate::models::dead_code::DeadCodeSummary;
 
     DeadCodeSummary {
-        total_files_analyzed: accurate_report.total_lines / 100, // Rough estimate
+        total_files_analyzed: accurate_report.total_files, // actual .rs files walked
         files_with_dead_code: files_with_dead_code_count,
         total_dead_lines: accurate_report.dead_lines,
         dead_percentage: accurate_report.dead_code_percentage as f32,

--- a/src/cli/handlers/query_handler/modes_raw_search.rs
+++ b/src/cli/handlers/query_handler/modes_raw_search.rs
@@ -56,11 +56,7 @@ pub(super) fn handle_raw_search_mode(
 ) -> anyhow::Result<()> {
     let ctx_after = context_lines.or(after_context).unwrap_or(0);
     let ctx_before = context_lines.or(before_context).unwrap_or(0);
-    // When --exclude-tests is set in raw mode, filter test file paths
-    let mut excl_files: Vec<&str> = exclude_file.iter().map(|s| s.as_str()).collect();
-    if exclude_tests && excl_files.is_empty() {
-        excl_files.push("test");
-    }
+    let excl_files: Vec<&str> = exclude_file.iter().map(|s| s.as_str()).collect();
     let raw_opts = RawSearchOptions {
         pattern: query,
         literal,
@@ -75,7 +71,38 @@ pub(super) fn handle_raw_search_mode(
         count_mode: count,
     };
     let output = raw_search(project_path, &raw_opts).map_err(|e| anyhow::anyhow!("{}", e))?;
+    // --exclude-tests in raw mode: filter results from test files by path
+    // heuristic. The glob exclude can't reliably express nested test paths
+    // (e.g. src/**/foo_tests_basic.rs), so filter the output directly.
+    let output = if exclude_tests {
+        drop_test_file_results(output)
+    } else {
+        output
+    };
     print_raw_search_output(&output, format, quiet)
+}
+
+/// Drop raw-search results originating from test files (for `--exclude-tests`).
+#[provable_contracts_macros::contract("pmat-core.yaml", equation = "check_compliance")]
+fn drop_test_file_results(output: RawSearchOutput) -> RawSearchOutput {
+    use super::options::is_test_path;
+    match output {
+        RawSearchOutput::Files(files) => {
+            RawSearchOutput::Files(files.into_iter().filter(|f| !is_test_path(f)).collect())
+        }
+        RawSearchOutput::Counts(counts) => RawSearchOutput::Counts(
+            counts
+                .into_iter()
+                .filter(|c| !is_test_path(&c.file_path))
+                .collect(),
+        ),
+        RawSearchOutput::Lines(lines) => RawSearchOutput::Lines(
+            lines
+                .into_iter()
+                .filter(|l| !is_test_path(&l.file_path))
+                .collect(),
+        ),
+    }
 }
 
 fn print_raw_search_output(

--- a/src/cli/handlers/query_handler/options.rs
+++ b/src/cli/handlers/query_handler/options.rs
@@ -266,13 +266,34 @@ pub(super) fn build_query_options(
 
 // ── Filters ─────────────────────────────────────────────────────────────────
 
-/// Check if a result looks like a test function
+/// Check if a result looks like a test function.
+///
+/// Mirrors `is_test_chunk` (the index-build filter): besides `test_`-prefixed
+/// names and `tests/` dirs, it catches mid-filename variants like
+/// `*_tests_basic.rs` (commonly `include!()`-ed into a #[cfg(test)] module, so
+/// they lack a standalone test attribute) and test-helper prefixes.
+#[provable_contracts_macros::contract("pmat-core.yaml", equation = "check_compliance")]
 pub(super) fn is_test_function(r: &QueryResult) -> bool {
     r.function_name.starts_with("test_")
-        || r.file_path.starts_with("tests/")
-        || r.file_path.contains("/tests/")
-        || r.file_path.contains("_tests.")
-        || r.file_path.contains("_test.")
+        || r.function_name.starts_with("setup_test")
+        || r.function_name.starts_with("create_test")
+        || is_test_path(&r.file_path)
+}
+
+/// Path-based test-file heuristic, shared by `is_test_function` and the raw
+/// (literal/regex) search post-filter. Catches `tests/` dirs, `_test.rs`, and
+/// mid-filename `_tests_basic.rs` / `_test_helpers.rs` (`include!()`-ed into a
+/// #[cfg(test)] module, so they have no standalone test attribute).
+#[provable_contracts_macros::contract("pmat-core.yaml", equation = "check_compliance")]
+pub(super) fn is_test_path(file_path: &str) -> bool {
+    file_path.starts_with("tests/")
+        || file_path.starts_with("test/")
+        || file_path.contains("/tests/")
+        || file_path.contains("/test/")
+        || file_path.contains("_tests") // _tests.rs, _tests_basic.rs, …
+        || file_path.contains("_test.")
+        || file_path.contains("_test_")
+        || file_path.contains("fixtures") // test-support fixtures (e.g. *_coverage_fixtures.rs)
 }
 
 /// Normalize a definition type filter string to the canonical form
@@ -353,5 +374,45 @@ pub(super) fn apply_post_enrichment_sort(results: &mut [QueryResult], rank_by: &
                     .unwrap_or(std::cmp::Ordering::Equal)
             });
         }
+    }
+}
+
+#[cfg(test)]
+mod is_test_path_tests {
+    use super::is_test_path;
+
+    #[test]
+    fn excludes_standard_test_paths() {
+        assert!(is_test_path("tests/foo.rs"));
+        assert!(is_test_path("src/services/foo/tests/bar.rs"));
+        assert!(is_test_path("src/foo_test.rs"));
+        assert!(is_test_path("src/foo_tests.rs"));
+    }
+
+    #[test]
+    fn excludes_include_macro_test_fragments() {
+        // The original --exclude-tests leak: include!()-ed test fragments whose
+        // name has `_tests_` mid-filename (no standalone #[cfg(test)]).
+        assert!(is_test_path(
+            "src/ast/polyglot/language_mapper_tests_basic.rs"
+        ));
+        assert!(is_test_path("src/foo/bar_test_helpers.rs"));
+    }
+
+    #[test]
+    fn excludes_fixture_support_files() {
+        assert!(is_test_path(
+            "src/services/context_graph_coverage_fixtures.rs"
+        ));
+        assert!(is_test_path("fixtures/typescript/calculator.ts"));
+    }
+
+    #[test]
+    fn keeps_production_source() {
+        assert!(!is_test_path("src/lib.rs"));
+        assert!(!is_test_path("src/services/agent_context/query/options.rs"));
+        assert!(!is_test_path("src/cli/handlers/query_handler.rs"));
+        // `latest.rs` must not trip the `_test`/`_tests` checks.
+        assert!(!is_test_path("src/services/latest.rs"));
     }
 }

--- a/src/mcp_pmcp/tool_functions/tdg_tools_storage.rs
+++ b/src/mcp_pmcp/tool_functions/tdg_tools_storage.rs
@@ -16,6 +16,7 @@ pub async fn tdg_analyze_with_storage(
 }
 
 /// Create storage backend based on the provided backend type
+#[provable_contracts_macros::contract("pmat-core.yaml", equation = "check_compliance")]
 fn create_storage_backend(
     backend_type: Option<&str>,
 ) -> Result<Box<dyn crate::tdg::storage_backend::StorageBackend>> {

--- a/src/services/agent_context/function_index/helpers_call_graph.rs
+++ b/src/services/agent_context/function_index/helpers_call_graph.rs
@@ -48,6 +48,11 @@ pub(crate) fn is_test_chunk(chunk_name: &str, file_path: &str) -> bool {
         || file_path.starts_with("test/")
         || file_path.ends_with("_test.rs")
         || file_path.ends_with("_tests.rs")
+        // Mid-filename variants (`*_tests_basic.rs`, `*_test_helpers.rs`): these
+        // are commonly `include!()`-ed into a #[cfg(test)] module, so the file
+        // has no standalone test attribute and the `ends_with` checks miss it.
+        || file_path.contains("_tests_")
+        || file_path.contains("_test_")
         || file_path.ends_with("_test.cpp")
         || file_path.ends_with("_test.cc")
         || file_path.ends_with("_test.c")
@@ -62,8 +67,11 @@ pub(crate) fn is_test_chunk(chunk_name: &str, file_path: &str) -> bool {
     {
         return true;
     }
-    // Function-level: skip test_ prefixed and TEST_F/TEST/TEST_P (gtest)
+    // Function-level: skip test_ prefixed, common test-helper prefixes, and
+    // gtest TEST_F/TEST_P/TEST(.
     if chunk_name.starts_with("test_")
+        || chunk_name.starts_with("setup_test")
+        || chunk_name.starts_with("create_test")
         || chunk_name.starts_with("TEST_F")
         || chunk_name.starts_with("TEST_P")
         || (chunk_name.starts_with("TEST") && chunk_name.len() > 4 && chunk_name.as_bytes()[4] == b'(')

--- a/src/services/cargo_dead_code_analyzer.rs
+++ b/src/services/cargo_dead_code_analyzer.rs
@@ -47,6 +47,9 @@ pub struct AccurateDeadCodeReport {
     pub dead_code_percentage: f64,
     /// Total lines analyzed
     pub total_lines: usize,
+    /// Total source files analyzed (`.rs` files walked, excluding ignored/hidden dirs)
+    #[serde(default)]
+    pub total_files: usize,
     /// Dead lines count
     pub dead_lines: usize,
     /// Summary by type

--- a/src/services/cargo_dead_code_analyzer/analysis.rs
+++ b/src/services/cargo_dead_code_analyzer/analysis.rs
@@ -48,6 +48,7 @@ impl CargoDeadCodeAnalyzer {
     /// These attributes are explicit admissions that code is unused.
     /// Detecting them is fast (~10ms for large projects) and catches
     /// code that developers knowingly left as dead.
+    #[provable_contracts_macros::contract("pmat-core.yaml", equation = "check_compliance")]
     fn scan_for_suppression_attributes(&self) -> Result<Vec<(PathBuf, DeadItem)>> {
         use regex::Regex;
         use std::fs;
@@ -64,15 +65,24 @@ impl CargoDeadCodeAnalyzer {
             r#"^\s*(?:pub\s+)?(?:async\s+)?(?:const\s+)?(?:static\s+)?(?:unsafe\s+)?(fn|struct|enum|type|trait|mod|const|static)\s+(\w+)"#
         ).expect("Invalid regex");
 
-        // Walk through all Rust files
-        for entry in walkdir::WalkDir::new(&self.project_path)
-            .max_depth(self.max_depth)
-            .into_iter()
+        // Walk through all Rust files. Use ignore::WalkBuilder (not raw walkdir)
+        // so the walk respects .gitignore and skips hidden directories — matching
+        // the complexity/function-index analyzers. The raw walkdir only skipped
+        // `target/`, so it descended into hidden trees like `.claude/worktrees/`
+        // (git-worktree copies), inflating the analyzed file count ~60x and
+        // surfacing worktree duplicates as dead code.
+        for entry in ignore::WalkBuilder::new(&self.project_path)
+            .max_depth(Some(self.max_depth))
+            .hidden(true)
+            .git_ignore(true)
+            .git_global(true)
+            .build()
             .filter_map(std::result::Result::ok)
         {
             let path = entry.path();
 
-            // Skip target directory and non-Rust files
+            // Belt-and-suspenders: also skip target/ explicitly (covered by
+            // git_ignore inside a repo, but harmless otherwise).
             if path.starts_with(self.project_path.join("target")) {
                 continue;
             }

--- a/src/services/cargo_dead_code_analyzer/parsing.rs
+++ b/src/services/cargo_dead_code_analyzer/parsing.rs
@@ -156,26 +156,36 @@ impl CargoDeadCodeAnalyzer {
     }
 
     /// Calculate overall metrics
+    #[provable_contracts_macros::contract("pmat-core.yaml", equation = "check_compliance")]
     async fn calculate_metrics(&self, files: Vec<FileDeadCode>) -> Result<AccurateDeadCodeReport> {
         let mut total_lines = 0;
+        let mut total_files = 0;
         let mut dead_lines = 0;
         let mut dead_by_type = HashMap::new();
         let total_dead_items = files.iter().map(|f| f.dead_items.len()).sum();
 
-        // Count lines in all Rust files (with max depth limit to prevent hanging)
-        for entry in walkdir::WalkDir::new(&self.project_path)
-            .max_depth(self.max_depth) // Critical fix: limit traversal depth
-            .into_iter()
+        // Count lines in all Rust files. Use ignore::WalkBuilder so the walk
+        // respects .gitignore and skips hidden dirs (e.g. `.claude/worktrees/`
+        // git-worktree copies) — a raw walkdir here counted ~26M lines across
+        // worktree duplicates, so the `total_files_analyzed` estimate
+        // (total_lines / 100) ballooned to ~263k instead of ~4.2k.
+        for entry in ignore::WalkBuilder::new(&self.project_path)
+            .max_depth(Some(self.max_depth)) // limit traversal depth
+            .hidden(true)
+            .git_ignore(true)
+            .git_global(true)
+            .build()
             .filter_map(std::result::Result::ok)
         {
             let path = entry.path();
 
-            // Skip target directory and non-Rust files
+            // Belt-and-suspenders: also skip target/ explicitly.
             if path.starts_with(self.project_path.join("target")) {
                 continue;
             }
 
             if path.extension().and_then(|s| s.to_str()) == Some("rs") {
+                total_files += 1;
                 if let Ok(content) = std::fs::read_to_string(path) {
                     total_lines += content.lines().count();
                 }
@@ -209,6 +219,7 @@ impl CargoDeadCodeAnalyzer {
             total_dead_items,
             dead_code_percentage,
             total_lines,
+            total_files,
             dead_lines,
             dead_by_type,
         })


### PR DESCRIPTION
Two defects from the v3.19.0 self-dogfood, each root-caused, with **provable contracts** on the touched functions and **`/dogfood` regression protocols**.

## dead-code: `analyze dead-code` total_files 263890 → **4224**
Both file walks in `CargoDeadCodeAnalyzer` used raw `walkdir` (only skipped `target/`), descending into the hidden `.claude/worktrees/` git-worktree copies (~26M lines / 100 ≈ 263k). Now use `ignore::WalkBuilder` (hidden + `.gitignore` aware), matching complexity/function-index. `total_files_analyzed` is now an **actual `.rs` file count** (new `AccurateDeadCodeReport.total_files`), not the `total_lines/100` estimate.

## `--exclude-tests`: test code no longer leaks
`is_test_chunk` (index build) + `is_test_function`/`is_test_path` (query) now match `*_tests_basic.rs`/`*_test_helpers.rs` (`include!()`-ed fragments), `setup_test*`/`create_test*` helpers, and `*fixtures*` files. Raw (`--literal`/`--regex`) + coverage-gaps paths post-filter via `is_test_path` (the glob exclude couldn't express nested test paths).
**Known limitation (documented):** `#[cfg(test)]`-mod functions in production files with arbitrary names still leak — needs AST attribute detection (follow-up).

## Provable contracts
`check_compliance` added to the 6 fix functions: `create_storage_backend`, `calculate_metrics`, `scan_for_suppression_attributes`, `is_test_function`, `is_test_path`, `drop_test_file_results`.

## /dogfood
New **P7** (dead-code count sanity / no worktree paths), **P8** (`--exclude-tests` excludes test code), **Gate 6** (provable-contract coverage policy).

## Verification
- dead-code `total_files=4224`; `--literal`/`--coverage-gaps --exclude-tests` no longer list `create_test_ast_item`/`setup_test_project`/`build_simple_call_graph`
- `cargo clippy --all-targets -- -D warnings` → 0 errors; `is_test_path_tests` (4) + `cargo_dead_code` (14) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)