### PR TITLE
fix: give the six unmeasured claims real data sources (v3.27.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,55 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.27.0] - 2026-07-28
+
+v3.26.0 made the ladder stop *lying* about the six claims that verified nothing —
+they reported `NOT MEASURED` instead of `PASSED`. This release gives them real
+data sources, so they verify something.
+
+### Fixed — the coverage claims now read coverage
+All three consulted either nothing at all or `target/llvm-cov/coverage.json`, a
+path no tool in this repository has ever written (`make coverage` produces
+`target/coverage/lcov.info`). They now use the same artifact discovery
+`pmat query --coverage` already relies on.
+
+- **[4] DifferentialCoverage was a hard-coded pass** — every path out of the
+  function returned `passed`, and it never consulted coverage at all. It now
+  parses `git diff -U0` hunk headers for the lines the work actually introduced
+  and checks each against its recorded hit count, reporting the uncovered ones by
+  `file:line`. Verified end to end: given a change touching an uncovered line, it
+  reports `1/2 changed line(s) uncovered: src/main.rs:6`.
+- **[16] PerFileCoverage** now computes per-file percentages from the coverage
+  map and names the files below threshold, worst first and deterministically
+  ordered. Verified: `1 file(s) below 95.0% threshold: src/main.rs: 66.7%`.
+- **[5] AbsoluteCoverage** falls back to the raw llvm-cov artifact when
+  `.pmat-metrics/trends/test-coverage.json` is absent — which is the state of
+  every repository straight after its first coverage run. Verified: `66.7% <
+  95.0% threshold`.
+
+Coverage is deliberately *not* derived on demand: unlike cargo-deny or clippy, an
+llvm-cov run is many minutes, so a gate must not trigger one. With no artifact
+present these claims still report `NOT MEASURED`, now naming the command that
+produces one.
+
+### Fixed — TDG, examples, benchmarks
+- **[6] TdgRegression read `.pmat-metrics/tdg-score.json`, which has no writer.**
+  `.pmat/baseline.json` carries the same figure as `summary.avg_score` and *is*
+  written — by `pmat analyze tdg --update-baseline`, which the pre-commit hook
+  runs on every commit. The documented path is still preferred; the baseline is
+  the fallback. Verified: `88.5 >= 0.0 (baseline)`.
+- **[12] ExamplesCompile** now derives its verdict with a bounded
+  `cargo build --examples`, the way the supply-chain and lint claims do, instead
+  of passing because a cache nothing writes was absent.
+- **[21] RegressionGate** is the one input a gate must not derive — a criterion
+  run is minutes to hours. A project with no `benches/` is now a genuine N/A
+  rather than an unmeasured claim; one with benches says plainly that no result
+  has been recorded.
+
+With this, every claim in the ladder either measures something, derives it
+within a bounded subprocess, or states exactly what is missing and how to
+produce it. None of them reports success for work it did not do.
+
 ## [3.26.0] - 2026-07-28
 
 An audit of the falsification ladder and of v3.25.0's own new code. The headline

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5430,7 +5430,7 @@ dependencies = [
 
 [[package]]
 name = "pmat"
-version = "3.26.0"
+version = "3.27.0"
 dependencies = [
  "actix",
  "actix-rt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pmat"
-version = "3.26.0"
+version = "3.27.0"
 edition = "2021"
 rust-version = "1.91.0"
 authors = ["Pragmatic AI Labs"]

--- a/src/cli/handlers/work_falsification/advanced_checks.rs
+++ b/src/cli/handlers/work_falsification/advanced_checks.rs
@@ -3,6 +3,7 @@
 
 use super::cache::{read_cached_metric, read_lint_cache_fallback};
 use super::churn_checks::get_changed_files;
+use super::coverage_source;
 pub(crate) use super::formal_checks::test_formal_proof_verification;
 use super::lint_refresh::{refresh_lint_cache, LintRefresh, LINT_STATUS_PATH};
 use crate::cli::handlers::work_contract::{EvidenceType, FalsificationResult};
@@ -360,24 +361,33 @@ pub(crate) async fn test_per_file_coverage(
 ) -> Result<FalsificationResult> {
     print!("Checking per-file coverage... ");
 
-    // Try to read per-file coverage from llvm-cov output
-    let coverage_json = project_path.join("target/llvm-cov/coverage.json");
-
-    if !coverage_json.exists() {
-        // Nothing writes target/llvm-cov/coverage.json; `make coverage`
-        // produces target/coverage/{summary.txt,lcov.info}. Until the reader is
-        // pointed at an artifact that exists, this claim measures nothing.
+    // Read whatever a coverage run actually left. This used to look for
+    // `target/llvm-cov/coverage.json`, which nothing has ever written, so the
+    // check passed on every repository without measuring anything.
+    let Some(coverage) = coverage_source::load(project_path) else {
         return Ok(FalsificationResult::unmeasured(format!(
-            "No per-file coverage data at {} (run 'make coverage'), threshold: {:.1}%",
-            coverage_json.display(),
-            threshold
+            "No per-file coverage data (threshold {:.1}%) — {}",
+            threshold,
+            coverage_source::COVERAGE_HINT
         )));
-    }
+    };
 
-    let content = std::fs::read_to_string(&coverage_json)?;
-    let json: serde_json::Value = serde_json::from_str(&content)?;
+    let mut files_below: Vec<(PathBuf, f64)> = coverage
+        .iter()
+        .filter(|(path, _)| !is_excluded_from_per_file_coverage(path))
+        .filter_map(|(path, lines)| {
+            coverage_source::file_percent(lines)
+                .filter(|pct| *pct < threshold)
+                .map(|pct| (PathBuf::from(path), pct))
+        })
+        .collect();
+    // Worst first, and deterministic so the message does not churn between runs.
+    files_below.sort_by(|a, b| {
+        a.1.partial_cmp(&b.1)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.0.cmp(&b.0))
+    });
 
-    let files_below = collect_files_below_threshold(&json, threshold);
     Ok(build_per_file_coverage_result(files_below, threshold))
 }
 

--- a/src/cli/handlers/work_falsification/core_checks.rs
+++ b/src/cli/handlers/work_falsification/core_checks.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(coverage_nightly, coverage(off))]
 //! Core falsification checks: manifest, coverage, TDG, complexity, spec, roadmap, git.
 
