### PR TITLE
fix: fatal errors could exit silently, plus five copies of dead advice (v3.28.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,11 +19,79 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   → 20 tools) before shipping, and the test asserts the other two forms are
   absent. A hint is only worth printing if it has been run.
 
+- **Fatal errors could exit silently.** Root cause of the above. The top-level
+  handler in `src/bin/pmat.rs` reported failures with `tracing::error!`, which
+  is subject to the `EnvFilter` — and MCP-server mode installs
+  `EnvFilter::new("off")` to keep the JSON-RPC stream clean. Any command
+  matching `pmat agent mcp-server` sets that mode (`EarlyCliArgs::is_mcp_server`,
+  `src/cli/mod.rs:133`), so the filter discarded the fatal message and the
+  process exited 1 with *both* streams empty. The diagnostic was never missing —
+  it was written and then thrown away. It had already said exactly what was
+  wrong: "Agent daemon feature not enabled. Build with --features agent-daemon".
+
+  Fatal errors now go to stderr directly via `cli::write_fatal_error`, so a
+  process's last words no longer depend on log configuration. stderr is safe
+  under MCP; only stdout carries protocol frames. Side benefit: ordinary CLI
+  errors lost their timestamp/`ERROR` prefix and now read as plain
+  `Error: Path not found: /nonexistent`.
+
+- **The same dead advice was in four more places.** 3.28.1's first pass fixed
+  the printed serve hint and missed every other copy, including the doc comment
+  three lines above it. All now name only `MCP_VERSION=1 pmat`:
+  - `src/bin/pmat.rs` — the no-subcommand error, which steered users straight
+    into the silent failure above
+  - `src/cli/commands/commands_enum/definition.rs` — the `serve` doc comment,
+    i.e. what `pmat serve --help` prints, so help and error text disagreed
+  - `src/cli/handlers/utility_serve_handlers.rs` — the module doc
+  - `src/mcp_pmcp/mod.rs` — claimed this server "is activated by
+    `pmat agent mcp-server`", which is false: that starts
+    `ClaudeCodeAgentMcpServer` (four agent-monitoring tools), and
+    `detect_execution_mode` reads `MCP_VERSION` and nothing else
+
+- **Three analysis commands gave a clean bill of health for paths that do not
+  exist.** Found by sweeping every command for "exits 0 without measuring
+  anything" while dogfooding the fixes above. A missing directory walks to zero
+  files, and `analyze satd`, `analyze duplicates` and `analyze big-o` reported
+  that as a pass — `analyze satd --path /nope` printed "Found 0 SATD violations
+  in 0 files" and exited 0. A CI gate cannot distinguish that from a genuinely
+  clean tree, so a typo in a path silently turned the gate green. All three now
+  fail with `Path not found: <path>`, matching the eight handlers that already
+  validated. Both live `satd` entry points are covered (`pmat analyze satd` and
+  the one `pmat enforce` calls). The shared guard is
+  `cli::ensure_analysis_path_exists`, which is what makes the `path_exists`
+  contract annotation these handlers already carried actually true at runtime.
+
+- **An orphaned test had been asserting the original bug for two releases.**
+  `tests/modules/serve_fail_loud.rs` still required the hint to contain
+  `PMAT_PMCP_MCP=1` — the dead environment variable 3.28.0 removed. It never
+  failed because `tests/all.rs` is not in the `--lib` suite CI runs. It now
+  asserts `MCP_VERSION=1` is present and both dead forms are absent.
+
+  The guard against silent exits was placed in the library
+  (`src/cli/mod.rs::write_fatal_error`) specifically so its unit tests run
+  under `--lib`, where CI will actually execute them.
+
 ### Known and unfixed
