### PR TITLE
fix(ci): Post-Release MSRV check — select pmat by name + scope to -p pmat

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -33,17 +33,30 @@ jobs:
       # checked a 1.95-requiring crate against 1.80 and always failed. Reading
       # the value at runtime keeps the verified toolchain in lockstep with the
       # crate's actual MSRV — no future drift.
+      #
+      # Select the `pmat` package by NAME, not `.packages[0]`: this is a 2-member
+      # workspace (pmat + pmat-dashboard) and `cargo metadata` does not guarantee
+      # ordering, so `.packages[0]` was pmat-dashboard (no rust-version → "null",
+      # which then failed `rustup toolchain install null`). Guard against an empty
+      # read so a future selector break fails loudly here instead of downstream.
       - name: Read declared MSRV from Cargo.toml
         id: msrv
         run: |
-          MSRV=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].rust_version')
+          MSRV=$(cargo metadata --no-deps --format-version 1 \
+            | jq -r '.packages[] | select(.name=="pmat") | .rust_version')
           echo "Declared MSRV: $MSRV"
+          if [ -z "$MSRV" ] || [ "$MSRV" = "null" ]; then
+            echo "::error::Could not read rust-version for package 'pmat' from Cargo.toml"
+            exit 1
+          fi
           echo "version=$MSRV" >> "$GITHUB_OUTPUT"
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ steps.msrv.outputs.version }}
           components: clippy
+      # Scope to `-p pmat`: it is pmat's MSRV we derived and are verifying.
+      # pmat-dashboard declares no rust-version and must not gate this check.
       - name: Check MSRV ${{ steps.msrv.outputs.version }} compilation
-        run: cargo check --all-features
+        run: cargo check -p pmat --all-features
       - name: Clippy on MSRV
-        run: cargo clippy -- -D warnings
+        run: cargo clippy -p pmat -- -D warnings


### PR DESCRIPTION
Follow-up to #599. That PR fixed the *hardcoded 1.80* but introduced a workspace bug: it read `.packages[0].rust_version`, and this is a **2-member workspace** (`pmat` + `pmat-dashboard`) where `cargo metadata` ordering isn't guaranteed. `.packages[0]` resolved to `pmat-dashboard` (no `rust-version`) → `null` → `rustup toolchain install null` → the job failed on every release.

Verified locally: `.packages[0].name` = `pmat-dashboard`; `select(.name=="pmat") | .rust_version` = `1.95.0`.

## Fix
- Select the package by **name**, not position: `.packages[] | select(.name=="pmat") | .rust_version`.
- **Guard**: fail loudly (`::error`) if the read is empty/`null`, instead of installing a `null` toolchain.
- Scope `cargo check` / `cargo clippy` to **`-p pmat`** — it's pmat's MSRV being verified; `pmat-dashboard` declares no MSRV and must not gate this job.

After merge I'll re-dispatch `post-release.yml` on master to confirm the MSRV job is green against 1.95.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)