+use super::coverage_source;
 use crate::cli::handlers::work_contract::{EvidenceType, FalsificationResult, FileManifest};
 use crate::cli::handlers::work_falsification::pre_run_tree::{
     dirty_file_paths, has_upstream, parse_ahead_count, pre_run_status, read_porcelain_status,
@@ -86,14 +87,83 @@ pub(crate) async fn test_differential_coverage(
         ));
     }
 
-    // Coverage data is assumed available from a previous run
-    // In production, this integrates with llvm-cov or similar
+    let Some(coverage) = coverage_source::load(project_path) else {
+        return Ok(FalsificationResult::unmeasured(format!(
+            "{} changed file(s), but no coverage artifact exists — {}",
+            changed_files.len(),
+            coverage_source::COVERAGE_HINT
+        )));
+    };
 
-    Ok(FalsificationResult::unmeasured(format!(
-        "{} changed file(s), but differential coverage is not wired to any coverage \
-         artifact — this claim verifies nothing today",
-        changed_files.len()
-    )))
+    // -U0 so hunk headers describe exactly the lines this work introduced.
+    let diff = Command::new("git")
+        .args(["diff", "-U0", baseline_commit, "HEAD", "--", "*.rs"])
+        .current_dir(project_path)
+        .output()
+        .context("Failed to get git diff for differential coverage")?;
+    let changed_lines = coverage_source::changed_lines(&String::from_utf8_lossy(&diff.stdout));
+
+    Ok(evaluate_differential_coverage(&changed_lines, &coverage))
+}
+
+/// Judge whether every line this work added is executed by the test suite.
+fn evaluate_differential_coverage(
+    changed_lines: &std::collections::HashMap<String, Vec<usize>>,
+    coverage: &coverage_source::LineCoverage,
+) -> FalsificationResult {
+    let mut uncovered: Vec<String> = Vec::new();
+    let mut checked = 0usize;
+
+    for (file, lines) in changed_lines {
+        // A file absent from the report is not instrumented (a test file, or
+        // excluded from coverage); it has no lines to require hits for.
+        let Some(file_cov) = coverage_source::lookup(coverage, file) else {
+            continue;
+        };
+        for line in lines {
+            // Lines with no coverage record are not instrumented — comments,
+            // blank lines, `use` statements. Only recorded lines can be missed.
+            let Some(hits) = file_cov.get(line) else {
+                continue;
+            };
+            checked += 1;
+            if *hits == 0 {
+                uncovered.push(format!("{}:{}", file, line));
+            }
+        }
+    }
+
+    if checked == 0 {
+        return FalsificationResult::unmeasured(format!(
+            "no instrumented lines among the changed lines — {}",
+            coverage_source::COVERAGE_HINT
+        ));
+    }
+
+    if uncovered.is_empty() {
+        return FalsificationResult::passed(format!("all {} changed line(s) covered", checked));
+    }
+
+    let shown: Vec<String> = uncovered.iter().take(5).cloned().collect();
+    let rest = uncovered.len().saturating_sub(shown.len());
+    let suffix = if rest > 0 {
+        format!(", +{} more", rest)
+    } else {
+        String::new()
+    };
+    FalsificationResult::failed(
+        format!(
+            "{}/{} changed line(s) uncovered: {}{}",
+            uncovered.len(),
+            checked,
+            shown.join(", "),
+            suffix
+        ),
+        EvidenceType::NumericComparison {
+            actual: uncovered.len() as f64,
+            threshold: 0.0,
+        },
+    )
 }
 
 /// Test absolute coverage threshold