-- **`pmat agent mcp-server` exits 1 silently.** It is advertised in `--help`
-  and recommended by the no-subcommand error message in `src/bin/pmat.rs`.
-  Found while dogfooding 3.28.0; not fixed here because it is a distinct
-  server with its own startup path.
+- **`pmat agent` is advertised in `--help` but compiled out.** `agent-daemon`
+  is not in `default`, so every `pmat agent …` subcommand fails on every
+  published binary. It now fails loudly with an accurate message, which is the
+  D75 contract, but the help surface should stop offering it at all.
+
+- **The MCP surface still reports success for paths that do not exist.**
+  The CLI fix above does not reach it. `tools/call analyze_complexity` with
+  `{"paths": ["/definitely-not-real"]}` returns `isError: false` and
+  `{"status":"completed","results":{"total_files":0,"violations":[]}}`; the same
+  holds for `analyze_satd`. An agent consuming this cannot distinguish it from
+  a clean repository, and unlike the CLI it has no exit code to check.
+
+  Not fixed here because it is deliberate, not accidental: the behaviour is
+  pinned by tests that say so in as many words —
+  `src/mcp_pmcp/quality_handlers_tests.rs` asserts `result.is_ok()` under the
+  comment "Should succeed (graceful handling of nonexistent paths)". Making
+  these tools strict is a semantic change to a published MCP contract and
+  belongs in its own release, not bundled into a patch. The graceful/strict
+  question is worth settling deliberately: `quality_gate` already errors on a
+  nonexistent `file`, so the surface is currently inconsistent with itself.
 
 ## [3.28.0] - 2026-07-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.28.1] - 2026-07-29
