### PR TITLE
fix(work): skip Rust-only supply-chain gate on non-Rust repos (PMAT-058) + harden PMAT-154 self-dirty exclusion

### DIFF
--- a/src/cli/handlers/work_falsification/supply_chain_checks.rs
+++ b/src/cli/handlers/work_falsification/supply_chain_checks.rs
@@ -7,12 +7,31 @@ use anyhow::Result;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+/// True if the project is a Rust crate/workspace (has a `Cargo.toml`).
+///
+/// PMAT-058: Rust-only supply-chain gates (`cargo deny` / `cargo audit`) are
+/// inapplicable to repos without a `Cargo.toml` (e.g. the infra fleet repo,
+/// pure-YAML/Makefile repos). Detect this and skip rather than hard-fail on a
+/// missing deny cache.
+pub(crate) fn is_rust_project(project_path: &Path) -> bool {
+    project_path.join("Cargo.toml").exists()
+}
+
 /// Test supply chain integrity: O(1) - reads from cached cargo deny status
 #[provable_contracts_macros::contract("pmat-core.yaml", equation = "check_compliance")]
 pub(crate) async fn test_supply_chain_integrity(
     project_path: &Path,
 ) -> Result<FalsificationResult> {
     print!("Reading deny cache... ");
+
+    // PMAT-058: cargo deny / audit only apply to Rust projects. A repo with no
+    // Cargo.toml has no supply chain to vet, so skip instead of failing on a
+    // missing (and unobtainable) deny cache.
+    if !is_rust_project(project_path) {
+        return Ok(FalsificationResult::passed(
+            "N/A (non-Rust repo: no Cargo.toml)".to_string(),
+        ));
+    }
 
     // O(1): Read from cache instead of running cargo deny
     // Try primary cache location, then fallback to work-item and .pmat directories

--- a/src/cli/handlers/work_falsification/tests.rs
+++ b/src/cli/handlers/work_falsification/tests.rs
@@ -11,6 +11,10 @@ mod tests {
     use crate::cli::handlers::work_falsification::churn_checks::{
         detect_fix_chains, extract_large_match_variants, extract_test_section,
     };
+    use crate::cli::handlers::work_falsification::pmat_owned_state::is_pmat_owned_state;
+    use crate::cli::handlers::work_falsification::supply_chain_checks::{
+        is_rust_project, test_supply_chain_integrity,
+    };
     use crate::cli::handlers::work_falsification::types::{
         CachedMetric, ClaimResult, FalsificationReport, CACHE_BLOCK_HOURS, CACHE_WARN_HOURS,
     };
@@ -97,6 +101,110 @@ mod tests {
             .filter(|l| !l.is_empty() && !l.starts_with("??"))
             .count();
         assert_eq!(dirty_count, 2, "Modified and staged files should count");
+    }
+
+    // PMAT-154: pmat's own post-commit hook regenerates .pmat/baseline.json,
+    // .pmat/context.db and .pmat/*.cache during `work complete`. These are
+    // self-generated artifacts and MUST NOT be counted as unpushed dirty work,
+    // or the github-sync falsifier hits the self-dirty loop on retries.
+    #[test]
+    fn test_github_sync_ignores_self_generated_pmat_artifacts() {
+        // Exactly the files the post-commit hook regenerates.
+        assert!(
+            is_pmat_owned_state(" M .pmat/baseline.json"),
+            ".pmat/baseline.json is a pmat-owned artifact"
+        );
+        assert!(
+            is_pmat_owned_state(" M .pmat/context.db"),
+            ".pmat/context.db is a pmat-owned artifact"
+        );
+        assert!(
+            is_pmat_owned_state(" M .pmat/tdg.cache"),
+            ".pmat/*.cache is a pmat-owned artifact"
+        );
+        assert!(
+            is_pmat_owned_state(" M .pmat/context.idx/manifest.cache"),
+            "nested .pmat/*.cache is a pmat-owned artifact"
+        );
+
+        // Look-alike user-owned files must still count as real dirty work.
+        assert!(
+            !is_pmat_owned_state(" M .pmat-baseline.json"),
+            ".pmat-baseline.json (user-owned look-alike) must NOT be ignored"
+        );
+        assert!(
+            !is_pmat_owned_state(" M src/baseline.json"),
+            "user source files must NOT be ignored"
+        );
+
+        // Full self-dirty scenario: HEAD == origin, only pmat artifacts dirty.
+        let status = concat!(
+            "## master...origin/master\n",
+            " M .pmat/baseline.json\n",
+            " M .pmat/context.db\n",
+            " M .pmat/tdg.cache\n"
+        );
+        let dirty_count = status
+            .lines()
+            .skip(1)
+            .filter(|l| !l.is_empty() && !l.starts_with("??"))
+            .filter(|l| !is_pmat_owned_state(l))
+            .count();
+        assert_eq!(
+            dirty_count, 0,
+            "pmat-self-generated artifacts must not trip the github-sync dirty check"
+        );
+    }
+
+    // PMAT-058: Rust-only supply-chain gates must be skipped (not failed) on a
+    // repo with no Cargo.toml (e.g. the infra fleet repo).
+    #[test]
+    fn test_is_rust_project_detection() {
+        use tempfile::TempDir;
+        let non_rust = TempDir::new().unwrap();
+        assert!(
+            !is_rust_project(non_rust.path()),
+            "dir without Cargo.toml is not a Rust project"
+        );
+
+        let rust = TempDir::new().unwrap();
+        std::fs::write(rust.path().join("Cargo.toml"), "[package]\nname = \"x\"\n").unwrap();
+        assert!(
+            is_rust_project(rust.path()),
+            "dir with Cargo.toml is a Rust project"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_supply_chain_skips_non_rust_repo() {
+        use tempfile::TempDir;
+        // No Cargo.toml and no deny cache. Without the PMAT-058 guard this would
+        // hard-fail with "No deny cache. Run 'cargo deny check' first".
+        let temp = TempDir::new().unwrap();
+        let result = test_supply_chain_integrity(temp.path()).await.unwrap();
+        assert!(
+            !result.falsified,
+            "supply-chain gate must not fail on a non-Rust repo"
+        );
+        assert!(
+            result.explanation.contains("N/A (non-Rust repo"),
+            "non-Rust skip must be clearly labeled, got: {}",
+            result.explanation
+        );
+    }
+
+    #[tokio::test]
+    async fn test_supply_chain_still_fails_rust_repo_without_cache() {
+        use tempfile::TempDir;
+        // A Rust repo (Cargo.toml present) with no deny cache must STILL fail —
+        // PMAT-058 must not weaken the gate for real Rust projects.
+        let temp = TempDir::new().unwrap();
+        std::fs::write(temp.path().join("Cargo.toml"), "[package]\nname = \"x\"\n").unwrap();
+        let result = test_supply_chain_integrity(temp.path()).await.unwrap();
+        assert!(
+            result.falsified,
+            "Rust repo with no deny cache must still fail the supply-chain gate"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes two `pmat work complete` defects tracked in the infra fleet as **PMAT-058** and **PMAT-154**.

### PMAT-058 — Rust-only gates fail on non-Rust repos
`pmat work complete` ran the cargo-deny supply-chain falsifier unconditionally. On a repo with **no `Cargo.toml`** (e.g. the infra fleet repo, pure-YAML/Makefile repos), there is no deny cache to read and no way to produce one, so the gate hard-failed with `No deny cache. Run 'cargo deny check' first` — a spurious **blocking** failure for a check that is inapplicable.

`test_supply_chain_integrity` now detects a non-Rust repo via `is_rust_project()` (presence of `Cargo.toml`) and **skips** with a clear `N/A (non-Rust repo: no Cargo.toml)` pass instead of failing.

- Rust repos with a missing cache **still fail** — the gate is not weakened for real Rust projects (covered by `test_supply_chain_still_fails_rust_repo_without_cache`).
- Coverage / TDG / differential-coverage gates already skip gracefully when their data is absent, so only the deny gate needed the guard.
- The `make lint` gate is Makefile-gated (not Rust-specific) and already skips when no Makefile is present — intentionally left unchanged.

### PMAT-154 — github-sync self-dirty loop (regression test)
The self-dirty fix (#392) already excludes the `.pmat/`, `.pmat-work/`, and `.pmat-metrics/` prefixes, which covers the post-commit-hook-regenerated `.pmat/baseline.json`, `.pmat/context.db`, and `.pmat/*.cache`. This PR adds an explicit regression test that names those exact artifacts and asserts that the user-owned look-alikes (`.pmat-baseline.json`, `src/baseline.json`) still count as real dirty work, so the exclusion can't silently over-broaden.

## Tests
4 new unit tests in `work_falsification/tests.rs`:
- `test_github_sync_ignores_self_generated_pmat_artifacts` (PMAT-154)
- `test_is_rust_project_detection` (PMAT-058)
- `test_supply_chain_skips_non_rust_repo` (PMAT-058)
- `test_supply_chain_still_fails_rust_repo_without_cache` (PMAT-058, guard against weakening)

`cargo build` / `cargo test -p pmat --lib work_falsification` (77 passed) / `cargo clippy -p pmat --lib --tests -- -D warnings` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)