@@ -104,44 +174,46 @@ pub(crate) async fn test_absolute_coverage(
 ) -> Result<FalsificationResult> {
     print!("Checking coverage threshold... ");
 
-    // Try to read coverage from cached metrics
-    let metrics_dir = project_path.join(".pmat-metrics/trends");
-    let coverage_file = metrics_dir.join("test-coverage.json");
+    // Prefer the recorded trend, then whatever a coverage run left on disk. The
+    // trends file is written only by `make coverage` / `pmat record-metric`, so
+    // requiring it made this claim vacuous in every repo that had simply run
+    // coverage once.
+    let measured = read_trend_coverage(project_path).or_else(|| {
+        coverage_source::load(project_path)
+            .as_ref()
+            .and_then(coverage_source::total_percent)
+    });
 
-    if !coverage_file.exists() {
-        return Ok(FalsificationResult::unmeasured(format!(
-            "No coverage data (run 'make coverage' to establish baseline), threshold: {:.1}%",
-            threshold
-        )));
+    Ok(match measured {
+        Some(pct) => judge_coverage(pct, threshold),
+        None => FalsificationResult::unmeasured(format!(
+            "No coverage data (threshold {:.1}%) — {}",
+            threshold,
+            coverage_source::COVERAGE_HINT
+        )),
+    })
+}
+
+/// Latest recorded coverage percentage from `.pmat-metrics/trends`.
+fn read_trend_coverage(project_path: &Path) -> Option<f64> {
+    let path = project_path.join(".pmat-metrics/trends/test-coverage.json");
+    let json: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(path).ok()?).ok()?;
+    json.as_array()?.last()?.get("value")?.as_f64()
+}
+
+/// Compare a measured coverage percentage against the claim's threshold.
+fn judge_coverage(pct: f64, threshold: f64) -> FalsificationResult {
+    if pct >= threshold {
+        return FalsificationResult::passed(format!("{:.1}% >= {:.1}%", pct, threshold));
     }
-
-    let content = std::fs::read_to_string(&coverage_file)?;
-    let json: serde_json::Value = serde_json::from_str(&content)?;
-
-    if let Some(entries) = json.as_array() {
-        if let Some(latest) = entries.last() {
-            if let Some(coverage) = latest.get("value").and_then(|v| v.as_f64()) {
-                if coverage >= threshold {
-                    return Ok(FalsificationResult::passed(format!(
-                        "{:.1}% >= {:.1}%",
-                        coverage, threshold
-                    )));
-                } else {
-                    return Ok(FalsificationResult::failed(
-                        format!("{:.1}% < {:.1}% threshold", coverage, threshold),
-                        EvidenceType::NumericComparison {
-                            actual: coverage,
-                            threshold,
-                        },
-                    ));
-                }
-            }
-        }
-    }
-
-    Ok(FalsificationResult::passed(
-        "No coverage entries found".to_string(),
-    ))
+    FalsificationResult::failed(
+        format!("{:.1}% < {:.1}% threshold", pct, threshold),
+        EvidenceType::NumericComparison {
+            actual: pct,
+            threshold,
+        },
+    )
 }
 
 /// Test TDG score regression
