### PR TITLE
Add MCP Toplist rank badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![MCP Toplist](https://mcptoplist.com/badge/mcp.so%2Fpaiml-mcp-agent-toolkit%2Fpaiml.svg)](https://mcptoplist.com/server/mcp.so%2Fpaiml-mcp-agent-toolkit%2Fpaiml)
+
 <h1 align="center">PMAT</h1>
 
 <p align="center">


### PR DESCRIPTION
Hi! [MCP Toplist](https://mcptoplist.com) tracks 81,686 MCP servers across the major
registries, and **PAIML MCP Agent Toolkit MCP Server** is currently ranked **#643**.

This PR adds a small live badge to your README showing that rank — it updates
automatically as the leaderboard changes:

[![MCP Toplist](https://mcptoplist.com/badge/mcp.so%2Fpaiml-mcp-agent-toolkit%2Fpaiml.svg)](https://mcptoplist.com/server/mcp.so%2Fpaiml-mcp-agent-toolkit%2Fpaiml)

Totally fine to close if you'd rather not — and if you'd like your server's
data corrected or removed from the leaderboard, just say so here or open an
issue at the site. Thanks for building PAIML MCP Agent Toolkit MCP Server!
