### PR TITLE
fix(ci): derive Post-Release MSRV check from Cargo.toml (unblock release verification)

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -25,16 +25,25 @@ jobs:
   msrv-check:
     name: MSRV verification
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        rust: [1.80.0]
     steps:
       - uses: actions/checkout@v4
+      # Derive the MSRV from Cargo.toml's declared `rust-version` instead of
+      # hardcoding it here. A hardcoded `1.80.0` went stale when v3.19.1 raised
+      # the declared MSRV to 1.95.0 (to match modernized deps), so this job
+      # checked a 1.95-requiring crate against 1.80 and always failed. Reading
+      # the value at runtime keeps the verified toolchain in lockstep with the
+      # crate's actual MSRV — no future drift.
+      - name: Read declared MSRV from Cargo.toml
+        id: msrv
+        run: |
+          MSRV=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].rust_version')
+          echo "Declared MSRV: $MSRV"
+          echo "version=$MSRV" >> "$GITHUB_OUTPUT"
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: ${{ matrix.rust }}
+          toolchain: ${{ steps.msrv.outputs.version }}
           components: clippy
-      - name: Check MSRV ${{ matrix.rust }} compilation
+      - name: Check MSRV ${{ steps.msrv.outputs.version }} compilation
         run: cargo check --all-features
       - name: Clippy on MSRV
         run: cargo clippy -- -D warnings


### PR DESCRIPTION
## Problem

The `Post-Release` workflow's `msrv-check` job hardcoded `rust: [1.80.0]`. v3.19.1 raised the crate's declared `rust-version` to **1.95.0** (to match modernized deps), so this job checks a 1.95-requiring crate against a 1.80 toolchain — it failed on **v3.19.1 and v3.19.2**. The published crates are correct; only this CI verification step was wrong.

## Fix (five whys → eliminate duplication)

Job red → checks against 1.80 → 1.80 hardcoded → MSRV bumped to 1.95 but workflow not updated → **the workflow duplicated a fact that already lives in `Cargo.toml`**.

The job now reads `rust_version` from `cargo metadata` at runtime and installs exactly that toolchain, so the verified MSRV tracks the declared MSRV automatically. No future drift when the MSRV moves again.

## Scope

CI-infra only — no crate/source change, no new release needed. After merge, the v3.19.2 `Post-Release` run can be re-dispatched and will verify against 1.95.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)