@@ -152,39 +224,52 @@ pub(crate) async fn test_tdg_regression(
 ) -> Result<FalsificationResult> {
     print!("Checking TDG score... ");
 
-    // Read current TDG score from cache
-    let tdg_file = project_path.join(".pmat-metrics/tdg-score.json");
-
-    if !tdg_file.exists() {
+    // Nothing writes .pmat-metrics/tdg-score.json, so that path alone made this
+    // claim permanently vacuous. `.pmat/baseline.json` carries the same score
+    // under `summary.avg_score` and IS written — by `pmat analyze tdg
+    // --update-baseline`, which the pre-commit hook runs on every commit.
+    let Some(current_tdg) = read_tdg_score(project_path) else {
         return Ok(FalsificationResult::unmeasured(format!(
-            "No TDG data (baseline: {:.1}); nothing writes .pmat-metrics/tdg-score.json",
+            "No TDG data (baseline: {:.1}); run 'pmat analyze tdg --update-baseline'",
             baseline_tdg
         )));
-    }
+    };
 
-    let content = std::fs::read_to_string(&tdg_file)?;
-    let json: serde_json::Value = serde_json::from_str(&content)?;
-
-    if let Some(current_tdg) = json.get("score").and_then(|v| v.as_f64()) {
-        if current_tdg >= baseline_tdg {
-            Ok(FalsificationResult::passed(format!(
-                "{:.1} >= {:.1} (baseline)",
-                current_tdg, baseline_tdg
-            )))
-        } else {
-            Ok(FalsificationResult::failed(
-                format!("{:.1} < {:.1} (regression)", current_tdg, baseline_tdg),
-                EvidenceType::NumericComparison {
-                    actual: current_tdg,
-                    threshold: baseline_tdg,
-                },
-            ))
-        }
+    if current_tdg >= baseline_tdg {
+        Ok(FalsificationResult::passed(format!(
+            "{:.1} >= {:.1} (baseline)",
+            current_tdg, baseline_tdg
+        )))
     } else {
-        Ok(FalsificationResult::passed(
-            "No TDG score in cache".to_string(),
+        Ok(FalsificationResult::failed(
+            format!("{:.1} < {:.1} (regression)", current_tdg, baseline_tdg),
+            EvidenceType::NumericComparison {
+                actual: current_tdg,
+                threshold: baseline_tdg,
+            },
         ))
     }
+}
+
+/// Current project TDG score, from whichever artifact carries one.
+///
+/// `.pmat-metrics/tdg-score.json` is the documented location but has no writer
+/// anywhere; `.pmat/baseline.json` is written by `pmat analyze tdg
+/// --update-baseline`, which the pre-commit hook runs on every commit, and
+/// records the same figure as `summary.avg_score`.
+fn read_tdg_score(project_path: &Path) -> Option<f64> {
+    let read_json = |path: PathBuf| -> Option<serde_json::Value> {
+        serde_json::from_str(&std::fs::read_to_string(path).ok()?).ok()
+    };
+
+    read_json(project_path.join(".pmat-metrics/tdg-score.json"))
+        .and_then(|j| j.get("score").and_then(serde_json::Value::as_f64))
+        .or_else(|| {
+            read_json(project_path.join(".pmat/baseline.json"))?
+                .get("summary")?
+                .get("avg_score")?
+                .as_f64()
+        })
 }
 
 /// Test complexity regression: no function should exceed threshold

--- a/src/cli/handlers/work_falsification/coverage_source.rs
+++ b/src/cli/handlers/work_falsification/coverage_source.rs
@@ -1,0 +1,180 @@
+#![cfg_attr(coverage_nightly, coverage(off))]
+//! Real line-coverage data for the ladder's coverage claims.
+//!
+//! Three claims — differential coverage, absolute coverage and per-file
+//! coverage — used to consult either nothing at all or
+//! `target/llvm-cov/coverage.json`, a path no tool in this repository has ever
+//! written (`make coverage` produces `target/coverage/lcov.info` and
+//! `summary.txt`). They therefore passed on every repository without measuring
+//! anything.
+//!
+//! This module points them at the artifact a coverage run actually leaves, via
+//! the same discovery `pmat query --coverage` already uses. Coverage is far too
+//! expensive to derive inside a gate — unlike cargo-deny or clippy, an
+//! llvm-cov run is many minutes — so when no artifact exists the claims report
+//! *not measured* rather than fabricating a verdict or blocking on data the
+//! user cannot cheaply produce.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+/// Line hits per file, keyed by project-relative path.
+pub(crate) type LineCoverage = HashMap<String, HashMap<usize, u64>>;
+
+/// Load coverage produced by `make coverage` (or any llvm-cov run).
+pub(crate) fn load(project_path: &Path) -> Option<LineCoverage> {
+    crate::services::agent_context::query::discover_line_coverage(project_path)
+}
+
+/// How to obtain coverage, for messages that would otherwise be a dead end.
+pub(crate) const COVERAGE_HINT: &str =
+    "run 'make coverage' (writes target/coverage/lcov.info) to enable this claim";
+
+/// Percentage of instrumented lines that were executed, over the whole project.
+pub(crate) fn total_percent(coverage: &LineCoverage) -> Option<f64> {
+    let (covered, total) = coverage.values().fold((0usize, 0usize), |(c, t), lines| {
+        (
+            c + lines.values().filter(|hits| **hits > 0).count(),
+            t + lines.len(),
+        )
+    });
+    (total > 0).then(|| covered as f64 * 100.0 / total as f64)
+}
+
+/// Percentage of instrumented lines executed in one file.
+pub(crate) fn file_percent(lines: &HashMap<usize, u64>) -> Option<f64> {
+    (!lines.is_empty()).then(|| {
+        lines.values().filter(|hits| **hits > 0).count() as f64 * 100.0 / lines.len() as f64
+    })
+}
+
+/// Look a file up by project-relative path, tolerating leading `./`.
+///
+/// lcov `SF:` records and `git diff --name-only` do not always agree on that
+/// prefix, and a lookup miss here would silently read as "no uncovered lines".
+pub(crate) fn lookup<'a>(
+    coverage: &'a LineCoverage,
+    path: &str,
+) -> Option<&'a HashMap<usize, u64>> {
+    let normalized = path.trim_start_matches("./");
+    coverage
+        .get(normalized)
+        .or_else(|| coverage.get(path))
+        .or_else(|| {
+            coverage
+                .iter()
+                .find(|(k, _)| k.trim_start_matches("./") == normalized)
+                .map(|(_, v)| v)
+        })
+}
+
+/// Line numbers added or modified per file between `baseline` and HEAD.
+///
+/// Parses `git diff -U0`, whose hunk headers give the post-image start line and
+/// length, so the result is exactly the set of lines this work introduced —
+/// which is what a *differential* coverage claim must judge.
+pub(crate) fn changed_lines(diff: &str) -> HashMap<String, Vec<usize>> {
+    let mut result: HashMap<String, Vec<usize>> = HashMap::new();
+    let mut current: Option<String> = None;
+
+    for line in diff.lines() {
+        if let Some(path) = line.strip_prefix("+++ b/") {
+            current = (path != "/dev/null").then(|| path.to_string());
+            continue;
+        }
+        let Some(hunk) = line.strip_prefix("@@ ") else {
+            continue;
+        };
+        let Some(ref file) = current else { continue };
+        // `@@ -old,len +new,len @@` — only the post-image side matters.
+        let Some(new_part) = hunk.split_whitespace().find(|p| p.starts_with('+')) else {
+            continue;
+        };
+        let mut nums = new_part.trim_start_matches('+').splitn(2, ',');
+        let Some(start) = nums.next().and_then(|n| n.parse::<usize>().ok()) else {
+            continue;
+        };
+        // A missing length means exactly one line; a length of 0 means a pure
+        // deletion, which adds nothing to cover.
+        let len = nums.next().map_or(1, |n| n.parse::<usize>().unwrap_or(1));
+        if len > 0 {
+            result
+                .entry(file.clone())
+                .or_default()
+                .extend(start..start + len);
+        }
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cov(pairs: &[(&str, &[(usize, u64)])]) -> LineCoverage {
+        pairs
+            .iter()
+            .map(|(f, lines)| (f.to_string(), lines.iter().copied().collect()))
+            .collect()
+    }
+
+    #[test]
+    fn total_percent_counts_executed_lines() {
+        let c = cov(&[("a.rs", &[(1, 1), (2, 0)]), ("b.rs", &[(1, 5), (2, 3)])]);
+        assert_eq!(total_percent(&c), Some(75.0));
+    }
+
+    #[test]
+    fn total_percent_is_none_without_instrumented_lines() {
+        assert_eq!(total_percent(&cov(&[])), None);
+        assert_eq!(total_percent(&cov(&[("a.rs", &[])])), None);
+    }
+
+    #[test]
+    fn file_percent_is_per_file() {
+        let c = cov(&[("a.rs", &[(1, 1), (2, 0), (3, 0), (4, 0)])]);
+        assert_eq!(file_percent(lookup(&c, "a.rs").unwrap()), Some(25.0));
+    }
+
+    #[test]
+    fn lookup_tolerates_a_leading_dot_slash() {
+        let c = cov(&[("src/a.rs", &[(1, 1)])]);
+        assert!(lookup(&c, "./src/a.rs").is_some());
+        assert!(lookup(&c, "src/a.rs").is_some());
+        assert!(lookup(&c, "src/missing.rs").is_none());
+    }
+
+    #[test]
+    fn changed_lines_reads_the_post_image_side() {
+        let diff = "diff --git a/src/a.rs b/src/a.rs\n\
+                    --- a/src/a.rs\n\
+                    +++ b/src/a.rs\n\
+                    @@ -10,0 +11,3 @@\n\
+                    +one\n+two\n+three\n";
+        let changed = changed_lines(diff);
+        assert_eq!(changed["src/a.rs"], vec![11, 12, 13]);
+    }
+
+    #[test]
+    fn changed_lines_handles_a_single_line_hunk() {
+        // A hunk with no length means exactly one line.
+        let diff = "+++ b/src/a.rs\n@@ -5 +5 @@\n-old\n+new\n";
+        assert_eq!(changed_lines(diff)["src/a.rs"], vec![5]);
+    }
+
+    #[test]
+    fn changed_lines_ignores_pure_deletions() {
+        // `+7,0` adds nothing, so there is nothing to require coverage for.
+        let diff = "+++ b/src/a.rs\n@@ -7,3 +7,0 @@\n-gone\n";
+        assert!(!changed_lines(diff).contains_key("src/a.rs"));
+    }
+
+    #[test]
+    fn changed_lines_tracks_multiple_files() {
+        let diff = "+++ b/src/a.rs\n@@ -1,0 +1,2 @@\n\
+                    +++ b/src/b.rs\n@@ -1,0 +9,1 @@\n";
+        let changed = changed_lines(diff);
+        assert_eq!(changed["src/a.rs"], vec![1, 2]);
+        assert_eq!(changed["src/b.rs"], vec![9]);
+    }
+}

--- a/src/cli/handlers/work_falsification/mod.rs
+++ b/src/cli/handlers/work_falsification/mod.rs
@@ -16,6 +16,7 @@ pub mod advanced_checks;
 pub mod cache;
 pub mod churn_checks;
 pub mod core_checks;
+pub mod coverage_source;
 pub mod deny_refresh;
 pub mod formal_checks;
 pub mod lint_refresh;

--- a/src/cli/handlers/work_falsification/supply_chain_checks.rs
+++ b/src/cli/handlers/work_falsification/supply_chain_checks.rs
@@ -3,13 +3,16 @@
 
 use super::cache::{read_cached_metric, read_deny_cache_fallback};
 use super::deny_refresh::{
-    refresh_deny_cache, DenyRefresh, CARGO_DENY_INSTALL_HINT, DENY_STATUS_PATH,
+    refresh_deny_cache, run_with_timeout, DenyRefresh, CARGO_DENY_INSTALL_HINT, DENY_STATUS_PATH,
 };
 use super::types::CachedMetric;
 use crate::cli::handlers::work_contract::{EvidenceType, FalsificationResult};
 use anyhow::Result;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+
+/// Examples are an incremental build, but a cold one can still be slow.
+const EXAMPLES_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(600);
 
 /// True if the project is a Rust crate/workspace (has a `Cargo.toml`).
 ///
@@ -205,10 +208,39 @@ pub(crate) async fn test_examples_compile(project_path: &Path) -> Result<Falsifi
         ));
     }
 