+
+### Fixed
+- **The `pmat serve` hint still named a route that does not work.** 3.28.0
+  replaced the dead `PMAT_PMCP_MCP=1` with `pmat agent mcp-server` — and
+  dogfooding the published 3.28.0 binary showed *that* command exits 1 with no
+  output whatsoever. It starts the separate agent-monitoring server, not the
+  one serving the 20 analysis tools. The hint now names only
+  `MCP_VERSION=1 pmat`, which was verified end-to-end (initialize + tools/list
+  → 20 tools) before shipping, and the test asserts the other two forms are
+  absent. A hint is only worth printing if it has been run.
+
+### Known and unfixed
+- **`pmat agent mcp-server` exits 1 silently.** It is advertised in `--help`
+  and recommended by the no-subcommand error message in `src/bin/pmat.rs`.
+  Found while dogfooding 3.28.0; not fixed here because it is a distinct
+  server with its own startup path.
+
 ## [3.28.0] - 2026-07-29
 
 Found by dogfooding v3.27.0 installed from crates.io across all three surfaces:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5430,7 +5430,7 @@ dependencies = [
 
 [[package]]
 name = "pmat"
-version = "3.28.0"
+version = "3.28.1"
 dependencies = [
  "actix",
  "actix-rt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pmat"
-version = "3.28.0"
+version = "3.28.1"
 edition = "2021"
 rust-version = "1.91.0"
 authors = ["Pragmatic AI Labs"]

--- a/src/bin/pmat.rs
+++ b/src/bin/pmat.rs
@@ -21,7 +21,7 @@ mod full {
     use std::io::IsTerminal;
     use std::process;
     use std::sync::Arc;
-    use tracing::{debug, error, info, trace};
+    use tracing::{debug, info, trace};
     use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 
     enum ExecutionMode {
@@ -159,7 +159,11 @@ mod full {
         let exit_code = match run_main().await {
             Ok(()) => ExitCode::Success,
             Err(e) => {
-                error!("Error: {:#}", e);
+                // NOT `tracing::error!` — MCP-server mode installs
+                // `EnvFilter::new("off")`, which silently discarded this, so
+                // `pmat agent mcp-server` exited 1 printing nothing at all.
+                // See `cli::write_fatal_error` for the full history.
+                cli::write_fatal_error(std::io::stderr(), &e);
                 categorize_error(&e)
             }
         };
@@ -245,9 +249,14 @@ mod full {
                 // "no command supplied" on a terminal.
                 let mut cmd = <pmat::cli::Cli as clap::CommandFactory>::command();
                 let _ = cmd.print_help();
+                // Names only the route that has been run end-to-end. This used
+                // to also offer `pmat agent mcp-server`, which is compiled out
+                // unless `--features agent-daemon` is set (it is not in
+                // `default`), so on every published binary it exits 1 — and,
+                // until `write_fatal_error` existed, did so in total silence.
                 eprintln!(
                     "\nerror: no subcommand given and stdin is not a terminal. \
-                 Set MCP_VERSION=1 (or run `pmat agent mcp-server`) to start the MCP server."
+                 Set MCP_VERSION=1 to start the MCP server (`MCP_VERSION=1 pmat`)."
                 );
                 process::exit(ExitCode::MisuseError as i32);
             }

--- a/src/cli/analysis/duplicates_detection.rs
+++ b/src/cli/analysis/duplicates_detection.rs
@@ -52,6 +52,9 @@ pub async fn handle_analyze_duplicates(
     output: Option<PathBuf>,
     top_files: usize,
 ) -> Result<()> {
+    // A nonexistent path previously produced an empty report and exit 0.
+    crate::cli::ensure_analysis_path_exists(&project_path)?;
+
     {
         use crate::cli::colors as c;
         eprintln!("{}", c::dim("Analyzing code similarity..."));

--- a/src/cli/commands/commands_enum/definition.rs
+++ b/src/cli/commands/commands_enum/definition.rs
@@ -809,7 +809,7 @@ pub enum Commands {
     /// [NOT IMPLEMENTED] HTTP/WebSocket server — exits with an error.
     ///
     /// Advertised as working for long enough that users discovered otherwise by
-    /// running it. Use `pmat agent mcp-server` for MCP over stdio today.
+    /// running it. Use `MCP_VERSION=1 pmat` for MCP over stdio today.
     #[command(visible_aliases = &["server", "api"])]
     Serve {
         /// Port to bind the server to

--- a/src/cli/handlers/big_o_handlers/handlers.rs
+++ b/src/cli/handlers/big_o_handlers/handlers.rs
@@ -25,6 +25,9 @@ pub async fn handle_analyze_big_o(
     perf: bool,
     top_files: usize,
 ) -> Result<()> {
+    // A nonexistent path previously produced an empty report and exit 0.
+    crate::cli::ensure_analysis_path_exists(&project_path)?;
+
     let start_time = std::time::Instant::now();
 
     print_analysis_header(&project_path, confidence_threshold);

--- a/src/cli/handlers/complexity_handlers/satd.rs
+++ b/src/cli/handlers/complexity_handlers/satd.rs
@@ -25,6 +25,11 @@ pub async fn handle_analyze_satd(
     fail_on_violation: bool,
     timeout: u64,
 ) -> Result<()> {
+    // Without this, a nonexistent path walked to zero files and printed
+    // "Found 0 SATD violations in 0 files" with exit 0 — a clean bill of
+    // health for a tree that was never there.
+    crate::cli::ensure_analysis_path_exists(&path)?;
+
     // Print analysis info
     print_satd_analysis_info(strict, timeout);
 

--- a/src/cli/handlers/satd_handler_analysis.rs
+++ b/src/cli/handlers/satd_handler_analysis.rs
@@ -3,6 +3,12 @@
 // AFTER: Complexity 6 (A+ standard, single responsibility)
 #[provable_contracts_macros::contract("pmat-core.yaml", equation = "check_compliance")]
 pub async fn handle_analyze_satd(config: SatdAnalysisConfig) -> Result<()> {
+    // Without this, a nonexistent path walked to zero files and printed
+    // "Found 0 SATD violations in 0 files" with exit 0 — a clean bill of
+    // health for a tree that was never there, indistinguishable to a CI gate
+    // from a genuinely debt-free repository.
+    crate::cli::ensure_analysis_path_exists(&config.path)?;
+
     eprintln!("🔍 Analyzing Self-Admitted Technical Debt (SATD)...");
 
     // Delegate filter logging to extracted function

--- a/src/cli/handlers/utility_serve_handlers.rs
+++ b/src/cli/handlers/utility_serve_handlers.rs
@@ -42,13 +42,17 @@ pub fn write_serve_unimplemented_message<W: std::io::Write>(
         out,
         "  requested: transport={transport} host={host} port={port}"
     )?;
-    // `PMAT_PMCP_MCP` has no reader anywhere in the binary — MCP mode is gated
-    // on `MCP_VERSION` (src/bin/pmat.rs). Naming the dead variable sent anyone
-    // following this hint straight into "no subcommand given and stdin is not
-    // a terminal", which is the opposite of a workaround.
+    // Names only the route verified to serve the 20 analysis tools.
+    //
+    // Two earlier versions of this hint did not work. It first named
+    // `PMAT_PMCP_MCP=1`, an environment variable nothing in the binary reads
+    // (MCP mode is gated on `MCP_VERSION`, src/bin/pmat.rs). The fix for that
+    // led with `pmat agent mcp-server`, which dogfooding then showed exits 1
+    // with no output at all — it starts the separate agent-monitoring server,
+    // not this one. A hint is only worth printing if it has been run.
     writeln!(
         out,
-        "hint: use stdio MCP today — `pmat agent mcp-server`, or `MCP_VERSION=1 pmat`"
+        "hint: use stdio MCP today — `MCP_VERSION=1 pmat` (serves the analysis tools over stdio)"
     )?;
     writeln!(
         out,
@@ -118,12 +122,17 @@ mod tests {
         // `PMAT_PMCP_MCP=1`, an environment variable nothing in the binary
         // reads — so the test pinned advice that could not work.
         assert!(
-            s.contains("pmat agent mcp-server") || s.contains("MCP_VERSION=1"),
+            s.contains("MCP_VERSION=1"),
             "must point users at the working stdio transport, got: {s}"
         );
         assert!(
             !s.contains("PMAT_PMCP_MCP"),
             "must not name an environment variable no code reads, got: {s}"
+        );
+        assert!(
+            !s.contains("agent mcp-server"),
+            "must not name `pmat agent mcp-server`, which exits 1 without \
+             serving these tools, got: {s}"
         );
     }
 

--- a/src/cli/handlers/utility_serve_handlers.rs
+++ b/src/cli/handlers/utility_serve_handlers.rs
@@ -15,9 +15,11 @@
 //! transports are wired up. Honest failure is strictly better than a lying
 //! success.
 //!
-//! If you need an MCP server today, use stdio transport via
-//! `pmat agent mcp-server` (or `MCP_VERSION=1 pmat`) — see the
-//! `SimpleUnifiedServer` in `mcp_pmcp`.
+//! If you need an MCP server today, use stdio transport via `MCP_VERSION=1
+//! pmat` — see the `SimpleUnifiedServer` in `mcp_pmcp`. Do not add
+//! `pmat agent mcp-server` back here: it is compiled out unless
+//! `--features agent-daemon` is set, and it starts the agent-monitoring
+//! server, not the 20 analysis tools.
 #![cfg_attr(coverage_nightly, coverage(off))]
 
 use anyhow::Result;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -148,6 +148,50 @@ pub fn parse_early_for_tracing() -> EarlyCliArgs {
     }
 }
 
+/// Write the process's final diagnostic for a fatal error to `w`.
+///
+/// Lives in the library, not in `src/bin/pmat.rs`, so that the unit tests below
+/// run under the `--lib` suite CI actually executes.
+///
+/// # Why this is not `tracing::error!`
+///
+/// It used to be. But [`EarlyCliArgs::is_mcp_server`] causes the binary to
+/// install `EnvFilter::new("off")`, which discards every event including the
+/// fatal one. `pmat agent mcp-server` therefore exited 1 with both stdout and
+/// stderr completely empty, even though the command had already produced an
+/// accurate message ("Agent daemon feature not enabled. Build with --features
+/// agent-daemon"). The diagnostic existed; the log filter ate it.
+///
+/// A process's last words must not depend on log configuration. Writing to
+/// stderr is safe even under MCP, where only stdout carries JSON-RPC frames.
+pub fn write_fatal_error<W: std::io::Write>(mut w: W, error: &anyhow::Error) {
+    // `{:#}` renders the full anyhow context chain on one line.
+    let _ = writeln!(w, "Error: {error:#}");
+}
+
+/// Fail unless `path` exists, before any analysis reports a result for it.
+///
+/// Analysis subcommands walk a directory tree; a tree that is not there yields
+/// zero files, which several handlers then reported as a clean bill of health —
+/// `analyze satd --path /nope` printed "Found 0 SATD violations in 0 files" and
+/// exited 0, and `analyze duplicates` and `analyze big-o` did the same. A CI
+/// gate cannot tell that apart from a genuinely clean tree, so a typo in a path
+/// silently turned the gate green.
+///
+/// Several handlers already carry a `path_exists` contract annotation; this is
+/// the runtime check that makes the annotation true.
+///
+/// # Errors
+///
+/// Returns `Path not found: <path>` if `path` does not exist, matching the
+/// wording the other analysis handlers already use.
+pub fn ensure_analysis_path_exists(path: &Path) -> anyhow::Result<()> {
+    if !path.exists() {
+        anyhow::bail!("Path not found: {}", path.display());
+    }
+    Ok(())
+}
+
 // Core CLI execution: run(), apply_ux_settings(), parse_with_suggestions()
 include!("cli_run_command.rs");
 
@@ -168,3 +212,91 @@ mod language_detection_tests;
 #[cfg_attr(coverage_nightly, coverage(off))]
 #[cfg(test)]
 mod analysis_utilities_property_tests;
+
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg(test)]
+mod analysis_path_guard_tests {
+    use super::ensure_analysis_path_exists;
+    use std::path::Path;
+
+    #[test]
+    fn rejects_a_path_that_does_not_exist() {
+        let err = ensure_analysis_path_exists(Path::new("/definitely-not-a-real-path-9f3a"))
+            .expect_err("a missing path must not be reported as analysable");
+        let msg = err.to_string();
+        assert!(msg.contains("Path not found"), "got: {msg}");
+        assert!(
+            msg.contains("/definitely-not-a-real-path-9f3a"),
+            "must name the offending path so a typo is obvious, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn accepts_an_existing_directory() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        assert!(ensure_analysis_path_exists(dir.path()).is_ok());
+    }
+
+    #[test]
+    fn accepts_an_existing_file() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let file = dir.path().join("a.rs");
+        std::fs::write(&file, "fn main() {}").expect("write");
+        // `analyze satd --path` accepts a single file, not only a directory.
+        assert!(ensure_analysis_path_exists(&file).is_ok());
+    }
+}
+
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg(test)]
+mod fatal_error_tests {
+    use super::write_fatal_error;
+
+    fn rendered(error: &anyhow::Error) -> String {
+        let mut buf = Vec::new();
+        write_fatal_error(&mut buf, error);
+        String::from_utf8(buf).expect("diagnostic must be UTF-8")
+    }
+
+    #[test]
+    fn writes_the_error_message() {
+        let out = rendered(&anyhow::anyhow!(
+            "Agent daemon feature not enabled. Build with --features agent-daemon"
+        ));
+        assert!(
+            out.contains("Agent daemon feature not enabled"),
+            "fatal diagnostic must carry the message, got: {out:?}"
+        );
+        assert!(out.starts_with("Error: "), "got: {out:?}");
+        assert!(
+            out.ends_with('\n'),
+            "must be newline-terminated, got: {out:?}"
+        );
+    }
+
+    #[test]
+    fn includes_the_full_context_chain() {
+        // `{:#}` not `{}` — a bare `{}` would print only "outer" and drop the
+        // root cause, which is usually the part that says what to actually do.
+        let error = anyhow::anyhow!("root cause").context("outer");
+        let out = rendered(&error);
+        assert!(out.contains("outer"), "got: {out:?}");
+        assert!(
+            out.contains("root cause"),
+            "must render the whole anyhow context chain, got: {out:?}"
+        );
+    }
+
+    #[test]
+    fn never_writes_an_empty_diagnostic() {
+        // The defect this function exists to prevent: exiting non-zero having
+        // printed nothing, because a log filter discarded the only message.
+        for message in ["x", "", "  "] {
+            let out = rendered(&anyhow::anyhow!(message.to_string()));
+            assert!(
+                !out.trim().is_empty(),
+                "fatal path must never produce an empty diagnostic, got: {out:?}"
+            );
+        }
+    }
+}

--- a/src/mcp_pmcp/mod.rs
+++ b/src/mcp_pmcp/mod.rs
@@ -14,16 +14,21 @@
 //!
 //! # Usage
 //!
-//! The server is activated by `pmat agent mcp-server`, or by setting the
-//! `MCP_VERSION` environment variable (which is what MCP hosts such as Claude
-//! Desktop set). `PMAT_PMCP_MCP` is documented in older notes but no code has
-//! ever read it.
+//! The server is activated by setting the `MCP_VERSION` environment variable
+//! (which is what MCP hosts such as Claude Desktop set). That is the only
+//! trigger: `detect_execution_mode` in `src/bin/pmat.rs` reads `MCP_VERSION`
+//! and nothing else.
+//!
+//! Two other spellings have been documented here over time and neither works.
+//! `PMAT_PMCP_MCP` is read by no code at all. `pmat agent mcp-server` runs a
+//! *different* server — `ClaudeCodeAgentMcpServer`, which exposes four
+//! agent-monitoring tools rather than these analysis tools — and it is
+//! compiled out entirely unless `--features agent-daemon` is set, which is not
+//! in `default`.
 //!
 //! ## Running the pmcp server
 //!
 //! ```bash
-//! pmat agent mcp-server
-//! # or, as an MCP host would:
 //! MCP_VERSION=1 pmat
 //! ```
 //!

--- a/tests/modules/serve_fail_loud.rs
+++ b/tests/modules/serve_fail_loud.rs
@@ -36,10 +36,21 @@ fn pmat_serve_default_fails_with_exit_code_two() {
         stderr.contains("not yet implemented"),
         "stderr must clearly say HTTP is not implemented, got: {stderr}"
     );
+    // This asserted on `PMAT_PMCP_MCP=1` for as long as the hint named it —
+    // an environment variable no code reads. The test did not catch that
+    // because it pinned the string rather than the behaviour, and because
+    // `tests/all.rs` is not part of the `--lib` suite CI runs, so it went on
+    // asserting the bug for two releases after the hint was corrected.
     assert!(
-        stderr.contains("PMAT_PMCP_MCP=1"),
+        stderr.contains("MCP_VERSION=1"),
         "stderr must point users to the working stdio transport, got: {stderr}"
     );
+    for dead in ["PMAT_PMCP_MCP", "agent mcp-server"] {
+        assert!(
+            !stderr.contains(dead),
+            "stderr must not name `{dead}`, which does not start this server, got: {stderr}"
+        );
+    }
 }
 
 #[test]
@@ -65,6 +76,65 @@ fn pmat_serve_echoes_host_and_port() {
     assert!(
         stderr.contains("12345"),
         "stderr must echo requested port, got: {stderr}"
+    );
+}
+
+#[test]
+fn pmat_serve_help_does_not_advertise_a_dead_route() {
+    // `pmat serve --help` renders the doc comment on the `Serve` variant. That
+    // comment recommended `pmat agent mcp-server` while the runtime hint two
+    // files away had already been corrected, so the help text and the error
+    // text disagreed about how to start an MCP server.
+    let out = Command::new(env!("CARGO_BIN_EXE_pmat"))
+        .args(["serve", "--help"])
+        .output()
+        .expect("failed to spawn pmat binary");
+    let help = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        help.contains("MCP_VERSION=1"),
+        "serve help must name the working route, got: {help}"
+    );
+    for dead in ["PMAT_PMCP_MCP", "agent mcp-server"] {
+        assert!(
+            !help.contains(dead),
+            "serve help must not name `{dead}`, got: {help}"
+        );
+    }
+}
+
+/// A non-zero exit must always be accompanied by a diagnostic.
+///
+/// `pmat agent mcp-server` sets `EarlyCliArgs::is_mcp_server`, which installs
+/// `EnvFilter::new("off")`. The fatal error was logged with `tracing::error!`,
+/// so the filter discarded it and the command exited 1 with both streams
+/// empty — the user got a failure with no way to learn why.
+#[test]
+fn fatal_errors_are_never_silent() {
+    let out = Command::new(env!("CARGO_BIN_EXE_pmat"))
+        .args(["agent", "mcp-server"])
+        .stdin(std::process::Stdio::null())
+        .output()
+        .expect("failed to spawn pmat binary");
+
+    // Built without `--features agent-daemon` (not in `default`), this must
+    // fail. If the feature *is* enabled the command is a long-running server,
+    // so only assert the contract when it actually exited non-zero.
+    if out.status.success() {
+        return;
+    }
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !stderr.trim().is_empty(),
+        "a non-zero exit must explain itself on stderr; got an empty stream, \
+         which is the silent-failure regression this test exists to catch"
+    );
+    assert!(
+        stderr.contains("Error:"),
+        "fatal diagnostic must be present, got: {stderr}"
     );
 }
 


### PR DESCRIPTION
Dogfooding the **published 3.28.0 binary** caught this in my own fix from an hour ago.

3.28.0 replaced the dead `PMAT_PMCP_MCP=1` hint with `pmat agent mcp-server`. Running it:

```console
$ pmat agent mcp-server < requests.jsonl
exit=1
--- stdout ---   (empty)
--- stderr ---   (empty)
```

It exits 1 with **no output whatsoever** — it starts the separate agent-monitoring server, not the one serving the 20 analysis tools. So the "fix" swapped one dead route for another.

The hint now names only `MCP_VERSION=1 pmat`, verified end-to-end before shipping:

```console
$ MCP_VERSION=1 pmat < initialize+tools/list  →  tools: 20
```

The test now asserts **both** broken forms are absent, so neither can come back.

`pmat agent mcp-server` exiting 1 silently is recorded in the CHANGELOG as a distinct unfixed defect — it is advertised in `--help` and recommended by the no-subcommand error message in `src/bin/pmat.rs`, but it is a different server with its own startup path.

`pmat verify` green on all five stages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)