### PR TITLE
fix: collapse MCP residue onto one server and remove four fabricated values (v3.29.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.29.1] - 2026-08-01
+
+### Fixed
+
+- **MCP residue collapsed onto one server** (#696, #697, #698, #699). `pmat --help`
+  advertised `--mode <MODE> [cli, mcp]`, but the flag was never read — and
+  `--mode mcp <subcommand>` silently started a SECOND, legacy MCP server with a
+  disjoint 21-tool inventory whose tools took different arguments. An advertised
+  flag that reaches a different server is the defect. Also: `--file main.rs` could
+  match any file named `main.rs` anywhere, via a loose `ends_with` fallback.
+- **Four more fabricated values** in the analysis tail (#712, #720, #721, #723),
+  plus two worse defects found underneath them.
+
+### Not included
+
+Four round-4 fix branches are held back. They were authored against a base
+predating the v3.29.0 work and touch files it rewrote (lint-hotspot, entropy,
+dead-code, rust-project-score, tdg/project_score); merging them as-is would
+revert fixes that shipped in 3.29.0. They cover #693, #700–#709, #714, #717,
+#719, #637 and #640 and will be redone against the correct base.
+
 ## [3.29.0] - 2026-08-01
 
 ### Fixed — pmat no longer reports numbers it never measured

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5017,7 +5017,7 @@ dependencies = [
 
 [[package]]
 name = "pmat"
-version = "3.29.0"
+version = "3.29.1"
 dependencies = [
  "actix",
  "actix-rt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pmat"
-version = "3.29.0"
+version = "3.29.1"
 edition = "2021"
 rust-version = "1.91.0"
 authors = ["Pragmatic AI Labs"]

--- a/src/bin/pmat.rs
+++ b/src/bin/pmat.rs
@@ -256,12 +256,12 @@ mod full {
                 if !cli.is_mcp_server {
                     info!("Running unified MCP server (pmcp SDK)");
                 }
-                let unified_server = pmat::mcp_pmcp::UnifiedServer::new()
-                    .map_err(|e| anyhow::anyhow!("Failed to create unified server: {}", e))?;
-                unified_server
-                    .run()
-                    .await
-                    .map_err(|e| anyhow::anyhow!("{}", e))
+                // #697: this used to construct the server here, and `cli::run`
+                // constructed a second one for its `--mode mcp` branch. Two
+                // call sites, free to drift into two inventories. There is now
+                // exactly one, and `exactly_one_mcp_stdio_entry_point` fails if
+                // either route grows its own again.
+                pmat::mcp_pmcp::run_stdio_server().await
             }
             ExecutionMode::Cli => {
                 if !cli.is_mcp_server {

--- a/src/cli/cli_run_command.rs
+++ b/src/cli/cli_run_command.rs
@@ -23,14 +23,16 @@ pub async fn run(server: Arc<StatelessTemplateServer>) -> anyhow::Result<()> {
     // so this branch is only reached by other embedders of `cli::run`. It used
     // to call `crate::run_mcp_server`, a *second* MCP server whose 21-tool
     // inventory shares only 7 names with the unified server's 20 — and those 7
-    // take different arguments (`project_path` string vs `paths` array), with 6
-    // of the 21 self-described unimplemented stubs. `--mode mcp` must not reach
-    // a different server than `MCP_VERSION=1 pmat` does.
+    // take different arguments (`project_path` string vs `paths` array), with 7
+    // of the 21 describing themselves as "(unimplemented stub — KAIZEN-0200)"
+    // (that server has since been deleted, #696). `--mode mcp` must not reach a
+    // different server than
+    // `MCP_VERSION=1 pmat` does — #697: this branch built its own
+    // `UnifiedServer` while the binary built another, so "the same server" was
+    // an unenforced coincidence. Both now call the one entry point.
     if let Some(commands::Mode::Mcp) = cli.mode {
         info!("Forced MCP mode detected");
-        let unified = crate::mcp_pmcp::UnifiedServer::new()
-            .map_err(|e| anyhow::anyhow!("Failed to create unified server: {e}"))?;
-        return unified.run().await.map_err(|e| anyhow::anyhow!("{e}"));
+        return crate::mcp_pmcp::run_stdio_server().await;
     }
 
     // Use command dispatcher for improved modularity

--- a/src/cli/commands/analyze_commands/mod.rs
+++ b/src/cli/commands/analyze_commands/mod.rs
@@ -549,8 +549,20 @@ pub enum AnalyzeCommands {
         #[arg(short = 'f', long, value_enum, default_value = "summary")]
         format: LintHotspotOutputFormat,
 
-        /// Maximum allowed defect density (violations per 100 lines)
-        #[arg(long, default_value_t = 5.0)]
+        /// Maximum allowed defect density, in violations per line of code
+        /// (0.05 = 5 violations per 100 SLOC)
+        //
+        // #699: the help used to say "violations per 100 lines" while
+        // `check_quality_gates` compares against `violations / sloc`, and the
+        // default was 5.0 — i.e. 500 violations per 100 lines, a threshold no
+        // real file can reach, so the documented gate never fired. Observed on
+        // a fixture whose hotspot measured defect_density 2.0 (200 violations
+        // per 100 lines): `passed: true`, exit 0. 0.05 is the same threshold
+        // the help text already promised, spelled in the unit actually used.
+        #[arg(
+            long,
+            default_value_t = crate::cli::handlers::lint_hotspot_handlers::types::DEFAULT_MAX_DENSITY
+        )]
         max_density: f64,
 
         /// Minimum confidence for automated fixes (0.0-1.0)

--- a/src/cli/dead_code_formatter.rs
+++ b/src/cli/dead_code_formatter.rs
@@ -73,8 +73,10 @@ impl SummaryFormatter {
                 ));
             }
             if result.summary.dead_modules > 0 {
+                // `dead_modules` is a MODULE count on the cargo path; it was
+                // labelled "Dead variables" here (#721).
                 output.push_str(&format!(
-                    "- **Dead variables**: {}\n",
+                    "- **Dead modules**: {}\n",
                     result.summary.dead_modules
                 ));
             }
@@ -173,7 +175,9 @@ impl MarkdownFormatter {
             ),
             ("Dead Functions", result.summary.dead_functions.to_string()),
             ("Dead Classes", result.summary.dead_classes.to_string()),
-            ("Dead Variables", result.summary.dead_modules.to_string()),
+            // `dead_modules` is a MODULE count on the cargo path; it was
+            // labelled "Dead Variables" here (#721).
+            ("Dead Modules", result.summary.dead_modules.to_string()),
             (
                 "Unreachable Blocks",
                 result.summary.unreachable_blocks.to_string(),

--- a/src/cli/handlers/dead_code_handlers.rs
+++ b/src/cli/handlers/dead_code_handlers.rs
@@ -316,6 +316,37 @@ mod output_tests {
         assert!(r.contains("## Recommendations"));
     }
 
+    /// #721: the breakdown table printed `summary.dead_modules` under a
+    /// "Variables" heading. `dead_modules` is a MODULE count on the cargo path,
+    /// so a cargo run reported its dead modules under a row no producer fills,
+    /// while real Variable items were counted in no row at all.
+    #[test]
+    fn test_markdown_breakdown_labels_dead_modules_as_modules_not_variables() {
+        let r = format_dead_code_as_markdown(&populated_result()).unwrap();
+
+        assert!(
+            r.contains("| Modules | 1 |"),
+            "dead_modules must be labelled Modules; got:\n{r}"
+        );
+        assert!(
+            !r.contains("| Variables |"),
+            "the module count must not be labelled Variables; got:\n{r}"
+        );
+    }
+
+    /// #721 companion: Variable items are counted from the items themselves, in
+    /// their own row, exactly as the text renderer already did.
+    #[test]
+    fn test_markdown_breakdown_counts_variable_items_in_their_own_row() {
+        // populated_result() has exactly one Variable item (src/b.rs).
+        let r = format_dead_code_as_markdown(&populated_result()).unwrap();
+
+        assert!(
+            r.contains("| Other (fields, constants, statics) | 1 |"),
+            "Variable items must be counted in their own row; got:\n{r}"
+        );
+    }
+
     #[test]
     fn test_markdown_empty_skips_breakdown_and_files() {
         let r = format_dead_code_as_markdown(&empty_result()).unwrap();
@@ -495,5 +526,108 @@ mod output_tests {
         assert_eq!(summary.files_with_dead_code, 0);
         assert_eq!(summary.total_dead_lines, 0);
         assert_eq!(summary.dead_percentage, 0.0);
+    }
+}
+
+/// The multi-language path bills a flat 10 lines per dead function against a
+/// MEASURED file length, so the estimate could describe more lines than the file
+/// contains.
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg(test)]
+mod multi_language_percentage_tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn filters() -> DeadCodeAnalysisFilters {
+        DeadCodeAnalysisFilters {
+            top_files: None,
+            include_unreachable: false,
+            min_dead_lines: 0,
+            include_tests: false,
+            include: Vec::new(),
+            exclude: Vec::new(),
+            max_depth: 10,
+        }
+    }
+
+    /// Observed before the fix: a 2-line `h.py` holding one dead function
+    /// reported `dead_lines: 10, total_lines: 2, dead_percentage: 500.0`, and a
+    /// 10-line `m.py` with two reported `20 / 10 = 200.0%`. The project summary
+    /// read 250%.
+    #[test]
+    fn test_dead_lines_never_exceed_the_file_and_percentage_never_exceeds_100() {
+        let temp = TempDir::new().unwrap();
+        std::fs::write(
+            temp.path().join("m.py"),
+            "def used():\n    return 1\n\ndef dead_one():\n    return 2\n\ndef dead_two():\n    return 3\n\nprint(used())\n",
+        )
+        .unwrap();
+        // Two physical lines, one dead function: the flat estimate is 10.
+        std::fs::write(
+            temp.path().join("h.py"),
+            "def helper_dead():\n    return 4\n",
+        )
+        .unwrap();
+        std::fs::write(
+            temp.path().join("pyproject.toml"),
+            "[project]\nname=\"t\"\n",
+        )
+        .unwrap();
+
+        let result = run_multi_language_dead_code(temp.path(), &filters(), "python").unwrap();
+
+        for f in &result.files {
+            assert!(
+                f.dead_lines <= f.total_lines,
+                "{}: {} dead lines in a {}-line file -- a part exceeding its whole",
+                f.path,
+                f.dead_lines,
+                f.total_lines
+            );
+            assert!(
+                f.dead_percentage <= 100.0,
+                "{}: dead_percentage {} exceeds 100",
+                f.path,
+                f.dead_percentage
+            );
+        }
+
+        assert!(
+            result.summary.dead_percentage <= 100.0,
+            "project dead_percentage {} exceeds 100",
+            result.summary.dead_percentage
+        );
+    }
+
+    /// #720: the file count reported beside the summary must be the same number
+    /// the summary counted, and must be a FILE count.
+    #[test]
+    fn test_total_files_agrees_with_the_summary_it_heads() {
+        let temp = TempDir::new().unwrap();
+        std::fs::write(
+            temp.path().join("m.py"),
+            "def used():\n    return 1\n\ndef dead_one():\n    return 2\n\ndef dead_two():\n    return 3\n\nprint(used())\n",
+        )
+        .unwrap();
+        std::fs::write(
+            temp.path().join("h.py"),
+            "def helper_dead():\n    return 4\n",
+        )
+        .unwrap();
+        std::fs::write(
+            temp.path().join("pyproject.toml"),
+            "[project]\nname=\"t\"\n",
+        )
+        .unwrap();
+
+        let result = run_multi_language_dead_code(temp.path(), &filters(), "python").unwrap();
+
+        // Two .py files on disk. This was 4 -- the function count.
+        assert_eq!(result.total_files, 2, "total_files must be the file count");
+        assert_eq!(result.analyzed_files, 2);
+        assert_eq!(
+            result.total_files, result.summary.total_files_analyzed,
+            "the headline file count must agree with the summary beneath it"
+        );
     }
 }

--- a/src/cli/handlers/dead_code_handlers_analysis.rs
+++ b/src/cli/handlers/dead_code_handlers_analysis.rs
@@ -158,6 +158,16 @@ fn run_multi_language_dead_code(
                     reason: dead_fn.reason.clone(),
                 });
             }
+            // `add_item` bills a flat 10 lines per dead function, which is an
+            // estimate, while `total_lines` above is measured. Unbounded, the
+            // estimate exceeded the file it describes: a 2-line h.py with one
+            // dead function reported dead_lines 10 / total_lines 2 = 500.0%,
+            // and a 10-line m.py reported 20 / 10 = 200.0%. Dead code cannot
+            // occupy more lines than the file physically has, so the estimate is
+            // held to the measured file length before any percentage is taken.
+            if total_lines > 0 {
+                metrics.dead_lines = metrics.dead_lines.min(total_lines);
+            }
             // Lua has dynamic dispatch, so Medium confidence for non-local functions
             metrics.confidence = ConfidenceLevel::Medium;
             metrics.update_percentage();
@@ -191,8 +201,13 @@ fn run_multi_language_dead_code(
 
     Ok(crate::models::dead_code::DeadCodeResult {
         summary,
-        total_files: ml_result.total_functions.max(1),
-        analyzed_files: ml_result.total_functions.max(1),
+        // MEASURED file count (#720). These were `total_functions.max(1)` -- a
+        // FUNCTION count under a FILE label, which made a 2-file Python fixture
+        // with 4 functions print "Files Analyzed | 4" directly above a summary
+        // that correctly said 2, and `.max(1)` invented one file for an empty
+        // project.
+        total_files: ml_result.total_files,
+        analyzed_files: ml_result.total_files,
         files,
         files_with_dead_code_found,
         files_truncated,

--- a/src/cli/handlers/dead_code_handlers_output.rs
+++ b/src/cli/handlers/dead_code_handlers_output.rs
@@ -243,7 +243,7 @@ fn format_dead_code_as_markdown(
 
     // Build breakdown section if needed
     if result.summary.dead_functions > 0 {
-        sections.push(format_dead_code_breakdown_section(&result.summary));
+        sections.push(format_dead_code_breakdown_section(result));
     }
 
     // Build file details section if needed
@@ -274,20 +274,40 @@ fn format_dead_code_summary_section(result: &crate::models::dead_code::DeadCodeR
     )
 }
 
+/// Write the markdown breakdown table.
+///
+/// The `Modules` row prints `summary.dead_modules`, which is a MODULE count on
+/// the cargo path. It was labelled `Variables` here -- the same mislabel the
+/// text renderer carried (#721) -- so a cargo run reported its dead modules
+/// under a row heading no producer fills. Fields, constants and statics are
+/// counted from the items themselves, exactly as the text renderer does, so
+/// every reported dead item lands in one row.
 fn format_dead_code_breakdown_section(
-    summary: &crate::models::dead_code::DeadCodeSummary,
+    result: &crate::models::dead_code::DeadCodeResult,
 ) -> String {
+    use crate::models::dead_code::DeadCodeType;
+
+    let summary = &result.summary;
+    let other_items = result
+        .files
+        .iter()
+        .flat_map(|f| f.items.iter())
+        .filter(|item| matches!(item.item_type, DeadCodeType::Variable))
+        .count();
+
     format!(
         "## Dead Code Breakdown\n\n\
          | Type | Count |\n\
          |------|-------|\n\
          | Functions | {} |\n\
          | Classes | {} |\n\
-         | Variables | {} |\n\
+         | Modules | {} |\n\
+         | Other (fields, constants, statics) | {} |\n\
          | Unreachable Blocks | {} |\n",
         summary.dead_functions,
         summary.dead_classes,
         summary.dead_modules,
+        other_items,
         summary.unreachable_blocks
     )
 }

--- a/src/cli/handlers/defect_prediction_handler.rs
+++ b/src/cli/handlers/defect_prediction_handler.rs
@@ -281,11 +281,14 @@ fn format_detailed(result: &DefectPredictionResult) -> String {
         );
 
         let _ = writeln!(output, "    {}", c::label("Risk Metrics:"));
+        // #723: complexity was `lines / 100`, a length proxy. It is now a
+        // measured cyclomatic figure and renders as "not measured" when the
+        // language has no analyzer, never as a number nobody computed.
         let _ = writeln!(
             output,
             "      {} {}",
             c::label("Complexity:"),
-            c::number(&format!("{:.1}", prediction.metrics.complexity_score))
+            c::number(&format_optional_score(prediction.metrics.complexity_score))
         );
         // #657: an unmeasured churn renders as "not measured", never as a
         // number — 0.0 would read as "this file never changed".
@@ -349,12 +352,14 @@ fn format_csv(result: &DefectPredictionResult) -> String {
 
     for prediction in &result.predictions {
         output.push_str(&format!(
-            "{},{:?},{:.3},{:.3},{:.3},{},{},{:.3},{}\n",
+            "{},{:?},{:.3},{:.3},{},{},{},{:.3},{}\n",
             prediction.file_path,
             prediction.risk_level,
             prediction.defect_probability,
             prediction.confidence,
-            prediction.metrics.complexity_score,
+            // #723: measured cyclomatic, or "not measured" — same rule as the
+            // other optional scores in this row.
+            format_optional_score(prediction.metrics.complexity_score),
             format_optional_score(prediction.metrics.churn_score),
             format_optional_score(prediction.metrics.coupling_score),
             prediction.metrics.size_score,
@@ -469,7 +474,8 @@ mod tests {
                 risk_level: RiskLevel::High,
                 confidence: 0.9,
                 metrics: FileRiskMetrics {
-                    complexity_score: 0.8,
+                    complexity_score: Some(0.8),
+                    max_cyclomatic: Some(24),
                     churn_score,
                     coupling_score: Some(0.6),
                     size_score: 0.5,

--- a/src/cli/handlers/lint_hotspot_handlers/clippy.rs
+++ b/src/cli/handlers/lint_hotspot_handlers/clippy.rs
@@ -66,6 +66,27 @@ fn ensure_cargo_project(project_path: &Path) -> Result<()> {
     )
 }
 
+/// Directories a cargo span path may be relative to, most specific first.
+///
+/// cargo does NOT emit span paths relative to the directory it was spawned in —
+/// it emits them relative to the WORKSPACE ROOT. With
+/// `-p <repo>/src --file cli/handlers/x.rs`, cargo reports `src/cli/handlers/x.rs`,
+/// which resolved against `<repo>/src` gives `<repo>/src/src/cli/handlers/x.rs`
+/// and matches nothing: the file was reported with 0 violations when the
+/// project scan found 9 in it. Both candidates are tried, and each is compared
+/// for path IDENTITY, so offering two bases cannot make an unrelated file match.
+fn span_base_dirs(project_path: &Path) -> Result<Vec<PathBuf>> {
+    let mut bases = Vec::new();
+    if let Some(root) = find_workspace_root(project_path)? {
+        bases.push(std::fs::canonicalize(&root).unwrap_or(root));
+    }
+    let here = std::fs::canonicalize(project_path).unwrap_or_else(|_| project_path.to_path_buf());
+    if !bases.contains(&here) {
+        bases.push(here);
+    }
+    Ok(bases)
+}
+
 /// Run clippy on a single file and analyze the JSON output
 ///
 /// # Errors
@@ -86,15 +107,13 @@ pub(crate) async fn run_clippy_analysis_single_file(
         anyhow::bail!("--file path does not exist: {}", abs_file_path.display());
     }
     let abs_file_path = std::fs::canonicalize(&abs_file_path).unwrap_or(abs_file_path);
-    // cargo emits span paths relative to the directory it is run in.
-    let base_dir =
-        std::fs::canonicalize(project_path).unwrap_or_else(|_| project_path.to_path_buf());
+    let bases = span_base_dirs(project_path)?;
 
     let output = run_clippy_command(project_path, clippy_flags).await?;
     check_clippy_output(&output)?;
 
     let (file_violations, all_violations, severity_dist) =
-        parse_clippy_output(&output.stdout, &abs_file_path, file_path, &base_dir)?;
+        parse_clippy_output(&output.stdout, &abs_file_path, file_path, &bases)?;
 
     // #679: this used to be `.unwrap_or(100)`. An unreadable file produced a
     // FABRICATED SLOC of 100 and a defect density computed against it.
@@ -307,6 +326,113 @@ mod lint_hotspot_measurement_tests {
         let abs = Path::new("/tmp/dirty/src/lib.rs");
         let resolved = resolve_diagnostic_path("src/other.rs", base);
         assert!(!is_target_file(&resolved, abs, Path::new("src/lib.rs")));
+    }
+
+    // ── #698: `--file <bare name>` matched files in other directories ───────
+
+    #[test]
+    fn test_bare_filename_does_not_claim_a_file_in_another_directory() {
+        // PRE-FIX `is_target_file` ended with `diagnostic_path.ends_with(file_path)`,
+        // and `Path::ends_with` compares trailing COMPONENTS. Observed on a
+        // two-binary fixture (clean root `main.rs`, dirty `src/main.rs`):
+        // `--file main.rs` reported total_violations 22 / sloc 3 /
+        // defect_density 7.33 and exited 1, with every violation labelled
+        // `"file": "main.rs"` but carrying `src/main.rs` line numbers.
+        let base = Path::new("/tmp/fx2");
+        let abs = Path::new("/tmp/fx2/main.rs");
+        let rel = Path::new("main.rs");
+        let resolved = resolve_diagnostic_path("src/main.rs", base);
+        assert!(
+            !is_target_file(&resolved, abs, rel),
+            "a diagnostic in {resolved:?} must not be attributed to {abs:?}"
+        );
+    }
+
+    #[test]
+    fn test_workspace_member_lib_does_not_claim_the_root_lib() {
+        // Same defect, the shape that bites every cargo workspace:
+        // `--file src/lib.rs` swallowed `crates/<member>/src/lib.rs` too, so
+        // one file's report carried several crates' violations.
+        let base = Path::new("/repo");
+        let abs = Path::new("/repo/src/lib.rs");
+        let rel = Path::new("src/lib.rs");
+        let resolved = resolve_diagnostic_path("crates/dashboard/src/lib.rs", base);
+        assert!(
+            !is_target_file(&resolved, abs, rel),
+            "a diagnostic in {resolved:?} must not be attributed to {abs:?}"
+        );
+    }
+
+    #[test]
+    fn test_bare_filename_still_matches_its_own_file() {
+        // The tightening must not cost the legitimate match.
+        let base = Path::new("/tmp/fx2");
+        let abs = Path::new("/tmp/fx2/main.rs");
+        let rel = Path::new("main.rs");
+        let resolved = resolve_diagnostic_path("main.rs", base);
+        assert!(is_target_file(&resolved, abs, rel));
+    }
+
+    // ── #698 follow-on: spans are relative to the WORKSPACE ROOT, not to -p ──
+
+    #[test]
+    fn test_span_matches_when_project_path_is_below_the_workspace_root() {
+        // Measured on this repo: `-p <repo>/src --file cli/handlers/.../
+        // platform_routes.rs` reported total_violations 0 while the project
+        // scan reported 9 in that same file, because cargo emits
+        // `src/cli/handlers/.../platform_routes.rs` (workspace-root relative)
+        // and the only base tried was `<repo>/src`, giving `<repo>/src/src/...`.
+        // The loose `ends_with` used to paper over this for RELATIVE --file
+        // values only; with an absolute --file it was wrong even before #698.
+        // A unique dir per run: a fixed /tmp name collides when two `cargo
+        // test` processes overlap.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path();
+        let sub = root.join("src");
+        let target = sub.join("thing.rs");
+        std::fs::create_dir_all(&sub).expect("mkdir fixture");
+        std::fs::write(&target, "// fixture\n").expect("write fixture");
+
+        let abs = std::fs::canonicalize(&target).expect("canonicalize target");
+        let bases = vec![
+            std::fs::canonicalize(root).expect("canonicalize root"),
+            std::fs::canonicalize(&sub).expect("canonicalize sub"),
+        ];
+
+        assert!(
+            span_matches_target("src/thing.rs", &bases, &abs, &abs),
+            "a workspace-root-relative span must resolve to {abs:?}"
+        );
+        // Only the workspace-root base can match; the project-path base alone
+        // is what produced the 0-violation report.
+        assert!(
+            !span_matches_target("src/thing.rs", &bases[1..], &abs, &abs),
+            "this pins the wrong-base behaviour that caused the under-report"
+        );
+        // And identity is still required: another file is still rejected.
+        assert!(!span_matches_target("src/other.rs", &bases, &abs, &abs));
+    }
+
+    #[test]
+    fn test_span_base_dirs_lists_workspace_root_before_project_path() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path();
+        let sub = root.join("crates").join("member");
+        std::fs::create_dir_all(&sub).expect("mkdir fixture");
+        std::fs::write(root.join("Cargo.toml"), "[workspace]\nmembers = []\n")
+            .expect("write workspace manifest");
+        std::fs::write(sub.join("Cargo.toml"), "[package]\nname = \"member\"\n")
+            .expect("write member manifest");
+
+        let bases = span_base_dirs(&sub).expect("bases");
+        assert_eq!(bases.len(), 2, "got {bases:?}");
+        assert_eq!(bases[0], std::fs::canonicalize(root).expect("canon root"));
+        assert_eq!(bases[1], std::fs::canonicalize(&sub).expect("canon sub"));
+
+        // A crate that is its own workspace root yields exactly one base, not
+        // the same directory twice.
+        let solo = span_base_dirs(root).expect("bases");
+        assert_eq!(solo.len(), 1, "got {solo:?}");
     }
 
     // ── determinism ─────────────────────────────────────────────────────────

--- a/src/cli/handlers/lint_hotspot_handlers/clippy_parsing.rs
+++ b/src/cli/handlers/lint_hotspot_handlers/clippy_parsing.rs
@@ -5,7 +5,7 @@ fn parse_clippy_output(
     stdout: &[u8],
     abs_file_path: &Path,
     file_path: &Path,
-    base_dir: &Path,
+    base_dirs: &[PathBuf],
 ) -> Result<(
     Vec<ViolationDetail>,
     Vec<ViolationDetail>,
@@ -22,7 +22,7 @@ fn parse_clippy_output(
 
     for line in std::io::BufRead::lines(reader) {
         let line = line?;
-        if let Some(violation) = parse_clippy_line(&line, abs_file_path, file_path, base_dir)? {
+        if let Some(violation) = parse_clippy_line(&line, abs_file_path, file_path, base_dirs)? {
             if !seen.insert(violation_key(&violation)) {
                 continue;
             }
@@ -77,7 +77,7 @@ fn parse_clippy_line(
     line: &str,
     abs_file_path: &Path,
     file_path: &Path,
-    base_dir: &Path,
+    base_dirs: &[PathBuf],
 ) -> Result<Option<ViolationDetail>> {
     let Some(msg) = decode_clippy_line(line)? else {
         return Ok(None);
@@ -91,16 +91,30 @@ fn parse_clippy_line(
         return Ok(None);
     };
 
-    // #679: cargo emits span paths RELATIVE to the directory it ran in, so a
-    // user-supplied absolute `--file /abs/src/lib.rs` matched none of the
-    // comparisons below and the command reported 0 violations for a file that
-    // had 20. Resolve the span against the same base before comparing.
-    let resolved = resolve_diagnostic_path(&span.file_name, base_dir);
-    if !is_target_file(&resolved, abs_file_path, file_path) {
+    // #679: cargo emits span paths RELATIVE, so a user-supplied absolute
+    // `--file /abs/src/lib.rs` matched none of the comparisons below and the
+    // command reported 0 violations for a file that had 20. #698: they are
+    // relative to the WORKSPACE ROOT, not to `-p`, so `span_base_dirs` supplies
+    // both candidates and each is compared for path identity.
+    if !span_matches_target(&span.file_name, base_dirs, abs_file_path, file_path) {
         return Ok(None);
     }
 
     Ok(Some(create_violation_detail(file_path, span, diagnostic)))
+}
+
+/// Does a span's `file_name`, resolved against any plausible base, name the
+/// file the user asked for?
+fn span_matches_target(
+    span_file: &str,
+    base_dirs: &[PathBuf],
+    abs_file_path: &Path,
+    file_path: &Path,
+) -> bool {
+    base_dirs.iter().any(|base| {
+        let resolved = resolve_diagnostic_path(span_file, base);
+        is_target_file(&resolved, abs_file_path, file_path)
+    })
 }
 
 /// Resolve a diagnostic's `file_name` to an absolute path using the directory
@@ -125,11 +139,28 @@ fn find_primary_span(diagnostic: &DiagnosticMessage) -> Option<&DiagnosticSpan> 
         .find(|s| s.is_primary || diagnostic.spans.len() == 1)
 }
 
+/// Does this diagnostic belong to the file the user named with `--file`?
+///
+/// #698: the third arm used to be `diagnostic_path.ends_with(file_path)`.
+/// `Path::ends_with` matches on trailing path COMPONENTS, so `--file main.rs`
+/// claimed every file named `main.rs` anywhere in the project (and
+/// `--file src/lib.rs` claimed every workspace member's `src/lib.rs`).
+///
+/// Observed on a two-binary fixture whose root `main.rs` is clean and whose
+/// `src/main.rs` carries 8 `clippy::len_zero`:
+/// `--file main.rs` reported `total_violations: 22`, `sloc: 3`,
+/// `defect_density: 7.33`, every entry labelled `"file": "main.rs"` while
+/// carrying line/column numbers from `src/main.rs` — and the quality gate
+/// failed with exit 1 on a file that has nothing wrong with it. The same run
+/// with `--file src/main.rs` reported density 0.58 and exit 0.
+///
+/// `diagnostic_file` has already been resolved to an absolute (canonical where
+/// the file exists) path by `resolve_diagnostic_path`, so file identity is the
+/// only correct test. The `file_path` arm keeps the caller-supplied spelling
+/// working when the span is already exactly that string.
 fn is_target_file(diagnostic_file: &str, abs_file_path: &Path, file_path: &Path) -> bool {
     let diagnostic_path = PathBuf::from(diagnostic_file);
-    diagnostic_path == *abs_file_path
-        || diagnostic_path == *file_path
-        || diagnostic_path.ends_with(file_path)
+    diagnostic_path == *abs_file_path || diagnostic_path == *file_path
 }
 
 fn create_violation_detail(

--- a/src/cli/handlers/lint_hotspot_handlers/metrics.rs
+++ b/src/cli/handlers/lint_hotspot_handlers/metrics.rs
@@ -413,6 +413,53 @@ mod tests {
         assert_eq!(status.violations[0].rule, "max_defect_density");
     }
 
+    /// #699: the shipped default must be able to fail a realistically dirty
+    /// file. It was 5.0 — compared against `violations / sloc`, so it required
+    /// 5 lint violations on every single line. Observed on a real fixture run:
+    /// the hotspot measured `defect_density: 2.0` (6 violations over 3 SLOC,
+    /// i.e. 200 violations per 100 lines) and the gate reported
+    /// `"passed": true, "blocking": false` with exit 0.
+    #[test]
+    fn test_default_max_density_fails_a_measurably_dirty_hotspot() {
+        let hotspot = LintHotspot {
+            file: PathBuf::from("main.rs"),
+            defect_density: 2.0,
+            total_violations: 6,
+            sloc: 3,
+            severity_distribution: SeverityDistribution::default(),
+            top_lints: vec![],
+            detailed_violations: vec![],
+        };
+
+        let status = check_quality_gates(&hotspot, DEFAULT_MAX_DENSITY);
+        assert!(
+            !status.passed,
+            "a hotspot at 200 violations per 100 lines must not pass the default gate"
+        );
+        assert!(status.blocking);
+        assert_eq!(status.violations[0].rule, "max_defect_density");
+        assert_eq!(status.violations[0].threshold, DEFAULT_MAX_DENSITY);
+    }
+
+    /// The default is expressed in the unit the gate actually compares in
+    /// (`violations / sloc`), and stays reachable: a clean file must pass.
+    #[test]
+    fn test_default_max_density_passes_a_clean_hotspot() {
+        let hotspot = LintHotspot {
+            file: PathBuf::from("src/lib.rs"),
+            defect_density: 0.01, // 1 violation per 100 lines
+            total_violations: 2,
+            sloc: 200,
+            severity_distribution: SeverityDistribution::default(),
+            top_lints: vec![],
+            detailed_violations: vec![],
+        };
+
+        let status = check_quality_gates(&hotspot, DEFAULT_MAX_DENSITY);
+        assert!(status.passed);
+        assert!(!status.blocking);
+    }
+
     #[test]
     fn test_check_quality_gates_fail_violations() {
         let hotspot = LintHotspot {

--- a/src/cli/handlers/lint_hotspot_handlers/types.rs
+++ b/src/cli/handlers/lint_hotspot_handlers/types.rs
@@ -23,6 +23,18 @@ where
     serde::Serialize::serialize(&ordered, serializer)
 }
 
+/// Default `--max-density`: the quality gate fails above 5 violations per 100
+/// lines of code.
+///
+/// #699: this used to be spelled `5.0` in two unconnected places (the clap
+/// `default_value_t` and `contracts::contract_definitions::default_max_density`)
+/// while `check_quality_gates` compares against `violations / sloc`. 5 lint
+/// violations per LINE is unreachable, so the documented gate never fired:
+/// a fixture hotspot measuring `defect_density: 2.0` (200 violations per 100
+/// lines) reported `"passed": true` and exited 0. Both interfaces now read
+/// this one constant so they cannot drift apart again.
+pub const DEFAULT_MAX_DENSITY: f64 = 0.05;
+
 /// Parameters for lint hotspot analysis
 pub struct LintHotspotParams {
     pub project_path: PathBuf,

--- a/src/cli/handlers/lint_hotspot_tests_part3.rs
+++ b/src/cli/handlers/lint_hotspot_tests_part3.rs
@@ -41,13 +41,27 @@
         assert!(is_target_file("src/main.rs", &abs_path, &file_path));
     }
 
+    /// #698: this test used to be called `test_is_target_file_ends_with` and
+    /// was cited as the reason the loose `ends_with` arm had to stay. It never
+    /// exercised that arm — the diagnostic string equals `abs_path`, so it
+    /// matched on identity. Renamed to what it actually pins, and extended
+    /// with the case `ends_with` got wrong: a bare `--file main.rs` must NOT
+    /// claim `src/main.rs` (observed: 22 violations reported against a clean
+    /// 3-line `main.rs`).
     #[test]
-    fn test_is_target_file_ends_with() {
+    fn test_is_target_file_bare_name_matches_only_its_own_file() {
         let abs_path = PathBuf::from("/project/src/main.rs");
         let file_path = PathBuf::from("main.rs");
 
         assert!(is_target_file(
             "/project/src/main.rs",
+            &abs_path,
+            &file_path
+        ));
+
+        // A different `main.rs`, resolved absolutely, is a different file.
+        assert!(!is_target_file(
+            "/project/src/bin/tool/main.rs",
             &abs_path,
             &file_path
         ));

--- a/src/contracts/contract_definitions.rs
+++ b/src/contracts/contract_definitions.rs
@@ -146,7 +146,8 @@ pub struct AnalyzeLintHotspotContract {
     #[serde(default)]
     pub file: Option<PathBuf>,
 
-    /// Maximum allowed defect density
+    /// Maximum allowed defect density, in violations per line of code
+    /// (0.05 = 5 violations per 100 SLOC)
     #[serde(default = "default_max_density")]
     pub max_density: f64,
 
@@ -163,8 +164,12 @@ pub struct AnalyzeLintHotspotContract {
     pub dry_run: bool,
 }
 
+/// #699: reads the same constant as the `--max-density` clap default, so the
+/// CLI, MCP and HTTP interfaces gate on the same threshold. Both used to spell
+/// `5.0` independently, while the gate compares `violations / sloc` — a value
+/// no file can exceed, so the gate never fired on any interface.
 fn default_max_density() -> f64 {
-    5.0
+    crate::cli::handlers::lint_hotspot_handlers::types::DEFAULT_MAX_DENSITY
 }
 
 fn default_min_confidence() -> f64 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -534,107 +534,22 @@ pub use services::template_service::{
     generate_template, list_templates, scaffold_project, search_templates, validate_template,
 };
 
-// MCP server runner function (cognitive complexity ≤8)
-#[cfg(feature = "standard-deps")]
-#[cfg_attr(coverage_nightly, coverage(off))]
-#[provable_contracts_macros::contract("pmat-core.yaml", equation = "check_compliance")]
-pub async fn run_mcp_server<T: TemplateServerTrait + 'static>(server: Arc<T>) -> Result<()> {
-    use std::io::{self, BufRead};
-    use tracing::info;
-
-    info!("MCP server ready, waiting for requests on stdin...");
-
-    let stdin = io::stdin();
-    let mut stdout = io::stdout();
-
-    for line in stdin.lock().lines() {
-        let line = line?;
-
-        if should_skip_line(&line) {
-            continue;
-        }
-
-        process_mcp_line(&line, Arc::clone(&server), &mut stdout).await?;
-    }
-
-    Ok(())
-}
-
-/// Check if line should be skipped (cognitive complexity ≤2)
-#[cfg(feature = "standard-deps")]
-#[cfg_attr(coverage_nightly, coverage(off))]
-fn should_skip_line(line: &str) -> bool {
-    line.trim().is_empty()
-}
-
-/// Process a single MCP line request (cognitive complexity ≤8)
-#[cfg(feature = "standard-deps")]
-async fn process_mcp_line<T: TemplateServerTrait + 'static, W: std::io::Write>(
-    line: &str,
-    server: Arc<T>,
-    stdout: &mut W,
-) -> Result<()> {
-    match parse_mcp_request(line) {
-        Ok(request) => handle_valid_request(request, server, stdout).await,
-        Err(e) => handle_parse_error(&e, stdout),
-    }
-}
-
-/// Parse MCP request from line (cognitive complexity ≤2)
-#[cfg(feature = "standard-deps")]
-#[cfg_attr(coverage_nightly, coverage(off))]
-fn parse_mcp_request(line: &str) -> Result<crate::models::mcp::McpRequest> {
-    serde_json::from_str(line).map_err(anyhow::Error::from)
-}
-
-/// Handle valid MCP request (cognitive complexity ≤6)
-#[cfg(feature = "standard-deps")]
-async fn handle_valid_request<T: TemplateServerTrait + 'static, W: std::io::Write>(
-    request: crate::models::mcp::McpRequest,
-    server: Arc<T>,
-    stdout: &mut W,
-) -> Result<()> {
-    use tracing::info;
-
-    info!(
-        "Received request: method={}, id={:?}",
-        request.method, request.id
-    );
-
-    let response = handlers::handle_request(server, request).await;
-    write_response_to_stdout(&response, stdout)
-}
-
-/// Handle JSON parse error (cognitive complexity ≤4)
-#[cfg(feature = "standard-deps")]
-#[cfg_attr(coverage_nightly, coverage(off))]
-fn handle_parse_error<W: std::io::Write>(error: &anyhow::Error, stdout: &mut W) -> Result<()> {
-    use crate::models::mcp::McpResponse;
-    use tracing::error;
-
-    error!("Failed to parse JSON-RPC request: {}", error);
-
-    let error_response = McpResponse::error(
-        serde_json::Value::Null,
-        -32700,
-        format!("Parse error: {error}"),
-    );
-
-    write_response_to_stdout(&error_response, stdout)
-}
-
-/// Write response to stdout with error handling (cognitive complexity ≤3)
-#[cfg(feature = "standard-deps")]
-#[cfg_attr(coverage_nightly, coverage(off))]
-fn write_response_to_stdout<W: std::io::Write>(
-    response: &crate::models::mcp::McpResponse,
-    stdout: &mut W,
-) -> Result<()> {
-    let response_json = serde_json::to_string(response)?;
-    writeln!(stdout, "{response_json}")?;
-    stdout.flush()?;
-    Ok(())
-}
+// #696: `pub async fn run_mcp_server<T: TemplateServerTrait>(…)` used to live
+// here, together with its private helper chain (`should_skip_line`,
+// `process_mcp_line`, `parse_mcp_request`, `handle_valid_request`,
+// `handle_parse_error`, `write_response_to_stdout`). It was a SECOND MCP stdio
+// server, reachable from the library API and kept alive by its own tests, and
+// it did not serve what `pmat` serves: 21 tools against the live server's 20,
+// only 7 names in common, those 7 taking different arguments
+// (`project_path` string vs `paths` array), and 7 of the 21 describing
+// themselves as "(unimplemented stub — KAIZEN-0200)" and answering -32001.
+// An advertised path that reaches a different server is the defect, so it is
+// deleted rather than re-pointed.
+//
+// The one MCP stdio entry point is `crate::mcp_pmcp::run_stdio_server`, which
+// `src/bin/pmat.rs` and `cli::run` both call. `mcp_pmcp`'s
+// `lib_rs_exposes_no_second_mcp_stdio_server` test fails if this file grows
+// another one.
 
 // Tests previously included via #[path = "../tests/..."] are now compiled
 // only through tests/all.rs to avoid "file loaded as module multiple times"
@@ -645,50 +560,11 @@ fn write_response_to_stdout<W: std::io::Write>(
 mod lib_unit_tests {
     use super::*;
 
-    #[test]
-    fn test_should_skip_line() {
-        assert!(should_skip_line(""));
-        assert!(should_skip_line("   "));
-        assert!(should_skip_line("\t\n"));
-        assert!(!should_skip_line("{\"method\":\"test\"}"));
-    }
-
-    #[test]
-    fn test_parse_mcp_request_valid() {
-        let line = r#"{"jsonrpc":"2.0","method":"test","id":1}"#;
-        let result = parse_mcp_request(line);
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn test_parse_mcp_request_invalid() {
-        let line = "not valid json";
-        let result = parse_mcp_request(line);
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_write_response_to_stdout() {
-        use crate::models::mcp::McpResponse;
-
-        let response =
-            McpResponse::error(serde_json::Value::Null, -32600, "Test error".to_string());
-        let mut output = Vec::new();
-        let result = write_response_to_stdout(&response, &mut output);
-        assert!(result.is_ok());
-        assert!(!output.is_empty());
-    }
-
-    #[test]
-    fn test_handle_parse_error() {
-        let error = anyhow::anyhow!("Test error");
-        let mut output = Vec::new();
-        let result = handle_parse_error(&error, &mut output);
-        assert!(result.is_ok());
-
-        let output_str = String::from_utf8(output).unwrap();
-        assert!(output_str.contains("Parse error"));
-    }
+    // #696: the unit tests for the legacy MCP stdio server
+    // (`test_should_skip_line`, `test_parse_mcp_request_valid`,
+    // `test_parse_mcp_request_invalid`, `test_write_response_to_stdout`,
+    // `test_handle_parse_error`) went with the code they tested. The one MCP
+    // stdio server is covered in `mcp_pmcp`.
 
     #[tokio::test]
     async fn test_template_server_new() {
@@ -738,32 +614,9 @@ mod lib_unit_tests {
         let _client = S3Client; // Just verify it can be constructed
     }
 
-    #[tokio::test]
-    async fn test_process_mcp_line_valid() {
-        let server = Arc::new(TemplateServer::new().await.unwrap());
-        let mut output = Vec::new();
-
-        // Valid but will get error response (deprecated server)
-        let line = r#"{"jsonrpc":"2.0","method":"tools/list","id":1}"#;
-        let result = process_mcp_line(line, server, &mut output).await;
-
-        // Should succeed (write to output) even though server is deprecated
-        assert!(result.is_ok() || result.is_err()); // Either outcome is fine
-    }
-
-    #[tokio::test]
-    async fn test_process_mcp_line_invalid_json() {
-        let server = Arc::new(TemplateServer::new().await.unwrap());
-        let mut output = Vec::new();
-
-        let line = "not json at all";
-        let result = process_mcp_line(line, server, &mut output).await;
-
-        // Should succeed (error response written)
-        assert!(result.is_ok());
-        let output_str = String::from_utf8(output).unwrap();
-        assert!(output_str.contains("Parse error"));
-    }
+    // #696: `test_process_mcp_line_valid` / `test_process_mcp_line_invalid_json`
+    // were deleted with `process_mcp_line`. The first also asserted
+    // `result.is_ok() || result.is_err()`, which is true of every `Result`.
 
     #[tokio::test]
     async fn test_template_server_warm_cache() {

--- a/src/mcp_pmcp/mod.rs
+++ b/src/mcp_pmcp/mod.rs
@@ -125,7 +125,105 @@ pub mod tools; // Sprint 65 Phase 2B: MCP git-context integration
 
 // Export the simple unified server as the primary interface
 pub use simple_unified_server::SimpleUnifiedServer as UnifiedServer;
+
+/// Serve MCP on stdio. This is the crate's ONLY MCP stdio entry point.
+///
+/// Every route that claims to "start the MCP server" goes through here:
+/// `MCP_VERSION=1 pmat`, `pmat --mode mcp`, and [`crate::cli::run`] for library
+/// embedders. They must serve the same tool inventory, and the only way to
+/// guarantee that is for exactly one place to construct the server.
+///
+/// #696/#697: there used to be three answers to "which server does pmat
+/// serve?". `src/bin/pmat.rs` and `cli::run` each built their own
+/// [`UnifiedServer`] (same 20 tools, but two independent call sites free to
+/// drift), and `pmat::run_mcp_server` — reachable from the library API and
+/// exercised by its own test — ran a *different* server whose 21-tool
+/// inventory shared only 7 names with this one's 20, took different arguments
+/// for those 7 (`project_path` string vs `paths` array), and had 7 tools whose
+/// own descriptions read "(unimplemented stub — KAIZEN-0200)" and which return
+/// JSON-RPC -32001 when called. That server has been deleted; this is what
+/// replaces it.
+///
+/// The `exactly_one_mcp_stdio_entry_point` test pins the property.
+///
+/// # Errors
+///
+/// Returns an error if the server cannot be constructed or the transport fails.
+pub async fn run_stdio_server() -> anyhow::Result<()> {
+    let server = UnifiedServer::new()
+        .map_err(|e| anyhow::anyhow!("Failed to create unified server: {e}"))?;
+    server.run().await.map_err(|e| anyhow::anyhow!("{e}"))
+}
+
 // Keep PmcpServer for backward compatibility (will be removed)
 pub use server::PmcpServer;
 // Export the discovery service for MCP optimization
 pub use discovery::{Context, DiscoveryMetrics, DiscoveryService, ToolInfo};
+
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg(test)]
+mod single_entry_point_tests {
+    //! #696/#697 drift guards. These read the source of the call sites rather
+    //! than calling them, because the thing under test is "how many places
+    //! start an MCP server", which no runtime assertion can observe.
+
+    /// Source with `//` comment lines removed.
+    ///
+    /// The guards must fire on a *definition* or a *call*, not on a comment
+    /// that names one — the first draft of `lib_rs_exposes_no_second_mcp_stdio_server`
+    /// failed against the tombstone comment left where the deleted server was.
+    fn code_only(src: &str) -> String {
+        src.lines()
+            .filter(|l| !l.trim_start().starts_with("//"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    /// The binary and `cli::run` must both delegate to `run_stdio_server`, and
+    /// neither may construct a server of its own.
+    #[test]
+    fn exactly_one_mcp_stdio_entry_point() {
+        for (label, src) in [
+            ("src/bin/pmat.rs", include_str!("../bin/pmat.rs")),
+            (
+                "src/cli/cli_run_command.rs",
+                include_str!("../cli/cli_run_command.rs"),
+            ),
+        ] {
+            let code = code_only(src);
+            assert!(
+                !code.contains("UnifiedServer::new("),
+                "{label} constructs its own MCP server; it must call \
+                 mcp_pmcp::run_stdio_server() so every route serves one inventory"
+            );
+            assert!(
+                code.contains("run_stdio_server()"),
+                "{label} no longer routes MCP mode through run_stdio_server()"
+            );
+        }
+    }
+
+    /// #696: `pmat::run_mcp_server` was a second, disjoint MCP stdio server
+    /// reachable from the library API. It is gone; keep it gone.
+    #[test]
+    fn lib_rs_exposes_no_second_mcp_stdio_server() {
+        let code = code_only(include_str!("../lib.rs"));
+        assert!(
+            !code.contains("fn run_mcp_server"),
+            "src/lib.rs defines a second MCP stdio server (the legacy 21-tool \
+             one, sharing only 7 names with the live 20). Use \
+             mcp_pmcp::run_stdio_server instead."
+        );
+    }
+
+    /// The comment-stripper has to actually strip, or the guards above pass
+    /// vacuously the moment someone documents what they removed.
+    #[test]
+    fn code_only_drops_comment_lines_and_keeps_code() {
+        let src = "// fn run_mcp_server(x) {}\nfn live() {}\n    /// UnifiedServer::new()\n";
+        let code = code_only(src);
+        assert!(!code.contains("run_mcp_server"));
+        assert!(!code.contains("UnifiedServer::new("));
+        assert!(code.contains("fn live()"));
+    }
+}

--- a/src/models/dead_code.rs
+++ b/src/models/dead_code.rs
@@ -2,6 +2,12 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
+/// Lines `add_item` bills for a dead item whose real extent is unknown.
+///
+/// Exported so a producer that DOES know the real extent can swap this estimate
+/// out instead of adding a second figure on top of it.
+pub const UNREACHABLE_BLOCK_LINE_ESTIMATE: usize = 3;
+
 /// File-level dead code metrics with ranking support
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FileDeadCodeMetrics {
@@ -137,7 +143,7 @@ impl FileDeadCodeMetrics {
             }
             DeadCodeType::UnreachableCode => {
                 self.unreachable_blocks += 1;
-                self.dead_lines += 3; // Estimate 3 lines per unreachable block
+                self.dead_lines += UNREACHABLE_BLOCK_LINE_ESTIMATE;
             }
         }
         self.items.push(item);

--- a/src/services/dead_code_analyzer/analysis_ranking.rs
+++ b/src/services/dead_code_analyzer/analysis_ranking.rs
@@ -146,10 +146,13 @@ impl DeadCodeAnalyzer {
                     crate::models::dead_code::FileDeadCodeMetrics::new(file_path)
                 });
 
-                // Count unreachable lines
-                let unreachable_lines = unreachable.end_line - unreachable.start_line + 1;
-                entry.dead_lines += unreachable_lines as usize;
-                entry.unreachable_blocks += 1;
+                // The real extent is known here, so it replaces `add_item`'s flat
+                // 3-line estimate rather than being added on top of it.
+                //
+                // `unreachable_blocks` is NOT incremented here: `add_item` below
+                // already increments it, so doing both counted every block twice
+                // and the summary reported exactly double the item list it heads.
+                let unreachable_lines = (unreachable.end_line - unreachable.start_line + 1) as usize;
 
                 entry.add_item(crate::models::dead_code::DeadCodeItem {
                     item_type: crate::models::dead_code::DeadCodeType::UnreachableCode,
@@ -160,6 +163,12 @@ impl DeadCodeAnalyzer {
                     line: unreachable.start_line,
                     reason: unreachable.reason.clone(),
                 });
+
+                // Swap the flat estimate `add_item` just billed for the extent
+                // actually reported by the analyzer.
+                entry.dead_lines = entry.dead_lines.saturating_sub(
+                    crate::models::dead_code::UNREACHABLE_BLOCK_LINE_ESTIMATE,
+                ) + unreachable_lines;
             }
         }
 
@@ -176,6 +185,14 @@ impl DeadCodeAnalyzer {
         for (file_path, metrics) in &mut file_map {
             if let Ok(content) = std::fs::read_to_string(file_path) {
                 metrics.total_lines = content.lines().count();
+            }
+
+            // `add_item` bills flat per-item line estimates against this measured
+            // total, so the estimate could exceed the file it describes and yield
+            // a dead_percentage above 100. Dead code cannot occupy more lines than
+            // the file physically has.
+            if metrics.total_lines > 0 {
+                metrics.dead_lines = metrics.dead_lines.min(metrics.total_lines);
             }
 
             metrics.update_percentage();

--- a/src/services/dead_code_analyzer/analysis_tests.rs
+++ b/src/services/dead_code_analyzer/analysis_tests.rs
@@ -1,5 +1,114 @@
 #[cfg_attr(coverage_nightly, coverage(off))]
 #[cfg(test)]
+mod unreachable_block_accounting_tests {
+    use super::*;
+
+    fn empty_context() -> crate::services::context::ProjectContext {
+        crate::services::context::ProjectContext {
+            project_type: "rust".to_string(),
+            files: vec![],
+            summary: crate::services::context::ProjectSummary {
+                total_files: 0,
+                total_functions: 0,
+                total_structs: 0,
+                total_enums: 0,
+                total_traits: 0,
+                total_impls: 0,
+                dependencies: vec![],
+            },
+            graph: None,
+        }
+    }
+
+    fn report_with_one_unreachable_block(
+        file: &str,
+        start: u32,
+        end: u32,
+    ) -> super::super::types::DeadCodeReport {
+        use super::super::types::{DeadCodeReport, DeadCodeSummary, UnreachableBlock};
+        DeadCodeReport {
+            dead_functions: vec![],
+            dead_classes: vec![],
+            dead_variables: vec![],
+            unreachable_code: vec![UnreachableBlock {
+                start_line: start,
+                end_line: end,
+                file_path: file.to_string(),
+                reason: "after return".to_string(),
+            }],
+            summary: DeadCodeSummary {
+                total_dead_code_lines: 0,
+                percentage_dead: 0.0,
+                dead_by_type: std::collections::HashMap::new(),
+                confidence_level: 0.9,
+            },
+        }
+    }
+
+    /// The loop incremented `unreachable_blocks` itself AND called `add_item`,
+    /// which increments it too, so the counter came out at exactly twice the
+    /// item list it heads: one reported block counted as 2.
+    #[test]
+    fn test_unreachable_block_count_agrees_with_the_item_list() {
+        let analyzer = DeadCodeAnalyzer::new(100);
+        let report = report_with_one_unreachable_block("does_not_exist.rs", 10, 14);
+        let config = crate::models::dead_code::DeadCodeAnalysisConfig {
+            include_unreachable: true,
+            include_tests: true,
+            min_dead_lines: 0,
+        };
+
+        let metrics = analyzer
+            .aggregate_by_file(&report, &empty_context(), &config)
+            .unwrap();
+
+        let file = metrics.first().expect("one file must be reported");
+        let items = file
+            .items
+            .iter()
+            .filter(|i| {
+                matches!(
+                    i.item_type,
+                    crate::models::dead_code::DeadCodeType::UnreachableCode
+                )
+            })
+            .count();
+
+        assert_eq!(items, 1, "sanity: exactly one unreachable item was reported");
+        assert_eq!(
+            file.unreachable_blocks, items,
+            "unreachable_blocks ({}) must equal the item list it heads ({items})",
+            file.unreachable_blocks
+        );
+    }
+
+    /// The analyzer reports the block's real extent, so `dead_lines` must be
+    /// that extent -- not the extent PLUS `add_item`'s flat 3-line estimate.
+    #[test]
+    fn test_unreachable_dead_lines_use_the_measured_extent_not_extent_plus_estimate() {
+        let analyzer = DeadCodeAnalyzer::new(100);
+        // Lines 10..=14 inclusive is an extent of 5.
+        let report = report_with_one_unreachable_block("does_not_exist.rs", 10, 14);
+        let config = crate::models::dead_code::DeadCodeAnalysisConfig {
+            include_unreachable: true,
+            include_tests: true,
+            min_dead_lines: 0,
+        };
+
+        let metrics = analyzer
+            .aggregate_by_file(&report, &empty_context(), &config)
+            .unwrap();
+
+        let file = metrics.first().expect("one file must be reported");
+        assert_eq!(
+            file.dead_lines, 5,
+            "measured extent is 5 lines; 8 would mean the flat estimate was added on top"
+        );
+    }
+}
+
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg(test)]
 mod tests {
     use super::*;
 

--- a/src/services/dead_code_multi_language.rs
+++ b/src/services/dead_code_multi_language.rs
@@ -68,6 +68,53 @@ mod tests {
         assert!(!result.dead_functions.is_empty());
     }
 
+    /// #720: `total_files` must be a FILE count. The caller used to report
+    /// `total_functions.max(1)` as its file count, so this 1-file / 3-function
+    /// Python project printed "Files Analyzed | 3".
+    #[test]
+    fn test_total_files_is_a_file_count_not_a_function_count() {
+        let temp = create_test_python_project();
+        let result = analyze_dead_code_multi_language(temp.path()).unwrap();
+
+        assert_eq!(
+            result.total_files, 1,
+            "one .py file was walked, but total_files reported {}",
+            result.total_files
+        );
+        // `main` is deliberately skipped by the extractor, leaving
+        // used_function + unused_function.
+        assert_eq!(
+            result.total_functions, 2,
+            "sanity: the fixture yields 2 counted functions"
+        );
+        assert_ne!(
+            result.total_files, result.total_functions,
+            "a function count must never be reported as a file count"
+        );
+    }
+
+    /// #720: two C files, two functions -- the two counts happen to be equal in
+    /// the other fixture, so this one separates them in the opposite direction.
+    #[test]
+    fn test_total_files_counts_every_walked_file() {
+        let temp = TempDir::new().unwrap();
+        std::fs::write(
+            temp.path().join("main.c"),
+            "int main() { used_function(); return 0; }\n",
+        )
+        .unwrap();
+        std::fs::write(temp.path().join("a.c"), "void used_function() {}\n").unwrap();
+        std::fs::write(temp.path().join("b.c"), "void dead_one() {}\n").unwrap();
+
+        let result = analyze_dead_code_multi_language(temp.path()).unwrap();
+
+        assert_eq!(
+            result.total_files, 3,
+            "three .c files were walked, got {}",
+            result.total_files
+        );
+    }
+
     fn create_test_c_project() -> TempDir {
         let temp = TempDir::new().unwrap();
         std::fs::write(

--- a/src/services/dead_code_multi_language_rust.rs
+++ b/src/services/dead_code_multi_language_rust.rs
@@ -13,10 +13,15 @@ fn analyze_rust_dead_code_with_cargo(path: &Path) -> Result<Vec<DeadFunction>> {
     Ok(dead_functions)
 }
 
-fn count_rust_functions(path: &Path) -> Result<usize> {
+/// Returns `(defined functions, .rs files walked)`.
+///
+/// The file count is returned alongside the function count so the caller never
+/// has to substitute one for the other (#720): it used to report
+/// `total_functions.max(1)` as its file count.
+fn count_rust_functions_and_files(path: &Path) -> Result<(usize, usize)> {
     let rust_files = find_files_by_extension(path, &["rs"]);
     let (defined_functions, _) = analyze_rust_files(&rust_files)?;
-    Ok(defined_functions.len())
+    Ok((defined_functions.len(), rust_files.len()))
 }
 
 /// Analyze Rust files

--- a/src/services/dead_code_multi_language_strategies.rs
+++ b/src/services/dead_code_multi_language_strategies.rs
@@ -16,7 +16,7 @@ impl DeadCodeStrategy for RustDeadCodeStrategy {
         // This is the current working implementation for Rust
         let dead_functions = analyze_rust_dead_code_with_cargo(path)?;
 
-        let total_functions = count_rust_functions(path)?;
+        let (total_functions, total_files) = count_rust_functions_and_files(path)?;
         let dead_percentage = if total_functions > 0 {
             (dead_functions.len() as f64 / total_functions as f64) * 100.0
         } else {
@@ -27,6 +27,7 @@ impl DeadCodeStrategy for RustDeadCodeStrategy {
             language: "rust".to_string(),
             dead_functions,
             total_functions,
+            total_files,
             dead_code_percentage: dead_percentage,
         })
     }
@@ -70,6 +71,8 @@ impl DeadCodeStrategy for CDeadCodeStrategy {
             language: "c".to_string(),
             dead_functions,
             total_functions,
+            // Every .c/.h file walked for call analysis (#720).
+            total_files: c_all_files.len(),
             dead_code_percentage: dead_percentage,
         })
     }
@@ -109,6 +112,8 @@ impl DeadCodeStrategy for CppDeadCodeStrategy {
             language: "cpp".to_string(),
             dead_functions,
             total_functions,
+            // Every C++ source/header file walked (#720).
+            total_files: cpp_files.len(),
             dead_code_percentage: dead_percentage,
         })
     }
@@ -148,6 +153,9 @@ impl DeadCodeStrategy for PythonDeadCodeStrategy {
             language: "python".to_string(),
             dead_functions,
             total_functions,
+            // Every .py file walked (#720): a 2-file fixture with 4 functions
+            // used to report 4 files analyzed.
+            total_files: py_files.len(),
             dead_code_percentage: dead_percentage,
         })
     }
@@ -184,6 +192,8 @@ impl DeadCodeStrategy for LuaDeadCodeStrategy {
             language: "lua".to_string(),
             dead_functions,
             total_functions,
+            // Every .lua file walked (#720).
+            total_files: lua_files.len(),
             dead_code_percentage: dead_percentage,
         })
     }

--- a/src/services/dead_code_multi_language_types.rs
+++ b/src/services/dead_code_multi_language_types.rs
@@ -4,6 +4,14 @@ pub struct DeadCodeResult {
     pub language: String,
     pub dead_functions: Vec<DeadFunction>,
     pub total_functions: usize,
+    /// Source files the strategy actually walked (#720).
+    ///
+    /// The caller used to report `total_functions.max(1)` as its file count, so a
+    /// 2-file Python fixture with 4 functions printed "Files Analyzed | 4" while
+    /// the summary beside it correctly said 2. Every strategy already has the
+    /// file list in hand, so this is the count of that list -- never a function
+    /// count, and never `.max(1)` inventing a file for an empty project.
+    pub total_files: usize,
     pub dead_code_percentage: f64,
 }
 

--- a/src/services/facades/defect_prediction_facade.rs
+++ b/src/services/facades/defect_prediction_facade.rs
@@ -55,6 +55,12 @@ const COMMITS_AT_FULL_SCALE: f32 = 20.0;
 const CHANGED_LINES_AT_FULL_SCALE: f32 = 1000.0;
 /// Distinct import statements that put a file at the top of the coupling scale.
 const IMPORTS_AT_FULL_SCALE: f32 = 20.0;
+
+/// Cyclomatic complexity at which `complexity_score` reaches 1.0.
+///
+/// Matches the "very high complexity" band the complexity analyzer already
+/// reports on, so the two commands do not disagree about what "complex" means.
+const CYCLOMATIC_AT_FULL_SCALE: f32 = 30.0;
 /// `churn_score` above this is described as "frequent changes" — with the
 /// measured commit count named alongside, never on its own.
 const FREQUENT_CHANGE_SCORE: f32 = 0.5;
@@ -241,9 +247,17 @@ pub enum RiskLevel {
 /// See `contracts/pmat-no-fabrication-v1.yaml`, equation `measured_or_absent`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FileRiskMetrics {
-    /// Length-derived proxy: physical lines / 100, capped at 1.0. `lines` is
-    /// reported beside it so the reader can see what it is derived from.
-    pub complexity_score: f32,
+    /// Measured 0-1 cyclomatic complexity (the file's most complex function,
+    /// normalized by `CYCLOMATIC_AT_FULL_SCALE`), or `None` when the file's
+    /// language has no analyzer here.
+    ///
+    /// #723: this was `lines / 100` — a LENGTH proxy carrying the word
+    /// "complexity", and the same input as `size_score` (`lines / 1000`), so a
+    /// long flat file scored as complex and file length was counted twice in
+    /// the probability. `max_cyclomatic` is reported beside it as evidence.
+    pub complexity_score: Option<f32>,
+    /// Cyclomatic complexity of the file's most complex function.
+    pub max_cyclomatic: Option<u16>,
     /// Measured 0-1 git churn, or `None` when churn could not be measured.
     ///
     /// #657: this was the constant `0.3` for every file. It must never be a
@@ -430,9 +444,13 @@ const W_DUPLICATION: f32 = 0.10;
 ///
 /// This is what `confidence` reports: it is the share of the model that had
 /// data, per file. `duplication` is never measured by this command, so the
-/// ceiling is 0.90; a file with no git history drops to 0.65.
+/// ceiling is 0.90; a file with no git history drops to 0.65, and one whose
+/// language yields no function complexity (#723) drops a further 0.30.
 fn measured_weight(metrics: &FileRiskMetrics) -> f32 {
-    let mut weight = W_COMPLEXITY + W_SIZE;
+    let mut weight = W_SIZE;
+    if metrics.complexity_score.is_some() {
+        weight += W_COMPLEXITY;
+    }
     if metrics.churn_score.is_some() {
         weight += W_CHURN;
     }
@@ -450,8 +468,11 @@ fn measured_weight(metrics: &FileRiskMetrics) -> f32 {
 /// An absent factor drops its term *and* its weight, so the probability stays
 /// derived only from what was actually measured — never from a stand-in.
 fn combine_probability(metrics: &FileRiskMetrics) -> f32 {
-    let mut weighted = metrics.complexity_score * W_COMPLEXITY + metrics.size_score * W_SIZE;
+    let mut weighted = metrics.size_score * W_SIZE;
 
+    if let Some(complexity) = metrics.complexity_score {
+        weighted += complexity * W_COMPLEXITY;
+    }
     if let Some(churn) = metrics.churn_score {
         weighted += churn * W_CHURN;
     }
@@ -611,9 +632,21 @@ impl DefectPredictionFacade {
         let observation = churn.observation_for(file_path);
         let imports = count_imports(file_path, &content);
 
+        // MEASURED (#723) — was `lines / 100`, a length proxy under the name
+        // "complexity". The file's most complex function is the risk signal;
+        // `None` when the language has no analyzer, so the probability drops the
+        // term and its weight rather than assuming an average file.
+        let max_cyclomatic =
+            crate::cli::language_analyzer::analyze_file_complexity(file_path.as_path(), &content)
+                .await
+                .ok()
+                .and_then(|m| m.functions.iter().map(|f| f.metrics.cyclomatic).max());
+
         #[allow(clippy::cast_precision_loss)]
         let metrics = FileRiskMetrics {
-            complexity_score: (lines as f32 / 100.0).min(1.0),
+            complexity_score: max_cyclomatic
+                .map(|c| (f32::from(c) / CYCLOMATIC_AT_FULL_SCALE).min(1.0)),
+            max_cyclomatic,
             // Measured (#657) — no longer the constant 0.3.
             churn_score: observation.map(ChurnObservation::score),
             // Measured (#657) — no longer the constant 0.2.
@@ -681,10 +714,16 @@ fn confidence_for(metrics: &FileRiskMetrics) -> f32 {
 /// the claim, so the reader can check it.
 fn contributing_factors(metrics: &FileRiskMetrics) -> Vec<String> {
     let mut factors = Vec::new();
-    // One factor per input: `complexity_score` and `size_score` are both
-    // derived from the same line count, so they must not be reported as two
-    // independent findings.
-    if metrics.complexity_score > 0.7 || metrics.size_score > 0.7 {
+    // One factor per input. `complexity_score` is now a measured cyclomatic
+    // figure (#723) rather than a second reading of the line count, so it is a
+    // finding in its own right and names the number behind it.
+    if metrics.complexity_score.is_some_and(|c| c > 0.7) {
+        let cyclomatic = metrics.max_cyclomatic.unwrap_or(0);
+        factors.push(format!(
+            "Complex file (most complex function: cyclomatic {cyclomatic})"
+        ));
+    }
+    if metrics.size_score > 0.7 {
         factors.push(format!("Long file ({} lines)", metrics.lines));
     }
     if metrics
@@ -1024,7 +1063,8 @@ mod tests {
     /// Metrics with every factor measured, for the derivation tests.
     fn metrics_all_measured(churn: Option<f32>, coupling: Option<f32>) -> FileRiskMetrics {
         FileRiskMetrics {
-            complexity_score: 1.0,
+            complexity_score: Some(1.0),
+            max_cyclomatic: Some(30),
             churn_score: churn,
             coupling_score: coupling,
             size_score: 1.0,
@@ -1034,6 +1074,79 @@ mod tests {
             commits_in_window: churn.map(|_| 4),
             changed_lines_in_window: churn.map(|_| 80),
         }
+    }
+
+    /// #723: `complexity_score` was `lines / 100` — a LENGTH proxy carrying the
+    /// word "complexity", and the same input as `size_score` (`lines / 1000`),
+    /// so file length was counted twice in the probability. It is now the
+    /// file's most complex function.
+    #[tokio::test]
+    async fn test_complexity_score_measures_branching_not_file_length() {
+        let temp = TempDir::new().unwrap();
+
+        // Same length, wildly different branching.
+        let long_and_flat: String = (0..120).map(|n| format!("// line {n}\n")).collect();
+        std::fs::write(temp.path().join("flat.rs"), &long_and_flat).unwrap();
+
+        let mut branchy = String::from("fn branchy(x: i32) -> i32 {\n");
+        for i in 0..40 {
+            branchy.push_str(&format!("    if x == {i} {{ return {i}; }}\n"));
+        }
+        branchy.push_str("    0\n}\n");
+        std::fs::write(temp.path().join("branchy.rs"), &branchy).unwrap();
+
+        let result = facade()
+            .analyze_project(request(temp.path(), 0))
+            .await
+            .expect("analysis must succeed");
+
+        let by_name = |needle: &str| {
+            result
+                .predictions
+                .iter()
+                .find(|p| p.file_path.contains(needle))
+                .unwrap_or_else(|| panic!("{needle} missing from predictions"))
+        };
+
+        let branchy_score = by_name("branchy.rs").metrics.complexity_score;
+        assert!(
+            branchy_score.is_some_and(|c| c > 0.0),
+            "a 40-branch function must score above zero, got {branchy_score:?}"
+        );
+
+        // The old formula returned lines/100 for BOTH files, so a flat file of
+        // comment lines scored as complex as a deeply branching one.
+        let flat = &by_name("flat.rs").metrics;
+        assert!(
+            flat.complexity_score.unwrap_or(0.0) < branchy_score.unwrap(),
+            "a file of 120 comment lines must not out-score a 40-branch function \
+             (flat={:?}, branchy={branchy_score:?})",
+            flat.complexity_score
+        );
+    }
+
+    /// #723: the score is reported with the number behind it, and is absent —
+    /// never 0.0 — when nothing could be measured.
+    #[test]
+    fn test_absent_complexity_drops_its_weight_instead_of_scoring_zero() {
+        let mut unmeasured = metrics_all_measured(Some(0.5), Some(0.5));
+        unmeasured.complexity_score = None;
+        unmeasured.max_cyclomatic = None;
+
+        // Absent must not be equivalent to a measured 0.0: a measured zero
+        // would drag the probability down as if the file were trivially simple.
+        let mut zeroed = unmeasured.clone();
+        zeroed.complexity_score = Some(0.0);
+        zeroed.max_cyclomatic = Some(0);
+
+        assert!(
+            combine_probability(&unmeasured) > combine_probability(&zeroed),
+            "an unmeasured factor must drop its weight, not score as zero"
+        );
+        assert!(
+            confidence_for(&unmeasured) < confidence_for(&zeroed),
+            "confidence must fall when a factor could not be measured"
+        );
     }
 
     #[test]
@@ -1047,7 +1160,8 @@ mod tests {
     #[test]
     fn test_probability_varies_with_measured_churn() {
         let metrics = |churn: f32| FileRiskMetrics {
-            complexity_score: 0.5,
+            complexity_score: Some(0.5),
+            max_cyclomatic: Some(15),
             churn_score: Some(churn),
             coupling_score: Some(0.2),
             size_score: 0.1,

--- a/src/services/rust_borrow_checker_analysis.rs
+++ b/src/services/rust_borrow_checker_analysis.rs
@@ -125,8 +125,18 @@ impl RustBorrowChecker {
 
         let mut annotations = Vec::new();
 
+        // Byte offset of the start of every line, so a located line can be
+        // converted back to the byte span `Location` stores.
+        let lines: Vec<&str> = content.lines().collect();
+        let line_starts = line_start_offsets(&content);
+        // `syn` yields items in source order, so the search for each item's
+        // declaration only ever moves forward; this both keeps the scan linear
+        // and stops an earlier item's text from matching a later one.
+        let mut cursor_line = 0usize;
+
         for item in &syntax.items {
-            let item_annotations = self.analyze_item(item, file_path);
+            let span = measure_item_span(item, &lines, &line_starts, &mut cursor_line);
+            let item_annotations = self.analyze_item(item, file_path, span);
             annotations.extend(item_annotations);
         }
 
@@ -135,14 +145,21 @@ impl RustBorrowChecker {
 
     /// Analyze an item and generate proof annotations
     #[cfg(feature = "rust-ast")]
-    fn analyze_item(&self, item: &Item, file_path: &Path) -> Vec<(Location, ProofAnnotation)> {
+    fn analyze_item(
+        &self,
+        item: &Item,
+        file_path: &Path,
+        span: (u32, u32),
+    ) -> Vec<(Location, ProofAnnotation)> {
         let mut annotations = Vec::new();
+        // MEASURED byte span (#712). Both ends used to be the literals
+        // `0` and `100` for every item in every file, so all 2964 annotations
+        // this command produced over src/ shared ONE location and the derived
+        // annotationId could only tell them apart by property/method.
+        let (start, end) = span;
 
         match item {
             Item::Fn(item_fn) if !self.contains_unsafe(item_fn) => {
-                // Extract location from span (simplified)
-                let start = 0u32; // Would need proper span handling
-                let end = 100u32;
                 let loc = Location::new(file_path.to_owned(), start, end);
 
                 // Memory safety guarantee for safe functions
@@ -163,8 +180,6 @@ impl RustBorrowChecker {
                 // Analyze impl blocks for trait safety guarantees
                 if let Some((_, trait_path, _)) = &item_impl.trait_ {
                     if self.is_auto_trait(trait_path) {
-                        let start = 0u32;
-                        let end = 100u32;
                         let loc = Location::new(file_path.to_owned(), start, end);
                         let annotation = self.auto_trait_annotation(&loc, trait_path);
                         annotations.push((loc, annotation));
@@ -197,4 +212,79 @@ impl RustBorrowChecker {
 
         Ok(annotations)
     }
+}
+
+/// Byte offset at which each line of `content` begins.
+///
+/// `content.lines()` drops the terminators, so the offsets are accumulated from
+/// the raw bytes instead of from the split lines.
+#[cfg(feature = "rust-ast")]
+fn line_start_offsets(content: &str) -> Vec<usize> {
+    let mut offsets = vec![0usize];
+    for (idx, byte) in content.bytes().enumerate() {
+        if byte == b'\n' {
+            offsets.push(idx + 1);
+        }
+    }
+    offsets
+}
+
+/// Measure the byte span of one top-level item.
+///
+/// #712: this replaces the literals `start = 0` / `end = 100` that every item in
+/// every file used to receive ("Would need proper span handling"). Real byte
+/// offsets are not available from `syn` here -- `proc_macro2::Span::byte_range`
+/// needs the `span-locations` feature, which would add a thread-local source map
+/// that grows for the life of the process and pmat parses thousands of files --
+/// so the extent is measured from the source text instead: the declaration line
+/// is located by its keyword anchor, and the closing line comes from
+/// `find_brace_balanced_end`, the codebase's string-aware end-of-block finder
+/// (#652, #656).
+///
+/// `cursor_line` advances past each item found so the scan stays linear and an
+/// earlier item cannot match a later one.
+#[cfg(feature = "rust-ast")]
+fn measure_item_span(
+    item: &Item,
+    lines: &[&str],
+    line_starts: &[usize],
+    cursor_line: &mut usize,
+) -> (u32, u32) {
+    let anchor = match item {
+        Item::Fn(item_fn) => format!("fn {}", item_fn.sig.ident),
+        Item::Impl(_) => "impl".to_string(),
+        _ => return span_of_lines(line_starts, lines, *cursor_line, *cursor_line),
+    };
+
+    let Some(start_line) = (*cursor_line..lines.len()).find(|&i| lines[i].contains(&anchor)) else {
+        // Anchor not found (for example a macro-shaped declaration). Report the
+        // remaining region rather than a fixed constant.
+        return span_of_lines(line_starts, lines, *cursor_line, lines.len().saturating_sub(1));
+    };
+
+    let end_line = crate::cli::language_analyzer::find_brace_balanced_end(lines, start_line, true);
+    // Never let the cursor stall: an item always consumes at least its own line.
+    *cursor_line = end_line.max(start_line) + 1;
+
+    span_of_lines(line_starts, lines, start_line, end_line)
+}
+
+/// Convert an inclusive line range into a `[start_byte, end_byte)` span.
+#[cfg(feature = "rust-ast")]
+fn span_of_lines(
+    line_starts: &[usize],
+    lines: &[&str],
+    start_line: usize,
+    end_line: usize,
+) -> (u32, u32) {
+    if line_starts.is_empty() || start_line >= line_starts.len() {
+        return (0, 0);
+    }
+    let end_line = end_line.min(line_starts.len().saturating_sub(1));
+    let start = line_starts[start_line];
+    let end = line_starts[end_line] + lines.get(end_line).map_or(0, |l| l.len());
+    (
+        u32::try_from(start).unwrap_or(u32::MAX),
+        u32::try_from(end.max(start)).unwrap_or(u32::MAX),
+    )
 }

--- a/src/services/rust_borrow_checker_tests.rs
+++ b/src/services/rust_borrow_checker_tests.rs
@@ -49,6 +49,98 @@ mod tests {
         Location::new(std::path::PathBuf::from("src/seed.rs"), 0, 100)
     }
 
+    /// #712: every annotation used to carry the literal span `0..100`
+    /// ("Would need proper span handling"), so all 2964 annotations this
+    /// command produced over `src/` shared ONE location. Because the collector
+    /// deduplicates on `(location, property)`, that constant also silently
+    /// DISCARDED every function after the first in each file.
+    #[cfg(feature = "rust-ast")]
+    #[tokio::test]
+    async fn test_annotation_spans_are_measured_not_the_constant_0_to_100() {
+        let temp_dir = TempDir::new().unwrap();
+        let rust_file = temp_dir.path().join("spans.rs");
+        let source = concat!(
+            "fn alpha() {\n",
+            "    let x = 1;\n",
+            "}\n",
+            "\n",
+            "fn beta() {\n",
+            "    let y = 2;\n",
+            "}\n",
+        );
+        std::fs::write(&rust_file, source).unwrap();
+
+        let checker = RustBorrowChecker::default();
+        let cache = Arc::new(RwLock::new(ProofCache::new()));
+        let symbol_table = Arc::new(SymbolTable::new());
+        let result = checker
+            .collect(temp_dir.path(), &cache, &symbol_table)
+            .await
+            .unwrap();
+
+        let spans: std::collections::BTreeSet<(u32, u32)> = result
+            .annotations
+            .iter()
+            .map(|(loc, _)| (loc.span.start.0, loc.span.end.0))
+            .collect();
+
+        assert!(
+            !spans.contains(&(0, 100)),
+            "the placeholder span 0..100 must not survive; got {spans:?}"
+        );
+        assert_eq!(
+            spans.len(),
+            2,
+            "two functions must produce two distinct spans, got {spans:?}"
+        );
+
+        // Each span must actually bracket its function in the source text.
+        for (start, end) in spans {
+            let slice = &source[start as usize..end as usize];
+            assert!(
+                slice.starts_with("fn "),
+                "span {start}..{end} does not start at a fn: {slice:?}"
+            );
+            assert!(
+                slice.ends_with('}'),
+                "span {start}..{end} does not end at the closing brace: {slice:?}"
+            );
+        }
+    }
+
+    /// #712 companion: distinct locations mean distinct functions survive the
+    /// collector's `(location, property)` deduplication.
+    #[cfg(feature = "rust-ast")]
+    #[tokio::test]
+    async fn test_each_safe_function_yields_its_own_annotation() {
+        let temp_dir = TempDir::new().unwrap();
+        std::fs::write(
+            temp_dir.path().join("many.rs"),
+            "fn a() {}\nfn b() {}\nfn c() {}\nfn d() {}\n",
+        )
+        .unwrap();
+
+        let checker = RustBorrowChecker::default();
+        let cache = Arc::new(RwLock::new(ProofCache::new()));
+        let symbol_table = Arc::new(SymbolTable::new());
+        let result = checker
+            .collect(temp_dir.path(), &cache, &symbol_table)
+            .await
+            .unwrap();
+
+        let distinct: std::collections::BTreeSet<(u32, u32)> = result
+            .annotations
+            .iter()
+            .map(|(loc, _)| (loc.span.start.0, loc.span.end.0))
+            .collect();
+
+        assert_eq!(
+            distinct.len(),
+            4,
+            "four functions must have four distinct locations, got {distinct:?}"
+        );
+    }
+
     #[test]
     fn test_memory_safety_annotation() {
         let checker = RustBorrowChecker::default();

--- a/src/tests/lib.rs
+++ b/src/tests/lib.rs
@@ -395,28 +395,10 @@ fn test_s3_client_instantiation() {
     let _client = S3Client;
 }
 
-#[tokio::test]
-async fn test_run_mcp_server_basic() {
-    use crate::run_mcp_server;
-    use crate::stateless_server::StatelessTemplateServer;
-    use std::sync::Arc;
-
-    // Create a test server
-    let server = Arc::new(StatelessTemplateServer::new().unwrap());
-
-    // Create a simple invalid request that will cause the server to exit immediately
-    std::thread::spawn(move || {
-        // Simulate empty stdin which will cause the server to exit
-        let _result = tokio::runtime::Runtime::new()
-            .unwrap()
-            .block_on(run_mcp_server(server));
-    });
-
-    // Give the server a moment to start
-    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
-
-    // Test passes if server starts without panic
-}
+// #696: `test_run_mcp_server_basic` was deleted with `crate::run_mcp_server`.
+// It was also the only thing keeping that second, disjoint MCP server on a
+// reachable path — and it asserted nothing: it spawned the server on a detached
+// thread reading the test harness's real stdin, slept 100ms, and returned.
 
 #[test]
 fn test_public_exports() {


### PR DESCRIPTION
Follow-up to v3.29.0. Contains the two round-4 branches that cherry-picked cleanly onto the released tree.

## Fixed

- **#696–#699 — MCP residue collapsed onto one server.** `pmat --help` advertised `--mode <MODE> [cli, mcp]`, but the flag was never read; `--mode mcp <subcommand>` silently started a **second, legacy MCP server** with a disjoint 21-tool inventory whose tools took different arguments. An advertised flag that reaches a different server is the defect. Also `--file main.rs` could match any file of that name anywhere, via a loose `ends_with` fallback.
- **#712, #720, #721, #723** — four more fabricated values, plus two worse defects found underneath them.

## Held back — deliberately

Four round-4 branches are **not** included. They were authored against a base predating v3.29.0 and touch files that release rewrote (`lint-hotspot`, `entropy`, `dead-code`, `rust-project-score`, `tdg/project_score`). Merging them as-is would **revert fixes that shipped in 3.29.0** across 23 files.

They cover #693, #700–#709, #714, #717, #719, #637, #640 and will be redone against the correct base.

## Verification

Clippy clean (`--all-targets -D warnings`). Cherry-picks applied without conflict onto the released tree and build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)