-    // No cache available, and nothing in the repo writes one.
-    Ok(FalsificationResult::unmeasured(
-        "No examples cache; nothing writes .pmat-metrics/examples-status.json".to_string(),
-    ))
+    // No cache, and nothing writes one — so derive the verdict, the same way
+    // the supply-chain and lint claims do. `cargo build --examples` is bounded
+    // and incremental, unlike a coverage or benchmark run.
+    Ok(
+        match run_with_timeout(
+            Command::new("cargo")
+                .args(["build", "--examples"])
+                .current_dir(project_path),
+            EXAMPLES_TIMEOUT,
+        ) {
+            Ok(Some(output)) if output.status.success() => {
+                FalsificationResult::passed("examples compile".to_string())
+            }
+            Ok(Some(output)) => FalsificationResult::failed(
+                "examples do not compile".to_string(),
+                EvidenceType::CounterExample {
+                    details: String::from_utf8_lossy(&output.stderr)
+                        .lines()
+                        .filter(|l| l.trim_start().starts_with("error"))
+                        .take(5)
+                        .collect::<Vec<_>>()
+                        .join("; "),
+                },
+            ),
+            Ok(None) => FalsificationResult::unmeasured(format!(
+                "'cargo build --examples' did not finish within {}s",
+                EXAMPLES_TIMEOUT.as_secs()
+            )),
+            Err(e) => FalsificationResult::unmeasured(format!(
+                "could not run 'cargo build --examples': {e}"
+            )),
+        },
+    )
 }
 
 /// Run `make validate-book` and return the result.
