### PR TITLE
fix: pin pmcp to the tested series; make stale-binary measurement impossible (v3.28.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.28.3] - 2026-07-30
+
+### Fixed — v3.28.2's headline fix did not work for anyone who installed it
+
+v3.28.2 claimed the MCP stdio truncation was fixed, measured at 30/30. Verified
+against the **published** binary immediately after release: **11 of 30**, which
+is the unfixed baseline. The fix was real but only under the dependency set
+`Cargo.lock` pins, and that is not the set users get.
+
+`Cargo.toml` required `pmcp = "2.9"` — a caret requirement admitting anything
+below 3.0 — while `Cargo.lock` pinned **2.11.0**. `cargo install` ignores the
+lockfile, so users resolved **2.17.0**. Identical pmat source, same build mode,
+only the pmcp version differing:
+
+| pmcp | `tools/list` answered |
+|---|---|
+| 2.11.0 (`--locked`) | **30/30** |
+| 2.17.0 (fresh resolution) | **9/30** |
+
+pmcp 2.17's transport actor `select!`s between receive and outbound sends and
+drops in-flight receives, which defeats the request-in/response-out counting
+`EofSignalingTransport` relies on. The requirement is now `~2.11`, so a fresh
+`cargo install` resolves the series CI actually tests: **40/40, 0 hangs**,
+measured on `cargo install --path .` *without* `--locked`.
+
+The root defect was not the race. It was that **every release was validated
+against a dependency set users never receive**, so any behaviour depending on a
+dependency's internals could ship broken while all gates stayed green. Supporting
+pmcp 2.17 is separate follow-up work; it needs the drain logic reworked against
+that actor, and a fresh-resolution measurement to prove it.
+
+Guarded by `dependency_bound_tests::pmcp_requirement_is_bounded_to_a_tested_series`,
+which fails if the requirement is widened. Widening is fine — but only with a new
+fresh-resolution measurement of the race, which the test says in as many words.
+
+### Process
+
+Pre-release verification for anything touching dependency behaviour must use
+`cargo install --path .` without `--locked`, not `cargo build --release`. Three
+separate measurements in this work were taken against builds that did not match
+the artifact: a stale binary (a false "8/12 improved"), a workspace build
+(30/30 where users got 11/30), and a lockfile build. Only the last of these was
+caught before publishing.
+
 ## [3.28.2] - 2026-07-30
 
 ### Fixed — MCP stdio truncated responses it had already committed to

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5430,7 +5430,7 @@ dependencies = [
 
 [[package]]
 name = "pmat"
-version = "3.28.2"
+version = "3.28.3"
 dependencies = [
  "actix",
  "actix-rt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pmat"
-version = "3.28.2"
+version = "3.28.3"
 edition = "2021"
 rust-version = "1.91.0"
 authors = ["Pragmatic AI Labs"]
@@ -97,7 +97,15 @@ minijinja = { version = "2.16", default-features = false, optional = true }
 
 # MCP SDK - now core dependency for MCP server functionality
 # Sprint 46 Phase 4: Switched from "full" to explicit features (saves 150-250 KB)
-pmcp = { version = "2.9", features = ["websocket", "http", "sse", "validation"] }
+# Constrained to the 2.11 series, which is what CI and Cargo.lock actually
+# test. A caret "2.9" requirement let `cargo install pmat` resolve pmcp
+# 2.17, whose transport actor defeats the EOF-drain fix in
+# `simple_unified_server.rs`: identical pmat source answers `tools/list` in
+# 30/30 one-shot piped sessions against 2.11 and 9/30 against 2.17. Users
+# were getting a dependency set no test had ever run against, because
+# `cargo install` ignores Cargo.lock. Widen this only together with a
+# fresh-resolution (non---locked) measurement of that race.
+pmcp = { version = "~2.11", features = ["websocket", "http", "sse", "validation"] }
 
 # Caching
 lru = { version = "0.18", features = ["hashbrown"], optional = true }

--- a/build.rs
+++ b/build.rs
@@ -6,6 +6,10 @@ use std::io::Write;
 use std::path::Path;
 
 fn main() {
+    // Embed the source revision so a binary can be checked against the tree it
+    // claims to come from (see `emit_build_provenance`).
+    emit_build_provenance();
+
     // Only watch files that actually exist - missing files cause constant rebuilds
     println!("cargo:rerun-if-changed=assets/vendor/");
     println!("cargo:rerun-if-changed=assets/demo/");
@@ -1734,4 +1738,49 @@ fn make_contract_env_key(contract: &str, equation: &str) -> String {
     // Strip .yaml suffix
     let c = c.trim_end_matches("_YAML");
     format!("CONTRACT_{c}_{e}")
+}
+
+/// Embed the exact source revision the binary was built from.
+///
+/// Version numbers repeat across builds, so `pmat --version` alone cannot tell a
+/// fresh binary from a stale one. During v3.28.2 three separate measurements were
+/// reported against binaries that did not match the tree being tested — a stale
+/// artifact, a workspace build, and a lockfile build — and one of those shipped a
+/// headline fix that did not work. A commit SHA plus a dirty flag makes the
+/// mismatch checkable instead of a matter of trust.
+///
+/// Emits `unknown` when there is no git metadata, which is the normal case for a
+/// crates.io tarball build; verification tooling treats `unknown` as "cannot
+/// confirm" rather than as a pass.
+fn emit_build_provenance() {
+    let sha = std::process::Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    // `--porcelain` prints one line per modified path; empty means clean.
+    let dirty = std::process::Command::new("git")
+        .args(["status", "--porcelain", "--untracked-files=no"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| {
+            if String::from_utf8_lossy(&o.stdout).trim().is_empty() {
+                "clean"
+            } else {
+                "dirty"
+            }
+        })
+        .unwrap_or("unknown");
+
+    println!("cargo:rustc-env=PMAT_GIT_SHA={sha}");
+    println!("cargo:rustc-env=PMAT_GIT_DIRTY={dirty}");
+    // Rebuild when the checked-out revision changes, so the embedded SHA cannot
+    // go stale behind an otherwise-cached build.
+    println!("cargo:rerun-if-changed=.git/HEAD");
+    println!("cargo:rerun-if-changed=.git/index");
 }

--- a/scripts/dogfood-release.py
+++ b/scripts/dogfood-release.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Exercise a pmat release artifact against the behaviours previous releases broke.
+
+Run it on the binary that `scripts/verify-artifact.sh` hands back, never on a
+path typed by hand:
+
+    BIN=$(scripts/verify-artifact.sh) && python3 scripts/dogfood-release.py "$BIN"
+
+Each check corresponds to a defect that shipped, and each is known to FAIL on the
+release before its fix -- verified by running this against v3.28.1 and v3.28.2.
+A harness that has never gone red proves nothing.
+
+The MCP one-shot check is the one that matters most: it is the check v3.28.2
+claimed to pass (30/30) while the published artifact scored 11/30, because the
+measurement was taken against a workspace build rather than an install build.
+"""
+import json
+import subprocess
+import sys
+import tempfile
+import os
+
+# The binary under test must come from scripts/verify-artifact.sh, which builds
+# with fresh dependency resolution and refuses to hand back a binary whose
+# embedded commit SHA does not match HEAD. Passing a path by hand is what let
+# v3.28.2 ship a fix that did not work.
+if len(sys.argv) < 2:
+    sys.exit("usage: dogfood.py <path-to-verified-pmat>\n"
+             "       BIN=$(scripts/verify-artifact.sh) && dogfood.py \"$BIN\"")
+BIN = sys.argv[1]
+ENV = {"MCP_VERSION": "1", "PATH": "/usr/bin:/bin", "HOME": os.path.expanduser("~")}
+results = []
+
+
+def record(name, ok, detail=""):
+    results.append((name, ok, detail))
+    print(f"{'PASS' if ok else 'FAIL'}  {name}" + (f"  — {detail}" if detail else ""))
+
+
+def run(args, **kw):
+    return subprocess.run([BIN, *args], capture_output=True, text=True, timeout=300, **kw)
+
+
+# 0. Right binary?
+v = run(["--version"]).stdout.strip()
+record("binary reports build provenance", "commit:" in v, v.replace(chr(10), " | "))
+
+# 1. MCP one-shot: every consumed request answered (was 11/30, must be 30/30).
+reqs = [
+    {"jsonrpc": "2.0", "id": 1, "method": "initialize",
+     "params": {"protocolVersion": "2024-11-05", "capabilities": {},
+                "clientInfo": {"name": "dogfood", "version": "1"}}},
+    {"jsonrpc": "2.0", "method": "notifications/initialized"},
+    {"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}},
+]
+payload = "".join(json.dumps(r) + "\n" for r in reqs)
+answered = hangs = 0
+TRIALS = 30
+for _ in range(TRIALS):
+    try:
+        p = subprocess.run([BIN], input=payload, capture_output=True, text=True,
+                           env=ENV, timeout=45)
+    except subprocess.TimeoutExpired:
+        hangs += 1
+        continue
+    ids = set()
+    for line in p.stdout.splitlines():
+        line = line.strip()
+        if line.startswith("{"):
+            try:
+                m = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if "id" in m:
+                ids.add(m["id"])
+    if 2 in ids:
+        answered += 1
+record("MCP one-shot answers every request", answered == TRIALS and hangs == 0,
+       f"{answered}/{TRIALS} answered, {hangs} hangs")
+
+# 2. MCP still serves 20 tools with stdin held open.
+p = subprocess.Popen([BIN], stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                     stderr=subprocess.DEVNULL, text=True, bufsize=1, env=ENV)
+tools = -1
+try:
+    for r in reqs:
+        p.stdin.write(json.dumps(r) + "\n")
+        p.stdin.flush()
+    for _ in range(20):
+        line = p.stdout.readline()
+        if not line:
+            break
+        line = line.strip()
+        if line.startswith("{"):
+            m = json.loads(line)
+            if m.get("id") == 2:
+                tools = len(m["result"]["tools"])
+                break
+finally:
+    p.stdin.close()
+    p.wait(timeout=20)
+record("MCP serves 20 tools", tools == 20, f"{tools} tools")
+
+# 3. MCP rejects nonexistent paths (#639).
+call = [reqs[0], reqs[1],
+        {"jsonrpc": "2.0", "id": 3, "method": "tools/call",
+         "params": {"name": "analyze_complexity",
+                    "arguments": {"paths": ["/definitely-not-real-9f3a"]}}}]
+p = subprocess.run([BIN], input="".join(json.dumps(r) + "\n" for r in call),
+                   capture_output=True, text=True, env=ENV, timeout=120)
+rejected = False
+for line in p.stdout.splitlines():
+    line = line.strip()
+    if line.startswith("{"):
+        m = json.loads(line)
+        if m.get("id") == 3 and "error" in m:
+            rejected = "not found" in json.dumps(m["error"])
+record("MCP rejects nonexistent path", rejected)
+
+# 4. CLI rejects nonexistent paths.
+r = run(["analyze", "satd", "--path", "/definitely-not-real-9f3a"])
+record("CLI satd rejects nonexistent path", r.returncode != 0)
+
+# 5. five-whys withholds a cause it cannot derive (#637).
+r = run(["five-whys", "the thing is broken", "--depth", "2", "--format", "markdown"])
+record("five-whys withholds unlocatable cause", "Not determined" in r.stdout)
+record("five-whys reports TDG honestly", "not measured" in r.stdout,
+       "must not print 0.0/100 for an unmeasured metric")
+
+# 6. five-whys locates a real issue and cites it.
+with tempfile.TemporaryDirectory() as d:
+    os.makedirs(os.path.join(d, "src"), exist_ok=True)
+    with open(os.path.join(d, "src", "widget.rs"), "w") as f:
+        f.write("fn widget_throttle(retries: u32) -> u32 {\n"
+                "    if retries > 3 { retries * 2 } else { retries }\n}\n")
+    r = run(["five-whys", "widget_throttle retries miscounted",
+             "--depth", "3", "--format", "markdown", "--path", d])
+    record("five-whys cites located code", "widget.rs" in r.stdout)
+    # Confidence must not be the old constant 100%.
+    record("five-whys confidence is not pinned to 100%",
+           "**Confidence**: 100%" not in r.stdout)
+
+# 7. serve hint and fatal-error visibility (3.28.1 contracts still hold).
+r = run(["serve"])
+hint = r.stdout + r.stderr
+record("serve hint names only the working route",
+       "MCP_VERSION=1" in hint and "agent mcp-server" not in hint and "PMAT_PMCP_MCP" not in hint)
+r = subprocess.run([BIN, "agent", "mcp-server"], capture_output=True, text=True,
+                   stdin=subprocess.DEVNULL, timeout=60)
+record("fatal errors are never silent",
+       r.returncode == 0 or r.stderr.strip() != "")
+
+failed = [n for n, ok, _ in results if not ok]
+print()
+print(f"{len(results) - len(failed)}/{len(results)} checks passed")
+if failed:
+    print("FAILED:", ", ".join(failed))
+    sys.exit(1)

--- a/scripts/verify-artifact.sh
+++ b/scripts/verify-artifact.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+#
+# Build the artifact users actually get, prove it came from this tree, then hand
+# it to a caller for measurement.
+#
+# WHY THIS EXISTS
+#
+# v3.28.2 shipped a headline fix that did not work for anyone who installed it.
+# The fix was real, but every pre-release measurement was taken against a binary
+# that differed from the published artifact:
+#
+#   * a binary two hours stale, at a path `cargo metadata` reported but the build
+#     did not write to      -> produced a false "improved to 8/12"
+#   * a workspace build     -> 30/30, where users got 11/30
+#   * a lockfile build      -> pmcp 2.11, where `cargo install` resolves 2.17
+#
+# The last one was the killer: `cargo install` ignores Cargo.lock, so users build
+# against whatever the version requirements admit, which is not what CI tests.
+#
+# This script removes the possibility of measuring the wrong binary:
+#
+#   1. builds with `cargo install --path .` and deliberately WITHOUT `--locked`,
+#      so dependency resolution matches a real user install;
+#   2. refuses to continue unless the binary's embedded commit SHA equals HEAD
+#      and its embedded worktree state matches the working tree (see
+#      `emit_build_provenance` in build.rs);
+#   3. prints the absolute path of the verified binary on stdout, so callers
+#      cannot accidentally point at some other build.
+#
+# USAGE
+#   scripts/verify-artifact.sh                 # build + verify, print path
+#   scripts/verify-artifact.sh --allow-dirty   # permit a dirty worktree
+#   BIN=$(scripts/verify-artifact.sh) && "$BIN" --version
+#
+set -euo pipefail
+
+ALLOW_DIRTY=0
+for arg in "$@"; do
+  case "$arg" in
+    --allow-dirty) ALLOW_DIRTY=1 ;;
+    *) echo "unknown argument: $arg" >&2; exit 2 ;;
+  esac
+done
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT" || exit 1
+
+HEAD_SHA="$(git rev-parse HEAD)"
+if [ -z "$(git status --porcelain --untracked-files=no)" ]; then
+  TREE_STATE="clean"
+else
+  TREE_STATE="dirty"
+fi
+
+if [ "$TREE_STATE" = "dirty" ] && [ "$ALLOW_DIRTY" -eq 0 ]; then
+  cat >&2 <<EOF
+error: working tree is dirty.
+
+A measurement taken from a dirty tree cannot be reproduced from any commit, so
+it is not evidence about a release. Commit first, or pass --allow-dirty if you
+are deliberately measuring work in progress.
+EOF
+  exit 1
+fi
+
+ROOT="${VERIFY_ARTIFACT_ROOT:-$(mktemp -d -t pmat-artifact-XXXXXX)}"
+
+# SEC010: only ever build into an absolute path with no traversal component, so a
+# hostile VERIFY_ARTIFACT_ROOT cannot write outside where it claims to.
+case "$ROOT" in
+  /*) : ;;
+  *) echo "error: VERIFY_ARTIFACT_ROOT must be an absolute path, got: $ROOT" >&2; exit 2 ;;
+esac
+case "$ROOT" in
+  *..*) echo "error: VERIFY_ARTIFACT_ROOT must not contain '..', got: $ROOT" >&2; exit 2 ;;
+esac
+
+# REL002: clean up the temp root on failure only. Deliberately NOT an
+# unconditional EXIT trap: on success the caller runs the binary we just
+# verified, so removing it here would defeat the whole point of the script.
+CLEANUP_ROOT="$ROOT"
+VERIFIED=0
+cleanup_on_failure() {
+  [ "$VERIFIED" -eq 0 ] || return 0
+  # Only remove a root this script created via mktemp.
+  [ -z "${VERIFY_ARTIFACT_ROOT:-}" ] || return 0
+  # SEC011: never let an empty, root, or non-absolute value reach `rm -rf`.
+  case "${CLEANUP_ROOT:-}" in
+    ""|"/"|"/home"|"/tmp") return 0 ;;
+    /*/*) : ;;
+    *) return 0 ;;
+  esac
+  case "$CLEANUP_ROOT" in
+    *pmat-artifact-*) : ;;
+    *) return 0 ;;
+  esac
+  if [ -n "$CLEANUP_ROOT" ] && [ "$CLEANUP_ROOT" != "/" ] && [ -d "$CLEANUP_ROOT" ]; then
+    rm -rf -- "$CLEANUP_ROOT"
+  fi
+}
+trap cleanup_on_failure EXIT INT TERM
+
+mkdir -p "$ROOT"
+
+{
+  echo "building the install artifact (fresh dependency resolution, NOT --locked)"
+  echo "  tree:  $HEAD_SHA ($TREE_STATE)"
+  echo "  root:  $ROOT"
+} >&2
+
+# `env -u CARGO_REGISTRY_TOKEN`: a stale token in the environment overrides
+# credentials.toml and breaks cargo's registry access.
+env -u CARGO_REGISTRY_TOKEN cargo install --path . --root "$ROOT" --force >&2
+
+BIN="$ROOT/bin/pmat"
+[ -x "$BIN" ] || { echo "error: no binary produced at $BIN" >&2; exit 1; }
+
+# --- provenance gate -------------------------------------------------------
+LONG_VERSION="$("$BIN" --version 2>&1 || true)"
+BIN_SHA="$(printf '%s\n' "$LONG_VERSION" | sed -n 's/^commit: //p' | head -1)"
+BIN_TREE="$(printf '%s\n' "$LONG_VERSION" | sed -n 's/^worktree: //p' | head -1)"
+
+if [ -z "$BIN_SHA" ]; then
+  cat >&2 <<EOF
+error: the binary reports no build provenance.
+
+Expected '--version' to include a 'commit:' line, emitted by
+emit_build_provenance() in build.rs. Without it there is no way to tell this
+binary apart from a stale one, which is the failure this script exists to
+prevent.
+
+got:
+$LONG_VERSION
+EOF
+  exit 1
+fi
+
+if [ "$BIN_SHA" = "unknown" ]; then
+  echo "error: binary was built without git metadata; cannot confirm it matches this tree." >&2
+  exit 1
+fi
+
+if [ "$BIN_SHA" != "$HEAD_SHA" ]; then
+  cat >&2 <<EOF
+error: STALE OR MISMATCHED BINARY -- refusing to measure it.
+
+  binary was built from: $BIN_SHA
+  this tree is at:       $HEAD_SHA
+
+This is exactly the mistake that let v3.28.2 ship a fix that did not work.
+EOF
+  exit 1
+fi
+
+if [ "$BIN_TREE" != "$TREE_STATE" ]; then
+  echo "error: binary reports worktree '$BIN_TREE' but the tree is '$TREE_STATE'." >&2
+  exit 1
+fi
+
+VERIFIED=1
+echo "provenance OK: $BIN_SHA ($BIN_TREE)" >&2
+echo "$BIN"

--- a/src/cli/commands/cli_struct.rs
+++ b/src/cli/commands/cli_struct.rs
@@ -11,6 +11,22 @@ use super::commands_enum::Commands;
     name = "pmat",
     about = "PMAT - Professional Multi-language Analysis Toolkit for code quality, complexity, and technical debt",
     version,
+    // `--version` reports the revision the binary was actually built from.
+    //
+    // A version number repeats across builds, so it cannot distinguish a fresh
+    // binary from a stale one. v3.28.2 shipped a headline fix that did not work
+    // because three measurements were taken against binaries that did not match
+    // the tree under test. This makes that mismatch checkable.
+    //
+    // The plain version stays the first token, so existing assertions of the form
+    // `--version` output contains "3.28.3" keep working. `-V` remains short.
+    long_version = concat!(
+        env!("CARGO_PKG_VERSION"),
+        "\ncommit: ",
+        env!("PMAT_GIT_SHA"),
+        "\nworktree: ",
+        env!("PMAT_GIT_DIRTY"),
+    ),
     long_about = None,
     after_help = "EXAMPLES:
 # Analyze code complexity

--- a/src/mcp_pmcp/simple_unified_server.rs
+++ b/src/mcp_pmcp/simple_unified_server.rs
@@ -996,3 +996,43 @@ mod coverage_tests {
         assert!(result.is_ok());
     }
 }
+
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg(test)]
+mod dependency_bound_tests {
+    /// The `pmcp` requirement must stay bounded to a tested minor series.
+    ///
+    /// `cargo install pmat` ignores `Cargo.lock`, so users build against whatever
+    /// the version requirement admits — not what CI tested. A caret `"2.9"`
+    /// requirement let users resolve pmcp 2.17, whose transport actor defeats the
+    /// EOF-drain fix in this file: identical pmat source answers `tools/list` in
+    /// **40/40** one-shot piped sessions against pmcp 2.11 and **10/40** against
+    /// 2.17. v3.28.2 shipped a headline fix that did not work for anyone who
+    /// installed it, because every pre-release measurement used a lockfile build.
+    ///
+    /// Widening this requirement is allowed — but only together with a
+    /// fresh-resolution measurement (`cargo install --path .` *without*
+    /// `--locked`) of that race. This test exists so the requirement cannot be
+    /// widened silently.
+    #[test]
+    fn pmcp_requirement_is_bounded_to_a_tested_series() {
+        let manifest = std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/Cargo.toml"))
+            .expect("read own Cargo.toml");
+        let line = manifest
+            .lines()
+            .find(|l| l.trim_start().starts_with("pmcp = "))
+            .expect("pmcp dependency line must exist");
+
+        assert!(
+            line.contains("~2.11") || line.contains("=2.11"),
+            "pmcp must stay pinned to the tested 2.11 series. If you are widening \
+             it deliberately, re-measure the MCP one-shot truncation race with a \
+             fresh (non---locked) `cargo install` first and update this test with \
+             the new numbers. Got: {line}"
+        );
+        assert!(
+            !line.trim_start().starts_with("pmcp = { version = \"2."),
+            "a bare caret requirement admits untested minors; use ~ or =. Got: {line}"
+        );
+    }
+}


### PR DESCRIPTION
## v3.28.2 shipped a fix that did not work for anyone who installed it

Verified against the **published** binary right after release: **11 of 30** one-shot piped MCP sessions answered `tools/list` — the unfixed baseline. The fix was real, but only under the dependency set `Cargo.lock` pins, and that is not the set users get.

## Root cause: releases were validated against a dependency set users never receive

`Cargo.toml` required `pmcp = "2.9"` — a caret requirement admitting anything below 3.0 — while `Cargo.lock` pinned **2.11.0**. `cargo install` ignores the lockfile, so users resolved **2.17.0**. Identical pmat source, same build mode, only pmcp differing:

| pmcp | `tools/list` answered |
|---|---|
| 2.11.0 (`--locked`) | **30/30** |
| 2.17.0 (fresh resolution) | **9/30** |

pmcp 2.17's transport actor `select!`s between receive and outbound sends and drops in-flight receives — its own `Transport` docs say so — which defeats the request-in/response-out counting `EofSignalingTransport` relies on.

**The fix is one line:** `pmcp = "~2.11"`, so a fresh `cargo install` resolves the series CI actually tests. Measured on `cargo install --path .` *without* `--locked`: **40/40, 0 hangs**.

Supporting pmcp 2.17 is follow-up work — it needs the drain reworked against that actor plus a fresh-resolution measurement to prove it. Tracked for the dependency-update pass.

## Making the measurement mistake impossible

Three measurements in this work were taken against binaries that did not match the tree under test: a two-hour-stale artifact (which produced a false "improved to 8/12"), a workspace build (30/30 where users got 11/30), and a lockfile build. Version numbers repeat across builds, so `--version` could not tell them apart.

- **`build.rs`** embeds the commit SHA and worktree state. `pmat --version` reports them; `-V` stays short and the plain version remains the first token, so existing assertions keep working. Emits `unknown` when there is no git metadata (crates.io tarball builds), which tooling treats as "cannot confirm", not as a pass.
- **`scripts/verify-artifact.sh`** builds with fresh dependency resolution and **refuses** to return a binary whose embedded SHA differs from HEAD, whose worktree state differs, or which carries no provenance at all. Verified by planting the old 3.28.2 build as the artifact and watching it be rejected. Every pre-3.28.3 binary now fails that gate rather than being silently measured. `bashrs lint`: 0 errors.
- **`scripts/dogfood-release.py`** takes the verified path as an argument instead of hardcoding one. Each of its 11 checks is known to fail on the release before its fix.
- **`dependency_bound_tests`** asserts the pmcp requirement stays bounded, so it cannot be widened without a new fresh-resolution measurement — the test says so in as many words.

## Verification

`pmat verify` green on all five stages. Full dogfood against an artifact whose provenance matches this commit: **11/11**, including the MCP one-shot check at 30/30 — the check v3.28.2 claimed and failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)