@@ -430,9 +462,20 @@ pub(crate) async fn test_regression_gate(project_path: &Path) -> Result<Falsific
         }
     }
 
-    // No cache, and nothing in the repo writes one.
+    // Benchmarks are the one input a gate must not derive: a criterion run is
+    // minutes to hours, so unlike deny/lint/examples there is no bounded way to
+    // measure this on demand. A project with no benches has nothing to regress
+    // — that is a genuine N/A, not an unmeasured claim. Otherwise say plainly
+    // that no benchmark result exists.
+    if !project_path.join("benches").exists() {
+        return Ok(FalsificationResult::passed(
+            "N/A (no benches/ directory)".to_string(),
+        ));
+    }
+
     Ok(FalsificationResult::unmeasured(
-        "No benchmark cache (run benchmarks to populate .pmat-metrics/benchmark-status.json)"
+        "No benchmark result; run 'cargo bench' and record it to \
+         .pmat-metrics/benchmark-status.json"
             .to_string(),
     ))
 }

--- a/src/services/agent_context/query/coverage/mod.rs
+++ b/src/services/agent_context/query/coverage/mod.rs
@@ -14,3 +14,4 @@ pub use enrichment::{
 };
 pub use loader::{enrich_results_with_coverage, load_workspace_coverage};
 pub use parsing::build_coverage_map;
+pub(crate) use parsing::discover_line_coverage;

--- a/src/services/agent_context/query/coverage/parsing.rs
+++ b/src/services/agent_context/query/coverage/parsing.rs
@@ -163,6 +163,20 @@ pub(super) fn parse_lcov_to_coverage_map(
 
 // ── Coverage File Discovery ─────────────────────────────────────────────────
 
+/// Line coverage for the project, from whatever artifact a coverage run left.
+///
+/// Returns `None` when no coverage has been produced — the caller must then say
+/// it could not measure, rather than inventing a verdict. Exposed for the
+/// falsification ladder, whose coverage claims previously read
+/// `target/llvm-cov/coverage.json`, a path nothing has ever written, so they
+/// silently passed on every repository.
+#[cfg_attr(coverage_nightly, coverage(off))]
+pub(crate) fn discover_line_coverage(
+    project_root: &Path,
+) -> Option<HashMap<String, HashMap<usize, u64>>> {
+    try_load_lcov_info(project_root).or_else(|| try_load_coverage_json(project_root))
+}
+
 /// Try loading coverage from an lcov.info file before running cargo llvm-cov.
 ///
 /// Searches standard locations: `target/coverage/lcov.info`, `target/llvm-cov-target/lcov.info`.

--- a/src/services/agent_context/query/mod.rs
+++ b/src/services/agent_context/query/mod.rs
@@ -15,6 +15,7 @@ pub(crate) mod raw_search;
 pub(crate) mod suggest_rename;
 mod types;
 
+pub(crate) use coverage::discover_line_coverage;
 pub use coverage::{
     build_coverage_map, compute_impact_score, enrich_results_with_coverage, enrich_with_coverage,
     enrich_with_coverage_diff, format_coverage_summary, load_workspace_coverage,


### PR DESCRIPTION
v3.26.0 made the ladder stop reporting six claims as `PASSED` when they had verified nothing — they became `NOT MEASURED`. This gives them something to verify.

## The coverage claims now read coverage

All three consulted either nothing at all or `target/llvm-cov/coverage.json`, **a path no tool in this repository has ever written** (`make coverage` produces `target/coverage/lcov.info`). They now use the same artifact discovery `pmat query --coverage` already relies on.

| Claim | Was | Now (verified against a real lcov) |
|---|---|---|
| **[4] DifferentialCoverage** | a hard-coded pass — every path out of the function returned `passed`, and it never consulted coverage at all | parses `git diff -U0` hunk headers for the lines the work introduced, checks each against its hit count: `1/2 changed line(s) uncovered: src/main.rs:6` |
| **[16] PerFileCoverage** | read the nonexistent path | `1 file(s) below 95.0% threshold: src/main.rs: 66.7%` |
| **[5] AbsoluteCoverage** | required `.pmat-metrics/trends/test-coverage.json` | falls back to the raw artifact: `66.7% < 95.0% threshold` |

Coverage is **deliberately not derived on demand**: unlike cargo-deny or clippy, an llvm-cov run is many minutes, so a gate must not trigger one. With no artifact present these claims still report `NOT MEASURED`, now naming the command that produces one.

## TDG, examples, benchmarks

- **[6] TdgRegression** read `.pmat-metrics/tdg-score.json`, which has no writer. `.pmat/baseline.json` carries the same figure as `summary.avg_score` and *is* written — by the `pmat analyze tdg --update-baseline` that the pre-commit hook runs on every commit. Verified: `88.5 >= 0.0 (baseline)`.
- **[12] ExamplesCompile** derives its verdict with a bounded `cargo build --examples`, the way the supply-chain and lint claims do.
- **[21] RegressionGate** is the one input a gate must not derive — a criterion run is minutes to hours. A project with no `benches/` is now a genuine N/A rather than an unmeasured claim; one with benches says plainly that no result has been recorded.

Every claim in the ladder now either measures something, derives it within a bounded subprocess, or states exactly what is missing and how to produce it.

## Verification

`pmat verify` green on all five stages. Each coverage claim was checked against a purpose-built lcov fixture with known-uncovered lines, confirming it reports the right file and line rather than passing silently.

Worth noting: the `unreachable_pub` violations on this PR's new re-exports were caught **locally**, by the verify/CI clippy parity fix from v3.26.0 — before CI. That is exactly what that fix was for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)