### PR TITLE
fix: every defect from the round-5 dogfood sweep of released 3.29.0 (243: 48 blocker, 137 major, 58 minor)

### DIFF
--- a/src/cli/analysis/duplicates.rs
+++ b/src/cli/analysis/duplicates.rs
@@ -424,7 +424,6 @@ mod tests {
     #[test]
     fn test_format_output_dispatcher_human_arm() {
         let r = populated_report_with_blocks(1);
-        // Human/Summary/Detailed all go to format_human_output.
         let out = format_output(&r, crate::cli::DuplicateOutputFormat::Human).unwrap();
         let stripped = strip_ansi(&out);
         assert!(stripped.contains("Duplicate Code Analysis"));
@@ -433,9 +432,14 @@ mod tests {
     #[test]
     fn test_format_output_dispatcher_summary_and_detailed_arms() {
         let r = populated_report_with_blocks(1);
-        // Summary + Detailed share the human-output arm; verify both succeed.
-        format_output(&r, crate::cli::DuplicateOutputFormat::Summary).unwrap();
-        format_output(&r, crate::cli::DuplicateOutputFormat::Detailed).unwrap();
+        // Summary + Detailed used to share the human-output arm, which is what
+        // made all three formats byte-identical; each renders its own detail
+        // level now, so assert the difference rather than only that both
+        // succeed (see `summary_omits_the_per_block_listing`).
+        let summary = format_output(&r, crate::cli::DuplicateOutputFormat::Summary).unwrap();
+        let detailed = format_output(&r, crate::cli::DuplicateOutputFormat::Detailed).unwrap();
+        assert!(!strip_ansi(&summary).contains("Duplicate Blocks"));
+        assert!(strip_ansi(&detailed).contains("Duplicate Blocks"));
     }
 
     #[test]

--- a/src/cli/analysis/duplicates_detection.rs
+++ b/src/cli/analysis/duplicates_detection.rs
@@ -226,10 +226,17 @@ async fn write_duplicate_output(
     top_files: usize,
 ) -> Result<()> {
     let content = match format {
-        crate::cli::DuplicateOutputFormat::Human
-        | crate::cli::DuplicateOutputFormat::Summary
-        | crate::cli::DuplicateOutputFormat::Detailed => {
-            format_human_output_with_limit(report, top_files)?
+        // The three text formats used to collapse onto one renderer here, so
+        // `--format summary` printed the full per-block listing and
+        // `--format detailed` printed no more than `--format human`.
+        crate::cli::DuplicateOutputFormat::Human => {
+            format_text_output(report, top_files, TextDetail::Human)?
+        }
+        crate::cli::DuplicateOutputFormat::Summary => {
+            format_text_output(report, top_files, TextDetail::Summary)?
+        }
+        crate::cli::DuplicateOutputFormat::Detailed => {
+            format_text_output(report, top_files, TextDetail::Detailed)?
         }
         other => format_output(report, other)?,
     };

--- a/src/cli/analysis/duplicates_detection.rs
+++ b/src/cli/analysis/duplicates_detection.rs
@@ -65,7 +65,14 @@ pub async fn handle_analyze_duplicates(
 
     let start_time = std::time::Instant::now();
 
-    let mut report = run_duplicate_detection(
+    // `--top-files` used to be applied HERE, dropping duplicate blocks and then
+    // recomputing the report from what survived: the same tree reported 12.2%
+    // duplication at `--top-files 1` and 19.4% at `--top-files 0`, and one
+    // 301-line file read as "17.6% (53 / 301 lines)" or "33.6% (101 / 301
+    // lines)" depending only on how many rows the user asked to see. A display
+    // limit cannot be allowed to change the measurement, so the report is now
+    // whole-project and `top_files` travels to the renderer instead.
+    let report = run_duplicate_detection(
         &project_path,
         detection_type,
         threshold,
@@ -76,7 +83,6 @@ pub async fn handle_analyze_duplicates(
     )
     .await?;
 
-    apply_top_files_filtering(&mut report, top_files);
     print_duplicate_summary(&report);
 
     if perf {
@@ -93,7 +99,81 @@ pub async fn handle_analyze_duplicates(
         eprintln!("\n{}", c::pass("Analysis Complete"));
     }
 
-    write_duplicate_output(&report, format, output).await
+    write_duplicate_output(&report, format, output, top_files).await
+}
+
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg(test)]
+mod top_files_does_not_change_the_measurement_tests {
+    use super::*;
+
+    /// `--top-files N` dropped every duplicate block outside the top N files and
+    /// then restated the report from the survivors, so the SAME tree reported
+    /// "8 blocks / 12.2%" at `--top-files 1`, "17 / 14.8%" at 3 and "32 / 19.4%"
+    /// at 0 — the answer moved with the size of the list the user asked to see.
+    #[tokio::test]
+    async fn duplication_metrics_are_independent_of_top_files() {
+        use tempfile::TempDir;
+
+        let project = TempDir::new().unwrap();
+        let out = TempDir::new().unwrap();
+        // Two independent clone families plus one unique file: a top-N cut over
+        // files drops the whole second family, which is what used to move the
+        // headline numbers.
+        let family_a: String = (0..14)
+            .map(|line| format!("    let a{} = {line} * 3;\n", line % 3))
+            .collect();
+        let family_b: String = (0..14)
+            .map(|line| format!("    let b{} = {line} - 7;\n", line % 4))
+            .collect();
+        for name in ["a0.rs", "a1.rs", "a2.rs"] {
+            std::fs::write(project.path().join(name), &family_a).unwrap();
+        }
+        for name in ["b0.rs", "b1.rs"] {
+            std::fs::write(project.path().join(name), &family_b).unwrap();
+        }
+        std::fs::write(
+            project.path().join("c0.rs"),
+            "fn unique() {\n    let only = 1;\n}\n",
+        )
+        .unwrap();
+
+        let mut baseline: Option<(u64, u64, String)> = None;
+        for top_files in [1usize, 2, 3, 10, 0] {
+            let report_path = out.path().join(format!("dup-{top_files}.json"));
+            handle_analyze_duplicates(
+                project.path().to_path_buf(),
+                crate::cli::DuplicateType::Exact,
+                0.8,
+                5,
+                100,
+                crate::cli::DuplicateOutputFormat::Json,
+                false,
+                None,
+                None,
+                Some(report_path.clone()),
+                top_files,
+            )
+            .await
+            .expect("analysis must succeed");
+
+            let json: serde_json::Value =
+                serde_json::from_str(&std::fs::read_to_string(&report_path).unwrap()).unwrap();
+            let measured = (
+                json["total_duplicates"].as_u64().unwrap(),
+                json["duplicate_lines"].as_u64().unwrap(),
+                format!("{:.4}", json["duplication_percentage"].as_f64().unwrap()),
+            );
+
+            match &baseline {
+                None => baseline = Some(measured),
+                Some(expected) => assert_eq!(
+                    *expected, measured,
+                    "--top-files {top_files} changed the measured duplication"
+                ),
+            }
+        }
+    }
 }
 
 /// Run duplicate detection analysis
@@ -118,70 +198,6 @@ async fn run_duplicate_detection(
     .await
 }
 
-/// Apply top files filtering to report
-fn apply_top_files_filtering(report: &mut DuplicateReport, top_files: usize) {
-    if top_files == 0 {
-        return;
-    }
-
-    let top_file_names = get_top_files_by_duplication(&report.file_statistics, top_files);
-    filter_blocks_by_files(report, &top_file_names);
-    recalculate_statistics_after_filtering(report);
-}
-
-/// Get top files by duplication percentage
-fn get_top_files_by_duplication(
-    file_statistics: &BTreeMap<String, FileStats>,
-    top_files: usize,
-) -> std::collections::HashSet<String> {
-    let mut file_stats: Vec<_> = file_statistics.iter().collect();
-    // DETERMINISM: duplication percentage is not a total order (whole trees tie
-    // at 0.0), so without the path tie-break `.take(top_files)` kept whichever
-    // tied files the map iteration happened to visit first.
-    file_stats.sort_by(|a, b| {
-        b.1.duplication_percentage
-            .partial_cmp(&a.1.duplication_percentage)
-            .unwrap_or(std::cmp::Ordering::Equal)
-            .then_with(|| a.0.cmp(b.0))
-    });
-
-    file_stats
-        .into_iter()
-        .take(top_files)
-        .map(|(name, _)| name.clone())
-        .collect()
-}
-
-/// Filter blocks to only include those in specified files
-fn filter_blocks_by_files(
-    report: &mut DuplicateReport,
-    top_file_names: &std::collections::HashSet<String>,
-) {
-    report.duplicate_blocks.retain(|block| {
-        block
-            .locations
-            .iter()
-            .any(|loc| top_file_names.contains(&loc.file))
-    });
-}
-
-/// Recalculate statistics after filtering.
-///
-/// Delegates to `calculate_duplicate_statistics` so the per-file map is
-/// recomputed too. Round 2 fixed only the aggregate here, which left
-/// `file_statistics` reporting 447.06% for a 17-line file — and only in the
-/// `--top-files > 0` path, so `--top-files 0` still printed 447.06% at the top
-/// level as well.
-fn recalculate_statistics_after_filtering(report: &mut DuplicateReport) {
-    let duplicate_lines =
-        calculate_duplicate_statistics(&report.duplicate_blocks, &mut report.file_statistics);
-
-    report.duplicate_lines = duplicate_lines;
-    report.total_duplicates = report.duplicate_blocks.len();
-    report.duplication_percentage =
-        calculate_duplication_percentage(duplicate_lines, report.total_lines);
-}
-
 /// Print duplicate analysis summary
 fn print_duplicate_summary(report: &DuplicateReport) {
     use crate::cli::colors as c;
@@ -200,12 +216,23 @@ fn print_duplicate_summary(report: &DuplicateReport) {
 }
 
 /// Write duplicate output to file or stdout
+///
+/// `top_files` limits the rendered "Top Files by Duplication" list and nothing
+/// else — the machine-readable formats carry the whole measurement.
 async fn write_duplicate_output(
     report: &DuplicateReport,
     format: crate::cli::DuplicateOutputFormat,
     output: Option<PathBuf>,
+    top_files: usize,
 ) -> Result<()> {
-    let content = format_output(report, format)?;
+    let content = match format {
+        crate::cli::DuplicateOutputFormat::Human
+        | crate::cli::DuplicateOutputFormat::Summary
+        | crate::cli::DuplicateOutputFormat::Detailed => {
+            format_human_output_with_limit(report, top_files)?
+        }
+        other => format_output(report, other)?,
+    };
 
     if let Some(output_path) = output {
         tokio::fs::write(&output_path, &content).await?;

--- a/src/cli/analysis/duplicates_extraction.rs
+++ b/src/cli/analysis/duplicates_extraction.rs
@@ -272,11 +272,47 @@ fn find_block_end(lines: &[&str]) -> Option<usize> {
     None
 }
 
+/// The `--threshold` default. A value that differs from it was typed by the
+/// user, and the user is owed an answer about what it did.
+const DOCUMENTED_THRESHOLD_DEFAULT: f32 = 0.85;
+
+/// Say once, on stderr, that `--threshold` cannot move any block in or out.
+///
+/// Detection here is hash bucketing: two blocks are duplicates iff they hash
+/// identically under the detection type's normalisation, so every group this
+/// function returns has similarity 1.0 by construction and no cut-off in
+/// 0.0..=1.0 can change the result. The parameter was literally bound as
+/// `_threshold` and dropped, so `--threshold 0.01`, `0.5` and `0.99` printed
+/// the same "Duplication percentage" over the same tree with no indication
+/// that the number had been ignored. A real cut-off needs near-miss (Type-3)
+/// matching between blocks that do NOT hash alike, which this extractor does
+/// not do; until it does, the flag must say so rather than look effective.
+///
+/// Returns whether the value is inert, so the behaviour is testable.
+fn warn_threshold_has_no_effect(threshold: f32) -> bool {
+    if (threshold - DOCUMENTED_THRESHOLD_DEFAULT).abs() < 1e-6 {
+        return false;
+    }
+
+    static ONCE: std::sync::Once = std::sync::Once::new();
+    ONCE.call_once(|| {
+        eprintln!(
+            "warning: --threshold {threshold} was ignored: duplicate detection matches blocks by \
+hash under the selected --detection-type, so every reported clone is an exact match (similarity \
+1.0) and no similarity cut-off changes the result. Use --detection-type to widen or narrow \
+matching instead."
+        );
+    });
+    true
+}
+
 /// Find duplicate blocks from all blocks
 fn find_duplicate_blocks(
     all_blocks: Vec<(String, String, usize, usize, String)>,
-    _threshold: f32,
+    threshold: f32,
 ) -> Vec<DuplicateBlock> {
+    warn_threshold_has_no_effect(threshold);
+
     let mut hash_groups: HashMap<String, Vec<(String, usize, usize, String)>> = HashMap::new();
 
     // Group by hash
@@ -339,7 +375,12 @@ fn find_duplicate_blocks(
                 locations: duplicate_locations,
                 lines,
                 tokens,
-                similarity: 1.0, // Exact match for now
+                // 1.0 is not a placeholder: the group exists because its members
+                // hashed identically under the detection type's normalisation,
+                // which makes them exact matches at that level. Detection that
+                // reports anything else has to compare blocks that do NOT hash
+                // alike — see `warn_threshold_has_no_effect`.
+                similarity: 1.0,
             });
         }
     }
@@ -558,5 +599,32 @@ fn gamma(arg: usize) -> usize {
 
         let c = normalize_identifiers("let total = input - 1;");
         assert_ne!(a, c, "the operator is structure, not a name");
+    }
+}
+
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg(test)]
+mod threshold_tests {
+    use super::*;
+
+    /// `--threshold` was bound as `_threshold` and dropped: 0.01, 0.5 and 0.99
+    /// printed the same duplication percentage with nothing said about the
+    /// number being ignored. Hash bucketing cannot honour a similarity cut-off,
+    /// so a value that cannot act must be reported as inert.
+    #[test]
+    fn a_threshold_that_cannot_act_is_disclosed() {
+        for typed in [0.0_f32, 0.01, 0.5, 0.99, 1.0] {
+            assert!(
+                warn_threshold_has_no_effect(typed),
+                "--threshold {typed} changes nothing and must say so"
+            );
+        }
+    }
+
+    /// The default was not typed by anyone; it must not print a warning on
+    /// every ordinary run.
+    #[test]
+    fn the_default_threshold_is_quiet() {
+        assert!(!warn_threshold_has_no_effect(DOCUMENTED_THRESHOLD_DEFAULT));
     }
 }

--- a/src/cli/analysis/duplicates_extraction.rs
+++ b/src/cli/analysis/duplicates_extraction.rs
@@ -35,14 +35,38 @@ fn extract_blocks(
             extract_exact_blocks(&mut blocks, lines, &file_str, min_lines, max_tokens);
             extract_fuzzy_blocks(&mut blocks, lines, &file_str, min_lines, max_tokens);
         }
-        // Type-2 (renamed) and Type-4 (semantic) have no implementation here.
-        // They extract nothing rather than pretending: the caller reports the
-        // honest zero for an explicitly requested mode, which is different from
-        // the default silently reporting zero for everything.
-        crate::cli::DuplicateType::Renamed | crate::cli::DuplicateType::Semantic => {}
+        // Type-2 (renamed). `extract_fuzzy_blocks` hashes an
+        // identifier-normalised token stream, which is exactly what makes two
+        // blocks that differ only in names hash alike, so renamed shares it.
+        // Before, this arm extracted nothing and three byte-identical function
+        // bodies with renamed identifiers were reported as "0 blocks / 0.0%
+        // duplication" — a clean bill of health for a canonical Type-2 clone.
+        crate::cli::DuplicateType::Renamed => {
+            extract_fuzzy_blocks(&mut blocks, lines, &file_str, min_lines, max_tokens);
+        }
+        // Type-4 (semantic) has no implementation here — detecting behavioural
+        // equivalence needs analysis this extractor does not do. It must SAY so:
+        // returning an empty block list made `--detection-type semantic` print
+        // "0 duplicate blocks / 0.0% duplication" over provably duplicated code,
+        // which reads as a measurement rather than a missing feature.
+        crate::cli::DuplicateType::Semantic => {
+            warn_semantic_unimplemented();
+        }
     }
 
     blocks
+}
+
+/// Say once, on stderr, that `--detection-type semantic` measures nothing.
+fn warn_semantic_unimplemented() {
+    static ONCE: std::sync::Once = std::sync::Once::new();
+    ONCE.call_once(|| {
+        eprintln!(
+            "warning: --detection-type semantic (Type-4) is not implemented; \
+no semantic clones are detected and the reported 0% is not a measurement. \
+Use --detection-type all, exact, renamed, fuzzy or gapped."
+        );
+    });
 }
 
 /// Extract exact match blocks using sliding window
@@ -101,9 +125,15 @@ fn extract_fuzzy_blocks(
                 let content = normalize_block(block_lines);
 
                 if count_tokens(&content) <= max_tokens {
+                    // Hash the identifier-normalised token stream, not the
+                    // source text. Hashing the text made this extractor a
+                    // second, slower exact matcher: three structurally
+                    // identical functions differ in their signature line, so
+                    // they hashed differently and fuzzy/gapped/renamed reported
+                    // 0 blocks over provably duplicated code.
                     let mut hasher = DefaultHasher::new();
-                    content.hash(&mut hasher);
-                    let hash = format!("{:x}", hasher.finish());
+                    normalize_identifiers(&content).hash(&mut hasher);
+                    let hash = format!("f{:x}", hasher.finish());
 
                     blocks.push((hash, file_str.to_string(), i + 1, end, content));
                 }
@@ -113,6 +143,55 @@ fn extract_fuzzy_blocks(
             i += 1;
         }
     }
+}
+
+/// Cross-language keywords that carry a block's structure. Everything else that
+/// looks like a word is a name, and names are exactly what a Type-2 clone
+/// changes.
+const STRUCTURAL_KEYWORDS: &[&str] = &[
+    "and", "as", "async", "await", "bool", "break", "case", "catch", "class", "const", "continue",
+    "def", "delete", "do", "elif", "else", "enum", "export", "extends", "false", "final",
+    "finally", "float", "fn", "for", "from", "function", "if", "impl", "import", "in", "int",
+    "interface", "is", "let", "loop", "match", "mod", "move", "mut", "new", "nil", "none", "not",
+    "null", "or", "pass", "private", "protected", "public", "pub", "raise", "ref", "return",
+    "self", "static", "std", "str", "string", "struct", "super", "switch", "this", "throw",
+    "trait", "true", "try", "type", "typeof", "use", "var", "void", "where", "while", "with",
+    "yield",
+];
+
+/// Replace every non-keyword word with a single placeholder, keeping keywords,
+/// punctuation and operators.
+///
+/// Two blocks that differ only in identifier and literal names normalise to the
+/// same string, which is the definition of a Type-2 (renamed) clone.
+fn normalize_identifiers(content: &str) -> String {
+    fn flush(word: &mut String, out: &mut String) {
+        if word.is_empty() {
+            return;
+        }
+        if STRUCTURAL_KEYWORDS.contains(&word.as_str()) {
+            out.push_str(word);
+        } else {
+            out.push('v');
+        }
+        out.push(' ');
+        word.clear();
+    }
+
+    let mut out = String::with_capacity(content.len());
+    let mut word = String::new();
+    for ch in content.chars() {
+        if ch.is_alphanumeric() || ch == '_' {
+            word.push(ch);
+        } else {
+            flush(&mut word, &mut out);
+            if !ch.is_whitespace() {
+                out.push(ch);
+            }
+        }
+    }
+    flush(&mut word, &mut out);
+    out
 }
 
 /// Normalize code block (remove whitespace variations)
@@ -400,5 +479,84 @@ mod include_exclude_pattern_tests {
         ));
         assert!(!should_process_file(path, &Some("tests".to_string()), &None));
         assert!(!should_process_file(path, &None, &Some(".rs".to_string())));
+    }
+}
+
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg(test)]
+mod renamed_clone_tests {
+    use super::*;
+    use crate::cli::DuplicateType;
+    use std::path::Path;
+
+    /// Three copies of one body with every identifier renamed — the canonical
+    /// Type-2 clone.
+    const RENAMED_SOURCE: &str = "\
+fn alpha(input: usize) -> usize {
+    let total = input + 1;
+    let doubled = total * 2;
+    doubled
+}
+fn beta(value: usize) -> usize {
+    let sum = value + 1;
+    let twice = sum * 2;
+    twice
+}
+fn gamma(arg: usize) -> usize {
+    let acc = arg + 1;
+    let scaled = acc * 2;
+    scaled
+}
+";
+
+    fn blocks_for(kind: DuplicateType) -> Vec<(String, String, usize, usize, String)> {
+        let lines: Vec<&str> = RENAMED_SOURCE.lines().collect();
+        extract_blocks(&lines, Path::new("dup.rs"), 4, 1000, kind)
+    }
+
+    /// `--detection-type renamed` extracted nothing at all, so a file of three
+    /// renamed copies of one function was reported as 0 blocks / 0.0%
+    /// duplication.
+    #[test]
+    fn renamed_mode_finds_the_renamed_copies() {
+        let blocks = blocks_for(DuplicateType::Renamed);
+        assert!(!blocks.is_empty(), "renamed mode must extract blocks");
+
+        let duplicates = find_duplicate_blocks(blocks, 0.8);
+        assert!(
+            duplicates.iter().any(|d| d.locations.len() >= 3),
+            "three renamed copies of one body are one duplicate group, got {duplicates:?}"
+        );
+    }
+
+    /// Gapped and fuzzy are Type-3/Type-2 tolerant by definition; they used to
+    /// hash raw text, which made them a slower exact matcher.
+    #[test]
+    fn gapped_and_fuzzy_find_the_renamed_copies_too() {
+        for kind in [DuplicateType::Gapped, DuplicateType::Fuzzy] {
+            let duplicates = find_duplicate_blocks(blocks_for(kind.clone()), 0.8);
+            assert!(
+                duplicates.iter().any(|d| d.locations.len() >= 3),
+                "{kind:?} must report the renamed clones"
+            );
+        }
+    }
+
+    /// Exact match is Type-1 only: renamed copies are legitimately not exact
+    /// duplicates, and that zero IS a measurement.
+    #[test]
+    fn exact_mode_does_not_claim_renamed_copies() {
+        let duplicates = find_duplicate_blocks(blocks_for(DuplicateType::Exact), 0.8);
+        assert!(duplicates.iter().all(|d| d.locations.len() < 3));
+    }
+
+    #[test]
+    fn identifier_normalisation_erases_names_but_keeps_structure() {
+        let a = normalize_identifiers("let total = input + 1;");
+        let b = normalize_identifiers("let sum = value + 1;");
+        assert_eq!(a, b, "only the names differ");
+
+        let c = normalize_identifiers("let total = input - 1;");
+        assert_ne!(a, c, "the operator is structure, not a name");
     }
 }

--- a/src/cli/analysis/duplicates_extraction.rs
+++ b/src/cli/analysis/duplicates_extraction.rs
@@ -294,21 +294,51 @@ fn find_duplicate_blocks(
     duplicates
 }
 
-/// Check if file should be processed
+/// Check if file should be processed.
+///
+/// `--help` advertises these as globs ("Include file patterns (e.g.,
+/// \"**/*.rs\")"), but both were plain `path_str.contains` substring tests, so
+/// the example printed in the help text selected NOTHING: over a directory of
+/// .rs files `--include '**/*.rs'` analysed zero files and reported
+/// "Duplication percentage: 0.0%" with exit 0, while `--exclude '**/*.rs'`
+/// excluded nothing at all. A filter that silently matches no file is reported
+/// as a clean project.
+///
+/// A pattern that carries glob metacharacters is now matched as a glob;
+/// anything else keeps the substring behaviour, which is the only form that
+/// ever worked (`--include path_validator`) and which callers rely on.
 fn should_process_file(path: &Path, include: &Option<String>, exclude: &Option<String>) -> bool {
     let path_str = path.to_string_lossy();
 
     if let Some(excl) = exclude {
-        if path_str.contains(excl) {
+        if matches_file_pattern(&path_str, excl) {
             return false;
         }
     }
 
     if let Some(incl) = include {
-        return path_str.contains(incl);
+        return matches_file_pattern(&path_str, incl);
     }
 
     true
+}
+
+/// Match one `--include`/`--exclude` pattern against a path.
+fn matches_file_pattern(path_str: &str, pattern: &str) -> bool {
+    if !pattern.contains(['*', '?', '[', '{']) {
+        return path_str.contains(pattern);
+    }
+
+    // Matched against the whole path, which is usually absolute, so `*` has to
+    // be able to cross a separator — globset's default (`literal_separator`
+    // off) is what makes both `*.rs` and the documented `**/*.rs` match
+    // `/home/u/proj/src/utils/path_validator.rs`.
+    match globset::Glob::new(pattern) {
+        Ok(glob) => glob.compile_matcher().is_match(path_str),
+        // An unparseable pattern falls back to the historical substring test
+        // rather than quietly selecting nothing.
+        Err(_) => path_str.contains(pattern),
+    }
 }
 
 /// Check if file is source code
@@ -317,4 +347,58 @@ fn is_source_file(path: &Path) -> bool {
         path.extension().and_then(|s| s.to_str()),
         Some("rs" | "js" | "ts" | "py" | "java" | "cpp" | "c" | "kt" | "kts")
     )
+}
+
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg(test)]
+mod include_exclude_pattern_tests {
+    use super::*;
+    use std::path::Path;
+
+    const SOURCE: &str = "/home/u/proj/src/utils/path_validator.rs";
+
+    /// The pattern printed in `--help` selected zero files: `analyze duplicates
+    /// --include '**/*.rs'` over 2902 lines of Rust reported 0 duplicates and
+    /// 0.0% duplication with exit 0, and `--exclude '**/*.rs'` dropped nothing.
+    #[test]
+    fn documented_glob_patterns_match_source_files() {
+        for pattern in ["**/*.rs", "*.rs", "**", "*", "**/utils/*.rs"] {
+            assert!(
+                should_process_file(Path::new(SOURCE), &Some(pattern.to_string()), &None),
+                "--include '{pattern}' must select a .rs file"
+            );
+            assert!(
+                !should_process_file(Path::new(SOURCE), &None, &Some(pattern.to_string())),
+                "--exclude '{pattern}' must drop a .rs file"
+            );
+        }
+    }
+
+    #[test]
+    fn globs_that_do_not_match_still_filter() {
+        assert!(!should_process_file(
+            Path::new(SOURCE),
+            &Some("**/*.py".to_string()),
+            &None
+        ));
+        assert!(should_process_file(
+            Path::new(SOURCE),
+            &None,
+            &Some("**/*.py".to_string())
+        ));
+    }
+
+    /// Glob support must not remove the only form that ever worked: a bare
+    /// substring (`--include path_validator` selected 10 duplicate blocks).
+    #[test]
+    fn substring_patterns_are_still_honoured() {
+        let path = Path::new("src/utils/path_validator.rs");
+        assert!(should_process_file(
+            path,
+            &Some("path_validator".to_string()),
+            &None
+        ));
+        assert!(!should_process_file(path, &Some("tests".to_string()), &None));
+        assert!(!should_process_file(path, &None, &Some(".rs".to_string())));
+    }
 }

--- a/src/cli/analysis/duplicates_output.rs
+++ b/src/cli/analysis/duplicates_output.rs
@@ -251,9 +251,9 @@ fn write_block_header(output: &mut String, block_num: usize, block: &DuplicateBl
     writeln!(
         output,
         "  {}Block {}{} ({} lines, {} locations)",
-        c::BOLD,
+        c::seq(c::BOLD),
         block_num,
-        c::RESET,
+        c::seq(c::RESET),
         c::number(&block.lines.to_string()),
         c::number(&block.locations.len().to_string()),
     )?;
@@ -268,9 +268,9 @@ fn write_block_locations(output: &mut String, block: &DuplicateBlock) -> Result<
         writeln!(
             output,
             "    {}{}{}:{}{}{}-{}{}{}",
-            c::CYAN, loc.file, c::RESET,
-            c::BOLD_WHITE, loc.start_line, c::RESET,
-            c::BOLD_WHITE, loc.end_line, c::RESET,
+            c::seq(c::CYAN), loc.file, c::seq(c::RESET),
+            c::seq(c::BOLD_WHITE), loc.start_line, c::seq(c::RESET),
+            c::seq(c::BOLD_WHITE), loc.end_line, c::seq(c::RESET),
         )?;
     }
     Ok(())
@@ -280,8 +280,8 @@ fn write_block_locations(output: &mut String, block: &DuplicateBlock) -> Result<
 fn write_block_preview(output: &mut String, block: &DuplicateBlock) -> Result<()> {
     use crate::cli::colors as c;
     use std::fmt::Write;
-    writeln!(output, "    {}Preview:{}", c::DIM, c::RESET)?;
-    writeln!(output, "    {}{}{}", c::DIM, block.locations[0].content_preview, c::RESET)?;
+    writeln!(output, "    {}Preview:{}", c::seq(c::DIM), c::seq(c::RESET))?;
+    writeln!(output, "    {}{}{}", c::seq(c::DIM), block.locations[0].content_preview, c::seq(c::RESET))?;
     writeln!(output)?;
     Ok(())
 }
@@ -294,9 +294,9 @@ fn write_remaining_blocks_count(output: &mut String, total_blocks: usize) -> Res
         writeln!(
             output,
             "  {}... and {} more blocks{}",
-            c::DIM,
+            c::seq(c::DIM),
             total_blocks - 20,
-            c::RESET
+            c::seq(c::RESET)
         )?;
     }
     Ok(())
@@ -357,6 +357,53 @@ mod top_files_is_a_row_limit_tests {
         let report = report_with_files(25);
         let rendered = format_human_output_with_limit(&report, 0).unwrap();
         assert_eq!(row_count(&rendered), 25);
+    }
+
+    /// `--color never` produced the same 68 escape-bearing lines as `--color
+    /// auto` here: the block renderers interpolated the raw `pub const`
+    /// sequences, which cannot consult `colors_enabled()`. `c::seq` can.
+    #[test]
+    fn human_output_is_plain_text_when_colour_is_disabled() {
+        assert!(
+            !crate::cli::colors::colors_enabled(),
+            "cargo test captures stdout, so colour must resolve to off here"
+        );
+
+        let mut report = report_with_files(3);
+        report.duplicate_blocks = vec![DuplicateBlock {
+            hash: "deadbeef".to_string(),
+            lines: 12,
+            tokens: 40,
+            similarity: 1.0,
+            locations: vec![
+                DuplicateLocation {
+                    file: "src/a.rs".to_string(),
+                    start_line: 1,
+                    end_line: 12,
+                    content_preview: "fn dup() {}".to_string(),
+                },
+                DuplicateLocation {
+                    file: "src/b.rs".to_string(),
+                    start_line: 40,
+                    end_line: 51,
+                    content_preview: "fn dup() {}".to_string(),
+                },
+            ],
+        }];
+
+        let rendered = format_human_output(&report).unwrap();
+        assert!(
+            !rendered.contains('\u{1b}'),
+            "no ANSI escape may reach a redirected stdout: {:?}",
+            rendered
+                .lines()
+                .filter(|l| l.contains('\u{1b}'))
+                .collect::<Vec<_>>()
+        );
+        assert!(rendered.contains("Duplicate Code Analysis"));
+        assert!(rendered.contains("Block 1"));
+        assert!(rendered.contains("src/a.rs:1-12"));
+        assert!(rendered.contains("Preview:"));
     }
 
     /// Changing the row limit must not touch a single measured figure.

--- a/src/cli/analysis/duplicates_output.rs
+++ b/src/cli/analysis/duplicates_output.rs
@@ -5,13 +5,37 @@ fn format_output(
 ) -> Result<String> {
     match format {
         crate::cli::DuplicateOutputFormat::Json => format_json_output(report),
-        crate::cli::DuplicateOutputFormat::Human
-        | crate::cli::DuplicateOutputFormat::Summary
-        | crate::cli::DuplicateOutputFormat::Detailed => format_human_output(report),
+        crate::cli::DuplicateOutputFormat::Human => format_human_output(report),
+        crate::cli::DuplicateOutputFormat::Summary => {
+            format_text_output(report, DEFAULT_TOP_FILES, TextDetail::Summary)
+        }
+        crate::cli::DuplicateOutputFormat::Detailed => {
+            format_text_output(report, DEFAULT_TOP_FILES, TextDetail::Detailed)
+        }
         crate::cli::DuplicateOutputFormat::Sarif => format_sarif_output(report),
         crate::cli::DuplicateOutputFormat::Csv => format_csv_output(report),
     }
 }
+
+/// How much of the report a text rendering carries.
+///
+/// `--format summary`, `--format detailed` and `--format human` all routed to
+/// `format_human_output`, so the three produced byte-identical output: the
+/// format documented as "Summary statistics only" printed the whole per-block
+/// detail listing, and "Detailed duplicate listing" silently stopped at the
+/// twentieth block.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TextDetail {
+    /// Header + summary + top files. No per-block listing.
+    Summary,
+    /// Summary plus the first [`HUMAN_BLOCK_LIMIT`] blocks.
+    Human,
+    /// Summary plus EVERY block.
+    Detailed,
+}
+
+/// Blocks the default (`human`) rendering lists before summarising the rest.
+const HUMAN_BLOCK_LIMIT: usize = 20;
 
 /// Format output as JSON
 fn format_json_output(report: &DuplicateReport) -> Result<String> {
@@ -95,12 +119,24 @@ const DEFAULT_TOP_FILES: usize = 10;
 /// display control, and the row list was independently hardcoded to ten rows,
 /// so `--top-files 3` printed ten.
 pub fn format_human_output_with_limit(report: &DuplicateReport, top_files: usize) -> Result<String> {
+    format_text_output(report, top_files, TextDetail::Human)
+}
+
+/// The one text renderer behind `--format summary|human|detailed`; `detail`
+/// decides how much of the block listing it carries.
+fn format_text_output(
+    report: &DuplicateReport,
+    top_files: usize,
+    detail: TextDetail,
+) -> Result<String> {
     let mut output = String::new();
 
     write_header(&mut output)?;
     write_summary(&mut output, report)?;
     write_top_files_section(&mut output, report, top_files)?;
-    write_duplicate_blocks_section(&mut output, report)?;
+    if detail != TextDetail::Summary {
+        write_duplicate_blocks_section(&mut output, report, detail)?;
+    }
 
     Ok(output)
 }
@@ -219,7 +255,11 @@ fn extract_filename(file_path: &str) -> &str {
 }
 
 /// Write the duplicate blocks section
-fn write_duplicate_blocks_section(output: &mut String, report: &DuplicateReport) -> Result<()> {
+fn write_duplicate_blocks_section(
+    output: &mut String,
+    report: &DuplicateReport,
+    detail: TextDetail,
+) -> Result<()> {
     if report.duplicate_blocks.is_empty() {
         return Ok(());
     }
@@ -228,15 +268,28 @@ fn write_duplicate_blocks_section(output: &mut String, report: &DuplicateReport)
     use std::fmt::Write;
     writeln!(output, "{}\n", c::subheader("Duplicate Blocks"))?;
 
-    write_block_details(output, &report.duplicate_blocks)?;
-    write_remaining_blocks_count(output, report.duplicate_blocks.len())?;
+    // `detailed` is documented as the "Detailed duplicate listing"; capping it
+    // at twenty blocks like the default rendering is what made it identical to
+    // `human`.
+    let block_limit = match detail {
+        TextDetail::Detailed => usize::MAX,
+        _ => HUMAN_BLOCK_LIMIT,
+    };
+    write_block_details(output, &report.duplicate_blocks, block_limit)?;
+    if block_limit != usize::MAX {
+        write_remaining_blocks_count(output, report.duplicate_blocks.len())?;
+    }
 
     Ok(())
 }
 
 /// Write detailed information about duplicate blocks
-fn write_block_details(output: &mut String, duplicate_blocks: &[DuplicateBlock]) -> Result<()> {
-    for (i, block) in duplicate_blocks.iter().enumerate().take(20) {
+fn write_block_details(
+    output: &mut String,
+    duplicate_blocks: &[DuplicateBlock],
+    limit: usize,
+) -> Result<()> {
+    for (i, block) in duplicate_blocks.iter().enumerate().take(limit) {
         write_block_header(output, i + 1, block)?;
         write_block_locations(output, block)?;
         write_block_preview(output, block)?;
@@ -288,14 +341,14 @@ fn write_block_preview(output: &mut String, block: &DuplicateBlock) -> Result<()
 
 /// Write count of remaining blocks if there are more than 20
 fn write_remaining_blocks_count(output: &mut String, total_blocks: usize) -> Result<()> {
-    if total_blocks > 20 {
+    if total_blocks > HUMAN_BLOCK_LIMIT {
         use crate::cli::colors as c;
         use std::fmt::Write;
         writeln!(
             output,
             "  {}... and {} more blocks{}",
             c::seq(c::DIM),
-            total_blocks - 20,
+            total_blocks - HUMAN_BLOCK_LIMIT,
             c::seq(c::RESET)
         )?;
     }
@@ -406,6 +459,110 @@ mod top_files_is_a_row_limit_tests {
         assert!(rendered.contains("Preview:"));
     }
 
+    fn report_with_blocks(n: usize) -> DuplicateReport {
+        let mut report = report_with_files(3);
+        report.duplicate_blocks = (0..n)
+            .map(|i| DuplicateBlock {
+                hash: format!("h{i:02}"),
+                lines: 6,
+                tokens: 20,
+                similarity: 1.0,
+                locations: vec![
+                    DuplicateLocation {
+                        file: format!("src/a{i:02}.rs"),
+                        start_line: 1,
+                        end_line: 6,
+                        content_preview: "fn dup() {}".to_string(),
+                    },
+                    DuplicateLocation {
+                        file: format!("src/b{i:02}.rs"),
+                        start_line: 1,
+                        end_line: 6,
+                        content_preview: "fn dup() {}".to_string(),
+                    },
+                ],
+            })
+            .collect();
+        report
+    }
+
+    fn block_count(rendered: &str) -> usize {
+        rendered.lines().filter(|l| l.contains(" locations)")).count()
+    }
+
+    /// `summary`, `detailed` and `human` all routed to `format_human_output`,
+    /// so `md5sum` of the three renderings matched: "Summary statistics only"
+    /// printed the entire per-block detail listing.
+    #[test]
+    fn summary_omits_the_per_block_listing() {
+        let report = report_with_blocks(3);
+        let summary =
+            format_text_output(&report, DEFAULT_TOP_FILES, TextDetail::Summary).unwrap();
+
+        assert!(!summary.contains("Duplicate Blocks"), "{summary}");
+        assert_eq!(block_count(&summary), 0);
+        // The statistics themselves must survive.
+        assert!(summary.contains("Total duplicate blocks:"));
+        assert!(summary.contains("Duplication percentage:"));
+        assert!(summary.contains("Top Files by Duplication"));
+    }
+
+    /// The three text formats must not be byte-identical: `detailed` lists
+    /// every block, `human` stops at twenty, `summary` lists none.
+    #[test]
+    fn the_three_text_formats_differ() {
+        let report = report_with_blocks(25);
+        let summary =
+            format_text_output(&report, DEFAULT_TOP_FILES, TextDetail::Summary).unwrap();
+        let human = format_text_output(&report, DEFAULT_TOP_FILES, TextDetail::Human).unwrap();
+        let detailed =
+            format_text_output(&report, DEFAULT_TOP_FILES, TextDetail::Detailed).unwrap();
+
+        assert_eq!(block_count(&summary), 0);
+        assert_eq!(block_count(&human), HUMAN_BLOCK_LIMIT);
+        assert_eq!(block_count(&detailed), 25);
+
+        assert!(human.contains("... and 5 more blocks"));
+        assert!(
+            !detailed.contains("more blocks"),
+            "detailed lists every block, so nothing remains to summarise"
+        );
+
+        assert_ne!(summary, human);
+        assert_ne!(human, detailed);
+    }
+
+    /// The dispatcher is what `--format` reaches; assert there, too, so a
+    /// re-collapse of the match arms fails.
+    #[test]
+    fn the_format_dispatcher_keeps_the_three_text_formats_apart() {
+        let report = report_with_blocks(25);
+        let of = |f| format_output(&report, f).unwrap();
+        let summary = of(crate::cli::DuplicateOutputFormat::Summary);
+        let human = of(crate::cli::DuplicateOutputFormat::Human);
+        let detailed = of(crate::cli::DuplicateOutputFormat::Detailed);
+
+        assert_ne!(summary, human);
+        assert_ne!(human, detailed);
+        assert_ne!(summary, detailed);
+    }
+
+    /// SARIF `tool.driver.version` / `semanticVersion` were the literals
+    /// "1.0.0" and "2.97.0" — a run of any later pmat reported provenance for
+    /// a release it was not.
+    #[test]
+    fn sarif_reports_the_running_pmat_version() {
+        let report = report_with_blocks(1);
+        let sarif = format_sarif_output(&report).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&sarif).unwrap();
+        let driver = &parsed["runs"][0]["tool"]["driver"];
+
+        assert_eq!(driver["version"], env!("CARGO_PKG_VERSION"));
+        assert_eq!(driver["semanticVersion"], env!("CARGO_PKG_VERSION"));
+        assert_ne!(driver["version"], "1.0.0");
+        assert_ne!(driver["semanticVersion"], "2.97.0");
+    }
+
     /// Changing the row limit must not touch a single measured figure.
     #[test]
     fn the_summary_is_identical_at_every_row_limit() {
@@ -427,6 +584,11 @@ mod top_files_is_a_row_limit_tests {
 
 /// Format output as SARIF
 fn format_sarif_output(report: &DuplicateReport) -> Result<String> {
+    // `tool.driver.version` / `semanticVersion` were the literals "1.0.0" and
+    // "2.97.0" — two different, both wrong, answers to "which pmat produced
+    // this?". SARIF consumers key result provenance on these, so a run from
+    // any pmat since 2.97.0 claimed to be 2.97.0. The running version is the
+    // only honest value.
     let sarif = serde_json::json!({
         "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
         "version": "2.1.0",
@@ -434,9 +596,9 @@ fn format_sarif_output(report: &DuplicateReport) -> Result<String> {
             "tool": {
                 "driver": {
                     "name": "pmat-duplicates",
-                    "version": "1.0.0",
+                    "version": env!("CARGO_PKG_VERSION"),
                     "informationUri": "https://github.com/paiml/paiml-mcp-agent-toolkit",
-                    "semanticVersion": "2.97.0"
+                    "semanticVersion": env!("CARGO_PKG_VERSION")
                 }
             },
             "results": report.duplicate_blocks.iter().map(|block| {

--- a/src/cli/analysis/duplicates_output.rs
+++ b/src/cli/analysis/duplicates_output.rs
@@ -81,11 +81,25 @@ fn format_json_output(report: &DuplicateReport) -> Result<String> {
 /// ```
 #[provable_contracts_macros::contract("pmat-core.yaml", equation = "check_compliance")]
 pub fn format_human_output(report: &DuplicateReport) -> Result<String> {
+    format_human_output_with_limit(report, DEFAULT_TOP_FILES)
+}
+
+/// The CLI's `--top-files` default; also the row limit `format_human_output`
+/// renders with when no explicit limit is supplied.
+const DEFAULT_TOP_FILES: usize = 10;
+
+/// Same report, with the "Top Files by Duplication" list limited to `top_files`
+/// rows (`0` = every file).
+///
+/// The limit reaches the renderer instead of the report: `--top-files` is a
+/// display control, and the row list was independently hardcoded to ten rows,
+/// so `--top-files 3` printed ten.
+pub fn format_human_output_with_limit(report: &DuplicateReport, top_files: usize) -> Result<String> {
     let mut output = String::new();
 
     write_header(&mut output)?;
     write_summary(&mut output, report)?;
-    write_top_files_section(&mut output, report)?;
+    write_top_files_section(&mut output, report, top_files)?;
     write_duplicate_blocks_section(&mut output, report)?;
 
     Ok(output)
@@ -127,7 +141,11 @@ fn write_summary(output: &mut String, report: &DuplicateReport) -> Result<()> {
 }
 
 /// Write the top files by duplication section
-fn write_top_files_section(output: &mut String, report: &DuplicateReport) -> Result<()> {
+fn write_top_files_section(
+    output: &mut String,
+    report: &DuplicateReport,
+    top_files: usize,
+) -> Result<()> {
     if report.file_statistics.is_empty() {
         return Ok(());
     }
@@ -137,7 +155,7 @@ fn write_top_files_section(output: &mut String, report: &DuplicateReport) -> Res
     writeln!(output, "{}\n", c::subheader("Top Files by Duplication"))?;
 
     let sorted_files = get_sorted_file_stats(&report.file_statistics);
-    write_file_stats_list(output, &sorted_files)?;
+    write_file_stats_list(output, &sorted_files, top_files)?;
 
     Ok(())
 }
@@ -162,11 +180,21 @@ fn get_sorted_file_stats(
 fn write_file_stats_list(
     output: &mut String,
     sorted_files: &[(&String, &FileStats)],
+    top_files: usize,
 ) -> Result<()> {
     use crate::cli::colors as c;
     use std::fmt::Write;
 
-    for (i, (file_path, stats)) in sorted_files.iter().take(10).enumerate() {
+    // Was `.take(10)` regardless of `--top-files`, so the flag documented as
+    // "Number of top files to show by duplication (0 = all)" printed ten rows
+    // for `--top-files 3` and ten rows for `--top-files 0`.
+    let limit = if top_files == 0 {
+        usize::MAX
+    } else {
+        top_files
+    };
+
+    for (i, (file_path, stats)) in sorted_files.iter().take(limit).enumerate() {
         let filename = extract_filename(file_path);
         writeln!(
             output,
@@ -272,6 +300,82 @@ fn write_remaining_blocks_count(output: &mut String, total_blocks: usize) -> Res
         )?;
     }
     Ok(())
+}
+
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg(test)]
+mod top_files_is_a_row_limit_tests {
+    use super::*;
+
+    fn report_with_files(n: usize) -> DuplicateReport {
+        let mut file_statistics = BTreeMap::new();
+        for i in 0..n {
+            file_statistics.insert(
+                format!("src/f{i:02}.rs"),
+                FileStats {
+                    duplicate_lines: n - i,
+                    total_lines: 100,
+                    duplication_percentage: (n - i) as f32,
+                },
+            );
+        }
+        DuplicateReport {
+            total_duplicates: 7,
+            duplicate_lines: 42,
+            total_lines: 1000,
+            duplication_percentage: 4.2,
+            duplicate_blocks: vec![],
+            file_statistics,
+        }
+    }
+
+    fn row_count(rendered: &str) -> usize {
+        rendered
+            .lines()
+            .filter(|l| l.contains(" duplication ("))
+            .count()
+    }
+
+    /// The list was hardcoded to `.take(10)`, so every value of `--top-files`
+    /// printed ten rows.
+    #[test]
+    fn top_files_limits_the_printed_rows() {
+        let report = report_with_files(25);
+        for requested in [1usize, 2, 3, 10, 17] {
+            let rendered = format_human_output_with_limit(&report, requested).unwrap();
+            assert_eq!(
+                row_count(&rendered),
+                requested,
+                "--top-files {requested} must print {requested} rows"
+            );
+        }
+    }
+
+    /// `--top-files 0` is documented as "0 = all".
+    #[test]
+    fn top_files_zero_prints_every_file() {
+        let report = report_with_files(25);
+        let rendered = format_human_output_with_limit(&report, 0).unwrap();
+        assert_eq!(row_count(&rendered), 25);
+    }
+
+    /// Changing the row limit must not touch a single measured figure.
+    #[test]
+    fn the_summary_is_identical_at_every_row_limit() {
+        let report = report_with_files(25);
+        let summary_of = |limit: usize| {
+            format_human_output_with_limit(&report, limit)
+                .unwrap()
+                .lines()
+                .filter(|l| l.contains("Duplication percentage") || l.contains("Duplicate lines"))
+                .collect::<Vec<_>>()
+                .join("\n")
+        };
+        let baseline = summary_of(1);
+        for limit in [2usize, 3, 10, 0] {
+            assert_eq!(baseline, summary_of(limit), "limit {limit} changed the summary");
+        }
+    }
 }
 
 /// Format output as SARIF

--- a/src/cli/analysis/graph_metrics_algorithms.rs
+++ b/src/cli/analysis/graph_metrics_algorithms.rs
@@ -243,16 +243,30 @@ fn is_on_shortest_path(
     }
 }
 
-// Calculate closeness centrality
+// Closeness centrality, Wasserman-Faust normalised.
+//
+// This used to be `(node_count - 1) / sum_of_distances` where the sum ran over
+// the REACHABLE set only, so a node that reached exactly one neighbour scored
+// (N-1)/1 = N-1 — the maximum — while a hub that reached hundreds of nodes
+// scored a small fraction of it. On this repo that put 4557.0 on
+// near-isolated files, and since `filter_results` ranks by the SUM of the four
+// centralities, the unbounded value dominated the sort and inverted the top-k.
+// Scaling by reachable/(N-1) both bounds the value in [0,1] and charges a node
+// for the part of the graph it cannot reach.
 fn calculate_closeness(graph: &SimpleGraph, node: NodeIndex) -> f64 {
     let distances = graph.dijkstra(node, None);
     let total_distance: i32 = distances.values().sum();
+    // `dijkstra` seeds the source at distance 0; it is not a reachable *other*.
+    let reachable = distances.len().saturating_sub(1);
+    let node_count = graph.node_count();
 
-    if total_distance > 0 {
-        (graph.node_count() - 1) as f64 / f64::from(total_distance)
-    } else {
-        0.0
+    if total_distance <= 0 || reachable == 0 || node_count < 2 {
+        return 0.0;
     }
+
+    let inverse_mean_distance = reachable as f64 / f64::from(total_distance);
+    let reachable_fraction = reachable as f64 / (node_count - 1) as f64;
+    inverse_mean_distance * reachable_fraction
 }
 
 // Calculate PageRank
@@ -397,6 +411,63 @@ mod metrics_all_expansion_regression_tests {
         assert!(
             result.nodes.iter().any(|n| n.closeness_centrality > 0.0),
             "--metrics all reported closeness 0.0 for every node of a chain"
+        );
+    }
+
+    /// Closeness used to be unbounded and computed over the reachable subset
+    /// only, so the LAST reachable node of a chain (one neighbour, distance 1)
+    /// scored N-1 while the head that reaches everything scored 0.4.
+    #[test]
+    fn closeness_is_bounded_and_ranks_a_hub_above_a_near_isolated_node() {
+        let graph = chain_graph(5);
+        let head = calculate_closeness(&graph, NodeIndex(0));
+        let next_to_last = calculate_closeness(&graph, NodeIndex(3));
+        let last = calculate_closeness(&graph, NodeIndex(4));
+
+        for (name, value) in [("head", head), ("n3", next_to_last), ("tail", last)] {
+            assert!(
+                (0.0..=1.0).contains(&value),
+                "closeness must be normalised into [0,1]; {name} = {value}"
+            );
+        }
+        assert!(
+            head > next_to_last,
+            "the head reaches 4 nodes, n3 reaches 1: {head} vs {next_to_last}"
+        );
+        // The tail reaches nothing, so it has no closeness at all.
+        assert_eq!(last, 0.0);
+    }
+
+    /// The top-k sort key is the SUM of the centralities, so an unbounded
+    /// closeness inverted the whole ranking.
+    #[test]
+    fn top_k_ranking_is_not_dominated_by_a_near_isolated_node() {
+        let graph = chain_graph(5);
+        let result = calculate_metrics(
+            &graph,
+            vec![GraphMetricType::All],
+            vec![],
+            0.85,
+            100,
+            1e-6,
+        )
+        .unwrap();
+        let ranked = filter_results(result, 5, 0.0);
+        let order: Vec<&str> = ranked.nodes.iter().map(|n| n.name.as_str()).collect();
+        let rank_of = |name: &str| {
+            order
+                .iter()
+                .position(|n| *n == name)
+                .unwrap_or_else(|| panic!("{name} missing from {order:?}"))
+        };
+
+        assert_ne!(
+            order[0], "n3",
+            "a node reaching a single neighbour led the ranking: {order:?}"
+        );
+        assert!(
+            rank_of("n2") < rank_of("n3"),
+            "the middle of the chain must outrank a near-isolated node: {order:?}"
         );
     }
 

--- a/src/cli/analysis/graph_metrics_algorithms.rs
+++ b/src/cli/analysis/graph_metrics_algorithms.rs
@@ -9,8 +9,27 @@ fn calculate_metrics(
     max_iterations: usize,
     convergence_threshold: f64,
 ) -> Result<GraphMetricsResult> {
+    // `--metrics all` is the DEFAULT, and `GraphMetricType::All` matched neither
+    // the per-node arms below nor the `contains(&PageRank)` guard further down.
+    // The default run therefore reported pagerank frozen at its 1/N initializer
+    // (0.00021939447125932427 for every node of a 4558-node repo, hub and leaf
+    // alike) and betweenness/closeness at their 0.0 initializers, while
+    // `--metrics page-rank` on the same repo produced real, distinct values.
+    // Expand All into the concrete metrics it promises before anything reads it.
+    let metric_types = expand_all_metric_types(metric_types);
+
     let node_count = graph.node_count();
     let edge_count = graph.edge_count();
+
+    // Betweenness is computed once for the whole graph (Brandes) rather than
+    // per node: the per-node probe below is O(V^2) shortest-path queries *per
+    // node*, which cannot finish on a real repo, so wiring All through to it
+    // would have swapped a fabricated number for a hang.
+    let betweenness = if metric_types.contains(&crate::cli::GraphMetricType::Betweenness) {
+        Some(calculate_betweenness_all(graph))
+    } else {
+        None
+    };
 
     let mut node_metrics = Vec::new();
 
@@ -38,7 +57,9 @@ fn calculate_metrics(
         for metric_type in &metric_types {
             match metric_type {
                 crate::cli::GraphMetricType::Betweenness => {
-                    metrics.betweenness_centrality = calculate_betweenness(graph, node_idx);
+                    if let Some(bc) = &betweenness {
+                        metrics.betweenness_centrality = bc[node_idx.index()];
+                    }
                 }
                 crate::cli::GraphMetricType::Closeness => {
                     metrics.closeness_centrality = calculate_closeness(graph, node_idx);
@@ -98,6 +119,83 @@ fn calculate_metrics(
         max_degree,
         connected_components: graph.connected_components(),
     })
+}
+
+// Expand `GraphMetricType::All` into the concrete per-node metrics it stands for.
+// Anything else is passed through untouched.
+fn expand_all_metric_types(
+    metric_types: Vec<crate::cli::GraphMetricType>,
+) -> Vec<crate::cli::GraphMetricType> {
+    if metric_types.contains(&crate::cli::GraphMetricType::All) {
+        vec![
+            crate::cli::GraphMetricType::Centrality,
+            crate::cli::GraphMetricType::Betweenness,
+            crate::cli::GraphMetricType::Closeness,
+            crate::cli::GraphMetricType::PageRank,
+        ]
+    } else {
+        metric_types
+    }
+}
+
+// Betweenness centrality for every node at once (Brandes 2001, unweighted).
+// Runs in O(V*(V+E)) so the default `--metrics all` path terminates on a repo
+// sized graph; `calculate_betweenness` below is the original per-node probe and
+// is kept only for the small-graph unit tests that pin its behaviour.
+fn calculate_betweenness_all(graph: &SimpleGraph) -> Vec<f64> {
+    use std::collections::VecDeque;
+
+    let n = graph.node_count();
+    let mut centrality = vec![0.0f64; n];
+    if n < 3 {
+        return centrality;
+    }
+
+    for s in 0..n {
+        let mut stack: Vec<usize> = Vec::with_capacity(n);
+        let mut predecessors: Vec<Vec<usize>> = vec![Vec::new(); n];
+        let mut sigma = vec![0.0f64; n];
+        let mut distance = vec![-1i64; n];
+
+        sigma[s] = 1.0;
+        distance[s] = 0;
+        let mut queue = VecDeque::new();
+        queue.push_back(s);
+
+        while let Some(v) = queue.pop_front() {
+            stack.push(v);
+            for &w in graph.outgoing_edges(NodeIndex(v)) {
+                if distance[w] < 0 {
+                    distance[w] = distance[v] + 1;
+                    queue.push_back(w);
+                }
+                if distance[w] == distance[v] + 1 {
+                    sigma[w] += sigma[v];
+                    predecessors[w].push(v);
+                }
+            }
+        }
+
+        let mut delta = vec![0.0f64; n];
+        while let Some(w) = stack.pop() {
+            for &v in &predecessors[w] {
+                if sigma[w] > 0.0 {
+                    delta[v] += (sigma[v] / sigma[w]) * (1.0 + delta[w]);
+                }
+            }
+            if w != s {
+                centrality[w] += delta[w];
+            }
+        }
+    }
+
+    // Normalise by the number of ordered pairs that could route through a node.
+    let denominator = ((n - 1) * (n - 2)) as f64;
+    for c in &mut centrality {
+        *c /= denominator;
+    }
+
+    centrality
 }
 
 // Calculate betweenness centrality (simplified)
@@ -240,4 +338,80 @@ fn filter_results(
     result.nodes.truncate(top_k);
 
     result
+}
+
+/// Regression tests for the default `--metrics all` path.
+///
+/// `GraphMetricType::All` used to fall through the `_ => {}` arm and the
+/// `contains(&PageRank)` guard, so the DEFAULT invocation of
+/// `pmat analyze graph-metrics` reported the pagerank initializer (1/N, the same
+/// number for every node) and betweenness/closeness of 0.0.
+#[cfg(test)]
+mod metrics_all_expansion_regression_tests {
+    use super::*;
+    use crate::cli::GraphMetricType;
+
+    /// n1 -> n2 -> n3 -> n4 -> n5
+    fn chain_graph(len: usize) -> SimpleGraph {
+        let mut graph = SimpleGraph::new();
+        let nodes: Vec<_> = (0..len).map(|i| graph.add_node(format!("n{i}"))).collect();
+        for pair in nodes.windows(2) {
+            graph.add_edge(pair[0], pair[1]);
+        }
+        graph
+    }
+
+    fn distinct_count(values: impl Iterator<Item = f64>) -> usize {
+        let mut v: Vec<f64> = values.collect();
+        v.sort_by(f64::total_cmp);
+        v.dedup_by(|a, b| (*a - *b).abs() < 1e-12);
+        v.len()
+    }
+
+    #[test]
+    fn metrics_all_computes_pagerank_betweenness_and_closeness() {
+        let graph = chain_graph(5);
+        let result = calculate_metrics(
+            &graph,
+            vec![GraphMetricType::All],
+            vec![],
+            0.85,
+            100,
+            1e-6,
+        )
+        .unwrap();
+
+        assert_eq!(result.nodes.len(), 5);
+
+        let pagerank_values = distinct_count(result.nodes.iter().map(|n| n.pagerank));
+        assert!(
+            pagerank_values > 1,
+            "--metrics all left every node at the 1/N pagerank initializer: {:?}",
+            result.nodes.iter().map(|n| n.pagerank).collect::<Vec<_>>()
+        );
+
+        assert!(
+            result.nodes.iter().any(|n| n.betweenness_centrality > 0.0),
+            "--metrics all reported betweenness 0.0 for every node of a chain"
+        );
+        assert!(
+            result.nodes.iter().any(|n| n.closeness_centrality > 0.0),
+            "--metrics all reported closeness 0.0 for every node of a chain"
+        );
+    }
+
+    #[test]
+    fn betweenness_all_ranks_the_middle_of_a_chain_above_its_ends() {
+        let graph = chain_graph(5);
+        let centrality = calculate_betweenness_all(&graph);
+
+        assert!(
+            centrality[2] > centrality[0],
+            "middle of a chain must route more shortest paths than its head: {centrality:?}"
+        );
+        assert_eq!(
+            centrality[0], 0.0,
+            "the head of a chain lies on no shortest path between other nodes"
+        );
+    }
 }

--- a/src/cli/analysis/graph_metrics_export.rs
+++ b/src/cli/analysis/graph_metrics_export.rs
@@ -96,9 +96,17 @@ fn format_output(
         | crate::cli::GraphMetricsOutputFormat::Summary
         | crate::cli::GraphMetricsOutputFormat::Detailed => format_gm_as_human(result),
         crate::cli::GraphMetricsOutputFormat::Csv => format_gm_as_csv(result),
-        crate::cli::GraphMetricsOutputFormat::GraphML => {
-            Ok("GraphML export handled separately.".to_string())
-        }
+        // `-f graph-ml` used to return this developer note as the *document*:
+        // `analyze graph-metrics -f graph-ml -o out.graphml` exited 0 having
+        // written 34 bytes of English prose where a caller expected XML. The
+        // real writer (`export_to_graphml`) needs the `SimpleGraph` to emit
+        // edges, and only `--export-graphml` has it; `format_output` is handed
+        // the metrics alone, so a document produced here could never contain an
+        // edge. Refusing is honest, a nodes-only "GraphML" would not be.
+        crate::cli::GraphMetricsOutputFormat::GraphML => Err(anyhow::anyhow!(
+            "graph-ml is not a rendering format: GraphML is written by `--export-graphml` \
+             together with `-o <PATH>` (which writes <PATH>.graphml)"
+        )),
         crate::cli::GraphMetricsOutputFormat::Markdown => format_gm_as_markdown(result),
     }
 }

--- a/src/cli/analysis/graph_metrics_handler.rs
+++ b/src/cli/analysis/graph_metrics_handler.rs
@@ -94,15 +94,48 @@ async fn build_dependency_graph(
 
         if let Some(&from_idx) = node_indices.get(&file_name) {
             let deps = extract_dependencies(&content, file)?;
+            // One dependency edge per distinct neighbour. Every `use foo` line
+            // in a file used to push another copy of the same edge, so
+            // out_degree counted import STATEMENTS, not dependencies, and
+            // degree_centrality was inflated for files that import one module
+            // repeatedly.
+            let mut seen: std::collections::HashSet<usize> = std::collections::HashSet::new();
             for dep in deps {
                 if let Some(&to_idx) = node_indices.get(&dep) {
-                    graph.add_edge(from_idx, to_idx);
+                    if seen.insert(to_idx.index()) {
+                        graph.add_edge(from_idx, to_idx);
+                    }
                 }
             }
         }
     }
 
     Ok(graph)
+}
+
+/// Regression test for the duplicate-edge half of the graph-metrics defect:
+/// repeated imports of the same module used to push one edge each.
+#[cfg(test)]
+mod dependency_graph_edge_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn repeated_imports_of_one_module_produce_one_edge() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join("a.rs"), "use b;\nuse b;\nuse b;\n").expect("write a");
+        std::fs::write(dir.path().join("b.rs"), "pub fn x() {}\n").expect("write b");
+
+        let graph = build_dependency_graph(dir.path(), &None, &None)
+            .await
+            .expect("graph");
+
+        assert_eq!(graph.node_count(), 2);
+        assert_eq!(
+            graph.edge_count(),
+            1,
+            "three `use b` lines are one dependency, not three edges"
+        );
+    }
 }
 
 // Collect files based on patterns

--- a/src/cli/analysis/graph_metrics_tests_part3.rs
+++ b/src/cli/analysis/graph_metrics_tests_part3.rs
@@ -47,12 +47,21 @@
         assert!(output.contains("medium"));
     }
 
+    /// This test used to pin the defect: it asserted that `-f graph-ml` returns
+    /// the developer note "GraphML export handled separately", which the command
+    /// then wrote out as the whole output file with exit 0.
     #[test]
     fn test_format_output_graphml() {
         let result = create_mock_result();
-        let output = format_output(result, GraphMetricsOutputFormat::GraphML).unwrap();
+        let err = format_output(result, GraphMetricsOutputFormat::GraphML)
+            .expect_err("graph-ml must not render prose as a document");
 
-        assert!(output.contains("GraphML export handled separately"));
+        let message = err.to_string();
+        assert!(
+            !message.contains("handled separately"),
+            "the error must tell the user what to run: {message}"
+        );
+        assert!(message.contains("--export-graphml"), "{message}");
     }
 
     #[test]

--- a/src/cli/analysis/symbol_table_extraction.rs
+++ b/src/cli/analysis/symbol_table_extraction.rs
@@ -231,8 +231,11 @@ fn extract_symbols_simple(content: &str, file: &str) -> Result<Vec<Symbol>> {
 
     // Function patterns for different languages
     let patterns = vec![
+        // `const fn` is a function declaration, not a constant. Without the
+        // optional `const\s+` here, `const fn answer()` matched no function
+        // pattern at all and `answer` was missing from the table entirely.
         (
-            Regex::new(r"(?m)^(?:pub\s+)?(?:async\s+)?fn\s+(\w+)")?,
+            Regex::new(r"(?m)^(?:pub\s+)?(?:const\s+)?(?:async\s+)?fn\s+(\w+)")?,
             SymbolKind::Function,
         ),
         (Regex::new(r"(?m)^class\s+(\w+)")?, SymbolKind::Class),
@@ -250,12 +253,20 @@ fn extract_symbols_simple(content: &str, file: &str) -> Result<Vec<Symbol>> {
         // The old constant pattern was `^const\s+(\w+)\s*=`, which a Rust
         // `pub const KONST: u32 = 1;` fails twice over (the `pub`, and the type
         // annotation before `=`). This one covers both it and JS `const x = …`.
+        //
+        // Requiring the `:` (Rust type annotation) or `=` (JS initialiser) that
+        // must follow a real constant's name is what keeps `const fn answer()`
+        // out: the bare `const\s+(\w+)` form captured the `fn` *keyword* as a
+        // constant named "fn", which then out-ranked every real identifier in
+        // `most_referenced` (54 266 "references" on pmat itself).
         (
-            Regex::new(r"(?m)^(?:pub\s+)?const\s+(\w+)")?,
+            Regex::new(r"(?m)^(?:pub\s+)?const\s+(\w+)\s*[:=]")?,
             SymbolKind::Constant,
         ),
+        // Same keyword-capture trap as `const fn`: `static mut COUNTER` used to
+        // yield a symbol literally named "mut".
         (
-            Regex::new(r"(?m)^(?:pub\s+)?static\s+(\w+)")?,
+            Regex::new(r"(?m)^(?:pub\s+)?static\s+(?:mut\s+)?(\w+)\s*[:=]")?,
             SymbolKind::Variable,
         ),
         (
@@ -374,4 +385,54 @@ fn find_most_referenced(symbols: &[Symbol], limit: usize) -> (Vec<(String, usize
         refs.truncate(limit);
     }
     (refs, total)
+}
+
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg(test)]
+mod keyword_capture_tests {
+    use super::*;
+
+    /// `const fn answer()` used to produce a `Constant` named "fn" (the keyword
+    /// captured by the constant regex) and no `answer` at all, because the
+    /// function regex had no `const` alternative. Repo-wide that bogus "fn"
+    /// topped `most_referenced` with 54 266 textual "references".
+    #[test]
+    fn const_fn_is_a_function_named_after_the_fn_not_the_keyword() {
+        let content = "const fn answer() -> i32 { 42 }\npub fn other() -> i32 { answer() }\n";
+        let symbols = extract_symbols_simple(content, "lib.rs").unwrap();
+
+        let names: Vec<&str> = symbols.iter().map(|s| s.name.as_str()).collect();
+        assert!(
+            !names.contains(&"fn"),
+            "the `fn` keyword must never become a symbol: {names:?}"
+        );
+        assert!(
+            symbols
+                .iter()
+                .any(|s| s.name == "answer" && matches!(s.kind, SymbolKind::Function)),
+            "`const fn answer` must be a Function named answer: {names:?}"
+        );
+    }
+
+    /// Same keyword-capture trap on the `static` pattern.
+    #[test]
+    fn static_mut_is_named_after_the_variable_not_the_mut_keyword() {
+        let content = "pub static mut COUNTER: u32 = 0;\n";
+        let symbols = extract_symbols_simple(content, "lib.rs").unwrap();
+
+        let names: Vec<&str> = symbols.iter().map(|s| s.name.as_str()).collect();
+        assert!(!names.contains(&"mut"), "captured the keyword: {names:?}");
+        assert!(names.contains(&"COUNTER"), "lost the variable: {names:?}");
+    }
+
+    /// The constant/variable patterns must still find the ordinary forms.
+    #[test]
+    fn plain_constants_and_statics_are_still_extracted() {
+        let content = "pub const KONST: u32 = 1;\npub static STAT: u32 = 2;\nconst js = 3;\n";
+        let symbols = extract_symbols_simple(content, "lib.rs").unwrap();
+        let names: Vec<&str> = symbols.iter().map(|s| s.name.as_str()).collect();
+        assert!(names.contains(&"KONST"), "{names:?}");
+        assert!(names.contains(&"STAT"), "{names:?}");
+        assert!(names.contains(&"js"), "{names:?}");
+    }
 }

--- a/src/cli/analysis_utilities/makefile.rs
+++ b/src/cli/analysis_utilities/makefile.rs
@@ -29,7 +29,25 @@ pub async fn handle_analyze_makefile(
     print_makefile_analysis_summary(&lint_result);
 
     // Filter violations by rules if specified
-    let filtered_violations = filter_makefile_violations(&lint_result.violations, &rules);
+    let mut filtered_violations = filter_makefile_violations(&lint_result.violations, &rules);
+
+    // --gnu-version used to reach nothing but the report header: a Makefile
+    // built from `.ONESHELL:`, `::=` and `!=` produced byte-identical reports
+    // for --gnu-version 3.0 and 4.4, while --help promised "GNU Make version to
+    // check compatibility against". The linter itself takes no version, so the
+    // compatibility check lives here, against the source it was pointed at.
+    if let Some(ref requested) = gnu_version {
+        let source = std::fs::read_to_string(&path)?;
+        let mut incompat = check_gnu_version_compatibility(&source, requested)?;
+        if rules.is_empty() || rules == vec!["all"] || rules.contains(&GNU_VERSION_RULE.to_string())
+        {
+            eprintln!(
+                "📌 {} construct(s) newer than GNU Make {requested}",
+                incompat.len()
+            );
+            filtered_violations.append(&mut incompat);
+        }
+    }
 
     // Format output based on requested format
     let content = format_makefile_output(
@@ -47,6 +65,103 @@ pub async fn handle_analyze_makefile(
     handle_makefile_fix_mode(fix, &filtered_violations);
 
     Ok(())
+}
+
+/// Rule name carried by every `--gnu-version` incompatibility.
+const GNU_VERSION_RULE: &str = "gnuversion";
+
+/// GNU Make constructs and the release that introduced them.
+///
+/// Deliberately short: each entry is a construct whose introducing release is
+/// documented in the GNU Make NEWS file, recognised by a shape that cannot be
+/// confused with a recipe's shell syntax. Guessing more would put fabricated
+/// violations in the report, which is the failure mode this whole check exists
+/// to correct.
+const GNU_MAKE_FEATURES: &[(&str, &str)] = &[
+    (".ONESHELL:", "3.82"),
+    (".NOTINTERMEDIATE:", "4.4"),
+    ("::=", "4.0"),
+    ("!=", "4.0"),
+    ("$(file ", "4.0"),
+    ("$(intcmp ", "4.4"),
+    ("$(let ", "4.4"),
+];
+
+/// Parse a `major.minor` GNU Make version.
+fn parse_gnu_version(version: &str) -> Result<(u32, u32)> {
+    let mut parts = version.trim().split('.');
+    let major = parts
+        .next()
+        .and_then(|p| p.parse::<u32>().ok())
+        .ok_or_else(|| anyhow::anyhow!("invalid --gnu-version '{version}': expected e.g. 4.4"))?;
+    let minor = parts.next().unwrap_or("0").parse::<u32>().unwrap_or(0);
+    Ok((major, minor))
+}
+
+/// Does `line` use `token` as Make syntax rather than as shell text?
+///
+/// Recipe lines are handed to the shell verbatim, where `!=` is a string
+/// comparison and `::=` never appears; reporting those would be noise.
+fn uses_make_construct(line: &str, token: &str) -> bool {
+    if line.starts_with('\t') {
+        return false;
+    }
+    let trimmed = line.trim_start();
+    match token {
+        "!=" | "::=" => match trimmed.find(token) {
+            // Only a variable assignment: the whole left-hand side must be a
+            // Make variable name.
+            Some(pos) => {
+                let lhs = trimmed.get(..pos).unwrap_or_default().trim_end();
+                !lhs.is_empty()
+                    && lhs
+                        .chars()
+                        .all(|c| c.is_alphanumeric() || c == '_' || c == '.')
+            }
+            None => false,
+        },
+        _ => trimmed.contains(token),
+    }
+}
+
+/// Violations for constructs newer than the requested GNU Make version.
+///
+/// # Errors
+/// Returns an error when `requested` is not a `major.minor` version.
+fn check_gnu_version_compatibility(
+    source: &str,
+    requested: &str,
+) -> Result<Vec<makefile_linter::Violation>> {
+    use crate::services::makefile_linter::ast::SourceSpan;
+
+    let target = parse_gnu_version(requested)?;
+    let mut violations = Vec::new();
+
+    for (idx, line) in source.lines().enumerate() {
+        for (token, introduced_in) in GNU_MAKE_FEATURES {
+            let needs = parse_gnu_version(introduced_in)?;
+            if needs <= target || !uses_make_construct(line, token) {
+                continue;
+            }
+            let column = line.find(token).unwrap_or(0) + 1;
+            violations.push(makefile_linter::Violation {
+                rule: GNU_VERSION_RULE.to_string(),
+                severity: makefile_linter::Severity::Warning,
+                span: SourceSpan {
+                    start: 0,
+                    end: 0,
+                    line: idx + 1,
+                    column,
+                },
+                message: format!(
+                    "`{token}` requires GNU Make {introduced_in}, but compatibility was requested against {requested}"
+                ),
+                fix_hint: None,
+            });
+        }
+    }
+
+    Ok(violations)
 }
 
 // Helper: Print analysis summary
@@ -75,6 +190,12 @@ fn filter_makefile_violations(
 }
 
 // Helper: Handle fix mode
+//
+// This function does no I/O — it never has. It announced that it was applying
+// automatic fixes and then reported five violations as having been fixed, over
+// a Makefile whose md5 was identical before and after the run. Nothing here
+// rewrites a Makefile yet, so nothing here may say it did; the wording now
+// matches what the code actually does.
 fn handle_makefile_fix_mode(fix: bool, filtered_violations: &[makefile_linter::Violation]) {
     if !fix {
         return;
@@ -90,14 +211,14 @@ fn handle_makefile_fix_mode(fix: bool, filtered_violations: &[makefile_linter::V
         return;
     }
 
-    eprintln!("\n🔧 Applying automatic fixes...");
+    eprintln!("\n🔧 Fixable violations (suggestions only — no file was modified):");
     let fix_count = fixable_violations.len();
     for violation in fixable_violations {
         if let Some(fix_hint) = &violation.fix_hint {
-            eprintln!("  ✅ {}: {}", violation.rule, fix_hint);
+            eprintln!("  • {}: {}", violation.rule, fix_hint);
         }
     }
-    eprintln!("✨ {fix_count} violations automatically fixed.");
+    eprintln!("💡 {fix_count} fixable violation(s); applying them automatically is not implemented, so the Makefile is unchanged.");
 }
 
 // Helper: Format makefile output based on format
@@ -370,6 +491,95 @@ pub fn get_gcc_level(severity: &makefile_linter::Severity) -> &'static str {
         makefile_linter::Severity::Warning => "warning",
         makefile_linter::Severity::Performance => "note",
         makefile_linter::Severity::Info => "note",
+    }
+}
+
+#[cfg(test)]
+mod makefile_gnu_version_tests {
+    use super::*;
+
+    /// The Makefile from the report: `.ONESHELL:` (3.82+), `::=` and `!=`
+    /// (4.0+). Checking it against 3.0 and against 4.4 used to produce
+    /// byte-identical reports because --gnu-version reached only the header.
+    const MODERN: &str = ".ONESHELL:\nX ::= hello\nY != echo dynamic\n.PHONY: all\nall:\n\t@echo hi\n";
+
+    #[test]
+    fn test_old_gnu_version_reports_incompatible_constructs() {
+        let v = check_gnu_version_compatibility(MODERN, "3.0").unwrap();
+        let messages: Vec<&str> = v.iter().map(|x| x.message.as_str()).collect();
+        assert_eq!(v.len(), 3, "expected .ONESHELL:, ::= and != — got {messages:?}");
+        assert!(messages.iter().any(|m| m.contains(".ONESHELL:")));
+        assert!(messages.iter().any(|m| m.contains("::=")));
+        assert!(messages.iter().any(|m| m.contains("!=")));
+        assert!(v.iter().all(|x| x.rule == GNU_VERSION_RULE));
+    }
+
+    #[test]
+    fn test_new_gnu_version_reports_nothing() {
+        assert!(check_gnu_version_compatibility(MODERN, "4.4")
+            .unwrap()
+            .is_empty());
+    }
+
+    #[test]
+    fn test_gnu_version_boundaries() {
+        // 3.81 predates .ONESHELL: (3.82); 4.0 covers ::= and != but not $(let).
+        assert_eq!(check_gnu_version_compatibility(MODERN, "3.81").unwrap().len(), 3);
+        assert!(check_gnu_version_compatibility(MODERN, "4.0")
+            .unwrap()
+            .is_empty());
+        let let_fn = "X = $(let a,1,$(a))\n";
+        assert_eq!(check_gnu_version_compatibility(let_fn, "4.0").unwrap().len(), 1);
+        assert!(check_gnu_version_compatibility(let_fn, "4.4")
+            .unwrap()
+            .is_empty());
+    }
+
+    /// `!=` inside a recipe is shell string comparison, not Make's shell
+    /// assignment; reporting it would be a fabricated violation.
+    #[test]
+    fn test_shell_inequality_in_a_recipe_is_not_a_make_construct() {
+        let src = "all:\n\t@if [ \"$$a\" != \"$$b\" ]; then echo differ; fi\n";
+        assert!(check_gnu_version_compatibility(src, "3.0")
+            .unwrap()
+            .is_empty());
+    }
+
+    #[test]
+    fn test_bad_gnu_version_is_rejected() {
+        assert!(check_gnu_version_compatibility(MODERN, "banana").is_err());
+        assert_eq!(parse_gnu_version("4").unwrap(), (4, 0));
+        assert_eq!(parse_gnu_version("3.81").unwrap(), (3, 81));
+    }
+
+    /// `--fix` must not claim to have modified a file it never opened.
+    #[test]
+    fn test_fix_mode_does_not_claim_to_have_written() {
+        // The wording is the fix; assert the old claim is gone from the source
+        // of truth the user sees.
+        let violations = vec![makefile_linter::Violation {
+            rule: "phonydeclared".to_string(),
+            severity: makefile_linter::Severity::Warning,
+            span: crate::services::makefile_linter::ast::SourceSpan {
+                start: 0,
+                end: 0,
+                line: 1,
+                column: 1,
+            },
+            message: "target 'a' is not declared .PHONY".to_string(),
+            fix_hint: Some("Add 'a' to .PHONY declaration".to_string()),
+        }];
+        handle_makefile_fix_mode(true, &violations);
+        handle_makefile_fix_mode(false, &violations);
+
+        // Split so this probe cannot match its own source text.
+        let claim = concat!("violations automatically", " fixed.");
+        let source = include_str!("makefile.rs");
+        assert!(
+            !source.contains(claim),
+            "--fix must not report violations as fixed while it writes no file"
+        );
+        assert!(source.contains("is not implemented, so the Makefile is unchanged"));
     }
 }
 

--- a/src/cli/analysis_utilities/mod.rs
+++ b/src/cli/analysis_utilities/mod.rs
@@ -39,6 +39,10 @@ include!("churn.rs");
 include!("quality_gate_satd.rs");
 include!("quality_gate_entry.rs");
 include!("quality_gate_single_file.rs");
+
+#[cfg(test)]
+#[path = "quality_gate_parse_guard_tests.rs"]
+mod quality_gate_parse_guard_tests;
 include!("quality_gate_project.rs");
 include!("quality_gate_execute.rs");
 include!("quality_gate_config.rs");

--- a/src/cli/analysis_utilities/provability.rs
+++ b/src/cli/analysis_utilities/provability.rs
@@ -48,21 +48,45 @@ pub async fn handle_analyze_provability(
 }
 
 /// Get function IDs based on input parameters
+///
+/// `--functions` used to go through `parse_function_spec`, which manufactured a
+/// `FunctionId { file_path: String::new(), line_number: 0 }` out of a bare name
+/// — its "will search all files" comment described a search nobody wrote. The
+/// analyzer was then handed an empty path, read no source, and returned the
+/// 20% no-evidence baseline for a function that scores 100% when the same tree
+/// is analyzed unfiltered; a name that exists nowhere scored 20% just the same.
+/// A filter must narrow the functions actually discovered, never invent one.
 async fn get_function_ids(
     project_path: &Path,
     functions: &[String],
 ) -> Result<Vec<crate::services::lightweight_provability_analyzer::FunctionId>> {
-    use crate::cli::provability_helpers::{discover_project_functions, parse_function_spec};
+    use crate::cli::provability_helpers::{discover_project_functions, match_function_spec};
+
+    let discovered = discover_project_functions(project_path).await?;
 
     if functions.is_empty() {
-        discover_project_functions(project_path).await
-    } else {
-        let mut ids = Vec::new();
-        for spec in functions {
-            ids.push(parse_function_spec(spec, project_path)?);
-        }
-        Ok(ids)
+        return Ok(discovered);
     }
+
+    let mut ids = Vec::new();
+    let mut unmatched = Vec::new();
+    for spec in functions {
+        let matches = match_function_spec(spec, &discovered);
+        if matches.is_empty() {
+            unmatched.push(spec.clone());
+        }
+        ids.extend(matches);
+    }
+
+    if !unmatched.is_empty() {
+        anyhow::bail!(
+            "no function matching {} was found under {}",
+            unmatched.join(", "),
+            project_path.display()
+        );
+    }
+
+    Ok(ids)
 }
 
 /// Prepare summaries by filtering and converting
@@ -415,6 +439,44 @@ mod provability_tests {
         let m = create_file_metrics(std::path::Path::new("t.rs"), 5);
         assert_eq!(m.cyclomatic_complexity, 0);
         assert_eq!(m.cognitive_complexity, 0);
+    }
+
+    /// `--functions <name>` must select from the functions actually discovered.
+    /// It used to synthesise `FunctionId { file_path: "", line_number: 0 }`, so
+    /// the analyzer read no source and returned the 20% no-evidence baseline
+    /// for a function that scores 100% when the same tree is analyzed whole.
+    #[tokio::test]
+    async fn test_function_filter_keeps_the_real_source_location() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("lib.rs"),
+            "pub fn add(a: i32, b: i32) -> i32 {\n    a + b\n}\n",
+        )
+        .unwrap();
+
+        let ids = get_function_ids(dir.path(), &["add".to_string()])
+            .await
+            .unwrap();
+
+        assert_eq!(ids.len(), 1);
+        assert_eq!(ids[0].function_name, "add");
+        assert!(
+            !ids[0].file_path.is_empty(),
+            "filtering must not erase the file path"
+        );
+        assert_eq!(ids[0].line_number, 1, "line must survive filtering");
+    }
+
+    /// A name that exists nowhere used to be scored anyway.
+    #[tokio::test]
+    async fn test_unknown_function_name_is_an_error_not_a_score() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("lib.rs"), "pub fn add() {}\n").unwrap();
+
+        let err = get_function_ids(dir.path(), &["ghost".to_string()])
+            .await
+            .expect_err("a function that does not exist cannot be analyzed");
+        assert!(err.to_string().contains("ghost"), "{err}");
     }
 
     #[test]

--- a/src/cli/analysis_utilities/quality_gate_parse_guard_tests.rs
+++ b/src/cli/analysis_utilities/quality_gate_parse_guard_tests.rs
@@ -1,0 +1,58 @@
+//! `quality-gate --file` must refuse a file that does not parse.
+//!
+//! In its own file rather than at the end of `quality_gate_single_file.rs`,
+//! which is `include!`d into `mod.rs` ahead of other fragments: a test module
+//! there puts items after a test module in the expanded source
+//! (`clippy::items_after_test_module`, denied by `ci / lint`).
+
+use std::io::Write;
+
+fn write_temp(name: &str, body: &str) -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join(format!("pmat-qg-guard-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).expect("temp dir");
+    let p = dir.join(name);
+    let mut f = std::fs::File::create(&p).expect("create");
+    f.write_all(body.as_bytes()).expect("write");
+    p
+}
+
+/// The defect: the CLI reported "Quality Gate: PASSED / Total Violations: 0"
+/// for `def f(:` while the MCP `quality_gate` tool refused the same file.
+#[test]
+fn unparseable_python_is_refused_not_passed() {
+    let p = write_temp("bad.py", "def f(:\n  ???\n");
+    let err = crate::tdg::ensure_parseable(&p).expect_err("must refuse");
+    let msg = err.to_string();
+    assert!(msg.contains("not parseable as Python"), "{msg}");
+    assert!(msg.contains("did not parse"), "{msg}");
+}
+
+#[test]
+fn unparseable_rust_is_refused() {
+    let p = write_temp("bad.rs", "fn main( { let x = ;;;\n");
+    let err = crate::tdg::ensure_parseable(&p).expect_err("must refuse");
+    assert!(err.to_string().contains("not parseable as Rust"));
+}
+
+#[test]
+fn valid_source_passes_the_guard() {
+    let p = write_temp("good.py", "def f(x):\n    return x\n");
+    crate::tdg::ensure_parseable(&p).expect("valid python must pass");
+    let r = write_temp("good.rs", "pub fn f(x: i32) -> i32 { x }\n");
+    crate::tdg::ensure_parseable(&r).expect("valid rust must pass");
+}
+
+/// The guard is a *parse* gate, not a "source files only" gate — `quality-gate`
+/// legitimately scans prose for SATD markers, so a language this build has no
+/// grammar for must pass through rather than be refused.
+#[test]
+fn a_language_without_a_grammar_is_not_refused() {
+    let p = write_temp("notes.md", "# TODO: this is not code\n");
+    crate::tdg::ensure_parseable(&p).expect("markdown must not be refused");
+}
+
+#[test]
+fn an_unreadable_path_is_left_for_the_caller_to_report() {
+    let p = std::env::temp_dir().join("pmat-qg-guard-does-not-exist.rs");
+    crate::tdg::ensure_parseable(&p).expect("missing file is not this guard's error");
+}

--- a/src/cli/analysis_utilities/quality_gate_single_file.rs
+++ b/src/cli/analysis_utilities/quality_gate_single_file.rs
@@ -16,6 +16,13 @@ async fn handle_single_file_quality_gate(
         eprintln!("📄 Analyzing single file: {}", single_file.display());
     }
 
+    // A file that does not parse cannot be given a quality verdict. Without this
+    // the CLI reported "✅ Quality Gate: PASSED / Total Violations: 0" for
+    // `def f(:` in a .py file, while the MCP `quality_gate` tool — which gained
+    // the guard first — refused the very same file. Same binary, same input,
+    // opposite answers.
+    crate::tdg::ensure_parseable(&single_file)?;
+
     let mut violations = Vec::new();
     let mut results = QualityGateResults::default();
 

--- a/src/cli/cli_run_command.rs
+++ b/src/cli/cli_run_command.rs
@@ -36,7 +36,21 @@ pub async fn run(server: Arc<StatelessTemplateServer>) -> anyhow::Result<()> {
     }
 
     // Use command dispatcher for improved modularity
-    CommandDispatcher::execute_command(cli.command, server).await
+    let result = CommandDispatcher::execute_command(cli.command, server).await;
+
+    // `maintain bug-report` reads a captured-error store that nothing in the
+    // product ever wrote — `capture_command_error*` had no caller outside its
+    // own unit tests — so it always answered "No captured error found. Run a
+    // pmat command that fails first" even immediately after one did. The
+    // failing command is what has to write it.
+    if let Err(e) = &result {
+        crate::cli::handlers::bug_report_handler::capture_cli_failure(
+            &std::env::args().collect::<Vec<_>>(),
+            e,
+        );
+    }
+
+    result
 }
 
 /// Apply UX settings from CLI flags (TICKET-PMAT-6006)

--- a/src/cli/colors.rs
+++ b/src/cli/colors.rs
@@ -15,6 +15,14 @@
 //! The raw `pub const` sequences below cannot be made conditional — they are
 //! `const` and interpolated directly at ~490 call sites. Those sites still emit
 //! colour unconditionally; migrating them to the helpers is the remaining work.
+//!
+//! Where no semantic helper fits (a call site that opens a sequence in one
+//! `format!` argument and closes it in another), [`seq`] is the mechanical
+//! migration: `{c::BOLD}` becomes `{}` fed by `c::seq(c::BOLD)`, which is `""`
+//! when colour is off. `analyze provability` and `analyze duplicates` are
+//! migrated; they used to write 17 and 68 escape-bearing lines into a
+//! redirected file under `--color never`, indistinguishable from `--color
+//! auto`.
 
 // ── ANSI escape sequences ───────────────────────────────────────────────────
 
@@ -85,6 +93,23 @@ pub fn colors_enabled() -> bool {
             std::io::stdout().is_terminal(),
         )
     })
+}
+
+/// A raw escape sequence, gated on [`colors_enabled`].
+///
+/// Returns `sequence` when colour is on and `""` when it is off. This is the
+/// escape hatch for call sites that cannot use a semantic helper because the
+/// opening and closing sequences land in different `format!` arguments —
+/// `c::seq(c::BOLD)` is a drop-in for a bare `c::BOLD` interpolation and, unlike
+/// the `const`, honours `--color never`, `NO_COLOR` and a redirected stdout.
+#[must_use]
+#[inline]
+pub fn seq(sequence: &'static str) -> &'static str {
+    if colors_enabled() {
+        sequence
+    } else {
+        ""
+    }
 }
 
 /// Wrap `text` in `color` … `RESET`, or return it unchanged when colour is off.
@@ -460,6 +485,21 @@ mod tests {
     }
 
     // ── painting, exercised in both states ──────────────────────────────────
+
+    /// `--color never` was indistinguishable from `--color auto` on the
+    /// commands that interpolate the raw consts. `seq` is what lets those call
+    /// sites be migrated without restructuring their `format!`s.
+    #[test]
+    fn seq_is_empty_when_colour_is_disabled() {
+        assert!(
+            !colors_enabled(),
+            "cargo test captures stdout, so colour must resolve to off here"
+        );
+        for raw in [RESET, BOLD, DIM, GREEN, YELLOW, RED, CYAN, BOLD_WHITE] {
+            assert_eq!(seq(raw), "", "seq must not emit {raw:?} with colour off");
+            assert!(is_plain(seq(raw)));
+        }
+    }
 
     #[test]
     fn paint_wraps_only_when_enabled() {

--- a/src/cli/command_dispatcher/command_dispatcher_scoring.rs
+++ b/src/cli/command_dispatcher/command_dispatcher_scoring.rs
@@ -339,6 +339,10 @@ impl CommandDispatcher {
             }
             Commands::Maintain { command } => Self::route_maintain_command(command).await,
             Commands::Hooks(hooks_cmd) => handlers::handle_hooks_command(&hooks_cmd).await,
+            // Delegates instead of bailing inline. The inline `bail!`s surfaced
+            // as exit 1 while the sibling executor path (debug_exec.rs) went
+            // through the handlers, so the same command exited 1 or 2 depending
+            // on which dispatcher served it. One route, one exit code.
             Commands::Debug { command } => {
                 use crate::cli::commands::DebugCommands;
                 match command {
@@ -346,15 +350,18 @@ impl CommandDispatcher {
                         port,
                         host,
                         record_dir,
-                    } => {
-                        anyhow::bail!("Debug serve command not yet implemented (DEBUG-002). Port: {}, Host: {}, Record Dir: {:?}", port, host, record_dir)
-                    }
+                    } => handlers::debug_handlers::handle_debug_serve(port, host, record_dir).await,
                     DebugCommands::Replay {
                         recording,
                         position,
                         interactive,
                     } => {
-                        anyhow::bail!("Debug replay command not yet implemented (DEBUG-003). Recording: {:?}, Position: {:?}, Interactive: {}", recording, position, interactive)
+                        handlers::debug_handlers::handle_debug_replay(
+                            recording,
+                            position,
+                            interactive,
+                        )
+                        .await
                     }
                 }
             }

--- a/src/cli/command_dispatcher/command_routing.rs
+++ b/src/cli/command_dispatcher/command_routing.rs
@@ -413,7 +413,9 @@ fn handle_explain(pattern: Option<&str>) {
         Some(pat) => {
             let results = crate::explain::lookup(pat);
             if results.is_empty() {
-                eprintln!("No checks matching '{pat}'. Run `pmat explain` to list all.");
+                // A registered-ID miss and a typo are different failures; the
+                // one message used to claim both were "no such check".
+                eprintln!("{}", crate::explain::miss_message(pat));
                 std::process::exit(1);
             }
             for (i, e) in results.iter().enumerate() {

--- a/src/cli/command_dispatcher/command_routing.rs
+++ b/src/cli/command_dispatcher/command_routing.rs
@@ -185,7 +185,12 @@ impl CommandDispatcher {
                 }
                 #[cfg(not(feature = "org-intelligence"))]
                 {
-                    anyhow::bail!("Organizational intelligence feature is not enabled. Rebuild with --features org-intelligence")
+                    // `org analyze` is gone in EVERY build — the feature-enabled
+                    // arm bails with the same removal notice. Sending a user off
+                    // on a multi-minute rebuild to reach a second, different
+                    // error is worse than telling them now. Only `org localize`
+                    // is genuinely gated by the feature.
+                    crate::cli::handlers::org_handlers::org_not_enabled_error(&_org_cmd)
                 }
             }
             Commands::Prompt(prompt_cmd) => handlers::handle_prompt_command(prompt_cmd).await,
@@ -209,15 +214,18 @@ impl CommandDispatcher {
                 quick,
                 matrix,
                 fix,
-                format: _,
+                format,
                 verbose,
             } => {
+                // `format` was bound as `_` here, so every advertised value of
+                // --format printed the same human banner: `-f json` was not JSON.
                 crate::cli::handlers::ci_local_handler::handle_ci_local(
                     &path,
                     quick,
                     matrix.as_deref(),
                     fix,
                     verbose,
+                    format,
                 )
                 .await
             }

--- a/src/cli/command_dispatcher/metrics_commands.rs
+++ b/src/cli/command_dispatcher/metrics_commands.rs
@@ -21,9 +21,12 @@ impl CommandDispatcher {
     ) -> anyhow::Result<()> {
         use crate::services::metric_trends::{MetricTrendStore, TrendDirection};
 
-        // Default to trend mode when no flags specified
-        let _ = trend;
-
+        // `--trend` is the documented opt-in for the trend view (direction,
+        // std dev, slope, recommendations). It used to be dropped here with
+        // `let _ = trend`, so `show-metrics` and `show-metrics --trend`
+        // produced byte-identical output and the flag meant nothing. Without
+        // it the command reports the observations it holds, and nothing it
+        // would need a regression to say.
         let mut store = MetricTrendStore::new()?;
 
         let metrics = if let Some(m) = metric {
@@ -55,22 +58,39 @@ impl CommandDispatcher {
                     serde_json::Value::Object(hot_map),
                 );
 
-                // Add trend analysis
+                // Add trend analysis (only the observations without `--trend`)
                 for metric_name in metrics {
                     if let Ok(trend_analysis) = store.trend(&metric_name, days) {
                         if failures_only && trend_analysis.direction != TrendDirection::Regressing {
                             continue;
                         }
-                        results.insert(metric_name, serde_json::to_value(trend_analysis)?);
+                        let value = if trend {
+                            serde_json::to_value(&trend_analysis)?
+                        } else {
+                            serde_json::json!({
+                                "metric": trend_analysis.metric,
+                                "count": trend_analysis.count,
+                                "mean": trend_analysis.mean,
+                                "min": trend_analysis.min,
+                                "max": trend_analysis.max,
+                            })
+                        };
+                        results.insert(metric_name, value);
                     }
                 }
                 println!("{}", serde_json::to_string_pretty(&results)?);
             }
             _ => {
                 // Table output (default)
+                let heading = if trend {
+                    "Quality Metrics Trends"
+                } else {
+                    "Quality Metrics"
+                };
                 println!(
-                    "\n{}Quality Metrics Trends ({} days){}\n",
+                    "\n{}{} ({} days){}\n",
                     c::BOLD_BLUE,
+                    heading,
                     days,
                     c::RESET
                 );
@@ -105,50 +125,70 @@ impl CommandDispatcher {
                             continue;
                         }
 
-                        let direction_symbol = match trend_analysis.direction {
-                            TrendDirection::Improving => {
-                                format!("{}Improving{}", c::GREEN, c::RESET)
-                            }
-                            TrendDirection::Stable => {
-                                format!("{}Stable{}", c::YELLOW, c::RESET)
-                            }
-                            TrendDirection::Regressing => {
-                                format!("{}Regressing{}", c::RED, c::RESET)
-                            }
-                        };
-
-                        println!("{}{}{}", c::BOLD, metric_name, c::RESET);
-                        println!("  Direction: {}", direction_symbol);
-                        println!("  Mean: {:.2}", trend_analysis.mean);
-                        println!("  Std Dev: {:.2}", trend_analysis.std_dev);
-                        println!(
-                            "  Min/Max: {:.2} / {:.2}",
-                            trend_analysis.min, trend_analysis.max
+                        print!(
+                            "{}",
+                            Self::render_metric_block(&metric_name, &trend_analysis, trend)
                         );
-                        println!("  Slope: {:.2}/day", trend_analysis.slope);
-                        println!("  Observations: {}", trend_analysis.count);
-
-                        // Add recommendations for regressing metrics
-                        if trend_analysis.direction == TrendDirection::Regressing {
-                            let recommendations = Self::generate_metric_recommendations(
-                                &metric_name,
-                                trend_analysis.slope,
-                            );
-                            if !recommendations.is_empty() {
-                                println!("  {}Recommendations:{}", c::BOLD_YELLOW, c::RESET);
-                                for rec in recommendations {
-                                    println!("    - {}", rec);
-                                }
-                            }
-                        }
-
-                        println!();
                     }
                 }
             }
         }
 
         Ok(())
+    }
+
+    /// Render one metric's block for the table view.
+    ///
+    /// `trend` is `show-metrics --trend`. The trend view is direction, spread,
+    /// slope and the regression recommendations (that is what the workflow docs
+    /// show `--trend` printing); without the flag the block states only what was
+    /// observed. Both views used to be the same text, which is what made the
+    /// flag inert.
+    pub(crate) fn render_metric_block(
+        metric_name: &str,
+        analysis: &crate::services::metric_trends::TrendAnalysis,
+        trend: bool,
+    ) -> String {
+        use crate::services::metric_trends::TrendDirection;
+        use std::fmt::Write as _;
+
+        let mut out = String::new();
+        let _ = writeln!(out, "{}{}{}", c::BOLD, metric_name, c::RESET);
+
+        if trend {
+            let direction_symbol = match analysis.direction {
+                TrendDirection::Improving => format!("{}Improving{}", c::GREEN, c::RESET),
+                TrendDirection::Stable => format!("{}Stable{}", c::YELLOW, c::RESET),
+                TrendDirection::Regressing => format!("{}Regressing{}", c::RED, c::RESET),
+            };
+            let _ = writeln!(out, "  Direction: {direction_symbol}");
+        }
+
+        let _ = writeln!(out, "  Mean: {:.2}", analysis.mean);
+        if trend {
+            let _ = writeln!(out, "  Std Dev: {:.2}", analysis.std_dev);
+        }
+        let _ = writeln!(out, "  Min/Max: {:.2} / {:.2}", analysis.min, analysis.max);
+        if trend {
+            let _ = writeln!(out, "  Slope: {:.2}/day", analysis.slope);
+        }
+        let _ = writeln!(out, "  Observations: {}", analysis.count);
+
+        // Recommendations answer "this is regressing, now what" — part of the
+        // trend report, not of a plain observation listing.
+        if trend && analysis.direction == TrendDirection::Regressing {
+            let recommendations =
+                Self::generate_metric_recommendations(metric_name, analysis.slope);
+            if !recommendations.is_empty() {
+                let _ = writeln!(out, "  {}Recommendations:{}", c::BOLD_YELLOW, c::RESET);
+                for rec in recommendations {
+                    let _ = writeln!(out, "    - {rec}");
+                }
+            }
+        }
+
+        out.push('\n');
+        out
     }
 
     /// Execute record-metric command (Phase 3.4 O(1) Quality Gates - CI/CD)
@@ -251,5 +291,59 @@ impl CommandDispatcher {
         }
 
         recommendations
+    }
+}
+
+#[cfg(test)]
+mod trend_flag_tests {
+    use super::*;
+    use crate::services::metric_trends::{TrendAnalysis, TrendDirection};
+
+    fn regressing_lint() -> TrendAnalysis {
+        TrendAnalysis {
+            metric: "lint".to_string(),
+            count: 12,
+            mean: 23_390.5,
+            std_dev: 2156.3,
+            min: 20_000.0,
+            max: 25_500.0,
+            direction: TrendDirection::Regressing,
+            slope: 235.46,
+            p_value: 0.01,
+        }
+    }
+
+    /// `--trend` was `let _ = trend`: `show-metrics` and `show-metrics --trend`
+    /// printed byte-identical reports, so the documented opt-in changed nothing.
+    #[test]
+    fn trend_flag_selects_the_trend_view() {
+        let analysis = regressing_lint();
+        let plain = CommandDispatcher::render_metric_block("lint", &analysis, false);
+        let with_trend = CommandDispatcher::render_metric_block("lint", &analysis, true);
+
+        assert_ne!(plain, with_trend, "--trend must change the report");
+
+        for trend_only in ["Direction", "Std Dev", "Slope", "Recommendations"] {
+            assert!(
+                with_trend.contains(trend_only),
+                "--trend must report {trend_only}"
+            );
+            assert!(
+                !plain.contains(trend_only),
+                "{trend_only} belongs to the trend view, not the default listing"
+            );
+        }
+    }
+
+    /// The observations themselves are not the trend report; both views state them.
+    #[test]
+    fn observations_are_reported_either_way() {
+        let analysis = regressing_lint();
+        for trend in [false, true] {
+            let block = CommandDispatcher::render_metric_block("lint", &analysis, trend);
+            assert!(block.contains("Observations: 12"));
+            assert!(block.contains("Mean: 23390.50"));
+            assert!(block.contains("Min/Max: 20000.00 / 25500.00"));
+        }
     }
 }

--- a/src/cli/command_dispatcher/semantic_commands.rs
+++ b/src/cli/command_dispatcher/semantic_commands.rs
@@ -12,6 +12,25 @@ use crate::cli::commands::{EmbedCommands, SearchMode, SemanticCommands};
 use crate::cli::semantic_commands::SemanticCli;
 use crate::cli::OutputFormat;
 use crate::services::configuration_service::ConfigurationService;
+use std::path::Path;
+
+/// Where a workspace's embeddings live when the config names no path.
+///
+/// This used to default to a single machine-global `~/.pmat/embeddings.db`,
+/// shared by every project on the machine, while chunk paths are stored
+/// workspace-relative (`./src/main.rs`). One project's leftover index was
+/// therefore returned for every OTHER project, at paths that do not resolve
+/// there: `pmat semantic search` in this repo returned five `./src/main.rs`
+/// chunks from an unrelated crate, and an unrelated crate got the same five.
+/// Keying the store to the workspace makes a relative chunk path mean something
+/// again.
+fn default_vector_db_path(workspace: &Path) -> String {
+    workspace
+        .join(".pmat")
+        .join("embeddings.db")
+        .to_string_lossy()
+        .to_string()
+}
 
 impl CommandDispatcher {
     /// Execute embed commands for semantic search (PMAT-SEARCH-011)
@@ -30,22 +49,15 @@ impl CommandDispatcher {
         // surfaced in --help. The toggle still gates passive/auto behavior
         // (auto-sync, MCP tool registration) elsewhere.
 
-        // Get database path
-        let db_path = semantic_config.vector_db_path.unwrap_or_else(|| {
-            dirs::home_dir()
-                .map(|h| {
-                    h.join(".pmat")
-                        .join("embeddings.db")
-                        .to_string_lossy()
-                        .to_string()
-                })
-                .unwrap_or_else(|| "embeddings.db".to_string())
-        });
-
         // Get workspace path
         let workspace = semantic_config
             .workspace_path
             .unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
+
+        // Get database path — scoped to the workspace being searched.
+        let db_path = semantic_config
+            .vector_db_path
+            .unwrap_or_else(|| default_vector_db_path(&workspace));
 
         // Initialize semantic CLI (no API key needed)
         let semantic_cli = SemanticCli::new(&db_path, &workspace)
@@ -116,22 +128,15 @@ impl CommandDispatcher {
         // surfaced in --help. The toggle still gates passive/auto behavior
         // (auto-sync, MCP tool registration) elsewhere.
 
-        // Get database path
-        let db_path = semantic_config.vector_db_path.unwrap_or_else(|| {
-            dirs::home_dir()
-                .map(|h| {
-                    h.join(".pmat")
-                        .join("embeddings.db")
-                        .to_string_lossy()
-                        .to_string()
-                })
-                .unwrap_or_else(|| "embeddings.db".to_string())
-        });
-
         // Get workspace path
         let workspace = semantic_config
             .workspace_path
             .unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
+
+        // Get database path — scoped to the workspace being searched.
+        let db_path = semantic_config
+            .vector_db_path
+            .unwrap_or_else(|| default_vector_db_path(&workspace));
 
         // Initialize semantic CLI (no API key needed)
         let semantic_cli = SemanticCli::new(&db_path, &workspace)
@@ -184,5 +189,32 @@ impl CommandDispatcher {
                 Ok(())
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod vector_store_scoping_tests {
+    use super::*;
+
+    /// Two workspaces must not share one embeddings store: with the old
+    /// machine-global `~/.pmat/embeddings.db` default, `pmat semantic search`
+    /// returned another project's chunks at `./src/main.rs` — a path that does
+    /// not exist in the project being searched.
+    #[test]
+    fn test_default_store_is_per_workspace() {
+        let a = default_vector_db_path(Path::new("/home/u/projects/alpha"));
+        let b = default_vector_db_path(Path::new("/home/u/projects/beta"));
+
+        assert_ne!(a, b, "two projects shared one embeddings store");
+        assert!(a.starts_with("/home/u/projects/alpha/"), "{a}");
+        assert!(b.starts_with("/home/u/projects/beta/"), "{b}");
+        assert!(a.ends_with("embeddings.db"), "{a}");
+    }
+
+    /// The store lives beside the project's other pmat state.
+    #[test]
+    fn test_default_store_lives_under_dot_pmat() {
+        let p = default_vector_db_path(Path::new("/w"));
+        assert_eq!(p, "/w/.pmat/embeddings.db");
     }
 }

--- a/src/cli/command_dispatcher/test_commands.rs
+++ b/src/cli/command_dispatcher/test_commands.rs
@@ -41,6 +41,13 @@ impl CommandDispatcher {
     }
 
     /// Create test configuration from CLI parameters (Toyota Way Extract Method)
+    ///
+    /// `TestSuite::Performance` — the CLI default — used to appear in none of
+    /// these arms, so `pmat test performance` produced a config with all three
+    /// `enable_*` flags false; `run_performance_test_suite` then skipped every
+    /// block and printed "✅ All performance tests passed!" without running a
+    /// single measurement, identically in an empty directory and in a
+    /// 4260-file repository. Performance means "everything performance-related".
     pub(crate) fn create_test_config(
         suite: &TestSuite,
         iterations: usize,
@@ -50,10 +57,20 @@ impl CommandDispatcher {
     ) -> crate::test_performance::PerformanceTestConfig {
         crate::test_performance::PerformanceTestConfig {
             enable_regression_tests: regression
-                || matches!(suite, TestSuite::Regression | TestSuite::All),
-            enable_memory_tests: memory || matches!(suite, TestSuite::Memory | TestSuite::All),
+                || matches!(
+                    suite,
+                    TestSuite::Regression | TestSuite::Performance | TestSuite::All
+                ),
+            enable_memory_tests: memory
+                || matches!(
+                    suite,
+                    TestSuite::Memory | TestSuite::Performance | TestSuite::All
+                ),
             enable_throughput_tests: throughput
-                || matches!(suite, TestSuite::Throughput | TestSuite::All),
+                || matches!(
+                    suite,
+                    TestSuite::Throughput | TestSuite::Performance | TestSuite::All
+                ),
             test_iterations: iterations,
         }
     }
@@ -238,5 +255,39 @@ impl CommandDispatcher {
             println!("Results written to: {}", output_path.display());
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test_config_selection_tests {
+    use super::*;
+
+    /// `pmat test performance` — the default suite — must actually select
+    /// something to measure. It used to select nothing and report a pass.
+    #[test]
+    fn test_performance_suite_enables_every_sub_suite() {
+        let config =
+            CommandDispatcher::create_test_config(&TestSuite::Performance, 3, false, false, false);
+        assert!(
+            config.enable_throughput_tests,
+            "Performance selected no throughput tests"
+        );
+        assert!(
+            config.enable_regression_tests,
+            "Performance selected no regression tests"
+        );
+        assert!(
+            config.enable_memory_tests,
+            "Performance selected no memory tests"
+        );
+    }
+
+    #[test]
+    fn test_named_sub_suites_stay_narrow() {
+        let memory =
+            CommandDispatcher::create_test_config(&TestSuite::Memory, 1, false, false, false);
+        assert!(memory.enable_memory_tests);
+        assert!(!memory.enable_throughput_tests);
+        assert!(!memory.enable_regression_tests);
     }
 }

--- a/src/cli/command_structure/executor/dispatch_ext_advanced.rs
+++ b/src/cli/command_structure/executor/dispatch_ext_advanced.rs
@@ -74,7 +74,10 @@ impl CommandExecutor {
                 }
                 #[cfg(not(feature = "org-intelligence"))]
                 {
-                    anyhow::bail!("Organizational intelligence feature is not enabled. Rebuild with --features org-intelligence")
+                    // See command_routing.rs: `org analyze` no longer exists in
+                    // any build, so this arm must not promise a rebuild will
+                    // bring it back.
+                    crate::cli::handlers::org_handlers::org_not_enabled_error(&_org_cmd)
                 }
             }
             Commands::Prompt(prompt_cmd) => {

--- a/src/cli/commands/analyze_commands/mod.rs
+++ b/src/cli/commands/analyze_commands/mod.rs
@@ -1702,11 +1702,26 @@ mod include_flags_are_switches_tests {
     }
 
     fn parse(args: &[&str]) -> AnalyzeCommands {
-        let mut argv = vec!["pmat"];
-        argv.extend_from_slice(args);
-        Harness::try_parse_from(argv)
-            .unwrap_or_else(|e| panic!("failed to parse {args:?}: {e}"))
-            .cmd
+        // 8MB stack, on its own thread: clap's generated parser recurses deeply
+        // enough over this command tree to overflow the default 2MB test stack,
+        // the same reason every other clap parsing test in this crate spawns a
+        // thread (see `cli::commands::tests_cli_parsing`). Parsing inline aborts
+        // the whole test binary with SIGABRT — invisible under
+        // `RUST_MIN_STACK=8388608`, which is how `pmat verify` runs the suite,
+        // but fatal in CI's coverage job, which sets no such variable.
+        let argv: Vec<String> = std::iter::once("pmat".to_string())
+            .chain(args.iter().map(|s| (*s).to_string()))
+            .collect();
+        std::thread::Builder::new()
+            .stack_size(8 * 1024 * 1024)
+            .spawn(move || {
+                Harness::try_parse_from(&argv)
+                    .unwrap_or_else(|e| panic!("failed to parse {argv:?}: {e}"))
+                    .cmd
+            })
+            .expect("spawn clap parse thread")
+            .join()
+            .expect("clap parse thread panicked")
     }
 
     fn comprehensive_flags(args: &[&str]) -> (bool, bool, bool, bool, bool) {

--- a/src/cli/commands/analyze_commands/mod.rs
+++ b/src/cli/commands/analyze_commands/mod.rs
@@ -162,11 +162,12 @@ pub enum AnalyzeCommands {
         #[arg(long, default_value = "60")]
         timeout: u64,
 
-        /// Use ML-based scoring (aprender LinearRegression)
+        /// NOT IMPLEMENTED: ML-based scoring (aprender LinearRegression)
         ///
-        /// When enabled, complexity scores are calculated using trained ML models
-        /// instead of heuristic formulas. This provides more accurate, data-driven
-        /// scores that account for language-specific patterns and project context.
+        /// The handler never consumed this flag, so `--ml` returned exactly the
+        /// heuristic scores under a promise of "trained ML models instead of
+        /// heuristic formulas". It now errors instead of relabelling them; the
+        /// help text stays visible so the refusal is discoverable (GH-97).
         #[arg(long)]
         ml: bool,
     },
@@ -833,24 +834,69 @@ pub enum AnalyzeCommands {
         #[arg(long, short = 'f', value_enum, default_value = "summary")]
         format: ComprehensiveOutputFormat,
 
-        /// Enable duplicate detection analysis
-        #[arg(long, default_value = "true")]
+        // `#[arg(long, default_value = "true")]` on a `bool` gives clap
+        // ArgAction::SetTrue over a value that is already true: passing the
+        // flag is a literal no-op and `--include-tdg=false` is *rejected*, so
+        // five flags documented as "Enable X" could neither enable nor disable
+        // anything. Taking a value (with the bare flag still meaning `=true`)
+        // is what makes them switches.
+        /// Enable duplicate detection analysis (`--include-duplicates=false` to disable)
+        #[arg(
+            long,
+            action = clap::ArgAction::Set,
+            num_args = 0..=1,
+            require_equals = true,
+            default_value = "true",
+            default_missing_value = "true"
+        )]
         include_duplicates: bool,
 
-        /// Enable dead code analysis
-        #[arg(long, default_value = "true")]
+        /// Enable dead code analysis (`--include-dead-code=false` to disable)
+        #[arg(
+            long,
+            action = clap::ArgAction::Set,
+            num_args = 0..=1,
+            require_equals = true,
+            default_value = "true",
+            default_missing_value = "true"
+        )]
         include_dead_code: bool,
 
-        /// Enable defect prediction analysis
-        #[arg(long, default_value = "true")]
+        /// Enable defect prediction analysis (`--include-defects=false` to disable)
+        #[arg(
+            long,
+            action = clap::ArgAction::Set,
+            num_args = 0..=1,
+            require_equals = true,
+            default_value = "true",
+            default_missing_value = "true"
+        )]
         include_defects: bool,
 
-        /// Enable complexity analysis
-        #[arg(long, default_value = "true")]
+        /// Enable complexity analysis (`--include-complexity=false` to disable)
+        #[arg(
+            long,
+            action = clap::ArgAction::Set,
+            num_args = 0..=1,
+            require_equals = true,
+            default_value = "true",
+            default_missing_value = "true"
+        )]
         include_complexity: bool,
 
-        /// Enable TDG (Technical Debt Gradient) analysis
-        #[arg(long, default_value = "true")]
+        /// Enable SATD analysis (`--include-tdg=false` to disable)
+        ///
+        /// NOTE: this switch drives SATD detection, not a Technical Debt
+        /// Gradient run — comprehensive analysis has no TDG stage. The help
+        /// text used to promise TDG results that never appeared in the report.
+        #[arg(
+            long,
+            action = clap::ArgAction::Set,
+            num_args = 0..=1,
+            require_equals = true,
+            default_value = "true",
+            default_missing_value = "true"
+        )]
         include_tdg: bool,
 
         /// Minimum confidence threshold for predictions
@@ -1316,12 +1362,30 @@ pub enum AnalyzeCommands {
         #[arg(long, short = 'f', value_enum, default_value = "summary")]
         format: ComplexityOutputFormat,
 
-        /// Include binary WASM (.wasm) files
-        #[arg(long, default_value = "true")]
+        // Both were `#[arg(long, default_value = "true")]` on a `bool`, i.e.
+        // clap SetTrue over an already-true value: `--include-binary` and
+        // `--include-text` were permanently on and `=false` was rejected, so
+        // neither flag could select or deselect a file kind.
+        /// Include binary WASM (.wasm) files (`--include-binary=false` to exclude)
+        #[arg(
+            long,
+            action = clap::ArgAction::Set,
+            num_args = 0..=1,
+            require_equals = true,
+            default_value = "true",
+            default_missing_value = "true"
+        )]
         include_binary: bool,
 
-        /// Include text WASM (.wat) files
-        #[arg(long, default_value = "true")]
+        /// Include text WASM (.wat) files (`--include-text=false` to exclude)
+        #[arg(
+            long,
+            action = clap::ArgAction::Set,
+            num_args = 0..=1,
+            require_equals = true,
+            default_value = "true",
+            default_missing_value = "true"
+        )]
         include_text: bool,
 
         /// Memory usage analysis
@@ -1612,4 +1676,114 @@ pub enum AnalyzeCommands {
         #[arg(long)]
         check: bool,
     },
+}
+
+#[cfg(test)]
+mod include_flags_are_switches_tests {
+    //! `#[arg(long, default_value = "true")]` on a `bool` makes clap emit
+    //! `ArgAction::SetTrue` for a value that is already `true`: the flag is a
+    //! no-op when passed and `--flag=false` is a parse error. Seven flags
+    //! documented as "Enable/Include X" behaved that way — `analyze
+    //! comprehensive --include-tdg --include-duplicates` produced byte-identical
+    //! JSON to no flags at all, and `analyze web-assembly --include-text` could
+    //! not stop `.wasm` files being collected.
+    use super::AnalyzeCommands;
+    use clap::Parser;
+
+    #[derive(Parser)]
+    struct Harness {
+        #[command(subcommand)]
+        cmd: AnalyzeCommands,
+    }
+
+    fn parse(args: &[&str]) -> AnalyzeCommands {
+        let mut argv = vec!["pmat"];
+        argv.extend_from_slice(args);
+        Harness::try_parse_from(argv)
+            .unwrap_or_else(|e| panic!("failed to parse {args:?}: {e}"))
+            .cmd
+    }
+
+    fn comprehensive_flags(args: &[&str]) -> (bool, bool, bool, bool, bool) {
+        match parse(args) {
+            AnalyzeCommands::Comprehensive {
+                include_duplicates,
+                include_dead_code,
+                include_defects,
+                include_complexity,
+                include_tdg,
+                ..
+            } => (
+                include_duplicates,
+                include_dead_code,
+                include_defects,
+                include_complexity,
+                include_tdg,
+            ),
+            other => panic!("expected Comprehensive, got {other:?}"),
+        }
+    }
+
+    fn wasm_flags(args: &[&str]) -> (bool, bool) {
+        match parse(args) {
+            AnalyzeCommands::WebAssembly {
+                include_binary,
+                include_text,
+                ..
+            } => (include_binary, include_text),
+            other => panic!("expected WebAssembly, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn comprehensive_include_flags_default_on() {
+        assert_eq!(
+            comprehensive_flags(&["comprehensive"]),
+            (true, true, true, true, true)
+        );
+    }
+
+    #[test]
+    fn comprehensive_include_flags_can_be_turned_off() {
+        assert!(
+            !comprehensive_flags(&["comprehensive", "--include-tdg=false"]).4,
+            "--include-tdg=false must disable it"
+        );
+        assert!(
+            !comprehensive_flags(&["comprehensive", "--include-duplicates=false"]).0,
+            "--include-duplicates=false must disable it"
+        );
+        assert_eq!(
+            comprehensive_flags(&[
+                "comprehensive",
+                "--include-dead-code=false",
+                "--include-defects=false",
+                "--include-complexity=false",
+            ]),
+            (true, false, false, false, true)
+        );
+    }
+
+    #[test]
+    fn comprehensive_bare_flag_still_means_enabled() {
+        assert_eq!(
+            comprehensive_flags(&["comprehensive", "--include-tdg", "--include-duplicates"]),
+            (true, true, true, true, true)
+        );
+    }
+
+    #[test]
+    fn web_assembly_kind_flags_can_select_one_kind() {
+        assert_eq!(wasm_flags(&["web-assembly"]), (true, true));
+        assert_eq!(
+            wasm_flags(&["web-assembly", "--include-binary=false"]),
+            (false, true),
+            "--include-binary=false must select .wat only"
+        );
+        assert_eq!(
+            wasm_flags(&["web-assembly", "--include-text=false"]),
+            (true, false),
+            "--include-text=false must select .wasm only"
+        );
+    }
 }

--- a/src/cli/commands/analyze_commands/mod.rs
+++ b/src/cli/commands/analyze_commands/mod.rs
@@ -1273,7 +1273,12 @@ pub enum AnalyzeCommands {
         #[arg(long, default_value = "50")]
         confidence_threshold: u8,
 
-        /// Analyze space complexity in addition to time
+        /// NO-OP: space complexity is always reported alongside time
+        ///
+        /// Read as "switches an extra analysis on"; nothing reads the flag past
+        /// the config struct, and every renderer prints space complexity either
+        /// way. Kept accepted so existing invocations do not break, but the
+        /// help must not promise an analysis the flag does not enable.
         #[arg(long)]
         analyze_space: bool,
 

--- a/src/cli/commands/cli_struct.rs
+++ b/src/cli/commands/cli_struct.rs
@@ -51,8 +51,8 @@ pmat quality-gate
 # Calculate repository health score
 pmat repo-score
 
-# Start background agent daemon
-pmat agent start"
+# Pre-flight the CI gate set before committing
+pmat verify --format json"
 )]
 #[cfg_attr(test, derive(Debug))]
 /// Cli.

--- a/src/cli/commands/commands_enum/definition.rs
+++ b/src/cli/commands/commands_enum/definition.rs
@@ -355,7 +355,12 @@ pub enum Commands {
     #[command(subcommand, visible_aliases = &["qd"])]
     Qdd(QddCommands),
 
-    /// Run interactive demo of all capabilities
+    /// [NOT AVAILABLE in the default build] Interactive demo — needs --features demo.
+    ///
+    /// `cargo install pmat` produces a build in which every demo mode (including
+    /// `--cli`) exits 1 with "Demo feature not enabled", so all the flags below
+    /// are inert. Listed the same way `serve` is: an entry that cannot run must
+    /// say so in the command list rather than advertise itself as working.
     #[command(visible_aliases = &["d", "show"])]
     Demo {
         /// Repository path (defaults to current directory)
@@ -1643,4 +1648,44 @@ pub enum Commands {
         #[command(subcommand)]
         command: StackCommands,
     },
+}
+
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg(test)]
+mod command_availability_tests {
+    use super::Commands;
+    use clap::Subcommand;
+
+    fn about_of(name: &str) -> String {
+        let cmd = Commands::augment_subcommands(clap::Command::new("pmat"));
+        let about = cmd
+            .get_subcommands()
+            .find(|s| s.get_name() == name)
+            .unwrap_or_else(|| panic!("{name} subcommand must exist"))
+            .get_about()
+            .map(std::string::ToString::to_string)
+            .unwrap_or_default();
+        about
+    }
+
+    /// The default (`cargo install pmat`) build cannot run any demo mode, yet
+    /// the command list advertised "Run interactive demo of all capabilities"
+    /// while the sibling `serve` entry was explicitly relabelled. A command list
+    /// that promises a working command the shipped binary cannot run is the
+    /// defect.
+    #[test]
+    fn demo_is_labelled_unavailable_like_serve() {
+        let demo = about_of("demo");
+        assert!(
+            demo.contains("NOT AVAILABLE") || demo.contains("NOT IMPLEMENTED"),
+            "demo must be labelled unavailable in the command list, got: {demo}"
+        );
+        assert!(
+            demo.contains("--features demo"),
+            "the label must name the feature that would enable it, got: {demo}"
+        );
+
+        let serve = about_of("serve");
+        assert!(serve.contains("NOT IMPLEMENTED"), "regression guard: {serve}");
+    }
 }

--- a/src/cli/commands/commands_enum/definition.rs
+++ b/src/cli/commands/commands_enum/definition.rs
@@ -1671,15 +1671,18 @@ mod command_availability_tests {
     use clap::Subcommand;
 
     fn about_of(name: &str) -> String {
-        let cmd = Commands::augment_subcommands(clap::Command::new("pmat"));
-        let about = cmd
-            .get_subcommands()
-            .find(|s| s.get_name() == name)
-            .unwrap_or_else(|| panic!("{name} subcommand must exist"))
-            .get_about()
-            .map(std::string::ToString::to_string)
-            .unwrap_or_default();
-        about
+        let name = name.to_string();
+        crate::cli::commands::on_big_stack(move || {
+            let cmd = Commands::augment_subcommands(clap::Command::new("pmat"));
+            let about = cmd
+                .get_subcommands()
+                .find(|s| s.get_name() == name)
+                .unwrap_or_else(|| panic!("{name} subcommand must exist"))
+                .get_about()
+                .map(std::string::ToString::to_string)
+                .unwrap_or_default();
+            about
+        })
     }
 
     /// The default (`cargo install pmat`) build cannot run any demo mode, yet
@@ -1724,18 +1727,20 @@ mod command_availability_tests {
     /// deleted — so its own entry must say so in every build.
     #[test]
     fn org_analyze_is_labelled_removed_in_every_build() {
-        let cmd = Commands::augment_subcommands(clap::Command::new("pmat"));
-        let org = cmd
-            .get_subcommands()
-            .find(|s| s.get_name() == "org")
-            .expect("org subcommand must exist");
-        let analyze = org
-            .get_subcommands()
-            .find(|s| s.get_name() == "analyze")
-            .expect("org analyze subcommand must exist")
-            .get_about()
-            .map(std::string::ToString::to_string)
-            .unwrap_or_default();
+        let analyze = crate::cli::commands::on_big_stack(|| {
+            let cmd = Commands::augment_subcommands(clap::Command::new("pmat"));
+            let about = cmd
+                .get_subcommands()
+                .find(|s| s.get_name() == "org")
+                .expect("org subcommand must exist")
+                .get_subcommands()
+                .find(|s| s.get_name() == "analyze")
+                .expect("org analyze subcommand must exist")
+                .get_about()
+                .map(std::string::ToString::to_string)
+                .unwrap_or_default();
+            about
+        });
         assert!(
             analyze.contains("REMOVED"),
             "org analyze must be labelled removed, got: {analyze}"

--- a/src/cli/commands/commands_enum/definition.rs
+++ b/src/cli/commands/commands_enum/definition.rs
@@ -445,6 +445,20 @@ pub enum Commands {
     RedTeam(crate::cli::handlers::RedTeamCmd),
 
     /// Organizational intelligence analysis (GitHub org defect patterns)
+    ///
+    /// `cargo install pmat` produces a build in which every `org` subcommand
+    /// exits with an error: `org localize` is compiled out (its whole handler is
+    /// `#[cfg(feature = "org-intelligence")]`) and `org analyze` is gone for
+    /// good, its upstream API having been removed in aprender-orchestrate 0.41.
+    /// Labelled the way `serve` and `demo` are: an entry the shipped binary
+    /// cannot run must say so in the command list rather than advertise itself
+    /// as working.
+    #[cfg_attr(
+        not(feature = "org-intelligence"),
+        command(
+            about = "[NOT AVAILABLE in the default build] Organizational intelligence — needs --features org-intelligence"
+        )
+    )]
     #[command(subcommand, visible_aliases = &["organization"])]
     Org(OrgCommands),
 
@@ -764,7 +778,7 @@ pub enum Commands {
         hardware: Option<PathBuf>,
     },
 
-    /// Infrastructure Score (0-100 + 10 bonus) for CI/CD quality
+    /// Infrastructure Score (0-100 + 12 bonus) for CI/CD quality
     ///
     /// Evaluates GitHub Actions workflows across 5 dimensions:
     /// - Workflow Architecture (25 pts)
@@ -772,7 +786,7 @@ pub enum Commands {
     /// - Quality Pipeline (20 pts)
     /// - Deployment & Release (15 pts)
     /// - Supply Chain Security (15 pts)
-    /// - Provable Contracts (10 pts bonus)
+    /// - Provable Contracts (12 pts bonus: PV-01..PV-05 = 3+3+2+2+2)
     ///
     /// Hard cutoff: <90 = auto-fail.
     #[command(name = "infra-score", visible_aliases = &["infra", "ci-score"])]
@@ -1687,5 +1701,44 @@ mod command_availability_tests {
 
         let serve = about_of("serve");
         assert!(serve.contains("NOT IMPLEMENTED"), "regression guard: {serve}");
+    }
+
+    /// Same defect as `demo`: in the default build every `org` subcommand exits
+    /// with an error (`localize` is compiled out, `analyze` was removed
+    /// upstream), yet the command list advertised it as a working feature.
+    #[cfg(not(feature = "org-intelligence"))]
+    #[test]
+    fn org_is_labelled_unavailable_in_the_default_build() {
+        let org = about_of("org");
+        assert!(
+            org.contains("NOT AVAILABLE") || org.contains("NOT IMPLEMENTED"),
+            "org must be labelled unavailable in the command list, got: {org}"
+        );
+        assert!(
+            org.contains("--features org-intelligence"),
+            "the label must name the feature that would enable it, got: {org}"
+        );
+    }
+
+    /// `org analyze` is dead with the feature ON as well — its upstream API was
+    /// deleted — so its own entry must say so in every build.
+    #[test]
+    fn org_analyze_is_labelled_removed_in_every_build() {
+        let cmd = Commands::augment_subcommands(clap::Command::new("pmat"));
+        let org = cmd
+            .get_subcommands()
+            .find(|s| s.get_name() == "org")
+            .expect("org subcommand must exist");
+        let analyze = org
+            .get_subcommands()
+            .find(|s| s.get_name() == "analyze")
+            .expect("org analyze subcommand must exist")
+            .get_about()
+            .map(std::string::ToString::to_string)
+            .unwrap_or_default();
+        assert!(
+            analyze.contains("REMOVED"),
+            "org analyze must be labelled removed, got: {analyze}"
+        );
     }
 }

--- a/src/cli/commands/config_hooks.rs
+++ b/src/cli/commands/config_hooks.rs
@@ -121,7 +121,14 @@ pub enum HooksCommands {
         verbose: bool,
 
         /// Enable O(1) cache check (skip if unchanged)
-        #[arg(long, default_value = "true")]
+        ///
+        /// This carried `default_value = "true"` with no `--no-cache`, so the
+        /// cache was consulted whether or not you asked for it: a bare
+        /// `hooks run --all-files` answered "All quality gates passed (cached)"
+        /// without running a single gate, and nothing short of
+        /// `hooks cache clear` could force a real run. It is opt-in, as the
+        /// help text has always said.
+        #[arg(long)]
         cache: bool,
     },
 
@@ -171,4 +178,50 @@ pub enum ConfigFormat {
     Toml,
     /// Environment variables format
     Env,
+}
+
+#[cfg(test)]
+mod hooks_run_cache_flag_tests {
+    //! Regression: `hooks run` declared `--cache` with `default_value = "true"`
+    //! and shipped no `--no-cache`, so the cache was consulted even when the
+    //! user did not ask for it and a bare run answered "(cached)" without
+    //! running any gate.
+    use crate::cli::commands::{Commands, HooksCommands};
+    use clap::Parser;
+
+    fn parse(args: &[&str]) -> crate::cli::Cli {
+        let owned: Vec<String> = args.iter().map(|s| (*s).to_string()).collect();
+        std::thread::Builder::new()
+            .stack_size(8 * 1024 * 1024)
+            .spawn(move || crate::cli::Cli::try_parse_from(&owned).expect("clap accepts these"))
+            .expect("spawn")
+            .join()
+            .expect("thread panicked")
+    }
+
+    fn cache_flag(cli: &crate::cli::Cli) -> bool {
+        match &cli.command {
+            Commands::Hooks(HooksCommands::Run { cache, .. }) => *cache,
+            other => panic!("expected `hooks run`, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_hooks_run_cache_is_opt_in() {
+        assert!(
+            !cache_flag(&parse(&["pmat", "hooks", "run", "--all-files"])),
+            "omitting --cache must run the gates for real, not answer from cache"
+        );
+    }
+
+    #[test]
+    fn test_hooks_run_cache_flag_enables_cache() {
+        assert!(cache_flag(&parse(&[
+            "pmat",
+            "hooks",
+            "run",
+            "--all-files",
+            "--cache"
+        ])));
+    }
 }

--- a/src/cli/commands/misc_commands_comply.rs
+++ b/src/cli/commands/misc_commands_comply.rs
@@ -169,7 +169,12 @@ pub enum ComplyCommands {
     },
 
     /// Layer 3 (Governance): Generate audit artifact with sovereign trail (COMPLY-045)
-    /// Requires clean git state. Produces signed compliance evidence.
+    /// Requires clean git state. Produces UNSIGNED compliance evidence pinned to the HEAD commit.
+    //
+    // The help used to promise "signed compliance evidence". `AuditArtifact`
+    // carries no signature, digest or attestation field of any kind — nothing
+    // in the artifact is verifiable after the fact beyond the git SHA it names,
+    // so the word "signed" was a claim the command never backed.
     Audit {
         /// Project path (defaults to current directory)
         #[arg(short = 'p', long = "path", default_value = ".")]

--- a/src/cli/commands/misc_commands_cuda_oracle.rs
+++ b/src/cli/commands/misc_commands_cuda_oracle.rs
@@ -13,6 +13,12 @@ pub enum CudaTdgOutputFormat {
 }
 
 /// CUDA-SIMD TDG subcommands
+///
+/// The per-subcommand path is `Option<PathBuf>` with NO `default_value`. It used
+/// to default to `"."`, which silently overrode the top-level `cuda-tdg [PATH]`
+/// positional that `--help` documents: `pmat cuda-tdg /does/not/exist score`
+/// graded the current directory and exited 0. `None` now means "fall back to the
+/// top-level path" — see `resolve_subcommand_path`.
 #[derive(Debug, Clone, Subcommand)]
 #[cfg_attr(test, derive(PartialEq))]
 pub enum CudaTdgCommand {
@@ -24,9 +30,8 @@ pub enum CudaTdgCommand {
 
     /// Score codebase with 100-point Popper falsification system
     Score {
-        /// Path to analyze
-        #[arg(default_value = ".")]
-        path: PathBuf,
+        /// Path to analyze (defaults to the top-level `cuda-tdg [PATH]`, then `.`)
+        path: Option<PathBuf>,
 
         /// Show detailed category breakdown
         #[arg(long)]
@@ -35,9 +40,8 @@ pub enum CudaTdgCommand {
 
     /// Generate detailed defect report
     Report {
-        /// Path to analyze
-        #[arg(default_value = ".")]
-        path: PathBuf,
+        /// Path to analyze (defaults to the top-level `cuda-tdg [PATH]`, then `.`)
+        path: Option<PathBuf>,
 
         /// Output format (html, json, markdown)
         #[arg(long, default_value = "markdown")]
@@ -71,9 +75,8 @@ pub enum CudaTdgCommand {
 
     /// Quality gate for CI/CD (exits non-zero on failure)
     Gate {
-        /// Path to analyze
-        #[arg(default_value = ".")]
-        path: PathBuf,
+        /// Path to analyze (defaults to the top-level `cuda-tdg [PATH]`, then `.`)
+        path: Option<PathBuf>,
 
         /// Minimum score to pass (0-100)
         #[arg(long, default_value = "85")]
@@ -86,9 +89,8 @@ pub enum CudaTdgCommand {
 
     /// Generate Kaizen continuous improvement report
     Kaizen {
-        /// Path to analyze
-        #[arg(default_value = ".")]
-        path: PathBuf,
+        /// Path to analyze (defaults to the top-level `cuda-tdg [PATH]`, then `.`)
+        path: Option<PathBuf>,
 
         /// Start date for analysis (YYYY-MM-DD)
         #[arg(long)]

--- a/src/cli/commands/misc_commands_spec_debug.rs
+++ b/src/cli/commands/misc_commands_spec_debug.rs
@@ -163,7 +163,11 @@ pub enum AnnotateOutputFormat {
 /// Debug subcommands for time-travel debugging
 #[derive(Debug, Clone, Subcommand)]
 pub enum DebugCommands {
-    /// Start DAP (Debug Adapter Protocol) server for time-travel debugging
+    /// [NOT IMPLEMENTED] DAP (Debug Adapter Protocol) server — exits with an error.
+    ///
+    /// Advertised as a working server with no marker at all, so the only way to
+    /// discover it binds no socket was to run it (DEBUG-002). Labelled like
+    /// `pmat serve`, which has the same status.
     #[command(visible_aliases = &["srv", "server"])]
     Serve {
         /// Port to bind DAP server (default: 5678)
@@ -179,7 +183,9 @@ pub enum DebugCommands {
         record_dir: Option<PathBuf>,
     },
 
-    /// Replay execution recording with time-travel navigation
+    /// [NOT IMPLEMENTED] Replay an execution recording — exits with an error.
+    ///
+    /// Same status as `debug serve` (DEBUG-003): nothing replays anything yet.
     #[command(visible_aliases = &["play", "view"])]
     Replay {
         /// Path to execution recording file (.pmat format)
@@ -256,7 +262,9 @@ pub enum MaintainCommands {
         format: OutputFormat,
     },
 
-    /// Validate project health (build, tests, coverage, complexity)
+    // The summary used to promise "build, tests, coverage, complexity" while a
+    // flagless run executed the build check alone (see determine_checks_to_run).
+    /// Validate project health (build only by default; --all adds tests, coverage, complexity, SATD)
     Health {
         /// Project directory
         #[arg(long, default_value = ".")]

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -51,3 +51,26 @@ pub use org_prompt::*;
 // Work commands
 pub mod work_commands;
 pub use work_commands::*;
+
+/// Run `f` on a thread with an 8MB stack, for tests that build or parse the
+/// clap command tree.
+///
+/// Clap's generated builder recurses deeply enough over this crate's command
+/// enums to overflow the default 2MB test stack: the test binary dies with
+/// `fatal runtime error: stack overflow` / SIGABRT, taking every other test
+/// with it. That is invisible under `RUST_MIN_STACK=8388608`, which is how
+/// `pmat verify` and the Makefile run the suite — but CI's coverage job runs a
+/// bare `cargo test --lib`, so a single unwrapped `augment_subcommands` or
+/// `try_parse_from` in a test turns `ci / coverage` red with an abort that
+/// names no test.
+///
+/// Several older tests spawn this thread by hand; new ones should call this.
+#[cfg(test)]
+pub(crate) fn on_big_stack<T: Send + 'static>(f: impl FnOnce() -> T + Send + 'static) -> T {
+    std::thread::Builder::new()
+        .stack_size(8 * 1024 * 1024)
+        .spawn(f)
+        .expect("spawn 8MB-stack test thread")
+        .join()
+        .expect("8MB-stack test thread panicked")
+}

--- a/src/cli/commands/org_prompt.rs
+++ b/src/cli/commands/org_prompt.rs
@@ -10,7 +10,11 @@ use std::path::PathBuf;
 #[derive(Subcommand)]
 #[cfg_attr(test, derive(Debug))]
 pub enum OrgCommands {
-    /// Analyze GitHub organization for defect patterns
+    /// [REMOVED] Analyze GitHub organization for defect patterns — no longer available in any build.
+    ///
+    /// aprender-orchestrate 0.41 removed the organizational-analysis API this
+    /// wrapped, with no replacement, so every arm (feature on or off) bails. The
+    /// flags below are inert; they are kept only so the error names them.
     Analyze {
         /// GitHub organization name
         #[arg(long)]

--- a/src/cli/commands/work_commands_test_discovery.rs
+++ b/src/cli/commands/work_commands_test_discovery.rs
@@ -12,8 +12,22 @@ pub enum TestDiscoveryCommands {
         #[arg(short = 'o', long = "output", default_value = "test-failures.json")]
         output: PathBuf,
 
-        /// Use cargo nextest (faster, parallel)
-        #[arg(long, default_value = "true")]
+        /// Use cargo nextest (faster, parallel); `--use-nextest false` runs `cargo test`
+        ///
+        /// `#[arg(long, default_value = "true")]` derived `ArgAction::SetTrue`,
+        /// which ignores the default and can only ever set the flag to true:
+        /// the value was true whether or not the flag was passed, `--use-nextest
+        /// false` was rejected as an unexpected argument, and the `cargo test`
+        /// branch in `handle_discovery_run` was unreachable. `ArgAction::Set`
+        /// with an optional value keeps nextest the default while making the
+        /// flag actually settable.
+        #[arg(
+            long,
+            action = clap::ArgAction::Set,
+            num_args = 0..=1,
+            default_value_t = true,
+            default_missing_value = "true"
+        )]
         use_nextest: bool,
 
         /// Maximum test timeout in seconds
@@ -100,4 +114,36 @@ pub enum TestDiscoveryFormat {
     Json,
     Markdown,
     Text,
+}
+
+#[cfg(test)]
+mod use_nextest_flag_tests {
+    //! `--use-nextest` must be a real switch: it used to derive
+    //! `ArgAction::SetTrue`, so the value was true no matter what the user
+    //! typed and `cargo test` could never run.
+    use super::TestDiscoveryCommands;
+    use clap::Parser;
+
+    #[derive(Parser, Debug)]
+    struct Harness {
+        #[command(subcommand)]
+        cmd: TestDiscoveryCommands,
+    }
+
+    fn use_nextest_of(args: &[&str]) -> bool {
+        match Harness::try_parse_from(args).expect("parse test-discovery run").cmd {
+            TestDiscoveryCommands::Run { use_nextest, .. } => use_nextest,
+            other => panic!("expected `run`, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn use_nextest_defaults_on_but_can_be_switched_off() {
+        assert!(use_nextest_of(&["td", "run"]), "nextest stays the default");
+        assert!(use_nextest_of(&["td", "run", "--use-nextest"]));
+        assert!(
+            !use_nextest_of(&["td", "run", "--use-nextest", "false"]),
+            "--use-nextest false must select `cargo test`"
+        );
+    }
 }

--- a/src/cli/commands/work_commands_test_discovery.rs
+++ b/src/cli/commands/work_commands_test_discovery.rs
@@ -131,10 +131,25 @@ mod use_nextest_flag_tests {
     }
 
     fn use_nextest_of(args: &[&str]) -> bool {
-        match Harness::try_parse_from(args).expect("parse test-discovery run").cmd {
-            TestDiscoveryCommands::Run { use_nextest, .. } => use_nextest,
-            other => panic!("expected `run`, got {other:?}"),
-        }
+        // 8MB stack on its own thread — clap's generated parser overflows the
+        // default 2MB test stack, the same reason the other clap parsing tests
+        // in this crate spawn a thread. Inline it aborts the whole test binary
+        // with SIGABRT under CI's coverage job, which sets no RUST_MIN_STACK.
+        let argv: Vec<String> = args.iter().map(|s| (*s).to_string()).collect();
+        std::thread::Builder::new()
+            .stack_size(8 * 1024 * 1024)
+            .spawn(move || {
+                match Harness::try_parse_from(&argv)
+                    .expect("parse test-discovery run")
+                    .cmd
+                {
+                    TestDiscoveryCommands::Run { use_nextest, .. } => use_nextest,
+                    other => panic!("expected `run`, got {other:?}"),
+                }
+            })
+            .expect("spawn clap parse thread")
+            .join()
+            .expect("clap parse thread panicked")
     }
 
     #[test]

--- a/src/cli/coverage_helpers.rs
+++ b/src/cli/coverage_helpers.rs
@@ -53,9 +53,16 @@ pub async fn get_changed_files_for_coverage(
         .await?;
 
     if !output.status.success() {
-        // If git command fails, return empty list instead of erroring
-        eprintln!("⚠️ Git command failed, returning empty changelist");
-        return Ok(vec![]);
+        // A mistyped or missing base ref used to be swallowed into an empty changelist,
+        // so `analyze incremental-coverage -b totally-bogus-branch` printed an all-zero
+        // "clean" gate report on stdout and exited 0. A coverage gate must never report a
+        // pass because the ref it was asked to diff against does not exist.
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!(
+            "git diff {base_branch}...{target} failed in {}: {}",
+            project_path.display(),
+            stderr.trim()
+        );
     }
 
     let stdout = String::from_utf8_lossy(&output.stdout);
@@ -441,5 +448,24 @@ mod tests {
     fn test_setup_coverage_analyzer_force_refresh() {
         let result = setup_coverage_analyzer(None, true);
         assert!(result.is_ok());
+    }
+
+    /// A base ref that does not exist must surface as an error, not as an empty
+    /// changelist that the incremental-coverage report renders as a clean 0/0 gate.
+    #[tokio::test]
+    async fn test_get_changed_files_errors_on_missing_base_ref() {
+        let repo = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let result =
+            get_changed_files_for_coverage(repo, "totally-bogus-branch-xyz", Some("HEAD")).await;
+        assert!(
+            result.is_err(),
+            "missing base ref must error, got {:?}",
+            result.map(|v| v.len())
+        );
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("totally-bogus-branch-xyz"),
+            "error must name the failed ref: {msg}"
+        );
     }
 }

--- a/src/cli/diagnose.rs
+++ b/src/cli/diagnose.rs
@@ -103,7 +103,14 @@ pub struct DiagnosticSummary {
     pub degraded: usize,
     pub skipped: usize,
     pub all_passed: bool,
-    pub success_rate: f64,
+    /// Share of the checks that actually EXECUTED and passed.
+    ///
+    /// The denominator used to be `total`, which counts skipped checks, so
+    /// `--skip ast.rust` reported "success_rate: 87.5" next to `failed: 0`
+    /// and `all_passed: true` — a rate that fell as the user skipped more,
+    /// with nothing failing. `None` (null) when no check ran at all: there is
+    /// no rate to report, and `0.0` there read as "everything failed".
+    pub success_rate: Option<f64>,
 }
 
 #[derive(Debug, Serialize)]

--- a/src/cli/diagnose_feature_tests.rs
+++ b/src/cli/diagnose_feature_tests.rs
@@ -48,9 +48,13 @@ impl FeatureTest for TypeScriptAstTest {
         "ast.typescript"
     }
 
+    /// This test used to be `let _test_code = TEST_CODE;` followed by a literal
+    /// `"typescript_test": "passed"` — it exercised no parser at all, yet counted
+    /// towards `diagnose`'s success rate exactly like the one test that did
+    /// (ast.rust). It now runs the TypeScript AST parser over the sample and
+    /// reports what the parser actually found; a build without the
+    /// `typescript-ast` feature fails here instead of quietly reporting a pass.
     async fn execute(&self) -> Result<serde_json::Value> {
-        // Test TypeScript parsing capability
-
         const TEST_CODE: &str = r"
             export function factorial(n: number): number {
                 if (n <= 1) return 1;
@@ -58,16 +62,37 @@ impl FeatureTest for TypeScriptAstTest {
             }
         ";
 
+        let file = tempfile::Builder::new().suffix(".ts").tempfile()?;
+        tokio::fs::write(file.path(), TEST_CODE).await?;
+
         let start = Instant::now();
-        // Just verify TypeScript can be processed
-        let _test_code = TEST_CODE; // Use the code to avoid warnings
+        let context = crate::services::ast_typescript::analyze_typescript_file(file.path())
+            .await
+            .map_err(|e| anyhow::anyhow!("TypeScript AST parse failed: {e}"))?;
         let parse_time = start.elapsed();
 
+        let functions = count_ast_functions(&context);
+        anyhow::ensure!(
+            functions >= 1,
+            "Expected at least 1 parsed TypeScript function, got {functions}"
+        );
+
         Ok(json!({
-            "typescript_test": "passed",
+            "typescript_test": "parsed",
+            "parsed_items": context.items.len(),
+            "parsed_functions": functions,
             "parse_time_us": parse_time.as_micros(),
         }))
     }
+}
+
+/// Number of function items in a parsed file context.
+fn count_ast_functions(context: &crate::services::context::FileContext) -> usize {
+    context
+        .items
+        .iter()
+        .filter(|item| matches!(item, crate::services::context::AstItem::Function { .. }))
+        .count()
 }
 
 /// Python ast test.
@@ -79,9 +104,10 @@ impl FeatureTest for PythonAstTest {
         "ast.python"
     }
 
+    /// Same defect as `ast.typescript`: the body was `let _test_code = TEST_CODE;`
+    /// and a hardcoded "passed", so `diagnose` reported a working Python AST on
+    /// a build where the parser could not run at all. It now parses the sample.
     async fn execute(&self) -> Result<serde_json::Value> {
-        // Test Python parsing capability
-
         const TEST_CODE: &str = r"
 def quicksort(arr):
     if len(arr) <= 1:
@@ -91,15 +117,27 @@ def quicksort(arr):
     middle = [x for x in arr if x == pivot]
     right = [x for x in arr if x > pivot]
     return quicksort(left) + middle + quicksort(right)
-        ";
+";
+
+        let file = tempfile::Builder::new().suffix(".py").tempfile()?;
+        tokio::fs::write(file.path(), TEST_CODE).await?;
 
         let start = Instant::now();
-        // Just verify Python can be processed
-        let _test_code = TEST_CODE; // Use the code to avoid warnings
+        let context = crate::services::ast_python::analyze_python_file(file.path())
+            .await
+            .map_err(|e| anyhow::anyhow!("Python AST parse failed: {e}"))?;
         let parse_time = start.elapsed();
 
+        let functions = count_ast_functions(&context);
+        anyhow::ensure!(
+            functions >= 1,
+            "Expected at least 1 parsed Python function, got {functions}"
+        );
+
         Ok(json!({
-            "python_test": "passed",
+            "python_test": "parsed",
+            "parsed_items": context.items.len(),
+            "parsed_functions": functions,
             "parse_time_us": parse_time.as_micros(),
         }))
     }
@@ -173,15 +211,54 @@ impl FeatureTest for ComplexityAnalysisTest {
         "analysis.complexity"
     }
 
+    /// The timed region used to be empty ("Just verify complexity analysis is
+    /// available"), so this reported `status: completed` in 0ms without touching
+    /// the analyzer. It now runs the complexity analyzer over a fixture whose
+    /// cyclomatic complexity is known to exceed 1, and fails if the analyzer
+    /// finds no functions.
     async fn execute(&self) -> Result<serde_json::Value> {
-        // Complexity analysis test
+        const TEST_CODE: &str = r#"
+            pub fn classify(n: i32) -> &'static str {
+                if n < 0 {
+                    "negative"
+                } else if n == 0 {
+                    "zero"
+                } else if n % 2 == 0 {
+                    "even"
+                } else {
+                    "odd"
+                }
+            }
+        "#;
+
+        let file = tempfile::Builder::new().suffix(".rs").tempfile()?;
+        tokio::fs::write(file.path(), TEST_CODE).await?;
 
         let start = Instant::now();
-        // Just verify complexity analysis is available
+        let metrics = crate::services::ast_rust::analyze_rust_file_with_complexity(file.path())
+            .await
+            .map_err(|e| anyhow::anyhow!("complexity analysis failed: {e}"))?;
         let duration = start.elapsed();
 
+        anyhow::ensure!(
+            !metrics.functions.is_empty(),
+            "Complexity analysis found no functions in the fixture"
+        );
+        let max_cyclomatic = metrics
+            .functions
+            .iter()
+            .map(|f| f.metrics.cyclomatic)
+            .max()
+            .unwrap_or(0);
+        anyhow::ensure!(
+            max_cyclomatic > 1,
+            "Branching fixture measured cyclomatic {max_cyclomatic}, expected > 1"
+        );
+
         Ok(json!({
-            "status": "completed",
+            "status": "measured",
+            "functions_analyzed": metrics.functions.len(),
+            "max_cyclomatic": max_cyclomatic,
             "analysis_time_ms": duration.as_millis(),
         }))
     }
@@ -196,23 +273,120 @@ impl FeatureTest for DeepContextTest {
         "analysis.deep_context"
     }
 
+    /// This used to construct the analyzer and drop it (`let _ = analyzer;`),
+    /// timing nothing, and report `status: completed`. It now runs the analyzer
+    /// over a two-file throwaway project and reports how many files it actually
+    /// came back with; the churn/DAG phases are left out so the self-diagnostic
+    /// stays fast and does not depend on the cwd being a git repository.
     async fn execute(&self) -> Result<serde_json::Value> {
-        use crate::services::deep_context::DeepContextConfig;
-        use std::path::Path;
+        use crate::services::deep_context::{AnalysisType, DeepContextConfig};
 
-        let config = DeepContextConfig::default();
+        const TEST_CODE: &str = r"
+            pub fn add(a: i32, b: i32) -> i32 {
+                a + b
+            }
+        ";
+
+        let dir = tempfile::tempdir()?;
+        tokio::fs::write(
+            dir.path().join("Cargo.toml"),
+            "[package]\nname = \"diagnose-fixture\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+        )
+        .await?;
+        tokio::fs::create_dir_all(dir.path().join("src")).await?;
+        tokio::fs::write(dir.path().join("src").join("lib.rs"), TEST_CODE).await?;
+
+        let config = DeepContextConfig {
+            include_analyses: vec![AnalysisType::Ast, AnalysisType::Complexity],
+            ..DeepContextConfig::default()
+        };
         let analyzer = DeepContextAnalyzer::new(config);
-        let _test_path = Path::new(".");
 
         let start = Instant::now();
-        // Just verify we can create the analyzer
-        let _ = analyzer;
+        let context = analyzer.analyze_project(&dir.path().to_path_buf()).await?;
         let duration = start.elapsed();
 
+        let files_analyzed = context.analyses.ast_contexts.len();
+        anyhow::ensure!(
+            files_analyzed >= 1,
+            "Deep context analysis returned no files for a project containing src/lib.rs"
+        );
+
         Ok(json!({
-            "status": "completed",
+            "status": "measured",
+            "files_analyzed": files_analyzed,
             "analysis_time_ms": duration.as_millis(),
         }))
+    }
+}
+
+#[cfg(test)]
+mod feature_tests_do_real_work {
+    //! Four of the eight feature tests used to return a hardcoded "passed"
+    //! without executing any code, which pinned `diagnose`'s success rate at
+    //! 100% on an empty directory. These assert that each of the four now
+    //! reports something it could only know by running the subsystem it names.
+    use super::*;
+
+    #[tokio::test]
+    async fn python_ast_test_reports_functions_it_parsed() {
+        let metrics = PythonAstTest
+            .execute()
+            .await
+            .expect("python AST feature test must run the parser");
+        assert_eq!(
+            metrics.get("parsed_functions").and_then(|v| v.as_u64()),
+            Some(1),
+            "quicksort is one function: {metrics}"
+        );
+    }
+
+    #[tokio::test]
+    async fn typescript_ast_test_reports_functions_it_parsed() {
+        let metrics = TypeScriptAstTest
+            .execute()
+            .await
+            .expect("typescript AST feature test must run the parser");
+        assert!(
+            metrics
+                .get("parsed_functions")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0)
+                >= 1,
+            "factorial must be parsed as a function: {metrics}"
+        );
+    }
+
+    #[tokio::test]
+    async fn complexity_test_measures_a_branching_fixture() {
+        let metrics = ComplexityAnalysisTest
+            .execute()
+            .await
+            .expect("complexity feature test must run the analyzer");
+        assert!(
+            metrics
+                .get("max_cyclomatic")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0)
+                > 1,
+            "a four-branch function cannot measure cyclomatic 1: {metrics}"
+        );
+    }
+
+    #[tokio::test]
+    async fn deep_context_test_analyzes_a_real_project() {
+        let metrics = DeepContextTest
+            .execute()
+            .await
+            .expect("deep context feature test must run the analyzer");
+        assert!(
+            metrics
+                .get("files_analyzed")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0)
+                >= 1,
+            "the fixture project contains src/lib.rs: {metrics}"
+        );
     }
 }
 

--- a/src/cli/diagnose_runner.rs
+++ b/src/cli/diagnose_runner.rs
@@ -95,6 +95,27 @@ impl SelfDiagnostic {
         }
     }
 
+    /// Reject `--only`/`--skip` values that name no check.
+    ///
+    /// A misspelled `--only` matched nothing, so the run silently executed ZERO
+    /// checks and still exited 0, reporting "Total: 0 / Success Rate: 0.0%" —
+    /// a diagnostic that verified nothing while looking like it had run. A
+    /// filter that selects nothing is a typo, not a result.
+    fn validate_filters(&self, args: &DiagnoseArgs) -> Result<()> {
+        let known: Vec<&str> = self.tests.iter().map(|t| t.name()).collect();
+        for (flag, requested) in [("--only", &args.only), ("--skip", &args.skip)] {
+            for name in requested {
+                if !known.contains(&name.as_str()) {
+                    anyhow::bail!(
+                        "unknown {flag} feature test '{name}'. Available: {}",
+                        known.join(", ")
+                    );
+                }
+            }
+        }
+        Ok(())
+    }
+
     fn compute_summary(&self, features: &BTreeMap<String, FeatureResult>) -> DiagnosticSummary {
         let total = features.len();
         let mut passed = 0;
@@ -118,10 +139,17 @@ impl SelfDiagnostic {
             degraded,
             skipped,
             all_passed: failed == 0 && degraded == 0,
-            success_rate: if total > 0 {
-                (passed as f64 / total as f64) * 100.0
-            } else {
-                0.0
+            // Rate over the checks that RAN. Dividing by `total` counted the
+            // skipped ones as failures, so `--skip ast.rust` printed
+            // "Success Rate: 87.5%" beside "Failed: 0" / all_passed: true.
+            success_rate: {
+                let executed = total - skipped;
+                if executed > 0 {
+                    #[allow(clippy::cast_precision_loss)]
+                    Some((passed as f64 / executed as f64) * 100.0)
+                } else {
+                    None
+                }
             },
         }
     }
@@ -209,6 +237,7 @@ impl SelfDiagnostic {
 #[provable_contracts_macros::contract("pmat-core.yaml", equation = "check_compliance")]
 pub async fn handle_diagnose(args: DiagnoseArgs) -> Result<()> {
     let diagnostic = SelfDiagnostic::new();
+    diagnostic.validate_filters(&args)?;
     let report = diagnostic.run_diagnostic(&args).await;
 
     match args.format {
@@ -298,7 +327,12 @@ fn print_pretty_report(report: &DiagnosticReport) {
     println!(
         "  {}: {}",
         c::label("Success Rate"),
-        c::pct(report.summary.success_rate, 100.0, 80.0)
+        match report.summary.success_rate {
+            Some(rate) => c::pct(rate, 100.0, 80.0),
+            // No check executed, so there is no rate; "0.0%" read as a total
+            // failure of checks that were never run.
+            None => c::dim("not measured (no check executed)"),
+        }
     );
 
     if let Some(ctx) = &report.error_context {

--- a/src/cli/diagnose_tests.rs
+++ b/src/cli/diagnose_tests.rs
@@ -162,7 +162,7 @@ fn test_compute_summary_all_passed() {
     assert_eq!(summary.degraded, 0);
     assert_eq!(summary.skipped, 0);
     assert!(summary.all_passed);
-    assert!((summary.success_rate - 100.0).abs() < f64::EPSILON);
+    assert!((summary.success_rate.expect("two checks ran") - 100.0).abs() < f64::EPSILON);
 }
 
 #[test]
@@ -195,7 +195,7 @@ fn test_compute_summary_with_failures() {
     assert_eq!(summary.passed, 1);
     assert_eq!(summary.failed, 1);
     assert!(!summary.all_passed);
-    assert!((summary.success_rate - 50.0).abs() < f64::EPSILON);
+    assert!((summary.success_rate.expect("two checks ran") - 50.0).abs() < f64::EPSILON);
 }
 
 #[test]
@@ -253,7 +253,9 @@ fn test_compute_summary_empty() {
     assert_eq!(summary.total, 0);
     assert_eq!(summary.passed, 0);
     assert!(summary.all_passed);
-    assert!((summary.success_rate - 0.0).abs() < f64::EPSILON);
+    // No check executed, so there is no rate. This used to assert 0.0, which
+    // reads as "everything failed" for a run in which nothing was attempted.
+    assert!(summary.success_rate.is_none());
 }
 
 #[test]
@@ -306,7 +308,9 @@ fn test_compute_summary_mixed() {
     assert_eq!(summary.degraded, 1);
     assert_eq!(summary.skipped, 1);
     assert!(!summary.all_passed);
-    assert!((summary.success_rate - 25.0).abs() < f64::EPSILON);
+    // 1 passed of the 3 that RAN. This used to assert 25.0 (1 of 4), counting
+    // the skipped check in the denominator as though it had failed.
+    assert!((summary.success_rate.expect("three checks ran") - 100.0 / 3.0).abs() < 1e-9);
 }
 
 // ============================================================================
@@ -547,7 +551,7 @@ fn test_diagnostic_summary_serialization() {
         degraded: 1,
         skipped: 0,
         all_passed: false,
-        success_rate: 70.0,
+        success_rate: Some(70.0),
     };
 
     let json = serde_json::to_string(&summary).unwrap();
@@ -585,7 +589,7 @@ fn test_diagnostic_report_serialization() {
             degraded: 0,
             skipped: 0,
             all_passed: true,
-            success_rate: 100.0,
+            success_rate: Some(100.0),
         },
         error_context: None,
     };
@@ -612,7 +616,7 @@ fn test_diagnostic_report_with_error_context() {
             degraded: 0,
             skipped: 0,
             all_passed: false,
-            success_rate: 0.0,
+            success_rate: Some(0.0),
         },
         error_context: Some(CompactErrorContext {
             failed_features: vec!["test1".to_string()],
@@ -1058,7 +1062,9 @@ async fn test_run_diagnostic_with_nonexistent_only_filter() {
 
     let report = diagnostic.run_diagnostic(&args).await;
 
-    // No tests should match
+    // No tests should match. `handle_diagnose` rejects this filter before it
+    // gets here (see `unknown_only_filter_is_rejected_not_silently_empty`);
+    // this pins the low-level behaviour of the runner itself.
     assert!(report.features.is_empty());
     assert_eq!(report.summary.total, 0);
 }
@@ -1098,4 +1104,126 @@ fn test_diagnose_args_default_values() {
     assert!(args.only.is_empty());
     assert!(args.skip.is_empty());
     assert_eq!(args.timeout, 60);
+}
+
+// ============================================================================
+// Round-5 dogfood regressions: skipped checks in the rate, unvalidated filters
+// ============================================================================
+
+/// `--skip ast.rust` reported "success_rate: 87.5" beside `failed: 0`,
+/// `degraded: 0` and `all_passed: true`: the denominator was every check the
+/// binary knows about, so skipping a check looked exactly like failing one.
+#[test]
+fn skipped_checks_are_not_counted_as_failures_in_the_rate() {
+    let diagnostic = SelfDiagnostic::new();
+    let mut features = BTreeMap::new();
+
+    for name in ["a", "b", "c", "d", "e", "f", "g"] {
+        features.insert(
+            name.to_string(),
+            FeatureResult {
+                status: FeatureStatus::Ok,
+                duration_us: 1,
+                error: None,
+                metrics: None,
+            },
+        );
+    }
+    features.insert(
+        "skipped".to_string(),
+        FeatureResult {
+            status: FeatureStatus::Skipped("User requested skip".to_string()),
+            duration_us: 0,
+            error: None,
+            metrics: None,
+        },
+    );
+
+    let summary = diagnostic.compute_summary(&features);
+
+    assert_eq!(summary.failed, 0);
+    assert!(summary.all_passed);
+    assert!(
+        (summary.success_rate.expect("seven checks ran") - 100.0).abs() < f64::EPSILON,
+        "nothing failed, so the rate must be 100%, got {:?}",
+        summary.success_rate
+    );
+}
+
+/// Skipping everything leaves nothing to compute a rate from; reporting `0.0`
+/// there claimed a total failure of checks that were never attempted.
+#[test]
+fn a_run_with_nothing_executed_reports_no_rate() {
+    let diagnostic = SelfDiagnostic::new();
+    let mut features = BTreeMap::new();
+    features.insert(
+        "only.one".to_string(),
+        FeatureResult {
+            status: FeatureStatus::Skipped("User requested skip".to_string()),
+            duration_us: 0,
+            error: None,
+            metrics: None,
+        },
+    );
+
+    let summary = diagnostic.compute_summary(&features);
+
+    assert_eq!(summary.skipped, 1);
+    assert!(summary.success_rate.is_none());
+}
+
+/// `pmat diagnose --only nosuchfeature` matched no check, ran zero of them and
+/// still exited 0 with "Total: 0 / Success Rate: 0.0%". A filter naming a check
+/// that does not exist is a typo, and must be reported as one.
+#[tokio::test]
+async fn unknown_only_filter_is_rejected_not_silently_empty() {
+    let args = DiagnoseArgs {
+        format: DiagnosticFormat::Json,
+        only: vec!["nosuchfeature".to_string()],
+        skip: vec![],
+        timeout: 60,
+    };
+
+    let err = handle_diagnose(args)
+        .await
+        .expect_err("an --only value that names no check must fail");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("nosuchfeature") && msg.contains("--only"),
+        "error must name the bad value and the flag: {msg}"
+    );
+    assert!(
+        msg.contains("ast.rust"),
+        "error must list the available checks: {msg}"
+    );
+}
+
+/// Same defect on the other filter: an unknown `--skip` value skipped nothing.
+#[tokio::test]
+async fn unknown_skip_filter_is_rejected() {
+    let args = DiagnoseArgs {
+        format: DiagnosticFormat::Json,
+        only: vec![],
+        skip: vec!["ast.rust".to_string(), "typo.here".to_string()],
+        timeout: 60,
+    };
+
+    let err = handle_diagnose(args)
+        .await
+        .expect_err("a --skip value that names no check must fail");
+    assert!(err.to_string().contains("typo.here"), "{err}");
+}
+
+/// A valid filter still runs.
+#[tokio::test]
+async fn known_filters_are_accepted() {
+    let diagnostic = SelfDiagnostic::new();
+    let args = DiagnoseArgs {
+        format: DiagnosticFormat::Json,
+        only: vec!["ast.rust".to_string()],
+        skip: vec![],
+        timeout: 60,
+    };
+
+    assert!(diagnostic.validate_filters(&args).is_ok());
 }

--- a/src/cli/handlers/advanced_analysis_handlers.rs
+++ b/src/cli/handlers/advanced_analysis_handlers.rs
@@ -55,21 +55,21 @@ use tracing::{debug, info};
 /// # use pmat::cli::handlers::advanced_analysis_handlers::handle_analyze_deep_context;
 /// # use std::path::PathBuf;
 /// # async fn example() -> anyhow::Result<()> {
-/// // Full analysis with specific includes
+/// // Pattern-selected analysis written to a file
 /// handle_analyze_deep_context(
 ///     PathBuf::from("./src"),
 ///     Some(PathBuf::from("context.json")),
 ///     DeepContextOutputFormat::Json,
-///     true,                              // full analysis
-///     vec!["complexity".to_string(), "dependencies".to_string()],
-///     vec![],
+///     false,                             // --full is not implemented (rejected)
+///     vec![],                            // --include is not implemented (rejected)
+///     vec![],                            // --exclude is not implemented (rejected)
 ///     90,                                // 90 day history
 ///     Some(DagType::CallGraph),
-///     Some(5),                           // max depth 5
+///     None,                              // --max-depth is not implemented (rejected)
 ///     vec!["**/*.rs".to_string()],       // only Rust files
 ///     vec!["**/tests/**".to_string()],   // exclude tests
 ///     Some("persistent".to_string()),
-///     true,                              // parallel processing
+///     false,                             // --parallel is not implemented (rejected)
 ///     true,                              // verbose output
 ///     20,                                // top 20 files
 /// ).await?;
@@ -81,6 +81,8 @@ use tracing::{debug, info};
 ///
 /// Returns `Ok(())` if analysis completes successfully, or an error if:
 /// - Project path doesn't exist
+/// - An unimplemented flag was supplied (see
+///   `reject_unimplemented_deep_context_flags`)
 /// - No files found to analyze
 /// - Output file cannot be written
 /// - Analysis encounters errors
@@ -92,14 +94,14 @@ pub async fn handle_analyze_deep_context(
     format: DeepContextOutputFormat,
     full: bool,
     include: Vec<String>,
-    _exclude: Vec<String>,
+    exclude: Vec<String>,
     period_days: u32,
     _dag_type: Option<DagType>,
-    _max_depth: Option<usize>,
+    max_depth: Option<usize>,
     include_patterns: Vec<String>,
     exclude_patterns: Vec<String>,
     _cache_strategy: Option<String>,
-    _parallel: bool,
+    parallel: bool,
     verbose: bool,
     top_files: usize,
 ) -> Result<()> {
@@ -109,6 +111,8 @@ pub async fn handle_analyze_deep_context(
     // "Average Complexity: 0.0 / 1. No functions detected - verify file
     // discovery patterns" with exit 0. Found alongside GH-663/GH-666.
     crate::cli::ensure_analysis_path_exists(&project_path)?;
+
+    reject_unimplemented_deep_context_flags(full, &include, &exclude, max_depth, parallel)?;
 
     info!("🔍 Starting deep context analysis");
     info!("📂 Project path: {}", project_path.display());
@@ -186,6 +190,55 @@ pub async fn handle_analyze_deep_context(
     );
 
     Ok(())
+}
+
+/// Refuse the flags `analyze deep-context` accepts but does not implement.
+///
+/// `--full`, `--include`, `--exclude`, `--max-depth` and `--parallel` were
+/// bound to underscore-prefixed parameters and never read, so nine variants of
+/// the command over the same corpus produced one identical report (same md5
+/// after stripping the duration line) — including `--exclude-pattern '*.py'`
+/// runs that still listed `main.py`. `--exclude-pattern`/`--include-pattern`
+/// now really filter; the flags below still do nothing, and a flag that --help
+/// documents as changing the analysis must fail loudly rather than be dropped
+/// on the floor.
+///
+/// `--dag-type` and `--period-days` are not checked here: clap supplies a
+/// default for both, so there is no way to tell "user asked for it" from "clap
+/// filled it in". `--period-days` does reach the SARIF path.
+fn reject_unimplemented_deep_context_flags(
+    full: bool,
+    include: &[String],
+    exclude: &[String],
+    max_depth: Option<usize>,
+    parallel: bool,
+) -> Result<()> {
+    let mut unsupported = Vec::new();
+    if full {
+        unsupported.push("--full");
+    }
+    if !include.is_empty() {
+        unsupported.push("--include");
+    }
+    if !exclude.is_empty() {
+        unsupported.push("--exclude");
+    }
+    if max_depth.is_some() {
+        unsupported.push("--max-depth");
+    }
+    if parallel {
+        unsupported.push("--parallel");
+    }
+
+    if unsupported.is_empty() {
+        return Ok(());
+    }
+
+    anyhow::bail!(
+        "analyze deep-context does not implement {}; the flag(s) would be accepted and ignored. \
+         Use --include-pattern / --exclude-pattern to select files and --top-files to size the report.",
+        unsupported.join(", ")
+    )
 }
 
 /// Append the exclusions every deep-context run applies.
@@ -550,3 +603,70 @@ fn format_deep_context_text(
 #[cfg(test)]
 #[path = "advanced_analysis_handlers_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+mod unimplemented_flag_tests {
+    //! A deep-context flag either changes the analysis or is refused.
+    use super::*;
+
+    #[test]
+    fn supported_invocation_is_accepted() {
+        assert!(reject_unimplemented_deep_context_flags(false, &[], &[], None, false).is_ok());
+    }
+
+    #[test]
+    fn full_is_refused_rather_than_ignored() {
+        let err = reject_unimplemented_deep_context_flags(true, &[], &[], None, false)
+            .expect_err("--full changes nothing, so it must not be accepted");
+        assert!(err.to_string().contains("--full"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn deep_context_refuses_full_instead_of_producing_the_same_report() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("main.rs"), "fn main() {}\n").unwrap();
+
+        let err = handle_analyze_deep_context(
+            dir.path().to_path_buf(),
+            None,
+            DeepContextOutputFormat::Json,
+            true, // --full
+            vec![],
+            vec![],
+            30,
+            None,
+            None,
+            vec![],
+            vec![],
+            None,
+            false,
+            false,
+            10,
+        )
+        .await
+        .expect_err("--full used to produce a report byte-identical to the default one");
+        assert!(err.to_string().contains("--full"), "{err}");
+    }
+
+    #[test]
+    fn every_unimplemented_flag_is_named() {
+        let err = reject_unimplemented_deep_context_flags(
+            true,
+            &["complexity".to_string()],
+            &["churn".to_string()],
+            Some(0),
+            true,
+        )
+        .unwrap_err()
+        .to_string();
+        for flag in [
+            "--full",
+            "--include",
+            "--exclude",
+            "--max-depth",
+            "--parallel",
+        ] {
+            assert!(err.contains(flag), "{flag} missing from: {err}");
+        }
+    }
+}

--- a/src/cli/handlers/advanced_analysis_handlers_tests_part1.rs
+++ b/src/cli/handlers/advanced_analysis_handlers_tests_part1.rs
@@ -442,7 +442,11 @@ clean:
         )
         .await;
 
-        assert!(result.is_ok());
+        // This used to assert `is_ok()`, which is precisely the defect: `--full`
+        // was accepted and discarded, so "full mode" produced a report
+        // byte-identical to the default one. An unimplemented flag is refused.
+        let err = result.expect_err("--full is not implemented");
+        assert!(err.to_string().contains("--full"), "{err}");
     }
 
     #[tokio::test]
@@ -468,7 +472,10 @@ clean:
         )
         .await;
 
-        assert!(result.is_ok());
+        // `--include` selected no analyses — the report was the same with and
+        // without it — so it is refused rather than silently dropped.
+        let err = result.expect_err("--include is not implemented");
+        assert!(err.to_string().contains("--include"), "{err}");
     }
 
     #[tokio::test]
@@ -626,7 +633,10 @@ clean:
         )
         .await;
 
-        assert!(result.is_ok());
+        // `--max-depth` never reached the file walk, so depth 5 and no limit at
+        // all produced the same report; it is refused until it is threaded in.
+        let err = result.expect_err("--max-depth is not implemented");
+        assert!(err.to_string().contains("--max-depth"), "{err}");
     }
 
     #[tokio::test]

--- a/src/cli/handlers/agy_handler.rs
+++ b/src/cli/handlers/agy_handler.rs
@@ -3,10 +3,81 @@ use std::path::Path;
 
 pub async fn handle_agy_command(cmd: &AgyCommands, _base_path: &Path) -> anyhow::Result<()> {
     match cmd {
-        AgyCommands::Sync { work_dir, out_dir } => {
-            println!("✅ MACS-017: Transpiling PMAT contracts from {} to Google Anti-Gravity formats in {}", work_dir.display(), out_dir.display());
-            // TODO(MACS-017): Implement strict PMAT rules -> AGY rules generation
-        }
+        AgyCommands::Sync { work_dir, out_dir } => sync_contracts_to_agy(work_dir, out_dir),
     }
-    Ok(())
+}
+
+/// `agy sync` used to be a single `println!` of a ✅ success banner followed by
+/// `// TODO(MACS-017)` and `Ok(())`: it never read `--work-dir`, never created
+/// `--out-dir`, and reported success even for `--work-dir /does/not/exist`.
+/// There is no PMAT→Anti-Gravity transpiler behind it, so the command now fails
+/// loudly. A command that does nothing must not print ✅ and exit 0.
+fn sync_contracts_to_agy(work_dir: &Path, out_dir: &Path) -> anyhow::Result<()> {
+    if !work_dir.exists() {
+        anyhow::bail!(
+            "agy sync: contract directory not found: {}",
+            work_dir.display()
+        );
+    }
+
+    anyhow::bail!(
+        "agy sync is not implemented: no PMAT -> Google Anti-Gravity transpiler exists yet, \
+         so nothing was written to {}. Contracts under {} were left untouched. \
+         Track this under MACS-017.",
+        out_dir.display(),
+        work_dir.display()
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cli::commands::AgyCommands;
+    use std::path::PathBuf;
+
+    #[tokio::test]
+    async fn test_sync_errors_when_work_dir_is_missing() {
+        let cmd = AgyCommands::Sync {
+            work_dir: PathBuf::from("/does/not/exist/pmat-work"),
+            out_dir: PathBuf::from("/does/not/exist/outdir"),
+        };
+
+        let err = handle_agy_command(&cmd, Path::new(""))
+            .await
+            .expect_err("a nonexistent --work-dir must be an error, not a success banner");
+        assert!(
+            err.to_string().contains("not found"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_sync_does_not_report_success_without_writing_anything() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let work_dir = temp.path().join(".pmat-work");
+        std::fs::create_dir_all(&work_dir).unwrap();
+        std::fs::write(
+            work_dir.join("CB-001.yaml"),
+            "id: CB-001\ntitle: Example contract\n",
+        )
+        .unwrap();
+        let out_dir = temp.path().join("outdir");
+
+        let cmd = AgyCommands::Sync {
+            work_dir: work_dir.clone(),
+            out_dir: out_dir.clone(),
+        };
+
+        let err = handle_agy_command(&cmd, Path::new(""))
+            .await
+            .expect_err("an unimplemented transpile must not return Ok");
+        assert!(
+            err.to_string().contains("not implemented"),
+            "unexpected error: {err}"
+        );
+        assert!(
+            !out_dir.exists(),
+            "nothing was transpiled, so --out-dir must not be claimed as written"
+        );
+    }
 }

--- a/src/cli/handlers/analysis_handlers/advanced_routes.rs
+++ b/src/cli/handlers/analysis_handlers/advanced_routes.rs
@@ -179,7 +179,11 @@ pub(super) async fn route_build_tdg_analysis(cmd: AnalyzeCommands) -> Result<()>
         run_cargo_build(&path, release)?;
     }
 
-    println!("\u{1f4ca} Running TDG analysis...");
+    // This banner was the one progress line on stdout (every sibling line in
+    // new_tdg_handler uses eprintln!), so it landed ahead of the JSON/SARIF
+    // document and `analyze build-tdg -f json | jq` failed to parse for
+    // everyone. Progress belongs on stderr; stdout carries the document only.
+    eprintln!("\u{1f4ca} Running TDG analysis...");
     let config = TdgAnalysisConfig {
         path: path.clone(),
         threshold: Some(threshold),

--- a/src/cli/handlers/analysis_handlers/advanced_routes.rs
+++ b/src/cli/handlers/analysis_handlers/advanced_routes.rs
@@ -191,7 +191,10 @@ pub(super) async fn route_build_tdg_analysis(cmd: AnalyzeCommands) -> Result<()>
         verbose: false,
     };
 
-    let result = crate::cli::handlers::new_tdg_handler::handle_analyze_tdg(config).await;
+    // `build-tdg` is the gated entry point: its --threshold used to be
+    // discarded, so the documented "fails fast if TDG score exceeds threshold"
+    // gate exited 0 for every threshold from 0.0 to 1000.
+    let result = crate::cli::handlers::new_tdg_handler::handle_analyze_tdg_gated(config).await;
 
     if fail_on_regression {
         check_quality_regression(&path)?;
@@ -436,19 +439,53 @@ pub(super) async fn route_clippy_analysis(cmd: AnalyzeCommands) -> Result<()> {
         )
         .await?;
 
+        let report = clippy_result_payload(&result);
+
         if let Some(output_path) = output {
             use std::fs;
-            let content = serde_json::to_string_pretty(&result)?;
-            fs::write(&output_path, content)?;
+            fs::write(&output_path, &report)?;
             eprintln!("\u{1f4c1} Results written to {}", output_path.display());
         } else {
-            eprintln!("{result:?}");
+            println!("{report}");
+        }
+
+        if result.is_error {
+            anyhow::bail!("Clippy analysis failed");
         }
 
         Ok(())
     } else {
         unreachable!("Expected Clippy command")
     }
+}
+
+/// The JSON payload an MCP tool result carries, as a CLI report.
+///
+/// `analyze clippy` used to `eprintln!("{result:?}")` — the Debug rendering of
+/// the MCP transport envelope — so stdout was empty and the only output was an
+/// unparseable `CallToolResult { content: [Text { text: "{\n \"action\"…" }],
+/// is_error: false, … }` on stderr. The envelope is an implementation detail of
+/// the MCP server; a CLI prints the payload, on stdout, so it can be piped.
+fn clippy_result_payload(result: &pmcp::ToolResult) -> String {
+    let texts: Vec<&str> = result
+        .content
+        .iter()
+        .filter_map(|c| match c {
+            pmcp::Content::Text { text } => Some(text.as_str()),
+            _ => None,
+        })
+        .collect();
+
+    if texts.is_empty() {
+        // Never invent a report: say the tool returned no text payload.
+        return serde_json::json!({
+            "error": "clippy analysis returned no text content",
+            "is_error": result.is_error,
+        })
+        .to_string();
+    }
+
+    texts.join("\n")
 }
 
 #[cfg(test)]
@@ -516,5 +553,36 @@ mod converter_tests {
             convert_cache_strategy(cli::DeepContextCacheStrategy::Offline),
             "offline"
         );
+    }
+
+    // ── clippy_result_payload ───────────────────────────────────────────────
+
+    #[test]
+    fn clippy_report_is_the_payload_not_the_mcp_envelope() {
+        let payload = "{\n  \"action\": \"analyzed\",\n  \"results\": {}\n}";
+        let result = pmcp::ToolResult::new(vec![pmcp::Content::Text {
+            text: payload.to_string(),
+        }]);
+
+        let report = clippy_result_payload(&result);
+
+        assert_eq!(report, payload);
+        assert!(
+            serde_json::from_str::<serde_json::Value>(&report).is_ok(),
+            "the CLI report must be parseable JSON"
+        );
+        // What the command used to print: the Debug rendering of the transport
+        // envelope, which no consumer can parse.
+        assert!(
+            serde_json::from_str::<serde_json::Value>(&format!("{result:?}")).is_err(),
+            "the MCP envelope Debug rendering is not a report"
+        );
+    }
+
+    #[test]
+    fn clippy_report_says_so_when_there_is_no_text_payload() {
+        let result = pmcp::ToolResult::new(vec![]);
+        let report = clippy_result_payload(&result);
+        assert!(report.contains("no text content"), "got: {report}");
     }
 }

--- a/src/cli/handlers/analysis_handlers/core_routes.rs
+++ b/src/cli/handlers/analysis_handlers/core_routes.rs
@@ -149,7 +149,6 @@ pub(super) async fn route_dead_code_analysis(cmd: AnalyzeCommands) -> Result<()>
 /// Route defects analysis command
 pub(super) async fn route_defects_analysis(cmd: AnalyzeCommands) -> Result<()> {
     use crate::cli::handlers::analyze_defects_handler::{handle_analyze_defects, OutputFormat};
-    use crate::services::defect_detector::Severity;
 
     if let AnalyzeCommands::Defects {
         path,
@@ -167,15 +166,7 @@ pub(super) async fn route_defects_analysis(cmd: AnalyzeCommands) -> Result<()> {
         };
 
         // Parse severity filter if provided
-        let severity_filter = severity
-            .as_deref()
-            .and_then(|s| match s.to_lowercase().as_str() {
-                "critical" => Some(Severity::Critical),
-                "high" => Some(Severity::High),
-                "medium" => Some(Severity::Medium),
-                "low" => Some(Severity::Low),
-                _ => None,
-            });
+        let severity_filter = parse_defect_severity_filter(severity.as_deref())?;
 
         let exit_code = handle_analyze_defects(
             path.as_deref(),
@@ -193,6 +184,32 @@ pub(super) async fn route_defects_analysis(cmd: AnalyzeCommands) -> Result<()> {
         Ok(())
     } else {
         unreachable!("Expected Defects command")
+    }
+}
+
+/// Parse `analyze defects --severity` into a filter.
+///
+/// `--severity` is an `Option<String>` on the clap side, so clap cannot reject a
+/// bad value for us. The match used to end in `_ => None`, which is the SAME
+/// value as "the flag was not given": `--severity bogus` printed the complete
+/// unfiltered report and exited as if the filter had been honoured. A filter
+/// nobody applied must be an error, not a silent no-op.
+fn parse_defect_severity_filter(
+    severity: Option<&str>,
+) -> Result<Option<crate::services::defect_detector::Severity>> {
+    use crate::services::defect_detector::Severity;
+
+    let Some(raw) = severity else {
+        return Ok(None);
+    };
+    match raw.to_lowercase().as_str() {
+        "critical" => Ok(Some(Severity::Critical)),
+        "high" => Ok(Some(Severity::High)),
+        "medium" => Ok(Some(Severity::Medium)),
+        "low" => Ok(Some(Severity::Low)),
+        _ => {
+            anyhow::bail!("invalid --severity '{raw}': expected one of critical, high, medium, low")
+        }
     }
 }
 
@@ -356,5 +373,44 @@ mod ml_flag_tests {
             msg.contains("--ml is not implemented"),
             "unexpected error: {msg}"
         );
+    }
+
+    // ── --severity is validated, not silently dropped ───────────────────────
+
+    /// The reported defect: `analyze defects --severity bogus` mapped to
+    /// `None`, i.e. exactly what "no --severity at all" means, so the caller
+    /// got the full unfiltered report and exit 0.
+    #[test]
+    fn unrecognised_severity_is_rejected() {
+        let err = parse_defect_severity_filter(Some("bogus"))
+            .expect_err("an unknown --severity value must not mean 'no filter'");
+        let msg = err.to_string();
+        assert!(msg.contains("bogus"), "error must quote the value: {msg}");
+        assert!(
+            msg.contains("critical") && msg.contains("low"),
+            "error must list the accepted values: {msg}"
+        );
+    }
+
+    #[test]
+    fn recognised_severities_parse_case_insensitively() {
+        use crate::services::defect_detector::Severity;
+        assert_eq!(
+            parse_defect_severity_filter(Some("Critical")).unwrap(),
+            Some(Severity::Critical)
+        );
+        assert_eq!(
+            parse_defect_severity_filter(Some("high")).unwrap(),
+            Some(Severity::High)
+        );
+        assert_eq!(
+            parse_defect_severity_filter(Some("MEDIUM")).unwrap(),
+            Some(Severity::Medium)
+        );
+        assert_eq!(
+            parse_defect_severity_filter(Some("low")).unwrap(),
+            Some(Severity::Low)
+        );
+        assert_eq!(parse_defect_severity_filter(None).unwrap(), None);
     }
 }

--- a/src/cli/handlers/analysis_handlers/core_routes.rs
+++ b/src/cli/handlers/analysis_handlers/core_routes.rs
@@ -46,9 +46,22 @@ pub(super) async fn route_complexity_analysis(cmd: AnalyzeCommands) -> Result<()
         top_files,
         fail_on_violation,
         timeout,
-        ml: _, // GH-97: ML flag (not yet implemented in handler)
+        ml,
     } = cmd
     {
+        // GH-97: the ML scorer is not wired into this handler. The flag used to
+        // be destructured and thrown away (`ml: _`), so `analyze complexity
+        // --ml` returned byte-identical JSON to a plain run — the same
+        // heuristic numbers, presented under a banner promising "trained ML
+        // models instead of heuristic formulas". Refuse rather than relabel.
+        if ml {
+            anyhow::bail!(
+                "--ml is not implemented: complexity scores are still computed by the \
+                 heuristic formulas, so this flag would relabel them without changing them. \
+                 Re-run without --ml (see GH-97)."
+            );
+        }
+
         route_complexity_command(
             path,
             project_path,
@@ -303,4 +316,45 @@ async fn route_complexity_command(
         timeout,
     )
     .await
+}
+
+#[cfg(test)]
+mod ml_flag_tests {
+    use super::*;
+
+    fn complexity_command(ml: bool) -> AnalyzeCommands {
+        AnalyzeCommands::Complexity {
+            path: PathBuf::from("."),
+            project_path: None,
+            file: None,
+            files: Vec::new(),
+            toolchain: None,
+            format: cli::ComplexityOutputFormat::Summary,
+            output: None,
+            max_cyclomatic: None,
+            max_cognitive: None,
+            include: Vec::new(),
+            watch: false,
+            top_files: 10,
+            fail_on_violation: false,
+            timeout: 60,
+            ml,
+        }
+    }
+
+    /// `--ml` was destructured and discarded, so `analyze complexity --ml`
+    /// produced byte-identical JSON to a plain run: the heuristic scores under
+    /// a banner promising trained ML models. Refusing is honest; silently
+    /// relabelling is not.
+    #[tokio::test]
+    async fn ml_flag_is_refused_rather_than_ignored() {
+        let err = route_complexity_analysis(complexity_command(true))
+            .await
+            .expect_err("--ml must not silently return heuristic scores");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("--ml is not implemented"),
+            "unexpected error: {msg}"
+        );
+    }
 }

--- a/src/cli/handlers/analysis_handlers/entropy_semantic.rs
+++ b/src/cli/handlers/analysis_handlers/entropy_semantic.rs
@@ -103,49 +103,36 @@ fn format_summary_report(report: &crate::entropy::EntropyReport, top_violations:
         .as_ref()
         .map_or_else(String::new, |n| format!("Note: {n}\n"));
 
+    // COLOUR: every field here interpolated the raw `c::BOLD`/`c::RESET`
+    // consts, which are unconditional — `--color never`, `NO_COLOR=1` and a
+    // redirected stdout all still produced `^[[1mFiles Analyzed:^[[0m`
+    // (GH #684 class). The `c::header`/`c::label`/`c::number` helpers consult
+    // `colors_enabled()` and emit the bare payload when colour is off.
     format!(
-        "{}{}Entropy Analysis Summary{}\n\n\
-         {}Files Analyzed:{} {}{}{}\n\
-         {}Source Lines Analyzed:{} {}{}{}\n\
-         {}Pattern Diversity:{} {}{}{}\n\
-         {}Total Violations:{} {}{}{}\n\
-         {}Potential LOC Reduction:{} {}{}{} lines ({}{:.1}%{})\n\
+        "{}\n\n\
+         {} {}\n\
+         {} {}\n\
+         {} {}\n\
+         {} {}\n\
+         {} {} lines ({})\n\
          {}\n\
-         {}Top Violations:{}\n{}\n",
-        c::BOLD,
-        c::UNDERLINE,
-        c::RESET,
-        c::BOLD,
-        c::RESET,
-        c::BOLD_WHITE,
-        report.total_files_analyzed,
-        c::RESET,
-        c::BOLD,
-        c::RESET,
-        c::BOLD_WHITE,
-        report.entropy_metrics.total_loc,
-        c::RESET,
-        c::BOLD,
-        c::RESET,
-        c::BOLD_WHITE,
-        crate::entropy::EntropyReport::render_measurement(report.entropy_metrics.pattern_diversity),
-        c::RESET,
-        c::BOLD,
-        c::RESET,
-        c::BOLD_WHITE,
-        report.actionable_violations.len(),
-        c::RESET,
-        c::BOLD,
-        c::RESET,
-        c::BOLD_WHITE,
-        report.total_loc_reduction(),
-        c::RESET,
-        c::BOLD_WHITE,
-        report.reduction_percentage(),
-        c::RESET,
+         {}\n{}\n",
+        c::header("Entropy Analysis Summary"),
+        c::label("Files Analyzed:"),
+        c::number(&report.total_files_analyzed.to_string()),
+        c::label("Source Lines Analyzed:"),
+        c::number(&report.entropy_metrics.total_loc.to_string()),
+        c::label("Pattern Diversity:"),
+        c::number(&crate::entropy::EntropyReport::render_measurement(
+            report.entropy_metrics.pattern_diversity
+        )),
+        c::label("Total Violations:"),
+        c::number(&report.actionable_violations.len().to_string()),
+        c::label("Potential LOC Reduction:"),
+        c::number(&report.total_loc_reduction().to_string()),
+        c::number(&format!("{:.1}%", report.reduction_percentage())),
         note,
-        c::BOLD,
-        c::RESET,
+        c::label("Top Violations:"),
         format_violation_list(&violations)
     )
 }
@@ -214,16 +201,16 @@ pub(crate) fn format_violation_list(
             // "saves" renders "not estimated" where no per-pattern size was
             // measured (the low-diversity finding), instead of the old fixed
             // 15%-of-total_loc figure printed as if it were derived.
+            // COLOUR: `sev_color`/`c::RESET`/`c::BOLD` were interpolated raw, so
+            // `--color never` still emitted escapes around the severity and the
+            // "Fix:" label. `c::colored`/`c::label` honour `colors_enabled()`.
             format!(
-                "  {}. {}{:?}{} {} (saves {})\n     {}Fix:{} {}",
+                "  {}. {} {} (saves {})\n     {} {}",
                 c::number(&(i + 1).to_string()),
-                sev_color,
-                v.severity,
-                c::RESET,
+                c::colored(sev_color, &format!("{:?}", v.severity)),
                 v.message,
                 c::number(&v.render_loc_reduction()),
-                c::BOLD,
-                c::RESET,
+                c::label("Fix:"),
                 v.fix_suggestion
             )
         })
@@ -720,5 +707,91 @@ mod format_coverage_tests {
             "an unsupported format must be an error naming it, got {err}"
         );
         assert!(format_topic_results(&topic_result(), &OutputFormat::Junit).is_err());
+    }
+}
+
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg(test)]
+mod colour_gating_tests {
+    //! `analyze entropy --color never` (and `NO_COLOR=1`, and a redirected
+    //! stdout) still wrote `^[[1mFiles Analyzed:^[[0m ^[[1;37m1^[[0m`, because
+    //! the summary renderer interpolated the raw `c::BOLD` / `c::RESET` consts
+    //! rather than the helpers that consult `colors_enabled()`.
+    use super::{format_summary_report, format_violation_list};
+    use crate::entropy::entropy_calculator::{EntropyMetrics, EntropyReport};
+    use crate::entropy::violation_detector::{ActionableViolation, Severity};
+    use std::collections::BTreeMap;
+
+    fn violation(severity: Severity) -> ActionableViolation {
+        ActionableViolation {
+            severity,
+            pattern: None,
+            message: "Result handling repeated 7 times".to_string(),
+            fix_suggestion: "Extract a helper".to_string(),
+            estimated_loc_reduction: Some(12),
+            affected_files: vec![],
+            priority_score: 0.5,
+        }
+    }
+
+    fn report() -> EntropyReport {
+        EntropyReport {
+            total_files_analyzed: 3,
+            actionable_violations: vec![
+                violation(Severity::High),
+                violation(Severity::Medium),
+                violation(Severity::Low),
+            ],
+            pattern_summary: None,
+            entropy_metrics: EntropyMetrics {
+                file_level_entropy: Some(0.8),
+                module_level_entropy: Some(0.7),
+                project_level_entropy: Some(0.65),
+                pattern_diversity: Some(0.72),
+                total_patterns: 5,
+                total_instances: 21,
+                total_loc: 120,
+                patterns_by_type: BTreeMap::new(),
+            },
+            measurement_note: None,
+        }
+    }
+
+    #[test]
+    fn summary_emits_no_ansi_when_colour_is_disabled() {
+        assert!(
+            !crate::cli::colors::colors_enabled(),
+            "cargo test captures stdout, so colour must resolve to off here"
+        );
+        let out = format_summary_report(&report(), 10);
+        assert!(
+            !out.contains('\x1b'),
+            "entropy summary must be plain with colour off, got {out:?}"
+        );
+    }
+
+    #[test]
+    fn violation_list_emits_no_ansi_when_colour_is_disabled() {
+        let out = format_violation_list(&[
+            violation(Severity::High),
+            violation(Severity::Medium),
+            violation(Severity::Low),
+        ]);
+        assert!(
+            !out.contains('\x1b'),
+            "entropy violation list must be plain with colour off, got {out:?}"
+        );
+    }
+
+    #[test]
+    fn summary_keeps_its_payload_text() {
+        // The escapes must go, not the values they wrapped.
+        let out = format_summary_report(&report(), 10);
+        assert!(out.contains("Entropy Analysis Summary"), "{out}");
+        assert!(out.contains("Files Analyzed: 3"), "{out}");
+        assert!(out.contains("Source Lines Analyzed: 120"), "{out}");
+        assert!(out.contains("Top Violations:"), "{out}");
+        assert!(out.contains("Fix: Extract a helper"), "{out}");
+        assert!(out.contains("High"), "{out}");
     }
 }

--- a/src/cli/handlers/analysis_handlers/entropy_semantic.rs
+++ b/src/cli/handlers/analysis_handlers/entropy_semantic.rs
@@ -307,41 +307,199 @@ fn index_workspace(
     Ok(num_docs)
 }
 
+/// Reject a `--format` value this subcommand cannot actually produce.
+///
+/// `--format` accepts nine values but only `json` was ever implemented: yaml,
+/// csv, markdown, junit, summary, text, plain and table all fell through one
+/// `_ =>` arm, so eight of the nine advertised formats emitted byte-identical
+/// human text. The formats below are now produced for real; `junit` describes
+/// test cases, of which a clustering run has none, so it is refused rather than
+/// silently answered with prose.
+fn reject_unsupported_format(
+    subcommand: &str,
+    format: &crate::cli::enums::OutputFormat,
+) -> Result<()> {
+    if matches!(format, crate::cli::enums::OutputFormat::Junit) {
+        anyhow::bail!(
+            "`analyze {subcommand} --format junit` is not supported: there are no test cases to \
+             report. Use json, yaml, csv, markdown or table."
+        );
+    }
+    Ok(())
+}
+
+/// Machine-readable view of a clustering run, shared by json/yaml/csv/markdown.
+fn cluster_results_json(
+    result: &crate::services::local_semantic::LocalClusterResult,
+) -> serde_json::Value {
+    serde_json::json!({
+        "method": result.method,
+        "num_documents": result.num_documents,
+        "num_clusters": result.clusters.len(),
+        "clusters": result.clusters.iter().map(|c| serde_json::json!({
+            "id": c.id, "size": c.size,
+            "files": c.files.iter().map(|f| f.display().to_string()).collect::<Vec<_>>()
+        })).collect::<Vec<_>>()
+    })
+}
+
+/// Render clustering results in the requested format.
+fn format_cluster_results(
+    result: &crate::services::local_semantic::LocalClusterResult,
+    format: &crate::cli::enums::OutputFormat,
+) -> Result<String> {
+    use crate::cli::enums::OutputFormat;
+    use std::fmt::Write as _;
+
+    reject_unsupported_format("cluster", format)?;
+
+    let mut out = String::new();
+    match format {
+        OutputFormat::Json => {
+            out.push_str(&serde_json::to_string_pretty(&cluster_results_json(
+                result,
+            ))?);
+        }
+        OutputFormat::Yaml => {
+            out.push_str(&serde_yaml_ng::to_string(&cluster_results_json(result))?);
+        }
+        OutputFormat::Csv => {
+            out.push_str("cluster_id,size,file\n");
+            for cluster in &result.clusters {
+                for file in &cluster.files {
+                    let _ = writeln!(out, "{},{},{}", cluster.id, cluster.size, file.display());
+                }
+            }
+        }
+        OutputFormat::Markdown => {
+            let _ = writeln!(out, "# Clustering Results ({})\n", result.method);
+            let _ = writeln!(out, "- **Documents**: {}", result.num_documents);
+            let _ = writeln!(out, "- **Clusters**: {}\n", result.clusters.len());
+            out.push_str("| Cluster | Size | Files |\n| --- | --- | --- |\n");
+            for cluster in &result.clusters {
+                let files: Vec<String> = cluster
+                    .files
+                    .iter()
+                    .map(|f| f.display().to_string())
+                    .collect();
+                let _ = writeln!(
+                    out,
+                    "| {} | {} | {} |",
+                    cluster.id,
+                    cluster.size,
+                    files.join("<br>")
+                );
+            }
+        }
+        _ => {
+            let _ = writeln!(out, "\n\u{1f4ca} Clustering Results ({}):", result.method);
+            let _ = writeln!(out, "   Documents: {}", result.num_documents);
+            let _ = writeln!(out, "   Clusters: {}\n", result.clusters.len());
+            for cluster in &result.clusters {
+                let _ = writeln!(out, "   Cluster {} ({} files):", cluster.id, cluster.size);
+                for file in cluster.files.iter().take(5) {
+                    let _ = writeln!(out, "     - {}", file.display());
+                }
+                if cluster.files.len() > 5 {
+                    let _ = writeln!(out, "     ... and {} more", cluster.files.len() - 5);
+                }
+                out.push('\n');
+            }
+        }
+    }
+    Ok(out)
+}
+
 /// Output clustering results in the requested format
 fn output_cluster_results(
     result: &crate::services::local_semantic::LocalClusterResult,
     format: &crate::cli::enums::OutputFormat,
 ) -> Result<()> {
+    println!("{}", format_cluster_results(result, format)?);
+    Ok(())
+}
+
+/// Machine-readable view of a topic run, shared by json/yaml/csv/markdown.
+fn topic_results_json(
+    result: &crate::services::local_semantic::LocalTopicResult,
+) -> serde_json::Value {
+    serde_json::json!({
+        "num_documents": result.num_documents,
+        "num_topics": result.topics.len(),
+        "topics": result.topics.iter().map(|t| serde_json::json!({
+            "id": t.id, "document_count": t.document_count,
+            "top_terms": t.top_terms.iter().map(|(term, weight)| {
+                serde_json::json!({"term": term, "weight": weight})
+            }).collect::<Vec<_>>()
+        })).collect::<Vec<_>>()
+    })
+}
+
+/// Render topic extraction results in the requested format.
+fn format_topic_results(
+    result: &crate::services::local_semantic::LocalTopicResult,
+    format: &crate::cli::enums::OutputFormat,
+) -> Result<String> {
+    use crate::cli::enums::OutputFormat;
+    use std::fmt::Write as _;
+
+    reject_unsupported_format("topics", format)?;
+
+    let mut out = String::new();
     match format {
-        crate::cli::enums::OutputFormat::Json => {
-            let json_output = serde_json::json!({
-                "method": result.method,
-                "num_documents": result.num_documents,
-                "num_clusters": result.clusters.len(),
-                "clusters": result.clusters.iter().map(|c| serde_json::json!({
-                    "id": c.id, "size": c.size,
-                    "files": c.files.iter().map(|f| f.display().to_string()).collect::<Vec<_>>()
-                })).collect::<Vec<_>>()
-            });
-            println!("{}", serde_json::to_string_pretty(&json_output)?);
+        OutputFormat::Json => {
+            out.push_str(&serde_json::to_string_pretty(&topic_results_json(result))?);
+        }
+        OutputFormat::Yaml => {
+            out.push_str(&serde_yaml_ng::to_string(&topic_results_json(result))?);
+        }
+        OutputFormat::Csv => {
+            out.push_str("topic_id,document_count,term,weight\n");
+            for topic in &result.topics {
+                for (term, weight) in &topic.top_terms {
+                    let _ = writeln!(
+                        out,
+                        "{},{},{},{:.6}",
+                        topic.id, topic.document_count, term, weight
+                    );
+                }
+            }
+        }
+        OutputFormat::Markdown => {
+            out.push_str("# Topic Extraction Results\n\n");
+            let _ = writeln!(out, "- **Documents**: {}", result.num_documents);
+            let _ = writeln!(out, "- **Topics**: {}\n", result.topics.len());
+            for topic in &result.topics {
+                let _ = writeln!(
+                    out,
+                    "## Topic {} ({} documents)\n",
+                    topic.id, topic.document_count
+                );
+                for (term, weight) in topic.top_terms.iter().take(10) {
+                    let _ = writeln!(out, "- {term} ({weight:.3})");
+                }
+                out.push('\n');
+            }
         }
         _ => {
-            println!("\n\u{1f4ca} Clustering Results ({}):", result.method);
-            println!("   Documents: {}", result.num_documents);
-            println!("   Clusters: {}\n", result.clusters.len());
-            for cluster in &result.clusters {
-                println!("   Cluster {} ({} files):", cluster.id, cluster.size);
-                for file in cluster.files.iter().take(5) {
-                    println!("     - {}", file.display());
+            out.push_str("\n\u{1f4ca} Topic Extraction Results:\n");
+            let _ = writeln!(out, "   Documents: {}", result.num_documents);
+            let _ = writeln!(out, "   Topics: {}\n", result.topics.len());
+            for topic in &result.topics {
+                let _ = writeln!(
+                    out,
+                    "   Topic {} ({} documents):",
+                    topic.id, topic.document_count
+                );
+                out.push_str("     Top terms:\n");
+                for (term, weight) in topic.top_terms.iter().take(10) {
+                    let _ = writeln!(out, "       - {} ({:.3})", term, weight);
                 }
-                if cluster.files.len() > 5 {
-                    println!("     ... and {} more", cluster.files.len() - 5);
-                }
-                println!();
+                out.push('\n');
             }
         }
     }
-    Ok(())
+    Ok(out)
 }
 
 /// Output topic extraction results in the requested format
@@ -349,37 +507,7 @@ fn output_topic_results(
     result: &crate::services::local_semantic::LocalTopicResult,
     format: &crate::cli::enums::OutputFormat,
 ) -> Result<()> {
-    match format {
-        crate::cli::enums::OutputFormat::Json => {
-            let json_output = serde_json::json!({
-                "num_documents": result.num_documents,
-                "num_topics": result.topics.len(),
-                "topics": result.topics.iter().map(|t| serde_json::json!({
-                    "id": t.id, "document_count": t.document_count,
-                    "top_terms": t.top_terms.iter().map(|(term, weight)| {
-                        serde_json::json!({"term": term, "weight": weight})
-                    }).collect::<Vec<_>>()
-                })).collect::<Vec<_>>()
-            });
-            println!("{}", serde_json::to_string_pretty(&json_output)?);
-        }
-        _ => {
-            println!("\n\u{1f4ca} Topic Extraction Results:");
-            println!("   Documents: {}", result.num_documents);
-            println!("   Topics: {}\n", result.topics.len());
-            for topic in &result.topics {
-                println!(
-                    "   Topic {} ({} documents):",
-                    topic.id, topic.document_count
-                );
-                println!("     Top terms:");
-                for (term, weight) in topic.top_terms.iter().take(10) {
-                    println!("       - {} ({:.3})", term, weight);
-                }
-                println!();
-            }
-        }
-    }
+    println!("{}", format_topic_results(result, format)?);
     Ok(())
 }
 
@@ -457,5 +585,93 @@ mod stdout_purity_tests {
                 );
             }
         }
+    }
+}
+
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg(test)]
+mod format_coverage_tests {
+    //! Regression tests for `analyze cluster` / `analyze topics --format`:
+    //! the enum advertises nine values but only `json` was implemented, so
+    //! yaml, csv, markdown, junit, summary, text, plain and table all produced
+    //! byte-identical human text.
+    use super::{format_cluster_results, format_topic_results};
+    use crate::cli::enums::OutputFormat;
+    use crate::services::local_semantic::{
+        LocalCluster, LocalClusterResult, LocalTopic, LocalTopicResult,
+    };
+
+    fn cluster_result() -> LocalClusterResult {
+        LocalClusterResult {
+            clusters: vec![LocalCluster {
+                id: 0,
+                files: vec![std::path::PathBuf::from("src/lib.rs")],
+                size: 1,
+            }],
+            method: "kmeans".to_string(),
+            num_documents: 1,
+        }
+    }
+
+    fn topic_result() -> LocalTopicResult {
+        LocalTopicResult {
+            topics: vec![LocalTopic {
+                id: 0,
+                top_terms: vec![("network".to_string(), 0.5)],
+                document_count: 1,
+            }],
+            num_documents: 1,
+        }
+    }
+
+    #[test]
+    fn test_cluster_formats_are_distinguishable() {
+        let result = cluster_result();
+        let json = format_cluster_results(&result, &OutputFormat::Json).unwrap();
+        let yaml = format_cluster_results(&result, &OutputFormat::Yaml).unwrap();
+        let csv = format_cluster_results(&result, &OutputFormat::Csv).unwrap();
+        let markdown = format_cluster_results(&result, &OutputFormat::Markdown).unwrap();
+        let table = format_cluster_results(&result, &OutputFormat::Table).unwrap();
+
+        for (name, rendered) in [
+            ("json", &json),
+            ("yaml", &yaml),
+            ("csv", &csv),
+            ("markdown", &markdown),
+        ] {
+            assert_ne!(
+                rendered, &table,
+                "--format {name} must not be the human-text rendering"
+            );
+        }
+        assert!(csv.starts_with("cluster_id,size,file"));
+        assert!(markdown.starts_with("# Clustering Results"));
+        assert!(yaml.contains("method: kmeans"));
+    }
+
+    #[test]
+    fn test_topic_formats_are_distinguishable() {
+        let result = topic_result();
+        let csv = format_topic_results(&result, &OutputFormat::Csv).unwrap();
+        let markdown = format_topic_results(&result, &OutputFormat::Markdown).unwrap();
+        let yaml = format_topic_results(&result, &OutputFormat::Yaml).unwrap();
+        let table = format_topic_results(&result, &OutputFormat::Table).unwrap();
+
+        assert!(csv.starts_with("topic_id,document_count,term,weight"));
+        assert_ne!(markdown, table);
+        assert_ne!(yaml, table);
+        assert!(yaml.contains("num_topics"));
+    }
+
+    #[test]
+    fn test_junit_is_refused_rather_than_answered_with_prose() {
+        let err = format_cluster_results(&cluster_result(), &OutputFormat::Junit)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("junit"),
+            "an unsupported format must be an error naming it, got {err}"
+        );
+        assert!(format_topic_results(&topic_result(), &OutputFormat::Junit).is_err());
     }
 }

--- a/src/cli/handlers/analysis_handlers/entropy_semantic.rs
+++ b/src/cli/handlers/analysis_handlers/entropy_semantic.rs
@@ -391,6 +391,20 @@ fn format_cluster_results(
                 );
             }
         }
+        OutputFormat::Summary => {
+            // `summary` is documented as "summary statistics only"; it used to be
+            // byte-identical to the default rendering, listing every file.
+            let _ = writeln!(
+                out,
+                "{} clustering: {} document(s) in {} cluster(s)",
+                result.method,
+                result.num_documents,
+                result.clusters.len()
+            );
+            for cluster in &result.clusters {
+                let _ = writeln!(out, "  cluster {}: {} file(s)", cluster.id, cluster.size);
+            }
+        }
         _ => {
             let _ = writeln!(out, "\n\u{1f4ca} Clustering Results ({}):", result.method);
             let _ = writeln!(out, "   Documents: {}", result.num_documents);
@@ -479,6 +493,25 @@ fn format_topic_results(
                     let _ = writeln!(out, "- {term} ({weight:.3})");
                 }
                 out.push('\n');
+            }
+        }
+        OutputFormat::Summary => {
+            // Counts only — see the note on the cluster renderer: `summary` used
+            // to print the full per-topic term listing, identical to `text`.
+            let _ = writeln!(
+                out,
+                "{} document(s), {} topic(s)",
+                result.num_documents,
+                result.topics.len()
+            );
+            for topic in &result.topics {
+                let _ = writeln!(
+                    out,
+                    "  topic {}: {} document(s), {} term(s)",
+                    topic.id,
+                    topic.document_count,
+                    topic.top_terms.len()
+                );
             }
         }
         _ => {
@@ -631,6 +664,7 @@ mod format_coverage_tests {
         let yaml = format_cluster_results(&result, &OutputFormat::Yaml).unwrap();
         let csv = format_cluster_results(&result, &OutputFormat::Csv).unwrap();
         let markdown = format_cluster_results(&result, &OutputFormat::Markdown).unwrap();
+        let summary = format_cluster_results(&result, &OutputFormat::Summary).unwrap();
         let table = format_cluster_results(&result, &OutputFormat::Table).unwrap();
 
         for (name, rendered) in [
@@ -638,6 +672,7 @@ mod format_coverage_tests {
             ("yaml", &yaml),
             ("csv", &csv),
             ("markdown", &markdown),
+            ("summary", &summary),
         ] {
             assert_ne!(
                 rendered, &table,
@@ -647,6 +682,11 @@ mod format_coverage_tests {
         assert!(csv.starts_with("cluster_id,size,file"));
         assert!(markdown.starts_with("# Clustering Results"));
         assert!(yaml.contains("method: kmeans"));
+        // "Summary statistics only" means no per-file listing.
+        assert!(
+            !summary.contains("src/lib.rs"),
+            "--format summary must not print the full per-file listing: {summary}"
+        );
     }
 
     #[test]
@@ -655,12 +695,19 @@ mod format_coverage_tests {
         let csv = format_topic_results(&result, &OutputFormat::Csv).unwrap();
         let markdown = format_topic_results(&result, &OutputFormat::Markdown).unwrap();
         let yaml = format_topic_results(&result, &OutputFormat::Yaml).unwrap();
+        let summary = format_topic_results(&result, &OutputFormat::Summary).unwrap();
         let table = format_topic_results(&result, &OutputFormat::Table).unwrap();
 
         assert!(csv.starts_with("topic_id,document_count,term,weight"));
         assert_ne!(markdown, table);
         assert_ne!(yaml, table);
+        assert_ne!(summary, table);
         assert!(yaml.contains("num_topics"));
+        // "Summary statistics only": counts, not the per-topic term listing.
+        assert!(
+            !summary.contains("network"),
+            "--format summary must not print the term listing: {summary}"
+        );
     }
 
     #[test]

--- a/src/cli/handlers/analysis_handlers/entropy_semantic.rs
+++ b/src/cli/handlers/analysis_handlers/entropy_semantic.rs
@@ -293,14 +293,17 @@ fn index_workspace(
     workspace: &Path,
     language: Option<&str>,
 ) -> Result<usize> {
-    println!("\u{1f50d} Indexing source files...");
+    // Progress chatter goes to stderr: with `--format json` these banners used
+    // to precede the JSON document on stdout, so piping the output into a JSON
+    // parser failed on the very first character.
+    eprintln!("\u{1f50d} Indexing source files...");
     let num_docs = engine
         .index_directory(workspace, language)
         .map_err(|e| anyhow::anyhow!("Failed to index directory: {}", e))?;
     if num_docs == 0 {
         anyhow::bail!("No source files found to analyze");
     }
-    println!("\u{1f4c1} Indexed {} source files", num_docs);
+    eprintln!("\u{1f4c1} Indexed {} source files", num_docs);
     Ok(num_docs)
 }
 
@@ -401,7 +404,8 @@ pub(super) async fn route_semantic_analysis(cmd: AnalyzeCommands) -> Result<()> 
                 crate::cli::commands::ClusterMethod::Dbscan => "dbscan",
             };
             index_workspace(&mut engine, &workspace, language.as_deref())?;
-            println!("\u{1f9ee} Running {} clustering...", method_str);
+            // stderr, so `--format json` stdout stays a single JSON document.
+            eprintln!("\u{1f9ee} Running {} clustering...", method_str);
             let result = engine
                 .cluster(method_str, k)
                 .map_err(|e| anyhow::anyhow!("Clustering failed: {}", e))?;
@@ -413,12 +417,45 @@ pub(super) async fn route_semantic_analysis(cmd: AnalyzeCommands) -> Result<()> 
             format,
         } => {
             index_workspace(&mut engine, &workspace, language.as_deref())?;
-            println!("\u{1f52c} Extracting {} topics using LDA...", num_topics);
+            // stderr, so `--format json` stdout stays a single JSON document.
+            eprintln!("\u{1f52c} Extracting {} topics using LDA...", num_topics);
             let result = engine
                 .extract_topics(num_topics, language)
                 .map_err(|e| anyhow::anyhow!("Topic extraction failed: {}", e))?;
             output_topic_results(&result, &format)
         }
         _ => unreachable!("Expected semantic analysis command"),
+    }
+}
+
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg(test)]
+mod stdout_purity_tests {
+    /// `analyze cluster --format json` used to emit its progress banners with
+    /// println!, so stdout began with "🔍 Indexing source files..." and a JSON
+    /// consumer failed at character 0. Pin every banner in this module to
+    /// stderr — there is no way to observe the real process stdout from a unit
+    /// test, so the check is made against the module source itself.
+    #[test]
+    fn test_progress_banners_never_go_to_stdout() {
+        let src = include_str!("entropy_semantic.rs");
+        let banners = [
+            "Indexing source files",
+            "Indexed {} source files",
+            "clustering...",
+            "topics using LDA",
+        ];
+        for line in src.lines() {
+            let trimmed = line.trim_start();
+            if !trimmed.starts_with("println!") {
+                continue;
+            }
+            for banner in banners {
+                assert!(
+                    !trimmed.contains(banner),
+                    "progress banner must be written to stderr: {trimmed}"
+                );
+            }
+        }
     }
 }

--- a/src/cli/handlers/analysis_handlers/platform_routes_models.rs
+++ b/src/cli/handlers/analysis_handlers/platform_routes_models.rs
@@ -64,6 +64,12 @@ pub(super) async fn route_model_analysis(cmd: AnalyzeCommands) -> Result<()> {
                 format: format_name.to_string(),
                 size_bytes: file_size,
                 lfs_tracked: is_lfs_tracked(filename, &lfs_patterns),
+                // The format above comes from the EXTENSION; this is the only
+                // thing that has actually looked at the bytes.
+                header_valid:
+                    crate::cli::handlers::comply_cb_detect::model_header_matches_extension(
+                        file_path,
+                    ),
             });
         }
 
@@ -79,7 +85,12 @@ pub(super) async fn route_model_analysis(cmd: AnalyzeCommands) -> Result<()> {
         // Optionally run compliance checks
         if check {
             println!();
-            let violations = collect_model_violations(&project_path);
+            let mut violations = collect_model_violations(&project_path);
+            // A file whose header does not parse is not a model that "passes
+            // quality checks": every CB-10xx detector below reads headers, so a
+            // garbage file simply produces no findings and the check reported
+            // success on it.
+            violations.splice(0..0, unreadable_model_violations(&entries));
             if violations.is_empty() {
                 println!("\u{2705} All model files pass quality checks");
             } else {
@@ -107,6 +118,11 @@ struct ModelInventoryEntry {
     format: String,
     size_bytes: u64,
     lfs_tracked: bool,
+    /// True when the file's magic bytes agree with the format its extension
+    /// declares. `format` is derived from the extension and nothing else, so
+    /// without this an unreadable or truncated file is inventoried as a valid
+    /// model of its declared format.
+    header_valid: bool,
 }
 
 fn format_size(bytes: u64) -> String {
@@ -116,6 +132,11 @@ fn format_size(bytes: u64) -> String {
 fn print_model_inventory_table(entries: &[ModelInventoryEntry], total_size: u64) {
     let has_lfs = entries.iter().any(|e| e.lfs_tracked);
     let width = if has_lfs { 78 } else { 72 };
+    let invalid: Vec<&str> = entries
+        .iter()
+        .filter(|e| !e.header_valid)
+        .map(|e| e.file.as_str())
+        .collect();
 
     println!(
         "Model Inventory ({} files, {} total)",
@@ -138,11 +159,18 @@ fn print_model_inventory_table(entries: &[ModelInventoryEntry], total_size: u64)
         } else {
             entry.file.clone()
         };
+        // The declared format is the file EXTENSION's claim; `(?)` marks the
+        // ones whose bytes do not back that claim up.
+        let format_cell = if entry.header_valid {
+            entry.format.clone()
+        } else {
+            format!("{} (?)", entry.format)
+        };
         if has_lfs {
             println!(
                 "{:<40} {:<12} {:>12} {:>6}",
                 display_file,
-                entry.format,
+                format_cell,
                 format_size(entry.size_bytes),
                 if entry.lfs_tracked { "Yes" } else { "-" }
             );
@@ -150,12 +178,21 @@ fn print_model_inventory_table(entries: &[ModelInventoryEntry], total_size: u64)
             println!(
                 "{:<40} {:<12} {:>12}",
                 display_file,
-                entry.format,
+                format_cell,
                 format_size(entry.size_bytes)
             );
         }
     }
     println!("{}", "\u{2500}".repeat(width));
+    if !invalid.is_empty() {
+        println!(
+            "\u{26a0}\u{fe0f}  {} of {} file(s) marked (?) are NOT readable as the format their \
+             extension declares: {}",
+            invalid.len(),
+            entries.len(),
+            invalid.join(", ")
+        );
+    }
 }
 
 /// The human sentence emitted when a project contains no model files.
@@ -196,6 +233,9 @@ fn render_model_inventory_json(entries: &[ModelInventoryEntry], total_size: u64)
                 "size_bytes": e.size_bytes,
                 "size_human": format_size(e.size_bytes),
                 "lfs_tracked": e.lfs_tracked,
+                // `format` is what the extension DECLARES; `header_valid` is
+                // the only field here that read the file's bytes.
+                "header_valid": e.header_valid,
             })
         })
         .collect();
@@ -204,6 +244,7 @@ fn render_model_inventory_json(entries: &[ModelInventoryEntry], total_size: u64)
         "model_count": entries.len(),
         "total_size_bytes": total_size,
         "total_size_human": format_size(total_size),
+        "invalid_header_count": entries.iter().filter(|e| !e.header_valid).count(),
         "models": json_entries,
     });
 
@@ -246,6 +287,32 @@ fn is_lfs_tracked(filename: &str, lfs_patterns: &[String]) -> bool {
         }
     }
     false
+}
+
+/// One error per inventoried file whose bytes do not match the format its
+/// extension declares.
+///
+/// Uses CB-1003, the one unallocated slot in the CB-1000 MLOps series
+/// (1000, 1001, 1002, 1004-1008 are taken by the header-parsing detectors,
+/// none of which can fire on a file whose header never parsed).
+fn unreadable_model_violations(
+    entries: &[ModelInventoryEntry],
+) -> Vec<crate::cli::handlers::comply_cb_detect::CbPatternViolation> {
+    entries
+        .iter()
+        .filter(|e| !e.header_valid)
+        .map(|e| crate::cli::handlers::comply_cb_detect::CbPatternViolation {
+            pattern_id: "CB-1003".to_string(),
+            file: e.file.clone(),
+            line: 0,
+            description: format!(
+                "File is not readable as {}: its extension declares that format but the header \
+                 does not parse (truncated, empty or wrong format)",
+                e.format
+            ),
+            severity: crate::cli::handlers::comply_cb_detect::Severity::Error,
+        })
+        .collect()
 }
 
 fn collect_model_violations(
@@ -314,6 +381,87 @@ mod model_helper_tests {
         let out = no_models_stdout(path, &cli::OutputFormat::Table).unwrap();
         assert!(out.starts_with("No model files found"));
         assert!(out.contains("/tmp/some-fixture"));
+    }
+
+    // ── header validation (extension is a claim, not a measurement) ────────
+
+    fn entry(file: &str, format: &str, header_valid: bool) -> ModelInventoryEntry {
+        ModelInventoryEntry {
+            file: file.to_string(),
+            format: format.to_string(),
+            size_bytes: 0,
+            lfs_tracked: false,
+            header_valid,
+        }
+    }
+
+    /// The reported defect: format came from the filename extension only, so a
+    /// 0-byte `.safetensors`, an 8-byte `NOTAGGUF` and a text `.apr` were
+    /// inventoried as three valid models.
+    #[test]
+    fn test_garbage_files_are_not_reported_as_valid_models() {
+        use crate::cli::handlers::comply_cb_detect::model_header_matches_extension;
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("fake.apr"), b"hello world not an apr file").unwrap();
+        std::fs::write(tmp.path().join("garbage.gguf"), b"NOTAGGUF").unwrap();
+        std::fs::write(tmp.path().join("zero.safetensors"), b"").unwrap();
+
+        for name in ["fake.apr", "garbage.gguf", "zero.safetensors"] {
+            assert!(
+                !model_header_matches_extension(&tmp.path().join(name)),
+                "{name} must not validate as a model: its bytes are not that format"
+            );
+        }
+    }
+
+    #[test]
+    fn test_real_gguf_magic_validates() {
+        use crate::cli::handlers::comply_cb_detect::model_header_matches_extension;
+        let tmp = tempfile::tempdir().unwrap();
+        // "GGUF" + version 3 + tensor count 1, then padding to 64 bytes.
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(b"GGUF");
+        bytes.extend_from_slice(&3u32.to_le_bytes());
+        bytes.extend_from_slice(&1u64.to_le_bytes());
+        bytes.resize(64, 0);
+        let path = tmp.path().join("real.gguf");
+        std::fs::write(&path, &bytes).unwrap();
+        assert!(model_header_matches_extension(&path));
+    }
+
+    #[test]
+    fn test_inventory_json_discloses_unverified_headers() {
+        let out = render_model_inventory_json(
+            &[
+                entry("fake.apr", "APR", false),
+                entry("real.gguf", "GGUF", true),
+            ],
+            0,
+        )
+        .unwrap();
+        let doc: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(doc["invalid_header_count"], 1);
+        assert_eq!(doc["models"][0]["header_valid"], false);
+        assert_eq!(doc["models"][1]["header_valid"], true);
+    }
+
+    /// `--check` on a directory of garbage used to print only the missing
+    /// model-card/tokenizer advisories — every header-parsing detector silently
+    /// skips a file whose header does not parse, so the corrupt files
+    /// themselves were reported clean.
+    #[test]
+    fn test_check_reports_unreadable_models() {
+        let violations = unreadable_model_violations(&[
+            entry("fake.apr", "APR", false),
+            entry("real.gguf", "GGUF", true),
+        ]);
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].file, "fake.apr");
+        assert_eq!(violations[0].pattern_id, "CB-1003");
+        assert!(matches!(
+            violations[0].severity,
+            crate::cli::handlers::comply_cb_detect::Severity::Error
+        ));
     }
 
     // ── format_size (delegates to batuta_common::fmt) ──────────────────────

--- a/src/cli/handlers/analyze_defects_handler/handler.rs
+++ b/src/cli/handlers/analyze_defects_handler/handler.rs
@@ -42,15 +42,10 @@ pub async fn handle_analyze_defects(
 
     // Scan all files for defects
     let mut all_defects = Vec::new();
-    let mut files_with_defects = 0;
 
     for file_path in &files_to_scan {
         if let Ok(content) = fs::read_to_string(file_path) {
-            let defects = detector.detect(&content, file_path);
-            if !defects.is_empty() {
-                files_with_defects += 1;
-                all_defects.extend(defects);
-            }
+            all_defects.extend(detector.detect(&content, file_path));
         }
     }
 
@@ -60,7 +55,7 @@ pub async fn handle_analyze_defects(
     }
 
     // Calculate summary
-    let summary = calculate_summary(&files_to_scan, files_with_defects, &all_defects);
+    let summary = calculate_summary(&files_to_scan, &all_defects);
     let has_critical = all_defects
         .iter()
         .any(|d| matches!(d.severity, Severity::Critical));
@@ -119,9 +114,19 @@ pub(crate) fn is_hidden(entry: &walkdir::DirEntry) -> bool {
 #[provable_contracts_macros::contract("pmat-core.yaml", equation = "path_exists")]
 pub(crate) fn calculate_summary(
     files: &[std::path::PathBuf],
-    files_with_defects: usize,
     defects: &[DefectPattern],
 ) -> DefectSummary {
+    // `files_with_defects` used to be passed in, tallied while scanning — i.e.
+    // BEFORE the severity filter ran — so `--severity low` reported
+    // `files_with_defects: 22` above `total_defects: 0` and an empty `defects`
+    // array. Deriving it from the defects being summarized makes a count that
+    // disagrees with the list it heads impossible to construct.
+    let files_with_defects = defects
+        .iter()
+        .flat_map(|d| d.instances.iter().map(|i| i.file.as_str()))
+        .collect::<std::collections::BTreeSet<_>>()
+        .len();
+
     let mut critical = 0;
     let mut high = 0;
     let mut medium = 0;

--- a/src/cli/handlers/analyze_defects_handler/tests_output.rs
+++ b/src/cli/handlers/analyze_defects_handler/tests_output.rs
@@ -108,7 +108,7 @@ fn test_calculate_summary_with_defects() {
         },
     ];
 
-    let summary = calculate_summary(&files, 3, &defects);
+    let summary = calculate_summary(&files, &defects);
 
     assert_eq!(summary.total_files_scanned, 3);
     assert_eq!(summary.files_with_defects, 3);
@@ -466,4 +466,71 @@ fn test_print_defect_pattern_11_instances() {
 
     // Should show first 10 + "... (1 more)" message
     print_text_report(&report);
+}
+
+// =========================================================================
+// Round-5 dogfood regression: the summary must describe the list it heads
+// =========================================================================
+
+fn one_defect(severity: Severity, file: &str) -> DefectPattern {
+    DefectPattern {
+        id: format!("X-{file}"),
+        name: "defect".to_string(),
+        severity,
+        fix_recommendation: "Fix".to_string(),
+        bad_example: "bad".to_string(),
+        good_example: "good".to_string(),
+        evidence_description: "Evidence".to_string(),
+        evidence_url: None,
+        instances: vec![DefectInstance {
+            file: file.to_string(),
+            line: 1,
+            column: 1,
+            code_snippet: "bad".to_string(),
+        }],
+    }
+}
+
+/// `analyze defects --severity low --format json` on this repo printed
+/// `files_with_defects: 22` next to `total_defects: 0` and an empty `defects`
+/// array: the count was tallied while scanning, BEFORE the severity filter ran,
+/// and nothing recomputed it afterwards. `calculate_summary` now derives the
+/// count from the defects it is given, so a summary cannot outlive its list.
+#[test]
+fn files_with_defects_is_zero_once_the_severity_filter_empties_the_list() {
+    let files = vec![PathBuf::from("a.rs"), PathBuf::from("b.rs")];
+    let scanned = vec![
+        one_defect(Severity::Critical, "a.rs"),
+        one_defect(Severity::High, "b.rs"),
+    ];
+
+    // What `--severity low` does to the scan results.
+    let reported: Vec<DefectPattern> = scanned
+        .into_iter()
+        .filter(|d| d.severity == Severity::Low)
+        .collect();
+
+    let summary = calculate_summary(&files, &reported);
+
+    assert_eq!(summary.total_defects, 0);
+    assert_eq!(
+        summary.files_with_defects, 0,
+        "no defect is reported, so no file can have one"
+    );
+    assert_eq!(summary.total_files_scanned, 2, "the scan still happened");
+}
+
+/// The same derivation must not double-count a file that several patterns hit.
+#[test]
+fn files_with_defects_counts_distinct_files_not_patterns() {
+    let files = vec![PathBuf::from("a.rs")];
+    let reported = vec![
+        one_defect(Severity::Critical, "a.rs"),
+        one_defect(Severity::Low, "a.rs"),
+    ];
+
+    let summary = calculate_summary(&files, &reported);
+
+    assert_eq!(summary.total_defects, 2);
+    assert_eq!(summary.files_with_defects, 1);
 }

--- a/src/cli/handlers/analyze_defects_handler/tests_unit.rs
+++ b/src/cli/handlers/analyze_defects_handler/tests_unit.rs
@@ -331,7 +331,7 @@ fn test_calculate_summary_empty() {
     let files: Vec<PathBuf> = vec![];
     let defects: Vec<crate::services::defect_detector::DefectPattern> = vec![];
 
-    let summary = calculate_summary(&files, 0, &defects);
+    let summary = calculate_summary(&files, &defects);
 
     assert_eq!(summary.total_files_scanned, 0);
     assert_eq!(summary.files_with_defects, 0);

--- a/src/cli/handlers/big_o_handlers/handlers.rs
+++ b/src/cli/handlers/big_o_handlers/handlers.rs
@@ -136,20 +136,22 @@ mod analyze_space_noop_tests {
     #[test]
     fn help_text_does_not_promise_an_extra_analysis() {
         use clap::Subcommand;
-        let cmd = crate::cli::commands::AnalyzeCommands::augment_subcommands(clap::Command::new(
-            "analyze",
-        ));
-        let big_o = cmd
-            .get_subcommands()
-            .find(|s| s.get_name() == "big-o")
-            .expect("big-o subcommand must exist");
-        let help = big_o
-            .get_arguments()
-            .find(|a| a.get_id() == "analyze_space")
-            .expect("--analyze-space must exist")
-            .get_help()
-            .map(std::string::ToString::to_string)
-            .unwrap_or_default();
+        let help = crate::cli::commands::on_big_stack(|| {
+            let cmd = crate::cli::commands::AnalyzeCommands::augment_subcommands(
+                clap::Command::new("analyze"),
+            );
+            let help = cmd
+                .get_subcommands()
+                .find(|s| s.get_name() == "big-o")
+                .expect("big-o subcommand must exist")
+                .get_arguments()
+                .find(|a| a.get_id() == "analyze_space")
+                .expect("--analyze-space must exist")
+                .get_help()
+                .map(std::string::ToString::to_string)
+                .unwrap_or_default();
+            help
+        });
         assert!(
             help.contains("NO-OP"),
             "help must state the flag is inert, got: {help}"

--- a/src/cli/handlers/big_o_handlers/handlers.rs
+++ b/src/cli/handlers/big_o_handlers/handlers.rs
@@ -10,6 +10,16 @@ use tracing::{debug, info};
 use super::filters::apply_report_filters;
 use super::output::{format_analysis_output, write_analysis_output};
 
+/// Warning printed when `--analyze-space` is passed.
+///
+/// Space complexity is computed and printed for every function regardless of
+/// the flag — `analyze_space_complexity` reaches the config struct and no
+/// analyzer or renderer reads it — so `--analyze-space` changes nothing. It was
+/// accepted in silence, which read as if it had switched an extra analysis on.
+/// Named as a const so the note is covered by a test rather than only by eye.
+pub(super) const ANALYZE_SPACE_NOOP_NOTE: &str =
+    "note: --analyze-space is a no-op — space complexity is always reported alongside time";
+
 /// Handle Big-O complexity analysis command
 #[allow(clippy::too_many_arguments)]
 #[provable_contracts_macros::contract("pmat-core.yaml", equation = "path_exists")]
@@ -31,12 +41,7 @@ pub async fn handle_analyze_big_o(
     let start_time = std::time::Instant::now();
 
     if analyze_space {
-        // Space complexity is computed and printed for every function regardless of
-        // this flag, so --analyze-space changes nothing. It used to be accepted in
-        // silence, which read as if it had switched an extra analysis on.
-        eprintln!(
-            "note: --analyze-space is a no-op — space complexity is always reported alongside time"
-        );
+        eprintln!("{ANALYZE_SPACE_NOOP_NOTE}");
     }
 
     print_analysis_header(&project_path, confidence_threshold);
@@ -109,5 +114,49 @@ pub(super) fn print_analysis_summary(
     if perf {
         let functions_per_sec = report.analyzed_functions as f64 / elapsed.as_secs_f64();
         info!("⚡ Performance: {:.0} functions/second", functions_per_sec);
+    }
+}
+
+#[cfg(test)]
+mod analyze_space_noop_tests {
+    use super::*;
+
+    /// The note is the only thing that tells a user `--analyze-space` does
+    /// nothing; nothing covered it, so it could be deleted without a failure.
+    #[test]
+    fn the_noop_note_says_the_flag_is_a_no_op() {
+        assert!(ANALYZE_SPACE_NOOP_NOTE.contains("--analyze-space"));
+        assert!(ANALYZE_SPACE_NOOP_NOTE.contains("no-op"));
+        assert!(ANALYZE_SPACE_NOOP_NOTE.contains("always reported"));
+    }
+
+    /// The `--analyze-space` help text must not promise an extra analysis the
+    /// flag does not enable. It read "Analyze space complexity in addition to
+    /// time" while changing nothing at all.
+    #[test]
+    fn help_text_does_not_promise_an_extra_analysis() {
+        use clap::Subcommand;
+        let cmd = crate::cli::commands::AnalyzeCommands::augment_subcommands(clap::Command::new(
+            "analyze",
+        ));
+        let big_o = cmd
+            .get_subcommands()
+            .find(|s| s.get_name() == "big-o")
+            .expect("big-o subcommand must exist");
+        let help = big_o
+            .get_arguments()
+            .find(|a| a.get_id() == "analyze_space")
+            .expect("--analyze-space must exist")
+            .get_help()
+            .map(std::string::ToString::to_string)
+            .unwrap_or_default();
+        assert!(
+            help.contains("NO-OP"),
+            "help must state the flag is inert, got: {help}"
+        );
+        assert!(
+            !help.contains("in addition to time"),
+            "help must not promise an analysis the flag does not enable, got: {help}"
+        );
     }
 }

--- a/src/cli/handlers/big_o_handlers/handlers.rs
+++ b/src/cli/handlers/big_o_handlers/handlers.rs
@@ -30,6 +30,15 @@ pub async fn handle_analyze_big_o(
 
     let start_time = std::time::Instant::now();
 
+    if analyze_space {
+        // Space complexity is computed and printed for every function regardless of
+        // this flag, so --analyze-space changes nothing. It used to be accepted in
+        // silence, which read as if it had switched an extra analysis on.
+        eprintln!(
+            "note: --analyze-space is a no-op — space complexity is always reported alongside time"
+        );
+    }
+
     print_analysis_header(&project_path, confidence_threshold);
 
     let config = build_analysis_config(

--- a/src/cli/handlers/big_o_handlers/output.rs
+++ b/src/cli/handlers/big_o_handlers/output.rs
@@ -110,63 +110,57 @@ pub fn format_big_o_summary(report: &BigOAnalysisReport) -> String {
     } else {
         String::new()
     };
+    // COLOUR: these used to interpolate the raw `c::GREEN`/`c::RESET` consts,
+    // which are unconditional — so `--color never` and a redirected stdout
+    // still wrote `^[[32m0^[[0m` here (GH #684 class). `c::colored` consults
+    // `colors_enabled()` and yields the bare payload when colour is off.
     output.push_str(&format!(
-        "  {}: {}{}{}{}\n\n",
+        "  {}: {}{}\n\n",
         c::label("High Complexity Functions"),
-        high_color,
-        listed,
-        c::RESET,
+        c::colored(high_color, &listed.to_string()),
         high_suffix,
     ));
 
     output.push_str(&format!("{}\n", c::subheader("Complexity Distribution:")));
     let dist = &report.complexity_distribution;
     output.push_str(&format!(
-        "  {}O(1){}       : {} functions\n",
-        c::GREEN,
-        c::RESET,
+        "  {}       : {} functions\n",
+        c::colored(c::GREEN, "O(1)"),
         c::number(&format!("{:>4}", dist.constant))
     ));
     output.push_str(&format!(
-        "  {}O(log n){}   : {} functions\n",
-        c::GREEN,
-        c::RESET,
+        "  {}   : {} functions\n",
+        c::colored(c::GREEN, "O(log n)"),
         c::number(&format!("{:>4}", dist.logarithmic))
     ));
     output.push_str(&format!(
-        "  {}O(n){}       : {} functions\n",
-        c::YELLOW,
-        c::RESET,
+        "  {}       : {} functions\n",
+        c::colored(c::YELLOW, "O(n)"),
         c::number(&format!("{:>4}", dist.linear))
     ));
     output.push_str(&format!(
-        "  {}O(n log n){} : {} functions\n",
-        c::YELLOW,
-        c::RESET,
+        "  {} : {} functions\n",
+        c::colored(c::YELLOW, "O(n log n)"),
         c::number(&format!("{:>4}", dist.linearithmic))
     ));
     output.push_str(&format!(
-        "  {}O(n²){}      : {} functions\n",
-        c::RED,
-        c::RESET,
+        "  {}      : {} functions\n",
+        c::colored(c::RED, "O(n²)"),
         c::number(&format!("{:>4}", dist.quadratic))
     ));
     output.push_str(&format!(
-        "  {}O(n³){}      : {} functions\n",
-        c::RED,
-        c::RESET,
+        "  {}      : {} functions\n",
+        c::colored(c::RED, "O(n³)"),
         c::number(&format!("{:>4}", dist.cubic))
     ));
     output.push_str(&format!(
-        "  {}O(2^n){}     : {} functions\n",
-        c::BOLD_RED,
-        c::RESET,
+        "  {}     : {} functions\n",
+        c::colored(c::BOLD_RED, "O(2^n)"),
         c::number(&format!("{:>4}", dist.exponential))
     ));
     output.push_str(&format!(
-        "  {}Unknown{}    : {} functions\n",
-        c::DIM,
-        c::RESET,
+        "  {}    : {} functions\n",
+        c::colored(c::DIM, "Unknown"),
         c::number(&format!("{:>4}", dist.unknown))
     ));
 
@@ -228,12 +222,10 @@ pub fn format_big_o_summary(report: &BigOAnalysisReport) -> String {
                 c::GREEN
             };
             output.push_str(&format!(
-                "  {}. {} - score: {}{:.1}{}, {} functions\n",
+                "  {}. {} - score: {}, {} functions\n",
                 c::number(&(i + 1).to_string()),
                 c::path(filename),
-                score_color,
-                score,
-                c::RESET,
+                c::colored(score_color, &format!("{score:.1}")),
                 c::number(&function_count.to_string()),
             ));
         }
@@ -251,12 +243,10 @@ pub(super) fn format_big_o_detailed(report: &BigOAnalysisReport) -> String {
 
         for func in &report.high_complexity_functions {
             output.push_str(&format!(
-                "\n{} ({}:{}{}{})\n",
+                "\n{} ({}:{})\n",
                 c::label(&func.function_name),
                 c::path(&func.file_path.display().to_string()),
-                c::DIM,
-                func.line_number,
-                c::RESET,
+                c::colored(c::DIM, &func.line_number.to_string()),
             ));
             output.push_str(&format!(
                 "  {}: {} ({})\n",
@@ -274,7 +264,7 @@ pub(super) fn format_big_o_detailed(report: &BigOAnalysisReport) -> String {
             if !func.notes.is_empty() {
                 output.push_str(&format!("  {}:\n", c::label("Notes")));
                 for note in &func.notes {
-                    output.push_str(&format!("    {}─{} {note}\n", c::DIM, c::RESET));
+                    output.push_str(&format!("    {} {note}\n", c::colored(c::DIM, "─")));
                 }
             }
         }
@@ -293,4 +283,81 @@ pub(super) fn format_big_o_detailed(report: &BigOAnalysisReport) -> String {
     }
 
     output
+}
+
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg(test)]
+mod colour_gating_tests {
+    //! `analyze big-o --color never` (and a plain redirected stdout) still wrote
+    //! `^[[32m0^[[0m` for the high-complexity count and `^[[32mO(1)^[[0m` for
+    //! every distribution row, because those rows interpolated the raw
+    //! `c::GREEN` / `c::RESET` consts instead of a helper that consults
+    //! `colors_enabled()`.
+    use super::{format_big_o_detailed, format_big_o_summary};
+    use crate::models::complexity_bound::ComplexityBound;
+    use crate::services::big_o_analyzer::{
+        BigOAnalysisReport, ComplexityDistribution, FunctionComplexity,
+    };
+    use std::path::PathBuf;
+
+    fn report() -> BigOAnalysisReport {
+        BigOAnalysisReport {
+            analyzed_functions: 100,
+            high_complexity_functions: vec![FunctionComplexity {
+                function_name: "sort_data".to_string(),
+                file_path: PathBuf::from("src/utils.rs"),
+                line_number: 42,
+                time_complexity: ComplexityBound::quadratic().with_confidence(90),
+                space_complexity: ComplexityBound::linear().with_confidence(85),
+                confidence: 90,
+                notes: vec!["nested loop".to_string()],
+            }],
+            complexity_distribution: ComplexityDistribution {
+                constant: 20,
+                logarithmic: 10,
+                linear: 50,
+                linearithmic: 5,
+                quadratic: 10,
+                cubic: 2,
+                exponential: 1,
+                unknown: 2,
+            },
+            pattern_matches: vec![],
+            recommendations: vec!["Consider optimizing quadratic algorithms".to_string()],
+        }
+    }
+
+    #[test]
+    fn summary_emits_no_ansi_when_colour_is_disabled() {
+        assert!(
+            !crate::cli::colors::colors_enabled(),
+            "cargo test captures stdout, so colour must resolve to off here"
+        );
+        let out = format_big_o_summary(&report());
+        assert!(
+            !out.contains('\x1b'),
+            "big-o summary must be plain with colour off, got {out:?}"
+        );
+    }
+
+    #[test]
+    fn detailed_emits_no_ansi_when_colour_is_disabled() {
+        let out = format_big_o_detailed(&report());
+        assert!(
+            !out.contains('\x1b'),
+            "big-o detailed must be plain with colour off, got {out:?}"
+        );
+    }
+
+    #[test]
+    fn summary_keeps_its_payload_text() {
+        // The escapes must go, not the numbers they wrapped.
+        let out = format_big_o_summary(&report());
+        assert!(out.contains("O(1)"), "{out}");
+        assert!(out.contains("O(log n)"), "{out}");
+        assert!(out.contains("O(2^n)"), "{out}");
+        assert!(out.contains("Unknown"), "{out}");
+        assert!(out.contains("High Complexity Functions"), "{out}");
+        assert!(out.contains("utils.rs"), "{out}");
+    }
 }

--- a/src/cli/handlers/bottleneck_handler.rs
+++ b/src/cli/handlers/bottleneck_handler.rs
@@ -86,10 +86,7 @@ pub async fn handle_bottleneck(
 
     let analysis = analyze_bottlenecks(path, period, threshold)?;
 
-    let formatted = match format {
-        crate::cli::enums::OutputFormat::Json => serde_json::to_string_pretty(&analysis)?,
-        _ => format_text(&analysis),
-    };
+    let formatted = format_analysis(&analysis, format)?;
 
     if let Some(output_path) = output {
         std::fs::write(output_path, &formatted)?;
@@ -360,6 +357,224 @@ fn detect_coupling(commit_files: &[Vec<String>], min_co_changes: usize) -> Vec<C
     pairs
 }
 
+/// Render the analysis in the format the user asked for.
+///
+/// This used to be `match format { Json => .., _ => format_text() }`: eight of
+/// the nine formats `--help` advertises fell through the catch-all, so
+/// `-f csv`, `-f yaml` and `-f junit` all wrote the same ANSI-decorated table
+/// into files that were supposed to be CSV, YAML and JUnit XML — byte-identical
+/// output for every one of them.
+fn format_analysis(
+    analysis: &BottleneckAnalysis,
+    format: &crate::cli::enums::OutputFormat,
+) -> Result<String> {
+    use crate::cli::enums::OutputFormat as F;
+    Ok(match format {
+        F::Json => serde_json::to_string_pretty(analysis)?,
+        F::Yaml => serde_yaml_ng::to_string(analysis)?,
+        F::Markdown => format_markdown(analysis),
+        F::Csv => format_csv(analysis),
+        F::Junit => format_junit(analysis),
+        F::Summary => format_summary(analysis),
+        // The colour-free twins of the table: a redirected `-f text` had ANSI
+        // escapes in it.
+        F::Text | F::Plain => strip_ansi(&format_text(analysis)),
+        F::Table => format_text(analysis),
+    })
+}
+
+/// Drop SGR escape sequences — for the formats that promise plain text.
+fn strip_ansi(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut chars = text.chars();
+    while let Some(ch) = chars.next() {
+        if ch == '\u{1b}' {
+            for esc in chars.by_ref() {
+                if esc.is_ascii_alphabetic() {
+                    break;
+                }
+            }
+            continue;
+        }
+        out.push(ch);
+    }
+    out
+}
+
+/// One CSV field, quoted per RFC 4180 when it has to be.
+fn csv_field(value: &str) -> String {
+    if value.contains([',', '"', '\n']) {
+        format!("\"{}\"", value.replace('"', "\"\""))
+    } else {
+        value.to_string()
+    }
+}
+
+/// CSV: the bottleneck rows, then the coupling rows as a second block with its
+/// own header (a spreadsheet reads the first block; `csvkit` reads both).
+fn format_csv(analysis: &BottleneckAnalysis) -> String {
+    use std::fmt::Write;
+    let mut out = String::new();
+    let _ = writeln!(
+        out,
+        "path,touches,authors,lines,churn_ratio,pattern,recommendation"
+    );
+    for b in &analysis.bottlenecks {
+        let _ = writeln!(
+            out,
+            "{},{},{},{},{:.1},{},{}",
+            csv_field(&b.path),
+            b.touches,
+            b.authors,
+            b.lines,
+            b.churn_ratio,
+            csv_field(&b.pattern),
+            csv_field(&b.recommendation)
+        );
+    }
+    if !analysis.couplings.is_empty() {
+        let _ = writeln!(out);
+        let _ = writeln!(out, "file_a,file_b,co_changes");
+        for pair in &analysis.couplings {
+            let _ = writeln!(
+                out,
+                "{},{},{}",
+                csv_field(&pair.file_a),
+                csv_field(&pair.file_b),
+                pair.co_changes
+            );
+        }
+    }
+    out
+}
+
+/// Markdown report.
+fn format_markdown(analysis: &BottleneckAnalysis) -> String {
+    use std::fmt::Write;
+    let mut out = String::new();
+    let _ = writeln!(out, "# Architectural Bottleneck Analysis\n");
+    let _ = writeln!(out, "- **Period**: {} days", analysis.period_days);
+    let _ = writeln!(out, "- **Total commits**: {}", analysis.total_commits);
+    let _ = writeln!(
+        out,
+        "- **Files changed**: {}\n",
+        analysis.total_files_changed
+    );
+
+    if analysis.bottlenecks.is_empty() {
+        let _ = writeln!(out, "No bottleneck files detected.\n");
+    } else {
+        let _ = writeln!(out, "## Bottleneck Files\n");
+        let _ = writeln!(
+            out,
+            "| File | Touches | Authors | Lines | Churn ratio | Pattern | Recommendation |"
+        );
+        let _ = writeln!(out, "|---|---|---|---|---|---|---|");
+        for b in &analysis.bottlenecks {
+            let _ = writeln!(
+                out,
+                "| `{}` | {} | {} | {} | {:.1} | {} | {} |",
+                b.path, b.touches, b.authors, b.lines, b.churn_ratio, b.pattern, b.recommendation
+            );
+        }
+        let _ = writeln!(out);
+    }
+
+    if !analysis.couplings.is_empty() {
+        let _ = writeln!(out, "## Co-Change Coupling\n");
+        let _ = writeln!(out, "| File A | File B | Co-changes |");
+        let _ = writeln!(out, "|---|---|---|");
+        for pair in &analysis.couplings {
+            let _ = writeln!(
+                out,
+                "| `{}` | `{}` | {} |",
+                pair.file_a, pair.file_b, pair.co_changes
+            );
+        }
+    }
+    out
+}
+
+/// Three lines, no decoration.
+fn format_summary(analysis: &BottleneckAnalysis) -> String {
+    format!(
+        "period_days={}\ncommits={}\nfiles_changed={}\nbottlenecks={}\ncouplings={}\n",
+        analysis.period_days,
+        analysis.total_commits,
+        analysis.total_files_changed,
+        analysis.bottlenecks.len(),
+        analysis.couplings.len()
+    )
+}
+
+fn xml_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&apos;")
+}
+
+/// JUnit XML: every detected bottleneck is a failing testcase, so CI can gate
+/// on it.
+fn format_junit(analysis: &BottleneckAnalysis) -> String {
+    use std::fmt::Write;
+    let mut out = String::new();
+    let tests = analysis.bottlenecks.len() + analysis.couplings.len();
+    let _ = writeln!(out, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
+    let _ = writeln!(
+        out,
+        "<testsuites name=\"Architectural Bottlenecks\" tests=\"{tests}\" failures=\"{tests}\">"
+    );
+    let _ = writeln!(
+        out,
+        "  <testsuite name=\"Bottleneck Files\" tests=\"{}\" failures=\"{}\">",
+        analysis.bottlenecks.len(),
+        analysis.bottlenecks.len()
+    );
+    for b in &analysis.bottlenecks {
+        let _ = writeln!(
+            out,
+            "    <testcase name=\"{}\" classname=\"Bottleneck\">",
+            xml_escape(&b.path)
+        );
+        let _ = writeln!(
+            out,
+            "      <failure message=\"{} ({} touches, {} lines, churn ratio {:.1})\">{}</failure>",
+            xml_escape(&b.pattern),
+            b.touches,
+            b.lines,
+            b.churn_ratio,
+            xml_escape(&b.recommendation)
+        );
+        let _ = writeln!(out, "    </testcase>");
+    }
+    let _ = writeln!(out, "  </testsuite>");
+    let _ = writeln!(
+        out,
+        "  <testsuite name=\"Co-Change Coupling\" tests=\"{}\" failures=\"{}\">",
+        analysis.couplings.len(),
+        analysis.couplings.len()
+    );
+    for pair in &analysis.couplings {
+        let _ = writeln!(
+            out,
+            "    <testcase name=\"{} &lt;-&gt; {}\" classname=\"Coupling\">",
+            xml_escape(&pair.file_a),
+            xml_escape(&pair.file_b)
+        );
+        let _ = writeln!(
+            out,
+            "      <failure message=\"{} co-changes\" />",
+            pair.co_changes
+        );
+        let _ = writeln!(out, "    </testcase>");
+    }
+    let _ = writeln!(out, "  </testsuite>");
+    let _ = writeln!(out, "</testsuites>");
+    out
+}
+
 /// Format results as colorized text
 fn format_text(analysis: &BottleneckAnalysis) -> String {
     use crate::cli::colors as c;
@@ -561,6 +776,91 @@ mod tests {
         )
         .await;
         assert!(result.is_ok());
+    }
+
+    fn sample_analysis() -> BottleneckAnalysis {
+        BottleneckAnalysis {
+            period_days: 30,
+            total_commits: 13,
+            total_files_changed: 709,
+            bottlenecks: vec![BottleneckFile {
+                path: "src/cli/mod.rs".to_string(),
+                touches: 9,
+                authors: 2,
+                lines: 1200,
+                churn_ratio: 0.75,
+                pattern: "Registry/Dispatch".to_string(),
+                recommendation: "Consider proc-macro auto-discovery, e.g. inventory".to_string(),
+            }],
+            couplings: vec![CouplingPair {
+                file_a: "a.rs".to_string(),
+                file_b: "b.rs".to_string(),
+                co_changes: 4,
+            }],
+        }
+    }
+
+    /// `--help` advertises nine formats; eight of them fell through a catch-all
+    /// arm and emitted the SAME ANSI table (956 bytes each), so `-f csv` wrote
+    /// escape sequences into a .csv and `-f junit` was not XML.
+    #[test]
+    fn every_advertised_format_renders_itself() {
+        use crate::cli::enums::OutputFormat as F;
+        let analysis = sample_analysis();
+
+        let yaml = format_analysis(&analysis, &F::Yaml).unwrap();
+        let parsed: serde_yaml_ng::Value = serde_yaml_ng::from_str(&yaml).expect("valid yaml");
+        assert_eq!(parsed["total_commits"].as_u64(), Some(13));
+
+        let csv = format_analysis(&analysis, &F::Csv).unwrap();
+        assert!(csv.starts_with("path,touches,authors,lines,churn_ratio,pattern,recommendation\n"));
+        assert!(csv.contains("src/cli/mod.rs,9,2,1200,0.8,Registry/Dispatch,"));
+        assert!(csv.contains("file_a,file_b,co_changes\na.rs,b.rs,4"));
+
+        let junit = format_analysis(&analysis, &F::Junit).unwrap();
+        assert!(junit.starts_with("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"));
+        assert!(junit.contains("<testsuites"));
+        assert!(junit.contains("src/cli/mod.rs"));
+
+        let md = format_analysis(&analysis, &F::Markdown).unwrap();
+        assert!(md.starts_with("# Architectural Bottleneck Analysis"));
+        assert!(md.contains("| `src/cli/mod.rs` | 9 |"));
+
+        let summary = format_analysis(&analysis, &F::Summary).unwrap();
+        assert!(summary.contains("bottlenecks=1"));
+
+        let json = format_analysis(&analysis, &F::Json).unwrap();
+        let _: serde_json::Value = serde_json::from_str(&json).expect("valid json");
+
+        // No two formats may be byte-identical, and only the table may carry
+        // colour.
+        for (name, rendered) in [
+            ("yaml", &yaml),
+            ("csv", &csv),
+            ("junit", &junit),
+            ("markdown", &md),
+            ("summary", &summary),
+            ("json", &json),
+        ] {
+            assert!(
+                !rendered.contains('\u{1b}'),
+                "{name} carries ANSI escapes: {rendered:?}"
+            );
+        }
+    }
+
+    /// `-f text` / `-f plain` keep the table's shape but must not carry colour
+    /// into a redirected file.
+    #[test]
+    fn text_and_plain_are_the_table_without_escapes() {
+        use crate::cli::enums::OutputFormat as F;
+        let analysis = sample_analysis();
+        let text = format_analysis(&analysis, &F::Text).unwrap();
+        let plain = format_analysis(&analysis, &F::Plain).unwrap();
+        assert_eq!(text, plain);
+        assert!(!text.contains('\u{1b}'), "{text:?}");
+        assert!(text.contains("Architectural Bottleneck Analysis"));
+        assert!(text.contains("src/cli/mod.rs"));
     }
 
     /// GH #665: a monotonically larger `--period` must never report fewer

--- a/src/cli/handlers/bottleneck_handler.rs
+++ b/src/cli/handlers/bottleneck_handler.rs
@@ -142,8 +142,12 @@ fn analyze_bottlenecks(path: &Path, period: u32, threshold: usize) -> Result<Bot
         })
         .collect();
 
-    // Sort by touches descending
-    bottlenecks.sort_by_key(|b| std::cmp::Reverse(b.touches));
+    // Sort by touches descending. DETERMINISM: `touches` is not a total order
+    // (most files tie), the source is a `HashMap`, and `sort_by_key` is stable —
+    // so which of the tied files survived `truncate(20)` came out of the
+    // process's hash seed. Eight identical runs produced four distinct outputs.
+    // Path breaks the tie.
+    bottlenecks.sort_by(|a, b| b.touches.cmp(&a.touches).then_with(|| a.path.cmp(&b.path)));
     bottlenecks.truncate(20);
 
     // Detect co-change coupling
@@ -352,7 +356,14 @@ fn detect_coupling(commit_files: &[Vec<String>], min_co_changes: usize) -> Vec<C
         })
         .collect();
 
-    pairs.sort_by_key(|b| std::cmp::Reverse(b.co_changes));
+    // Same tie-break as `analyze_bottlenecks`: `co_changes` ties constantly and
+    // the pairs come out of a `HashMap`, so the surviving 15 were hash-seed
+    // dependent.
+    pairs.sort_by(|x, y| {
+        y.co_changes
+            .cmp(&x.co_changes)
+            .then_with(|| (&x.file_a, &x.file_b).cmp(&(&y.file_a, &y.file_b)))
+    });
     pairs.truncate(15);
     pairs
 }
@@ -930,5 +941,119 @@ mod tests {
             huge, small,
             "a larger --period reported fewer commits (pre-fix: 0)"
         );
+    }
+
+    // ── determinism ─────────────────────────────────────────────────────────
+    //
+    // `analyze bottleneck` produced four distinct md5s over eight identical
+    // runs: both result lists are built from a `HashMap`, ranked by a key that
+    // ties constantly (`touches` / `co_changes`) with a *stable* sort, and then
+    // truncated — so which of the tied entries survived came out of the
+    // process's hash seed. `RandomState` reseeds per `HashMap` instance, so
+    // repeated calls inside one test process reproduce the run-to-run variance.
+
+    /// Enough tied pairs to overflow `truncate(15)`, so an unstable tie-break
+    /// changes the *contents*, not just the order.
+    fn tied_commits() -> Vec<Vec<String>> {
+        (0..30)
+            .map(|i| vec!["src/shared.rs".to_string(), format!("src/mod_{i:02}.rs")])
+            .collect()
+    }
+
+    #[test]
+    fn detect_coupling_is_deterministic_across_runs() {
+        let commits = tied_commits();
+        let first = detect_coupling(&commits, 1);
+        assert_eq!(first.len(), 15, "the fixture must exercise the truncation");
+        for run in 1..25 {
+            let again = detect_coupling(&commits, 1);
+            let as_tuples = |p: &[CouplingPair]| {
+                p.iter()
+                    .map(|c| (c.file_a.clone(), c.file_b.clone(), c.co_changes))
+                    .collect::<Vec<_>>()
+            };
+            assert_eq!(
+                as_tuples(&first),
+                as_tuples(&again),
+                "run {run} disagreed with run 0: coupling output depends on HashMap order"
+            );
+        }
+    }
+
+    #[test]
+    fn detect_coupling_breaks_ties_by_path() {
+        let pairs = detect_coupling(&tied_commits(), 1);
+        let mut expected: Vec<(String, String)> = pairs
+            .iter()
+            .map(|p| (p.file_a.clone(), p.file_b.clone()))
+            .collect();
+        expected.sort();
+        let actual: Vec<(String, String)> = pairs
+            .iter()
+            .map(|p| (p.file_a.clone(), p.file_b.clone()))
+            .collect();
+        assert_eq!(actual, expected, "tied pairs must be ordered by path");
+    }
+
+    #[test]
+    fn analyze_bottlenecks_is_deterministic_across_runs() {
+        use std::process::Command;
+        use tempfile::TempDir;
+
+        let temp = TempDir::new().unwrap();
+        let repo = temp.path();
+        let git = |args: &[&str]| {
+            Command::new("git")
+                .args(args)
+                .current_dir(repo)
+                .output()
+                .expect("git must be available")
+        };
+        if !git(&["init"]).status.success() {
+            return;
+        }
+        let _ = git(&["config", "user.email", "t@example.com"]);
+        let _ = git(&["config", "user.name", "T"]);
+        std::fs::create_dir_all(repo.join("src")).unwrap();
+        // 30 files, each touched exactly once: every `touches` value ties, and
+        // the list is truncated to 20.
+        for i in 0..30 {
+            std::fs::write(
+                repo.join(format!("src/f{i:02}.rs")),
+                "pub fn f() {}\npub fn g() {}\n",
+            )
+            .unwrap();
+        }
+        let _ = git(&["add", "-A"]);
+        if !git(&["commit", "-m", "init", "--no-verify"])
+            .status
+            .success()
+        {
+            return;
+        }
+
+        let first = analyze_bottlenecks(repo, 99_999_999, 1).expect("analysis must run");
+        assert_eq!(
+            first.bottlenecks.len(),
+            20,
+            "the fixture must exercise the truncation"
+        );
+        let paths = |a: &BottleneckAnalysis| {
+            a.bottlenecks
+                .iter()
+                .map(|b| b.path.clone())
+                .collect::<Vec<_>>()
+        };
+        for run in 1..10 {
+            let again = analyze_bottlenecks(repo, 99_999_999, 1).expect("analysis must run");
+            assert_eq!(
+                paths(&first),
+                paths(&again),
+                "run {run} disagreed with run 0: bottleneck output depends on HashMap order"
+            );
+        }
+        let mut sorted = paths(&first);
+        sorted.sort();
+        assert_eq!(paths(&first), sorted, "tied files must be ordered by path");
     }
 }

--- a/src/cli/handlers/bug_report_handler_commands.rs
+++ b/src/cli/handlers/bug_report_handler_commands.rs
@@ -137,6 +137,18 @@ pub fn capture_command_error(command: &str, args: &[String], error: &str) {
     }
 }
 
+/// Capture a failing CLI invocation so `pmat maintain bug-report` can find it.
+///
+/// `capture_command_error*` had no caller outside this module's own unit tests,
+/// so nothing ever wrote the store `handle_bug_report` reads: every failing
+/// command left it empty and `maintain bug-report` answered "No captured error
+/// found. Run a pmat command that fails first" no matter how many just had.
+/// `cli::run` calls this on every dispatch error.
+pub fn capture_cli_failure(argv: &[String], error: &anyhow::Error) {
+    let args: Vec<String> = argv.iter().skip(1).cloned().collect();
+    capture_command_error("pmat", &args, &format!("{error:#}"));
+}
+
 /// Capture an error with exit code
 #[provable_contracts_macros::contract("pmat-core.yaml", equation = "check_compliance")]
 pub fn capture_command_error_with_code(command: &str, args: &[String], error: &str, code: i32) {

--- a/src/cli/handlers/bug_report_handler_tests.rs
+++ b/src/cli/handlers/bug_report_handler_tests.rs
@@ -37,6 +37,55 @@ mod tests {
         assert!(result.is_ok());
     }
 
+    /// The capture helpers had no production caller at all, so the store
+    /// `handle_bug_report` reads was never written and `maintain bug-report`
+    /// answered "No captured error found" after every failure. `cli::run` must
+    /// write it; `capture_cli_failure` is the one that does.
+    #[test]
+    #[serial(bug_report_error_file)]
+    fn a_failing_invocation_is_written_to_the_store_bug_report_reads() {
+        let _ = clear_error();
+
+        capture_cli_failure(
+            &[
+                "pmat".to_string(),
+                "tdg".to_string(),
+                "/does/not/exist".to_string(),
+            ],
+            &anyhow::anyhow!("path does not exist: /does/not/exist"),
+        );
+
+        let captured = load_error()
+            .expect("load")
+            .expect("a failing command must leave a captured error behind");
+        assert_eq!(captured.command, "pmat");
+        assert_eq!(captured.args, vec!["tdg", "/does/not/exist"]);
+        assert!(
+            captured.error_message.contains("/does/not/exist"),
+            "the captured message must be the real one: {}",
+            captured.error_message
+        );
+
+        let _ = clear_error();
+    }
+
+    /// …and the wiring itself: `cli::run` is the only place a CLI failure
+    /// surfaces, so if this call disappears the store goes back to being
+    /// written by nothing.
+    #[test]
+    fn cli_run_captures_dispatch_failures() {
+        let code = include_str!("../cli_run_command.rs")
+            .lines()
+            .filter(|l| !l.trim_start().starts_with("//"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            code.contains("capture_cli_failure("),
+            "cli::run no longer captures failing commands, so \
+             `pmat maintain bug-report` has nothing to report"
+        );
+    }
+
     #[test]
     #[serial(bug_report_error_file)]
     fn test_capture_command_error() {

--- a/src/cli/handlers/cache.rs
+++ b/src/cli/handlers/cache.rs
@@ -11,6 +11,7 @@ use crate::services::cache::{CacheOrchestrator, OrchestratorConfig};
 use anyhow::Result;
 use clap::Subcommand;
 use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
 
 /// Cache management commands
 #[derive(Debug, Clone, Subcommand)]
@@ -41,129 +42,188 @@ pub async fn handle_cache_command(command: &CacheCommand) -> Result<()> {
     }
 }
 
+/// Build the report from the live orchestrator plus whatever cache state is on
+/// disk under `root`.
+///
+/// This used to fetch `get_performance_metrics()` into `let _stats`, throw it
+/// away, and print literals — 85.0% effectiveness next to 0 evaluations,
+/// 100.0 req/sec, a 64.0 MB working set and 30.0% pressure — so an empty
+/// directory and this 4000-file repo produced byte-identical output. Every
+/// number below is now either read off the orchestrator or measured from the
+/// on-disk cache directories; anything that cannot be computed is `None`
+/// ("not measured"), never a plausible constant.
+fn build_cache_stats(orchestrator: &CacheOrchestrator, root: &Path) -> CacheStatsOutput {
+    let stats = orchestrator.get_orchestrator_stats();
+
+    // Effectiveness is an average over evaluations. With zero evaluations
+    // there is nothing to average, so we report nothing.
+    let overall_effectiveness = if stats.evaluations_performed > 0 {
+        Some(stats.current_metrics.effectiveness_score)
+    } else {
+        None
+    };
+
+    CacheStatsOutput {
+        orchestrator_stats: OrchestratorStatsOutput {
+            strategy_switches: stats.strategy_switches,
+            evaluations_performed: stats.evaluations_performed,
+            recommendations_generated: stats.recommendations_generated,
+            performance_improvements: stats.performance_improvements,
+            overall_effectiveness,
+        },
+        on_disk_caches: scan_on_disk_caches(root),
+    }
+}
+
+/// Cache directories pmat writes under a project root.
+const ON_DISK_CACHE_DIRS: [&str; 2] = [".pmat", ".pmat-cache"];
+
+fn scan_on_disk_caches(root: &Path) -> Vec<OnDiskCacheOutput> {
+    ON_DISK_CACHE_DIRS
+        .iter()
+        .filter_map(|name| {
+            let dir = root.join(name);
+            if !dir.is_dir() {
+                return None;
+            }
+            let (entries, bytes) = measure_dir(&dir);
+            Some(OnDiskCacheOutput {
+                path: dir.display().to_string(),
+                entries,
+                bytes,
+            })
+        })
+        .collect()
+}
+
+/// Count files and total bytes under `dir`, iteratively (cache trees nest).
+fn measure_dir(dir: &Path) -> (u64, u64) {
+    let mut entries = 0u64;
+    let mut bytes = 0u64;
+    let mut stack = vec![dir.to_path_buf()];
+
+    while let Some(current) = stack.pop() {
+        let Ok(read) = std::fs::read_dir(&current) else {
+            continue;
+        };
+        for entry in read.flatten() {
+            let Ok(meta) = entry.metadata() else {
+                continue;
+            };
+            if meta.is_dir() {
+                stack.push(entry.path());
+            } else {
+                entries += 1;
+                bytes += meta.len();
+            }
+        }
+    }
+
+    (entries, bytes)
+}
+
 async fn handle_cache_stats(detailed: bool, format: &str, history: bool) -> Result<()> {
     let config = OrchestratorConfig::default();
     let orchestrator = CacheOrchestrator::new(config);
+    let root = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
 
-    let _stats = orchestrator.get_performance_metrics();
+    let output = build_cache_stats(&orchestrator, &root);
 
     match format {
-        "json" => {
-            let output = serde_json::to_string_pretty(&CacheStatsOutput {
-                orchestrator_stats: OrchestratorStatsOutput {
-                    strategy_switches: 0,
-                    evaluations_performed: 0,
-                    recommendations_generated: 0,
-                    performance_improvements: 0,
-                    overall_effectiveness: 0.85,
-                },
-                tier_performance: std::collections::HashMap::new(),
-                strategy_effectiveness: vec![],
-                workload_analysis: WorkloadAnalysisOutput {
-                    request_rate: 100.0,
-                    working_set_size_mb: 64.0,
-                    temporal_locality: 0.75,
-                    spatial_locality: 0.60,
-                    read_write_ratio: 4.0,
-                    cache_pressure: 0.30,
-                },
-                recommendations: vec!["Cache performance is optimal".to_string()],
-            })?;
-            println!("{output}");
-        }
-        "table" => {
-            use crate::cli::colors as c;
-
-            println!("{}", c::header("PMAT Cache Strategy Statistics"));
-            println!("{}", c::rule());
-            println!();
-            println!("{}", c::subheader("Orchestrator Performance:"));
-            println!("   {}: {}", c::dim("Strategy Switches"), c::number("0"));
-            println!("   {}: {}", c::dim("Evaluations"), c::number("0"));
-            println!(
-                "   {}: {}",
-                c::dim("Overall Effectiveness"),
-                c::pct(85.0, 70.0, 50.0)
-            );
-            println!();
-            println!("{}", c::subheader("Workload Analysis:"));
-            println!(
-                "   {}: {} req/sec",
-                c::dim("Request Rate"),
-                c::number("100.0")
-            );
-            println!("   {}: {} MB", c::dim("Working Set"), c::number("64.0"));
-            println!(
-                "   {}: {}",
-                c::dim("Cache Pressure"),
-                c::pct_inverse(30.0, 50.0, 75.0)
-            );
-            println!();
-            if detailed {
-                println!("{}", c::subheader("Detailed Analysis:"));
-                println!(
-                    "   {}: Simplified cache strategy system",
-                    c::dim("Implementation")
-                );
-            }
-            if history {
-                println!(
-                    "{}",
-                    c::dim("Historical Data: Not available in this implementation")
-                );
-            }
-        }
+        "json" => println!("{}", serde_json::to_string_pretty(&output)?),
+        "table" => print_cache_stats_table(&output, &root, detailed, history),
         _ => return Err(anyhow::anyhow!("Unknown format: {format}")),
     }
 
     Ok(())
 }
 
-// Output structures for JSON serialization
-#[derive(Debug, Serialize, Deserialize)]
-struct CacheStatsOutput {
-    orchestrator_stats: OrchestratorStatsOutput,
-    tier_performance: std::collections::HashMap<String, TierPerformanceOutput>,
-    strategy_effectiveness: Vec<StrategyEffectivenessOutput>,
-    workload_analysis: WorkloadAnalysisOutput,
-    recommendations: Vec<String>,
+fn print_cache_stats_table(output: &CacheStatsOutput, root: &Path, detailed: bool, history: bool) {
+    use crate::cli::colors as c;
+
+    println!("{}", c::header("PMAT Cache Statistics"));
+    println!("{}", c::rule());
+    println!();
+    println!("{}", c::subheader("Orchestrator (this process):"));
+    let stats = &output.orchestrator_stats;
+    println!(
+        "   {}: {}",
+        c::dim("Strategy Switches"),
+        c::number(&stats.strategy_switches.to_string())
+    );
+    println!(
+        "   {}: {}",
+        c::dim("Evaluations"),
+        c::number(&stats.evaluations_performed.to_string())
+    );
+    match stats.overall_effectiveness {
+        Some(pct) => println!(
+            "   {}: {}",
+            c::dim("Overall Effectiveness"),
+            c::pct(pct * 100.0, 70.0, 50.0)
+        ),
+        None => println!(
+            "   {}: {}",
+            c::dim("Overall Effectiveness"),
+            c::dim("not measured (no cache evaluations in this process)")
+        ),
+    }
+    println!();
+
+    println!(
+        "{}",
+        c::subheader(&format!("On-disk caches under {}:", root.display()))
+    );
+    if output.on_disk_caches.is_empty() {
+        println!("   {}", c::dim("none found"));
+    } else {
+        for cache in &output.on_disk_caches {
+            println!(
+                "   {}: {} file(s), {:.1} MB",
+                c::dim(&cache.path),
+                c::number(&cache.entries.to_string()),
+                cache.bytes as f64 / (1024.0 * 1024.0)
+            );
+        }
+    }
+    println!();
+
+    if detailed {
+        println!("{}", c::subheader("Detailed Analysis:"));
+        println!(
+            "   {}",
+            c::dim("Per-tier hit rates require a live cache session; the CLI process has none.")
+        );
+    }
+    if history {
+        println!("{}", c::dim("Historical Data: not recorded"));
+    }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+// Output structures for JSON serialization
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+struct CacheStatsOutput {
+    orchestrator_stats: OrchestratorStatsOutput,
+    on_disk_caches: Vec<OnDiskCacheOutput>,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
 struct OrchestratorStatsOutput {
     strategy_switches: u64,
     evaluations_performed: u64,
     recommendations_generated: u64,
     performance_improvements: u64,
-    overall_effectiveness: f64,
+    /// `None` when no evaluation has run — an effectiveness score cannot be
+    /// averaged over zero samples.
+    overall_effectiveness: Option<f64>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
-struct TierPerformanceOutput {
-    hit_rate: f64,
-    avg_latency_ms: f64,
-    memory_usage_mb: f64,
-    throughput_ops_sec: f64,
-    efficiency_score: f64,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-struct StrategyEffectivenessOutput {
-    strategy_name: String,
-    effectiveness_score: f64,
-    hit_rate: f64,
-    latency_p95_ms: f64,
-    memory_efficiency: f64,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-struct WorkloadAnalysisOutput {
-    request_rate: f64,
-    working_set_size_mb: f64,
-    temporal_locality: f64,
-    spatial_locality: f64,
-    read_write_ratio: f64,
-    cache_pressure: f64,
+/// A cache directory that actually exists on disk, with what it really holds.
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+struct OnDiskCacheOutput {
+    path: String,
+    entries: u64,
+    bytes: u64,
 }
 
 #[cfg_attr(coverage_nightly, coverage(off))]
@@ -259,60 +319,13 @@ mod tests {
             evaluations_performed: 100,
             recommendations_generated: 10,
             performance_improvements: 8,
-            overall_effectiveness: 0.92,
+            overall_effectiveness: Some(0.92),
         };
 
         let json = serde_json::to_string(&stats).unwrap();
         assert!(json.contains("strategy_switches"));
         assert!(json.contains("5"));
         assert!(json.contains("0.92"));
-    }
-
-    #[test]
-    fn test_tier_performance_output_serialization() {
-        let perf = TierPerformanceOutput {
-            hit_rate: 0.85,
-            avg_latency_ms: 2.5,
-            memory_usage_mb: 64.0,
-            throughput_ops_sec: 1000.0,
-            efficiency_score: 0.9,
-        };
-
-        let json = serde_json::to_string(&perf).unwrap();
-        assert!(json.contains("hit_rate"));
-        assert!(json.contains("0.85"));
-    }
-
-    #[test]
-    fn test_strategy_effectiveness_output_serialization() {
-        let strategy = StrategyEffectivenessOutput {
-            strategy_name: "LRU".to_string(),
-            effectiveness_score: 0.88,
-            hit_rate: 0.82,
-            latency_p95_ms: 5.0,
-            memory_efficiency: 0.75,
-        };
-
-        let json = serde_json::to_string(&strategy).unwrap();
-        assert!(json.contains("LRU"));
-        assert!(json.contains("0.88"));
-    }
-
-    #[test]
-    fn test_workload_analysis_output_serialization() {
-        let workload = WorkloadAnalysisOutput {
-            request_rate: 150.0,
-            working_set_size_mb: 128.0,
-            temporal_locality: 0.8,
-            spatial_locality: 0.65,
-            read_write_ratio: 5.0,
-            cache_pressure: 0.4,
-        };
-
-        let json = serde_json::to_string(&workload).unwrap();
-        assert!(json.contains("request_rate"));
-        assert!(json.contains("150"));
-        assert!(json.contains("cache_pressure"));
     }
 
     #[test]
@@ -323,25 +336,64 @@ mod tests {
                 evaluations_performed: 50,
                 recommendations_generated: 5,
                 performance_improvements: 4,
-                overall_effectiveness: 0.88,
+                overall_effectiveness: Some(0.88),
             },
-            tier_performance: std::collections::HashMap::new(),
-            strategy_effectiveness: vec![],
-            workload_analysis: WorkloadAnalysisOutput {
-                request_rate: 100.0,
-                working_set_size_mb: 64.0,
-                temporal_locality: 0.75,
-                spatial_locality: 0.60,
-                read_write_ratio: 4.0,
-                cache_pressure: 0.30,
-            },
-            recommendations: vec!["Test recommendation".to_string()],
+            on_disk_caches: vec![OnDiskCacheOutput {
+                path: ".pmat".to_string(),
+                entries: 7,
+                bytes: 2048,
+            }],
         };
 
         let json = serde_json::to_string(&output).unwrap();
         assert!(json.contains("orchestrator_stats"));
-        assert!(json.contains("recommendations"));
-        assert!(json.contains("Test recommendation"));
+        assert!(json.contains("on_disk_caches"));
+        assert!(json.contains(".pmat"));
+    }
+
+    // === Regression: cache stats must not fabricate ===
+
+    #[test]
+    fn test_effectiveness_is_not_measured_without_evaluations() {
+        // `pmat cache stats` used to print "Overall Effectiveness: 85.0%"
+        // next to "Evaluations: 0" — a percentage averaged over nothing.
+        let orchestrator = CacheOrchestrator::new(OrchestratorConfig::default());
+        let dir = tempfile::TempDir::new().unwrap();
+
+        let output = build_cache_stats(&orchestrator, dir.path());
+        assert_eq!(output.orchestrator_stats.evaluations_performed, 0);
+        assert!(
+            output.orchestrator_stats.overall_effectiveness.is_none(),
+            "effectiveness cannot be computed from 0 evaluations"
+        );
+    }
+
+    #[test]
+    fn test_cache_stats_move_with_the_directory() {
+        // An empty directory and a directory holding a real .pmat cache used
+        // to produce byte-identical output.
+        let orchestrator = CacheOrchestrator::new(OrchestratorConfig::default());
+
+        let empty = tempfile::TempDir::new().unwrap();
+        let populated = tempfile::TempDir::new().unwrap();
+        std::fs::create_dir(populated.path().join(".pmat")).unwrap();
+        std::fs::write(
+            populated.path().join(".pmat").join("context.idx"),
+            b"0123456789",
+        )
+        .unwrap();
+
+        let empty_stats = build_cache_stats(&orchestrator, empty.path());
+        let populated_stats = build_cache_stats(&orchestrator, populated.path());
+
+        assert!(empty_stats.on_disk_caches.is_empty());
+        assert_eq!(populated_stats.on_disk_caches.len(), 1);
+        assert_eq!(populated_stats.on_disk_caches[0].entries, 1);
+        assert_eq!(populated_stats.on_disk_caches[0].bytes, 10);
+        assert_ne!(
+            empty_stats, populated_stats,
+            "cache stats must depend on the directory being reported on"
+        );
     }
 
     // === Handler tests ===
@@ -421,22 +473,16 @@ mod tests {
 
         let stats: OrchestratorStatsOutput = serde_json::from_str(json).unwrap();
         assert_eq!(stats.strategy_switches, 10);
-        assert_eq!(stats.overall_effectiveness, 0.95);
+        assert_eq!(stats.overall_effectiveness, Some(0.95));
     }
 
     #[test]
-    fn test_workload_analysis_output_deserialize() {
-        let json = r#"{
-            "request_rate": 200.0,
-            "working_set_size_mb": 256.0,
-            "temporal_locality": 0.9,
-            "spatial_locality": 0.7,
-            "read_write_ratio": 3.0,
-            "cache_pressure": 0.5
-        }"#;
+    fn test_on_disk_cache_output_deserialize() {
+        let json = r#"{ "path": ".pmat-cache", "entries": 42, "bytes": 8192 }"#;
 
-        let workload: WorkloadAnalysisOutput = serde_json::from_str(json).unwrap();
-        assert_eq!(workload.request_rate, 200.0);
-        assert_eq!(workload.cache_pressure, 0.5);
+        let cache: OnDiskCacheOutput = serde_json::from_str(json).unwrap();
+        assert_eq!(cache.path, ".pmat-cache");
+        assert_eq!(cache.entries, 42);
+        assert_eq!(cache.bytes, 8192);
     }
 }

--- a/src/cli/handlers/ci_local_handler.rs
+++ b/src/cli/handlers/ci_local_handler.rs
@@ -41,6 +41,14 @@ pub async fn handle_ci_local(
 ) -> Result<()> {
     use crate::cli::colors as c;
 
+    // A path that does not exist is not a CI failure. Without this check every
+    // check spawned into a missing cwd, failed with "No such file or directory
+    // (os error 2)", and the run reported 3 failing stages with fix hints
+    // ("Run `cargo fmt --all`") that address a problem the user does not have.
+    if !path.exists() {
+        anyhow::bail!("Path not found: {}", path.display());
+    }
+
     let human = is_human_format(format);
 
     if human {
@@ -449,6 +457,28 @@ fn get_fix_hint(check: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A missing path used to be reported as 3 failing CI stages, each with a
+    /// fix hint ("Run `cargo fmt --all`") for a problem the user does not have.
+    #[tokio::test]
+    async fn test_missing_path_is_a_path_error_not_three_failing_stages() {
+        let err = handle_ci_local(
+            Path::new("/does/not/exist/pmat-ci-local-missing"),
+            true,
+            None,
+            false,
+            false,
+            OutputFormat::Json,
+        )
+        .await
+        .expect_err("a missing path must be an error, not a CI verdict");
+        let msg = err.to_string();
+        assert!(msg.contains("Path not found"), "{msg}");
+        assert!(
+            !msg.contains("cargo fmt"),
+            "must not suggest a fix for a failure that did not happen: {msg}"
+        );
+    }
 
     #[test]
     fn test_build_check_list_quick() {

--- a/src/cli/handlers/ci_local_handler.rs
+++ b/src/cli/handlers/ci_local_handler.rs
@@ -29,7 +29,7 @@ pub async fn handle_ci_local(
 
     println!("{}\n", c::header("PMAT Local CI Simulation"));
 
-    let checks = build_check_list(quick, matrix);
+    let checks = build_check_list(quick, matrix)?;
     let total = checks.len();
     let mut results: Vec<CiCheckResult> = Vec::new();
 
@@ -101,6 +101,17 @@ pub async fn handle_ci_local(
         }
     }
 
+    if results.is_empty() {
+        // A run that executed no checks has verified nothing. Printing the
+        // strongest go-ahead ("safe to push") with exit 0 after 0 checks is how
+        // an unrecognised --matrix used to sail through CI scripts.
+        println!(
+            "\n{}",
+            c::fail("CI simulation ran 0 checks — nothing was verified")
+        );
+        std::process::exit(1);
+    }
+
     if failed > 0 {
         println!(
             "\n{}",
@@ -115,27 +126,29 @@ pub async fn handle_ci_local(
 }
 
 /// Build the list of checks to run
-fn build_check_list(quick: bool, matrix: Option<&str>) -> Vec<&'static str> {
+///
+/// An unrecognised `--matrix` is an error, not a warning: the catch-all arm used
+/// to eprintln! a note and return an empty list, so 0 checks ran and the summary
+/// still reported "CI simulation PASSED — safe to push" with exit 0.
+fn build_check_list(quick: bool, matrix: Option<&str>) -> Result<Vec<&'static str>> {
     if let Some(m) = matrix {
-        match m {
+        let checks = match m {
             "fmt" => vec!["cargo-fmt"],
             "clippy" => vec!["clippy-default", "clippy-all-features"],
             "test" => vec!["test-fast"],
             "cross" => vec!["cross-check-aarch64"],
             "bench" => vec!["bench-check"],
             "full" => full_checks(),
-            _ => {
-                eprintln!(
-                    "Unknown matrix: {}. Available: fmt, clippy, test, cross, bench, full",
-                    m
-                );
-                vec![]
-            }
-        }
+            _ => anyhow::bail!(
+                "Unknown matrix: {}. Available: fmt, clippy, test, cross, bench, full",
+                m
+            ),
+        };
+        Ok(checks)
     } else if quick {
-        vec!["cargo-fmt", "clippy-default", "test-fast"]
+        Ok(vec!["cargo-fmt", "clippy-default", "test-fast"])
     } else {
-        full_checks()
+        Ok(full_checks())
     }
 }
 
@@ -276,7 +289,7 @@ mod tests {
 
     #[test]
     fn test_build_check_list_quick() {
-        let checks = build_check_list(true, None);
+        let checks = build_check_list(true, None).unwrap();
         assert_eq!(checks.len(), 3);
         assert_eq!(checks[0], "cargo-fmt");
         assert_eq!(checks[1], "clippy-default");
@@ -285,7 +298,7 @@ mod tests {
 
     #[test]
     fn test_build_check_list_full() {
-        let checks = build_check_list(false, None);
+        let checks = build_check_list(false, None).unwrap();
         assert!(checks.len() >= 5);
         assert!(checks.contains(&"cargo-fmt"));
         assert!(checks.contains(&"clippy-default"));
@@ -295,20 +308,40 @@ mod tests {
 
     #[test]
     fn test_build_check_list_matrix_fmt() {
-        let checks = build_check_list(false, Some("fmt"));
+        let checks = build_check_list(false, Some("fmt")).unwrap();
         assert_eq!(checks, vec!["cargo-fmt"]);
     }
 
     #[test]
     fn test_build_check_list_matrix_clippy() {
-        let checks = build_check_list(false, Some("clippy"));
+        let checks = build_check_list(false, Some("clippy")).unwrap();
         assert_eq!(checks, vec!["clippy-default", "clippy-all-features"]);
     }
 
     #[test]
-    fn test_build_check_list_unknown_matrix() {
-        let checks = build_check_list(false, Some("nonexistent"));
-        assert!(checks.is_empty());
+    fn test_build_check_list_unknown_matrix_is_an_error() {
+        // Regression: this used to return an empty Vec, so ci-local ran 0
+        // checks and still printed "CI simulation PASSED — safe to push".
+        let err = build_check_list(false, Some("nonexistent")).unwrap_err();
+        assert!(err.to_string().contains("Unknown matrix"));
+    }
+
+    #[test]
+    fn test_build_check_list_never_returns_an_empty_list_when_ok() {
+        for matrix in [
+            None,
+            Some("fmt"),
+            Some("clippy"),
+            Some("test"),
+            Some("cross"),
+            Some("bench"),
+            Some("full"),
+        ] {
+            for quick in [true, false] {
+                let checks = build_check_list(quick, matrix).unwrap();
+                assert!(!checks.is_empty(), "empty check list for {matrix:?}");
+            }
+        }
     }
 
     #[test]

--- a/src/cli/handlers/ci_local_handler.rs
+++ b/src/cli/handlers/ci_local_handler.rs
@@ -3,6 +3,7 @@
 //! Runs the same quality gate matrix as GitHub Actions locally
 //! to eliminate push-wait-fix loops.
 
+use crate::contracts::OutputFormat;
 use anyhow::Result;
 use std::path::Path;
 use std::time::Instant;
@@ -16,6 +17,18 @@ struct CiCheckResult {
     fix_hint: Option<String>,
 }
 
+/// Is this format the human banner, or a machine-readable document?
+///
+/// `--format` used to be destructured as `format: _` in the dispatcher and
+/// never reached this handler, so `-f json` printed the same progress banner as
+/// `-f table` and `python3 -m json.tool` failed at character 0.
+fn is_human_format(format: OutputFormat) -> bool {
+    matches!(
+        format,
+        OutputFormat::Table | OutputFormat::Text | OutputFormat::Plain
+    )
+}
+
 /// Run local CI simulation
 #[provable_contracts_macros::contract("pmat-core.yaml", equation = "path_exists")]
 pub async fn handle_ci_local(
@@ -24,17 +37,24 @@ pub async fn handle_ci_local(
     matrix: Option<&str>,
     fix: bool,
     verbose: bool,
+    format: OutputFormat,
 ) -> Result<()> {
     use crate::cli::colors as c;
 
-    println!("{}\n", c::header("PMAT Local CI Simulation"));
+    let human = is_human_format(format);
+
+    if human {
+        println!("{}\n", c::header("PMAT Local CI Simulation"));
+    }
 
     let checks = build_check_list(quick, matrix)?;
     let total = checks.len();
     let mut results: Vec<CiCheckResult> = Vec::new();
 
     for (i, check_name) in checks.iter().enumerate() {
-        print!("  [{}/{}] {} ... ", i + 1, total, c::label(check_name));
+        if human {
+            print!("  [{}/{}] {} ... ", i + 1, total, c::label(check_name));
+        }
         let start = Instant::now();
 
         let result = run_check(check_name, path, fix, verbose).await;
@@ -48,17 +68,19 @@ pub async fn handle_ci_local(
             }
         };
 
-        if passed {
-            println!(
-                "{} {}",
-                c::pass(""),
-                c::dim(&format!("({:.1}s)", duration.as_secs_f64()))
-            );
-        } else {
-            println!("{}", c::fail(""));
+        if human {
+            if passed {
+                println!(
+                    "{} {}",
+                    c::pass(""),
+                    c::dim(&format!("({:.1}s)", duration.as_secs_f64()))
+                );
+            } else {
+                println!("{}", c::fail(""));
+            }
         }
 
-        if !passed && verbose {
+        if !passed && verbose && human {
             for line in output.lines().take(20) {
                 println!("    {}", c::dim(line));
             }
@@ -73,12 +95,49 @@ pub async fn handle_ci_local(
         });
     }
 
-    // Summary
-    println!("\n{}", c::separator());
     let passed = results.iter().filter(|r| r.passed).count();
     let failed = results.iter().filter(|r| !r.passed).count();
-    let total_time: f64 = results.iter().map(|r| r.duration.as_secs_f64()).sum();
 
+    if human {
+        print_human_summary(&results, passed, failed);
+    } else {
+        println!("{}", render_results(&results, format)?);
+    }
+
+    if results.is_empty() {
+        // A run that executed no checks has verified nothing. Printing the
+        // strongest go-ahead ("safe to push") with exit 0 after 0 checks is how
+        // an unrecognised --matrix used to sail through CI scripts.
+        if human {
+            println!(
+                "\n{}",
+                c::fail("CI simulation ran 0 checks — nothing was verified")
+            );
+        }
+        std::process::exit(1);
+    }
+
+    if failed > 0 {
+        if human {
+            println!(
+                "\n{}",
+                c::fail("CI simulation FAILED — fix issues before pushing")
+            );
+        }
+        std::process::exit(1);
+    } else if human {
+        println!("\n{}", c::pass("CI simulation PASSED — safe to push"));
+    }
+
+    Ok(())
+}
+
+/// The human banner: progress lines, a results line, and each failure's hint.
+fn print_human_summary(results: &[CiCheckResult], passed: usize, failed: usize) {
+    use crate::cli::colors as c;
+
+    println!("\n{}", c::separator());
+    let total_time: f64 = results.iter().map(|r| r.duration.as_secs_f64()).sum();
     println!(
         "\n{}",
         c::subheader(&format!(
@@ -87,8 +146,7 @@ pub async fn handle_ci_local(
         ))
     );
 
-    // Show failures with fix hints
-    for result in &results {
+    for result in results {
         if !result.passed {
             println!("\n  {} {}", c::fail("FAIL"), c::label(&result.name));
             // Show first 10 lines of error output
@@ -100,29 +158,134 @@ pub async fn handle_ci_local(
             }
         }
     }
+}
 
-    if results.is_empty() {
-        // A run that executed no checks has verified nothing. Printing the
-        // strongest go-ahead ("safe to push") with exit 0 after 0 checks is how
-        // an unrecognised --matrix used to sail through CI scripts.
-        println!(
-            "\n{}",
-            c::fail("CI simulation ran 0 checks — nothing was verified")
-        );
-        std::process::exit(1);
+/// Serializable view of one check, for the machine-readable formats.
+#[derive(serde::Serialize)]
+struct CiCheckRecord<'a> {
+    name: &'a str,
+    passed: bool,
+    duration_secs: f64,
+    output: &'a str,
+    fix_hint: Option<&'a str>,
+}
+
+#[derive(serde::Serialize)]
+struct CiRunRecord<'a> {
+    total: usize,
+    passed: usize,
+    failed: usize,
+    duration_secs: f64,
+    checks: Vec<CiCheckRecord<'a>>,
+}
+
+fn to_record(results: &[CiCheckResult]) -> CiRunRecord<'_> {
+    CiRunRecord {
+        total: results.len(),
+        passed: results.iter().filter(|r| r.passed).count(),
+        failed: results.iter().filter(|r| !r.passed).count(),
+        duration_secs: results.iter().map(|r| r.duration.as_secs_f64()).sum(),
+        checks: results
+            .iter()
+            .map(|r| CiCheckRecord {
+                name: &r.name,
+                passed: r.passed,
+                duration_secs: r.duration.as_secs_f64(),
+                output: &r.output,
+                fix_hint: r.fix_hint.as_deref(),
+            })
+            .collect(),
     }
+}
 
-    if failed > 0 {
-        println!(
-            "\n{}",
-            c::fail("CI simulation FAILED — fix issues before pushing")
-        );
-        std::process::exit(1);
-    } else {
-        println!("\n{}", c::pass("CI simulation PASSED — safe to push"));
+/// Render the run in a machine-readable format. Every value clap advertises in
+/// `--format` must produce that format; anything else is an advertised flag
+/// that silently does nothing.
+fn render_results(results: &[CiCheckResult], format: OutputFormat) -> Result<String> {
+    let record = to_record(results);
+    match format {
+        OutputFormat::Json => Ok(serde_json::to_string_pretty(&record)?),
+        OutputFormat::Yaml => Ok(serde_yaml_ng::to_string(&record)?),
+        OutputFormat::Csv => Ok(render_csv(&record)),
+        OutputFormat::Junit => Ok(render_junit(&record)),
+        OutputFormat::Markdown => Ok(render_markdown(&record)),
+        OutputFormat::Summary => Ok(format!(
+            "{} passed, {} failed, {} total ({:.1}s)",
+            record.passed, record.failed, record.total, record.duration_secs
+        )),
+        // is_human_format already routed these away.
+        OutputFormat::Table | OutputFormat::Text | OutputFormat::Plain => Ok(String::new()),
     }
+}
 
-    Ok(())
+fn csv_escape(field: &str) -> String {
+    format!("\"{}\"", field.replace('"', "\"\""))
+}
+
+fn render_csv(record: &CiRunRecord<'_>) -> String {
+    let mut out = String::from("name,passed,duration_secs,fix_hint\n");
+    for check in &record.checks {
+        out.push_str(&format!(
+            "{},{},{:.3},{}\n",
+            csv_escape(check.name),
+            check.passed,
+            check.duration_secs,
+            csv_escape(check.fix_hint.unwrap_or(""))
+        ));
+    }
+    out
+}
+
+fn xml_escape(text: &str) -> String {
+    text.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+}
+
+fn render_junit(record: &CiRunRecord<'_>) -> String {
+    let mut out = String::from("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+    out.push_str(&format!(
+        "<testsuite name=\"pmat ci-local\" tests=\"{}\" failures=\"{}\" time=\"{:.3}\">\n",
+        record.total, record.failed, record.duration_secs
+    ));
+    for check in &record.checks {
+        out.push_str(&format!(
+            "  <testcase name=\"{}\" time=\"{:.3}\"",
+            xml_escape(check.name),
+            check.duration_secs
+        ));
+        if check.passed {
+            out.push_str("/>\n");
+        } else {
+            out.push_str(">\n");
+            out.push_str(&format!(
+                "    <failure message=\"check failed\">{}</failure>\n",
+                xml_escape(check.output)
+            ));
+            out.push_str("  </testcase>\n");
+        }
+    }
+    out.push_str("</testsuite>\n");
+    out
+}
+
+fn render_markdown(record: &CiRunRecord<'_>) -> String {
+    let mut out = String::from("# PMAT Local CI Simulation\n\n");
+    out.push_str("| Check | Result | Seconds |\n|---|---|---|\n");
+    for check in &record.checks {
+        out.push_str(&format!(
+            "| {} | {} | {:.1} |\n",
+            check.name,
+            if check.passed { "pass" } else { "FAIL" },
+            check.duration_secs
+        ));
+    }
+    out.push_str(&format!(
+        "\n{} passed, {} failed, {} total ({:.1}s)\n",
+        record.passed, record.failed, record.total, record.duration_secs
+    ));
+    out
 }
 
 /// Build the list of checks to run
@@ -375,5 +538,90 @@ mod tests {
         // Just verify it doesn't panic - actual formatting check may pass or fail
         let result = run_check("cargo-fmt", Path::new("."), false, false).await;
         assert!(result.is_ok() || result.is_err());
+    }
+}
+
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg(test)]
+mod format_tests {
+    use super::*;
+
+    fn results() -> Vec<CiCheckResult> {
+        vec![
+            CiCheckResult {
+                name: "cargo-fmt".to_string(),
+                passed: true,
+                duration: std::time::Duration::from_millis(1500),
+                output: String::new(),
+                fix_hint: None,
+            },
+            CiCheckResult {
+                name: "clippy-default".to_string(),
+                passed: false,
+                duration: std::time::Duration::from_millis(500),
+                output: "error: needless <borrow> & \"quote\"".to_string(),
+                fix_hint: Some("cargo clippy --fix".to_string()),
+            },
+        ]
+    }
+
+    /// `-f json` used to print the human banner, so `python3 -m json.tool`
+    /// failed at character 0. Every advertised format must produce that format.
+    #[test]
+    fn json_is_valid_json_and_carries_the_results() {
+        let out = render_results(&results(), OutputFormat::Json).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&out).expect("valid JSON");
+        assert_eq!(parsed["total"], 2);
+        assert_eq!(parsed["failed"], 1);
+        assert_eq!(parsed["checks"][0]["name"], "cargo-fmt");
+        assert!(!out.contains("PMAT Local CI Simulation"));
+    }
+
+    /// `-f junit` emitted no XML at all.
+    #[test]
+    fn junit_is_xml_with_a_testcase_per_check() {
+        let out = render_results(&results(), OutputFormat::Junit).unwrap();
+        assert!(out.starts_with("<?xml"));
+        assert!(out.contains("<testsuite"));
+        assert_eq!(out.matches("<testcase").count(), 2);
+        assert!(out.contains("<failure"));
+        // Check output must be escaped, not injected raw.
+        assert!(!out.contains("<borrow>"));
+        assert!(out.contains("&lt;borrow&gt;"));
+    }
+
+    #[test]
+    fn csv_has_a_header_and_one_row_per_check() {
+        let out = render_results(&results(), OutputFormat::Csv).unwrap();
+        let lines: Vec<&str> = out.lines().collect();
+        assert_eq!(lines[0], "name,passed,duration_secs,fix_hint");
+        assert_eq!(lines.len(), 3);
+        assert!(lines[1].starts_with("\"cargo-fmt\",true"));
+    }
+
+    #[test]
+    fn yaml_round_trips() {
+        let out = render_results(&results(), OutputFormat::Yaml).unwrap();
+        let parsed: serde_json::Value = serde_yaml_ng::from_str(&out).expect("valid YAML");
+        assert_eq!(parsed["passed"], 1);
+    }
+
+    /// The three human formats keep the banner; the machine formats do not.
+    #[test]
+    fn only_table_text_plain_are_human() {
+        assert!(is_human_format(OutputFormat::Table));
+        assert!(is_human_format(OutputFormat::Text));
+        assert!(is_human_format(OutputFormat::Plain));
+        for f in [
+            OutputFormat::Json,
+            OutputFormat::Yaml,
+            OutputFormat::Csv,
+            OutputFormat::Junit,
+            OutputFormat::Markdown,
+            OutputFormat::Summary,
+        ] {
+            assert!(!is_human_format(f), "{f} must not print the human banner");
+            assert!(!render_results(&results(), f).unwrap().is_empty());
+        }
     }
 }

--- a/src/cli/handlers/cleanup_resources_handler.rs
+++ b/src/cli/handlers/cleanup_resources_handler.rs
@@ -20,17 +20,28 @@ pub enum CleanupTarget {
     All,
 }
 
+/// The targets `scan_targets` actually dispatches a scanner for.
+///
+/// `docker` and `caches` are declared in the enum and were accepted by
+/// `parse`, but no scanner exists for either — not even under `all`. So
+/// `--targets docker` printed a header, a blank line where the scan phase
+/// belongs, "Items found: 0" and exited 0, which is indistinguishable from a
+/// machine with nothing to clean. Until `cleanup_scanners.rs` grows a
+/// `scan_docker_targets`/`scan_cache_targets`, the names are rejected rather
+/// than silently no-op'd.
+pub const SCANNABLE_TARGETS: &[&str] = &["rust", "node", "git", "logs", "all"];
+
 impl CleanupTarget {
     #[provable_contracts_macros::contract("pmat-core.yaml", equation = "check_compliance")]
     /// Parse the input.
+    ///
+    /// Returns `None` for `docker` and `caches`: see [`SCANNABLE_TARGETS`].
     pub fn parse(s: &str) -> Option<Self> {
         match s.to_lowercase().as_str() {
             "rust" => Some(Self::Rust),
-            "docker" => Some(Self::Docker),
             "node" => Some(Self::Node),
             "git" => Some(Self::Git),
             "logs" => Some(Self::Logs),
-            "caches" => Some(Self::Caches),
             "all" => Some(Self::All),
             _ => None,
         }
@@ -68,6 +79,19 @@ pub async fn handle_cleanup_resources(
     min_age_days: u32,
     format: OutputFormat,
 ) -> Result<()> {
+    // A typo'd --project-dir used to be indistinguishable from a genuinely
+    // clean project: the walkers simply yielded nothing, so the command printed
+    // "Found 0 Rust target directories" and "Items found: 0" and exited 0 —
+    // for a directory that does not exist. The same flag drives the destructive
+    // --execute mode, and the handler already carries a `path_exists` contract
+    // that nothing enforced at runtime.
+    if !project_dir.exists() {
+        anyhow::bail!("Cleanup path does not exist: {}", project_dir.display());
+    }
+    if !project_dir.is_dir() {
+        anyhow::bail!("Cleanup path is not a directory: {}", project_dir.display());
+    }
+
     // Parse targets
     let parsed_targets: Vec<CleanupTarget> = targets
         .iter()
@@ -76,7 +100,7 @@ pub async fn handle_cleanup_resources(
 
     if parsed_targets.is_empty() {
         println!("⚠️  No valid cleanup targets specified");
-        println!("   Valid targets: rust, docker, node, git, logs, caches, all");
+        println!("   Valid targets: {}", SCANNABLE_TARGETS.join(", "));
         return Ok(());
     }
 

--- a/src/cli/handlers/cleanup_tests.rs
+++ b/src/cli/handlers/cleanup_tests.rs
@@ -18,10 +18,15 @@ mod tests {
         assert_eq!(CleanupTarget::parse("Rust"), Some(CleanupTarget::Rust));
     }
 
+    /// `docker` parsed as a valid target but `scan_targets` has no arm for it,
+    /// so `--targets docker` reported "Items found: 0" and exited 0 without
+    /// looking at anything. This test used to pin that: it asserted the name
+    /// parsed and said nothing about a scan ever running.
     #[test]
-    fn test_cleanup_target_parse_docker() {
-        assert_eq!(CleanupTarget::parse("docker"), Some(CleanupTarget::Docker));
-        assert_eq!(CleanupTarget::parse("DOCKER"), Some(CleanupTarget::Docker));
+    fn test_cleanup_target_parse_docker_is_rejected_until_a_scanner_exists() {
+        assert_eq!(CleanupTarget::parse("docker"), None);
+        assert_eq!(CleanupTarget::parse("DOCKER"), None);
+        assert!(!SCANNABLE_TARGETS.contains(&"docker"));
     }
 
     #[test]
@@ -42,10 +47,31 @@ mod tests {
         assert_eq!(CleanupTarget::parse("LOGS"), Some(CleanupTarget::Logs));
     }
 
+    /// Same as `docker`: accepted by `parse`, dispatched by nothing.
     #[test]
-    fn test_cleanup_target_parse_caches() {
-        assert_eq!(CleanupTarget::parse("caches"), Some(CleanupTarget::Caches));
-        assert_eq!(CleanupTarget::parse("CACHES"), Some(CleanupTarget::Caches));
+    fn test_cleanup_target_parse_caches_is_rejected_until_a_scanner_exists() {
+        assert_eq!(CleanupTarget::parse("caches"), None);
+        assert_eq!(CleanupTarget::parse("CACHES"), None);
+        assert!(!SCANNABLE_TARGETS.contains(&"caches"));
+    }
+
+    /// Every advertised target must have a scanner behind it: `scan_targets`
+    /// dispatches exactly Rust/Node/Git/Logs, and `all` means those four.
+    #[test]
+    fn test_every_parseable_target_is_scannable() {
+        for name in SCANNABLE_TARGETS {
+            assert!(
+                CleanupTarget::parse(name).is_some(),
+                "{name} is advertised as valid but does not parse"
+            );
+        }
+        for name in ["docker", "caches", "bogus", ""] {
+            assert_eq!(
+                CleanupTarget::parse(name).is_some(),
+                SCANNABLE_TARGETS.contains(&name),
+                "{name}: parse and the advertised list disagree"
+            );
+        }
     }
 
     #[test]
@@ -277,6 +303,70 @@ mod tests {
         let target = CleanupTarget::All;
         let debug = format!("{:?}", target);
         assert!(debug.contains("All"));
+    }
+
+    // ============================================================================
+    // --project-dir must exist (a typo must not read as "nothing to clean")
+    // ============================================================================
+
+    /// A nonexistent --project-dir used to print a full 0-item report and exit
+    /// 0, so a typo looked exactly like a clean project — with the same flag
+    /// driving the destructive --execute mode.
+    #[tokio::test]
+    async fn test_nonexistent_project_dir_is_an_error() {
+        let missing = std::path::Path::new("/does/not/exist/pmat-cleanup-probe");
+        let err = handle_cleanup_resources(
+            missing,
+            &["rust".to_string()],
+            false,
+            &[],
+            0,
+            OutputFormat::Table,
+        )
+        .await
+        .expect_err("a nonexistent --project-dir must not report a clean scan");
+        assert!(
+            err.to_string().contains("does not exist"),
+            "unexpected error: {err}"
+        );
+    }
+
+    /// A regular file is not a project directory either.
+    #[tokio::test]
+    async fn test_file_as_project_dir_is_an_error() {
+        let dir = TempDir::new().expect("tempdir");
+        let file = dir.path().join("not-a-dir.txt");
+        std::fs::write(&file, "x").expect("write");
+        let err = handle_cleanup_resources(
+            &file,
+            &["rust".to_string()],
+            false,
+            &[],
+            0,
+            OutputFormat::Table,
+        )
+        .await
+        .expect_err("a file is not a directory to clean");
+        assert!(
+            err.to_string().contains("not a directory"),
+            "unexpected error: {err}"
+        );
+    }
+
+    /// An existing directory still scans and still succeeds.
+    #[tokio::test]
+    async fn test_existing_project_dir_still_scans() {
+        let dir = TempDir::new().expect("tempdir");
+        handle_cleanup_resources(
+            dir.path(),
+            &["rust".to_string()],
+            false,
+            &[],
+            0,
+            OutputFormat::Table,
+        )
+        .await
+        .expect("an existing directory must still be scannable");
     }
 
     include!("cleanup_tests_part2.rs");

--- a/src/cli/handlers/complexity_handlers/analysis.rs
+++ b/src/cli/handlers/complexity_handlers/analysis.rs
@@ -92,8 +92,16 @@ pub(super) async fn analyze_project(
     detected_toolchain: Option<String>,
     config: &ComplexityConfig,
 ) -> Result<Vec<FileComplexityMetrics>> {
-    if let Some(ref toolchain) = detected_toolchain {
-        eprintln!("🔍 Analyzing {toolchain} project complexity...");
+    // Auto-detection used to RESTRICT the walk to the one language it guessed.
+    // A directory holding a.go, app.ts and main.py therefore reported
+    // "Files analyzed: 1 / Total functions: 1" — whichever toolchain detection
+    // happened to win that run — and printed the summary as if it covered the
+    // project, with no hint that two of three source files were skipped.
+    // Detection is only a label now; an explicit `--toolchain` still restricts.
+    let explicit_toolchain = config.toolchain.as_deref();
+
+    if let Some(toolchain) = explicit_toolchain {
+        eprintln!("🔍 Analyzing {toolchain} files only (--toolchain {toolchain})...");
         crate::cli::analysis_utilities::analyze_project_files(
             &config.project_path,
             Some(toolchain),
@@ -103,11 +111,15 @@ pub(super) async fn analyze_project(
         )
         .await
     } else {
-        // No specific toolchain detected - analyze all supported file types
-        eprintln!("🔍 Analyzing project complexity (multi-language)...");
+        match detected_toolchain {
+            Some(toolchain) => {
+                eprintln!("🔍 Analyzing {toolchain} project complexity (all languages)...");
+            }
+            None => eprintln!("🔍 Analyzing project complexity (multi-language)..."),
+        }
         crate::cli::analysis_utilities::analyze_project_files(
             &config.project_path,
-            None, // This will trigger analysis of all supported languages
+            None, // Analyze every supported language, not just the detected one
             &config.include,
             config.max_cyclomatic,
             config.max_cognitive,
@@ -146,15 +158,34 @@ pub(super) fn apply_complexity_filters(
     let filtered_count = original_count - file_metrics.len();
 
     if filtered_count > 0 {
-        let cyc_threshold = max_cyclomatic.unwrap_or(u16::MAX);
-        let cog_threshold = max_cognitive.unwrap_or(u16::MAX);
         eprintln!(
-            "ℹ️  Filtered {} file(s) with no functions exceeding thresholds (cyclomatic > {}, cognitive > {})",
-            filtered_count, cyc_threshold, cog_threshold
+            "ℹ️  Filtered {} file(s) with no functions exceeding thresholds ({})",
+            filtered_count,
+            describe_thresholds(max_cyclomatic, max_cognitive)
         );
     }
 
     filtered_count
+}
+
+/// Name the thresholds that were actually in force.
+///
+/// An unset threshold used to be printed as its saturating sentinel —
+/// "cognitive > 65535" — which reads as a real limit that no function can ever
+/// exceed, and told the user a gate was running that was not. A threshold that
+/// was never set is simply not named.
+fn describe_thresholds(max_cyclomatic: Option<u16>, max_cognitive: Option<u16>) -> String {
+    let mut in_force = Vec::new();
+    if let Some(threshold) = max_cyclomatic {
+        in_force.push(format!("cyclomatic > {threshold}"));
+    }
+    if let Some(threshold) = max_cognitive {
+        in_force.push(format!("cognitive > {threshold}"));
+    }
+    if in_force.is_empty() {
+        return "no thresholds set".to_string();
+    }
+    in_force.join(", ")
 }
 
 /// Aggregate over every analyzed file, then list only the top-N slice.
@@ -284,4 +315,107 @@ pub(crate) fn has_complexity_violations(
             cyclomatic_exceeded || cognitive_exceeded
         })
     })
+}
+
+#[cfg(test)]
+mod multi_language_tests {
+    //! Regression tests for two defects in this module: a detected toolchain
+    //! silently restricted the project walk to one language, and an unset
+    //! threshold was reported as the unreachable sentinel 65535.
+    use super::{analyze_project, describe_thresholds};
+    use crate::cli::handlers::complexity_handlers::ComplexityConfig;
+
+    fn write_polyglot(dir: &std::path::Path) {
+        std::fs::write(
+            dir.join("a.go"),
+            "package main\nfunc Add(a int, b int) int { if a > b { return a }\n return b }\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.join("app.ts"),
+            "export function add(a: number, b: number): number { return a > b ? a : b; }\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.join("main.py"),
+            "def add(a, b):\n    if a > b:\n        return a\n    return b\n",
+        )
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_detected_toolchain_does_not_drop_other_languages() {
+        let temp = tempfile::TempDir::new().unwrap();
+        write_polyglot(temp.path());
+
+        // No `--toolchain` flag: detection may name any one language, but it
+        // must not become the whole project.
+        let config = ComplexityConfig::from_args(
+            temp.path().to_path_buf(),
+            None,
+            None,
+            None,
+            Vec::new(),
+            60,
+            0,
+        );
+        let metrics = analyze_project(Some("typescript".to_string()), &config)
+            .await
+            .unwrap();
+
+        let mut extensions: Vec<String> = metrics
+            .iter()
+            .filter_map(|m| {
+                std::path::Path::new(&m.path)
+                    .extension()
+                    .and_then(|e| e.to_str())
+                    .map(str::to_string)
+            })
+            .collect();
+        extensions.sort();
+        extensions.dedup();
+
+        assert!(
+            extensions.len() >= 2,
+            "detecting one toolchain must not restrict the walk to it; analyzed {extensions:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_explicit_toolchain_still_restricts() {
+        let temp = tempfile::TempDir::new().unwrap();
+        write_polyglot(temp.path());
+
+        let config = ComplexityConfig::from_args(
+            temp.path().to_path_buf(),
+            Some("go".to_string()),
+            None,
+            None,
+            Vec::new(),
+            60,
+            0,
+        );
+        let metrics = analyze_project(Some("go".to_string()), &config)
+            .await
+            .unwrap();
+
+        assert!(
+            metrics.iter().all(|m| m.path.ends_with(".go")),
+            "--toolchain go must analyze only Go files"
+        );
+    }
+
+    #[test]
+    fn test_unset_threshold_is_not_reported_as_65535() {
+        let described = describe_thresholds(Some(20), None);
+        assert_eq!(described, "cyclomatic > 20");
+        assert!(
+            !described.contains("65535"),
+            "an unset cognitive threshold must not be printed as u16::MAX"
+        );
+        assert_eq!(
+            describe_thresholds(Some(20), Some(15)),
+            "cyclomatic > 20, cognitive > 15"
+        );
+    }
 }

--- a/src/cli/handlers/complexity_handlers/churn.rs
+++ b/src/cli/handlers/complexity_handlers/churn.rs
@@ -65,9 +65,17 @@ fn apply_churn_filters(
             .files
             .retain(|file| filter.should_include(&file.path));
 
-        // Update summary
+        // Update summary. Only the FILE count is derivable from the retained
+        // rows: `total_commits` is the count of DISTINCT commits in the window
+        // (see git_analysis::generate_summary), and this used to overwrite it
+        // with `sum(file.commit_count)` — a sum of file-touch events, which
+        // counts one commit once per file it touched. On this repo that turned
+        // a true 13 commits into 779 under `--include '**/*.rs'`, i.e. a filter
+        // made the total grow. Per-file commit SHAs are not carried on
+        // FileChurnMetrics, so the union cannot be recomputed here; leave the
+        // distinct-commit total for the window alone rather than replace it
+        // with a number that measures something else.
         analysis.summary.total_files_changed = analysis.files.len();
-        analysis.summary.total_commits = analysis.files.iter().map(|f| f.commit_count).sum();
     }
 
     // Apply top_files limit if specified (0 means show all)
@@ -220,8 +228,31 @@ mod churn_handler_tests {
         apply_churn_filters(&mut a, &filter, 0);
         assert_eq!(a.files.len(), 2);
         assert!(a.files.iter().all(|f| f.relative_path.starts_with("src/")));
-        // Summary totals must have been recomputed.
+        // The file count describes the retained rows.
         assert_eq!(a.summary.total_files_changed, 2);
-        assert_eq!(a.summary.total_commits, 4); // 3 + 1
+    }
+
+    /// A display filter can only remove rows; it must never raise
+    /// `total_commits`. The old code recomputed it as `sum(commit_count)`, so
+    /// `--include '**/*.rs'` reported 779 commits for a 30-day window holding
+    /// 13 — the sum of file-touch events, not commits.
+    #[test]
+    fn test_apply_churn_filters_does_not_inflate_total_commits() {
+        // 3 files touched by 4 distinct commits between them.
+        let mut a = make_analysis(vec![
+            make_file("src/a.rs", 3),
+            make_file("tests/b.rs", 2),
+            make_file("src/c.rs", 4),
+        ]);
+        a.summary.total_commits = 4; // the DISTINCT commit count for the window
+        let filter = FileFilter::new(vec!["src/**".into()], vec![]).unwrap();
+        apply_churn_filters(&mut a, &filter, 0);
+
+        assert!(
+            a.summary.total_commits <= 4,
+            "filtering raised total_commits to {} — a filter cannot add commits",
+            a.summary.total_commits
+        );
+        assert_eq!(a.summary.total_commits, 4);
     }
 }

--- a/src/cli/handlers/complexity_handlers/mod.rs
+++ b/src/cli/handlers/complexity_handlers/mod.rs
@@ -480,6 +480,11 @@ pub async fn handle_analyze_dag(
     // inheritance and full-dependency produced byte-identical output.
     let enriched_graph = filter_graph_by_dag_type(graph, &dag_type);
 
+    // `--max-depth` was only stored in `MermaidOptions`, which the renderer never
+    // reads, so every depth produced the same diagram. Traversal depth has to be
+    // applied to the graph itself, before it is rendered.
+    let enriched_graph = limit_graph_depth(enriched_graph, max_depth);
+
     // Generate Mermaid diagram
     let options = MermaidOptions {
         max_depth,
@@ -544,6 +549,84 @@ fn filter_graph_by_dag_type(
     }
 }
 
+/// Keep only the nodes reachable within `max_depth` traversal hops from a root.
+///
+/// Roots are the nodes nothing depends on (in-degree 0); a graph that is all
+/// cycles has no such node, so every node is treated as a root and the depth
+/// bound then measures distance from the nearest cycle entry. `--max-depth 0`
+/// is the roots alone.
+fn limit_graph_depth(
+    graph: crate::models::dag::DependencyGraph,
+    max_depth: Option<usize>,
+) -> crate::models::dag::DependencyGraph {
+    use rustc_hash::{FxHashMap, FxHashSet};
+    use std::collections::VecDeque;
+
+    let Some(max_depth) = max_depth else {
+        return graph;
+    };
+
+    let mut has_incoming: FxHashSet<&String> = FxHashSet::default();
+    for edge in &graph.edges {
+        if edge.from != edge.to {
+            has_incoming.insert(&edge.to);
+        }
+    }
+
+    let mut roots: Vec<&String> = graph
+        .nodes
+        .keys()
+        .filter(|id| !has_incoming.contains(*id))
+        .collect();
+    if roots.is_empty() {
+        roots = graph.nodes.keys().collect();
+    }
+
+    let mut successors: FxHashMap<&String, Vec<&String>> = FxHashMap::default();
+    for edge in &graph.edges {
+        successors.entry(&edge.from).or_default().push(&edge.to);
+    }
+
+    let mut depth: FxHashMap<&String, usize> = FxHashMap::default();
+    let mut queue: VecDeque<&String> = VecDeque::new();
+    for root in roots {
+        depth.insert(root, 0);
+        queue.push_back(root);
+    }
+
+    while let Some(node) = queue.pop_front() {
+        let next_depth = depth[node] + 1;
+        if next_depth > max_depth {
+            continue;
+        }
+        if let Some(children) = successors.get(node) {
+            for child in children {
+                if !depth.contains_key(*child) {
+                    depth.insert(child, next_depth);
+                    queue.push_back(child);
+                }
+            }
+        }
+    }
+
+    let kept: FxHashSet<String> = depth.keys().map(|id| (*id).clone()).collect();
+
+    let edges = graph
+        .edges
+        .iter()
+        .filter(|e| kept.contains(&e.from) && kept.contains(&e.to))
+        .cloned()
+        .collect();
+    let nodes = graph
+        .nodes
+        .iter()
+        .filter(|(id, _)| kept.contains(*id))
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect();
+
+    crate::models::dag::DependencyGraph { nodes, edges }
+}
+
 /// Report the size of the diagram that was actually emitted, plus the size of the
 /// graph it was rendered from when the renderer's node budget dropped some of it.
 fn report_graph_size(
@@ -593,4 +676,78 @@ fn count_rendered_elements(mermaid_content: &str) -> (usize, usize) {
 
 fn is_mermaid_edge_line(line: &str) -> bool {
     line.contains("-->") || line.contains("-.->") || line.contains(" --- ")
+}
+
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg(test)]
+mod dag_depth_tests {
+    use super::limit_graph_depth;
+    use crate::models::dag::{DependencyGraph, Edge, EdgeType, NodeInfo, NodeType};
+    use rustc_hash::FxHashMap;
+
+    /// a -> b -> c -> d, one chain four deep.
+    fn chain() -> DependencyGraph {
+        let mut graph = DependencyGraph::new();
+        for id in ["a", "b", "c", "d"] {
+            graph.add_node(NodeInfo {
+                id: id.to_string(),
+                label: id.to_string(),
+                node_type: NodeType::Function,
+                file_path: "src/lib.rs".to_string(),
+                line_number: 1,
+                complexity: 1,
+                metadata: FxHashMap::default(),
+            });
+        }
+        for (from, to) in [("a", "b"), ("b", "c"), ("c", "d")] {
+            graph.add_edge(Edge {
+                from: from.to_string(),
+                to: to.to_string(),
+                edge_type: EdgeType::Calls,
+                weight: 1,
+            });
+        }
+        graph
+    }
+
+    /// `--max-depth` was stored in `MermaidOptions` and never read, so
+    /// `analyze dag --max-depth 1` and no `--max-depth` at all wrote
+    /// byte-identical diagrams at every value.
+    #[test]
+    fn max_depth_limits_traversal() {
+        let full = limit_graph_depth(chain(), None);
+        assert_eq!(full.nodes.len(), 4);
+
+        let depth_1 = limit_graph_depth(chain(), Some(1));
+        assert_eq!(depth_1.nodes.len(), 2, "root plus one hop");
+        assert!(depth_1.nodes.contains_key("a") && depth_1.nodes.contains_key("b"));
+        assert_eq!(depth_1.edges.len(), 1);
+
+        let depth_0 = limit_graph_depth(chain(), Some(0));
+        assert_eq!(depth_0.nodes.len(), 1, "roots only");
+        assert!(depth_0.edges.is_empty());
+
+        let depth_9 = limit_graph_depth(chain(), Some(9));
+        assert_eq!(
+            depth_9.nodes.len(),
+            4,
+            "a depth past the graph keeps it all"
+        );
+    }
+
+    /// A graph that is one cycle has no in-degree-0 node; depth limiting must
+    /// still return a graph rather than dropping every node.
+    #[test]
+    fn cyclic_graph_is_not_emptied() {
+        let mut graph = chain();
+        graph.add_edge(Edge {
+            from: "d".to_string(),
+            to: "a".to_string(),
+            edge_type: EdgeType::Calls,
+            weight: 1,
+        });
+
+        let limited = limit_graph_depth(graph, Some(1));
+        assert!(!limited.nodes.is_empty());
+    }
 }

--- a/src/cli/handlers/comply_cb_detect/model_quality_parsing.rs
+++ b/src/cli/handlers/comply_cb_detect/model_quality_parsing.rs
@@ -29,6 +29,18 @@ fn walk_model_recursive(dir: &Path, files: &mut Vec<PathBuf>) {
     }
 }
 
+/// Whether the file's magic bytes agree with the format its extension claims.
+///
+/// `analyze models` derived the reported format from the FILENAME EXTENSION
+/// alone, so a 0-byte `.safetensors`, an 8-byte `NOTAGGUF` and a plain-text
+/// `.apr` were all inventoried as valid models of their declared format —
+/// while this validator, which reads the actual header, was never called from
+/// the inventory path. A format nobody verified must not be reported as fact.
+#[must_use]
+pub fn model_header_matches_extension(path: &Path) -> bool {
+    parse_model_header(path).is_some()
+}
+
 /// Parse minimal header from model file (never loads tensor data).
 fn parse_model_header(path: &Path) -> Option<ModelMetadata> {
     let ext = path.extension()?.to_str()?;

--- a/src/cli/handlers/comply_handlers/check_handlers/check.rs
+++ b/src/cli/handlers/comply_handlers/check_handlers/check.rs
@@ -290,19 +290,132 @@ fn output_compliance_report(
     Ok(())
 }
 
+/// `-f sarif` emits SARIF — pmat's own compliance findings, always.
+///
+/// This used to try the external `pv` binary and, when that was unavailable
+/// (which is the normal case: it needs a sibling contracts directory AND `pv`
+/// on PATH), silently print pmat's plain JSON report instead. The document
+/// carried no `$schema`, no `version` and no `runs[]`, so GitHub's
+/// upload-sarif action rejected it — and it was byte-identical to `-f json`
+/// apart from the timestamp, so nothing in the output said the fallback had
+/// happened. Even on the happy path the SARIF described pv's YAML contract
+/// lint and never the 154 compliance checks the command was run for; pv's runs
+/// are now MERGED into pmat's document rather than replacing it.
 fn output_sarif_or_fallback(report: &ComplianceReport, project_path: &Path) -> Result<()> {
     debug_assert!(
         project_path.exists(),
         "project_path must exist: {}",
         project_path.display()
     );
-    if let Some(sarif) = try_pv_lint_sarif(project_path) {
-        println!("{sarif}");
-        return Ok(());
+    let mut sarif = build_sarif(report, project_path);
+    if let Some(pv_runs) = pv_lint_runs(project_path) {
+        if let Some(runs) = sarif["runs"].as_array_mut() {
+            runs.extend(pv_runs);
+        }
     }
-    // Fallback: JSON output
-    println!("{}", serde_json::to_string_pretty(report)?);
+    println!("{}", serde_json::to_string_pretty(&sarif)?);
     Ok(())
+}
+
+/// The SARIF rule id for a check: its `CB-nnn` clause when it has one, else a
+/// slug of its name, so a consumer can suppress a single finding.
+fn sarif_rule_id(name: &str) -> String {
+    for token in name.split(|c: char| !(c.is_ascii_alphanumeric() || c == '-')) {
+        let upper = token.to_ascii_uppercase();
+        if upper.starts_with("CB-") && upper[3..].chars().all(|c| c.is_ascii_digit()) {
+            return upper;
+        }
+    }
+    let slug: String = name
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() {
+                c.to_ascii_lowercase()
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    format!("pmat/{}", slug.trim_matches('-'))
+}
+
+/// SARIF level for a check result. Skipped and passing checks produce no
+/// result at all — a SARIF run reports findings, not a roll call.
+fn sarif_level(check: &ComplianceCheck) -> Option<&'static str> {
+    match check.status {
+        CheckStatus::Fail => Some(match check.severity {
+            Severity::Critical | Severity::Error => "error",
+            Severity::Warning => "warning",
+            Severity::Info => "note",
+        }),
+        CheckStatus::Warn => Some("warning"),
+        CheckStatus::Pass | CheckStatus::Skip => None,
+    }
+}
+
+/// A SARIF 2.1.0 document for pmat's own compliance report.
+fn build_sarif(report: &ComplianceReport, project_path: &Path) -> serde_json::Value {
+    let uri = project_path.display().to_string();
+
+    let rules: Vec<serde_json::Value> = report
+        .checks
+        .iter()
+        .map(|check| {
+            serde_json::json!({
+                "id": sarif_rule_id(&check.name),
+                "name": check.name,
+                "shortDescription": { "text": check.name },
+            })
+        })
+        .collect();
+
+    let results: Vec<serde_json::Value> = report
+        .checks
+        .iter()
+        .filter_map(|check| {
+            let level = sarif_level(check)?;
+            Some(serde_json::json!({
+                "ruleId": sarif_rule_id(&check.name),
+                "level": level,
+                "message": { "text": format!("{}: {}", check.name, check.message) },
+                "locations": [{
+                    "physicalLocation": {
+                        "artifactLocation": { "uri": uri }
+                    }
+                }],
+            }))
+        })
+        .collect();
+
+    serde_json::json!({
+        "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+        "version": "2.1.0",
+        "runs": [{
+            "tool": {
+                "driver": {
+                    "name": "pmat",
+                    "version": PMAT_VERSION,
+                    "informationUri": "https://github.com/paiml/paiml-mcp-agent-toolkit",
+                    "rules": rules,
+                }
+            },
+            "results": results,
+        }]
+    })
+}
+
+/// pv's SARIF `runs[]`, when the external contract linter is available and
+/// produced a SARIF document. Anything else is reported on stderr rather than
+/// swallowed.
+fn pv_lint_runs(project_path: &Path) -> Option<Vec<serde_json::Value>> {
+    let raw = try_pv_lint_sarif(project_path)?;
+    match serde_json::from_str::<serde_json::Value>(&raw) {
+        Ok(value) => value.get("runs").and_then(|runs| runs.as_array()).cloned(),
+        Err(e) => {
+            eprintln!("Warning: `pv lint --format sarif` output was not JSON ({e}); reporting pmat's compliance checks only");
+            None
+        }
+    }
 }
 
 fn try_pv_lint_sarif(project_path: &Path) -> Option<String> {
@@ -428,6 +541,75 @@ mod build_compliance_report_tests {
         };
         // is_compliant=true, no warnings even with strict → Ok (no exit)
         assert!(apply_exit_policy(&report, true).is_ok());
+    }
+
+    /// `comply check -f sarif` used to print pmat's plain JSON report whenever
+    /// the external `pv` linter was unavailable: no `$schema`, no `version`, no
+    /// `runs[]` — a document GitHub's upload-sarif action rejects, and
+    /// byte-identical to `-f json` apart from the timestamp.
+    #[test]
+    fn sarif_is_sarif_and_carries_pmats_own_checks() {
+        let report = ComplianceReport {
+            project_version: "1.0".into(),
+            current_version: "1.0".into(),
+            is_compliant: false,
+            versions_behind: 0,
+            checks: vec![
+                check("Version Currency", CheckStatus::Pass),
+                ComplianceCheck {
+                    name: "CB-030: O(1) Hooks".into(),
+                    status: CheckStatus::Fail,
+                    message: "hook missing".into(),
+                    severity: Severity::Error,
+                },
+                ComplianceCheck {
+                    name: "Quality Thresholds".into(),
+                    status: CheckStatus::Warn,
+                    message: "close to the limit".into(),
+                    severity: Severity::Warning,
+                },
+                check("Disabled Check", CheckStatus::Skip),
+            ],
+            breaking_changes: vec![],
+            recommendations: vec![],
+            timestamp: Utc::now(),
+        };
+
+        let sarif = build_sarif(&report, Path::new("."));
+        assert_eq!(sarif["version"], "2.1.0");
+        assert!(sarif["$schema"].is_string(), "SARIF needs a $schema");
+        let runs = sarif["runs"].as_array().expect("SARIF needs runs[]");
+        assert_eq!(runs.len(), 1);
+        assert_eq!(runs[0]["tool"]["driver"]["name"], "pmat");
+
+        // One result per Fail/Warn, none for Pass/Skip.
+        let results = runs[0]["results"].as_array().expect("results[]");
+        assert_eq!(results.len(), 2, "{results:#?}");
+        assert_eq!(results[0]["ruleId"], "CB-030");
+        assert_eq!(results[0]["level"], "error");
+        assert!(results[0]["message"]["text"]
+            .as_str()
+            .expect("message")
+            .contains("hook missing"));
+        assert_eq!(results[1]["ruleId"], "pmat/quality-thresholds");
+        assert_eq!(results[1]["level"], "warning");
+
+        // The document must NOT be the plain compliance report.
+        assert!(sarif.get("checks").is_none());
+        assert!(sarif.get("is_compliant").is_none());
+    }
+
+    #[test]
+    fn sarif_rule_ids_prefer_the_cb_clause() {
+        assert_eq!(sarif_rule_id("CB-1204: Verification Ladder"), "CB-1204");
+        assert_eq!(
+            sarif_rule_id("Cargo.lock Present"),
+            "pmat/cargo-lock-present"
+        );
+        assert_eq!(
+            sarif_rule_id("OIP Tarantula Patterns (CB-120 to CB-124)"),
+            "CB-120"
+        );
     }
 }
 

--- a/src/cli/handlers/comply_handlers/check_handlers/check.rs
+++ b/src/cli/handlers/comply_handlers/check_handlers/check.rs
@@ -44,11 +44,16 @@ pub(crate) async fn handle_check(
     failures_only: bool,
     format: ComplyOutputFormat,
 ) -> Result<()> {
-    debug_assert!(
-        project_path.exists(),
-        "project_path must exist: {}",
-        project_path.display()
-    );
+    // A `debug_assert!` is not a guard in a release build: `comply check -p
+    // /does/not/exist` sailed past it, and the first thing that touched the
+    // filesystem was `load_or_create_project_config`, which tried to
+    // `create_dir_all("/does/not/exist/.pmat")`. That surfaced as "Permission
+    // denied (os error 13)" and exit 126 — an error about the wrong thing,
+    // pointing at a permissions problem the user does not have. Reject the
+    // missing path by name, like every other analysis handler does.
+    if !project_path.exists() {
+        anyhow::bail!("Path not found: {}", project_path.display());
+    }
 
     eprintln!("Checking PMAT compliance for {}", project_path.display());
 
@@ -648,3 +653,5 @@ include!("check_individual_ci.rs");
 
 include!("check_handlers_tests_inline.rs");
 include!("check_pv_enforcement_helpers_tests.rs");
+
+include!("check_path_guard_tests.rs");

--- a/src/cli/handlers/comply_handlers/check_handlers/check_path_guard_tests.rs
+++ b/src/cli/handlers/comply_handlers/check_handlers/check_path_guard_tests.rs
@@ -1,0 +1,51 @@
+// Regression test: `comply check -p <missing>` must say the path is missing.
+//
+// It used to guard existence with a `debug_assert!`, which is compiled out of
+// the released binary. The run then fell through to
+// `load_or_create_project_config`, which does `create_dir_all(<path>/.pmat)`,
+// so the user saw "Error: Permission denied (os error 13)" and exit 126 — an
+// error naming neither the path nor the real problem.
+
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg(test)]
+mod comply_check_path_guard_tests {
+    use crate::cli::commands::ComplyOutputFormat;
+    use std::path::PathBuf;
+
+    fn missing_path() -> PathBuf {
+        PathBuf::from("/nonexistent-pmat-comply-check-4b81/does/not/exist")
+    }
+
+    #[tokio::test]
+    async fn comply_check_rejects_a_missing_project_path() {
+        let path = missing_path();
+        let err = super::handle_check(&path, false, false, ComplyOutputFormat::Text)
+            .await
+            .expect_err("a missing project path must not produce a compliance report");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("Path not found"),
+            "expected the missing-path guard, got: {msg}"
+        );
+        assert!(
+            msg.contains(&path.display().to_string()),
+            "error must name the offending path, got: {msg}"
+        );
+        assert!(
+            !msg.contains("Permission denied"),
+            "the guard must not be reported as a permissions failure: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn comply_check_does_not_create_a_pmat_dir_under_a_missing_path() {
+        // The old code's first filesystem call was a `create_dir_all` under the
+        // path it had not checked.
+        let path = missing_path();
+        let _ = super::handle_check(&path, false, false, ComplyOutputFormat::Text).await;
+        assert!(
+            !path.join(".pmat").exists(),
+            "comply check must not materialise a config dir under a nonexistent path"
+        );
+    }
+}

--- a/src/cli/handlers/comply_handlers/check_handlers/check_review_audit.rs
+++ b/src/cli/handlers/comply_handlers/check_handlers/check_review_audit.rs
@@ -564,4 +564,54 @@ mod tests {
         fs::write(tmp.path().join("newfile.txt"), "x").unwrap();
         assert!(!check_git_clean(tmp.path()));
     }
+
+    // ── the help must not promise evidence the artifact does not carry ──────
+
+    /// `comply audit --help` promised "Produces signed compliance evidence"
+    /// while `AuditArtifact` has no signature, digest or attestation field —
+    /// the serialized document is plain JSON that anyone can edit undetectably.
+    #[test]
+    fn audit_help_does_not_claim_a_signature_the_artifact_lacks() {
+        use clap::Subcommand;
+        let cmd =
+            crate::cli::commands::ComplyCommands::augment_subcommands(clap::Command::new("comply"));
+        let audit = cmd
+            .get_subcommands()
+            .find(|s| s.get_name() == "audit")
+            .expect("comply audit subcommand must exist");
+        let help = audit
+            .get_long_about()
+            .or_else(|| audit.get_about())
+            .map(std::string::ToString::to_string)
+            .unwrap_or_default();
+
+        assert!(
+            !help.contains("signed compliance evidence"),
+            "audit help must not promise a signature: {help}"
+        );
+
+        // And the artifact still carries no such field, which is what makes the
+        // claim false — if one is ever added, this assertion is the reminder to
+        // restore the promise in the help text.
+        let artifact = AuditArtifact {
+            version: "0.0.0".to_string(),
+            timestamp: Utc::now(),
+            git_sha: "deadbeef".to_string(),
+            git_clean: true,
+            layer1_checks: vec![],
+            layer2_review: vec![],
+            reproducibility_level: "L0".to_string(),
+            muda_score: 0.0,
+            golden_traces: "not_configured".to_string(),
+        };
+        let doc: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&artifact).unwrap()).unwrap();
+        let keys: Vec<&String> = doc.as_object().unwrap().keys().collect();
+        assert!(
+            !keys
+                .iter()
+                .any(|k| k.contains("signature") || k.contains("digest") || k.contains("attest")),
+            "artifact keys changed: {keys:?}"
+        );
+    }
 }

--- a/src/cli/handlers/comply_handlers/check_handlers/check_review_audit.rs
+++ b/src/cli/handlers/comply_handlers/check_handlers/check_review_audit.rs
@@ -573,17 +573,20 @@ mod tests {
     #[test]
     fn audit_help_does_not_claim_a_signature_the_artifact_lacks() {
         use clap::Subcommand;
-        let cmd =
-            crate::cli::commands::ComplyCommands::augment_subcommands(clap::Command::new("comply"));
-        let audit = cmd
-            .get_subcommands()
-            .find(|s| s.get_name() == "audit")
-            .expect("comply audit subcommand must exist");
-        let help = audit
-            .get_long_about()
-            .or_else(|| audit.get_about())
-            .map(std::string::ToString::to_string)
-            .unwrap_or_default();
+        let help = crate::cli::commands::on_big_stack(|| {
+            let cmd = crate::cli::commands::ComplyCommands::augment_subcommands(
+                clap::Command::new("comply"),
+            );
+            let audit = cmd
+                .get_subcommands()
+                .find(|s| s.get_name() == "audit")
+                .expect("comply audit subcommand must exist");
+            audit
+                .get_long_about()
+                .or_else(|| audit.get_about())
+                .map(std::string::ToString::to_string)
+                .unwrap_or_default()
+        });
 
         assert!(
             !help.contains("signed compliance evidence"),

--- a/src/cli/handlers/comply_handlers/check_handlers/check_review_audit.rs
+++ b/src/cli/handlers/comply_handlers/check_handlers/check_review_audit.rs
@@ -200,6 +200,20 @@ struct AuditArtifact {
     golden_traces: String,
 }
 
+/// Whether `comply audit`'s decoration may share stdout with the artifact.
+///
+/// `-f json` is this subcommand's DEFAULT, and it used to print the
+/// "PMAT Comply Audit (Layer 3: Governance)" banner and a rule with `println!`
+/// ahead of the JSON document — with an empty stderr, so `2>/dev/null` did not
+/// help and `pmat comply audit | python3 -m json.tool` failed on the
+/// documented default invocation. Machine formats get the artifact alone.
+fn audit_banner_belongs_on_stdout(format: &ComplyOutputFormat) -> bool {
+    matches!(
+        format,
+        ComplyOutputFormat::Text | ComplyOutputFormat::Markdown
+    )
+}
+
 /// Handle `pmat comply audit` - generate governance audit artifact.
 #[provable_contracts_macros::contract("pmat-core.yaml", equation = "path_exists")]
 pub(crate) async fn handle_audit(
@@ -207,14 +221,19 @@ pub(crate) async fn handle_audit(
     format: ComplyOutputFormat,
     output: Option<&Path>,
 ) -> Result<()> {
-    println!("{}", c::header("PMAT Comply Audit (Layer 3: Governance)"));
-    println!("{}\n", c::rule());
+    if audit_banner_belongs_on_stdout(&format) {
+        println!("{}", c::header("PMAT Comply Audit (Layer 3: Governance)"));
+        println!("{}\n", c::rule());
+    }
 
     let git_clean = check_git_clean(project_path);
     if !git_clean {
-        println!("{}", c::fail("ERROR: Audit requires clean git state."));
-        println!("Commit or stash all changes before generating an audit artifact.");
-        println!(
+        // Errors go to stderr: this used to be printed to stdout too, so
+        // `comply audit -f json 2>/dev/null` still produced an unparseable
+        // document on the failure path.
+        eprintln!("{}", c::fail("ERROR: Audit requires clean git state."));
+        eprintln!("Commit or stash all changes before generating an audit artifact.");
+        eprintln!(
             "\n{}",
             c::dim("Rationale: Audit artifacts must be reproducible from a specific commit.")
         );
@@ -361,6 +380,18 @@ fn format_audit_markdown(artifact: &AuditArtifact) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn machine_formats_get_stdout_to_themselves() {
+        // `comply audit` defaults to -f json; a banner printed with println!
+        // ahead of the document made that default invocation unparseable.
+        assert!(!audit_banner_belongs_on_stdout(&ComplyOutputFormat::Json));
+        assert!(!audit_banner_belongs_on_stdout(&ComplyOutputFormat::Sarif));
+        assert!(audit_banner_belongs_on_stdout(&ComplyOutputFormat::Text));
+        assert!(audit_banner_belongs_on_stdout(
+            &ComplyOutputFormat::Markdown
+        ));
+    }
 
     fn item(category: &str, status: &str) -> ReviewItem {
         ReviewItem {

--- a/src/cli/handlers/comply_handlers/check_handlers/types.rs
+++ b/src/cli/handlers/comply_handlers/check_handlers/types.rs
@@ -190,9 +190,112 @@ pub(crate) fn calculate_versions_behind(project_version: &str) -> u32 {
     }
 }
 
+/// PMAT's own changelog, embedded at build time.
+///
+/// `comply diff` reports what changed *in PMAT* between the version a project
+/// is pinned to and the version installed, so the only honest source is PMAT's
+/// CHANGELOG.md — not a list written into the source.
+const EMBEDDED_CHANGELOG: &str = include_str!("../../../../../CHANGELOG.md");
+
+/// One released version parsed out of CHANGELOG.md.
+struct ChangelogSection {
+    version: semver::Version,
+    description: String,
+    breaking: bool,
+}
+
+/// Parse `## [x.y.z] - date` sections out of a Keep-a-Changelog document.
+///
+/// `[Unreleased]` and any heading whose bracketed token is not a semver
+/// version are skipped: they name no release, so no range contains them.
+fn parse_changelog(text: &str) -> Vec<ChangelogSection> {
+    let mut sections: Vec<ChangelogSection> = Vec::new();
+    let mut current: Option<(semver::Version, Vec<&str>)> = None;
+
+    for line in text.lines() {
+        if let Some(rest) = line.strip_prefix("## [") {
+            if let Some((version, body)) = current.take() {
+                sections.push(finish_section(version, &body));
+            }
+            let token = rest.split(']').next().unwrap_or("");
+            if let Ok(version) = semver::Version::parse(token) {
+                current = Some((version, Vec::new()));
+            }
+        } else if let Some((_, body)) = current.as_mut() {
+            body.push(line);
+        }
+    }
+    if let Some((version, body)) = current.take() {
+        sections.push(finish_section(version, &body));
+    }
+
+    sections
+}
+
+fn finish_section(version: semver::Version, body: &[&str]) -> ChangelogSection {
+    ChangelogSection {
+        version,
+        description: summarize_section(body),
+        breaking: body
+            .iter()
+            .any(|l| l.contains("BREAKING") || l.trim_start().starts_with("### Removed")),
+    }
+}
+
+/// First substantive line of a section, used as its one-line description.
+fn summarize_section(body: &[&str]) -> String {
+    let raw = body
+        .iter()
+        .map(|l| l.trim())
+        .find(|l| !l.is_empty() && !l.starts_with('#'))
+        .unwrap_or("");
+    let cleaned = raw
+        .trim_start_matches(['-', '*'])
+        .trim()
+        .replace("**", "")
+        .replace('`', "");
+    let cleaned = cleaned.trim();
+    if cleaned.chars().count() > 160 {
+        let truncated: String = cleaned.chars().take(157).collect();
+        format!("{truncated}...")
+    } else {
+        cleaned.to_string()
+    }
+}
+
+/// Sections in the half-open range `(from, to]`.
+///
+/// An unparsable bound yields nothing: a range we cannot evaluate has no
+/// entries we can honestly claim fall inside it.
+fn sections_in_range(from: &str, to: &str) -> Vec<ChangelogSection> {
+    let (Ok(from), Ok(to)) = (
+        semver::Version::parse(from.trim_start_matches('v')),
+        semver::Version::parse(to.trim_start_matches('v')),
+    ) else {
+        return Vec::new();
+    };
+
+    parse_changelog(EMBEDDED_CHANGELOG)
+        .into_iter()
+        .filter(|s| s.version > from && s.version <= to)
+        .collect()
+}
+
+/// Breaking changes released after `from_version`.
+///
+/// This used to be `vec![]` for every input, so `comply check` could never
+/// report a breaking change no matter how far behind a project was.
 #[provable_contracts_macros::contract("pmat-core.yaml", equation = "check_compliance")]
-pub(crate) fn get_breaking_changes_since(_from_version: &str) -> Vec<BreakingChange> {
-    vec![]
+pub(crate) fn get_breaking_changes_since(from_version: &str) -> Vec<BreakingChange> {
+    sections_in_range(from_version, PMAT_VERSION)
+        .into_iter()
+        .filter(|s| s.breaking)
+        .map(|s| BreakingChange {
+            version: s.version.to_string(),
+            description: s.description,
+            migration_guide: None,
+        })
+        .collect()
 }
 
 #[derive(Debug, Clone)]
@@ -202,25 +305,22 @@ pub(crate) struct ChangelogEntry {
     pub breaking: bool,
 }
 
+/// Changelog entries released in `(from, to]`.
+///
+/// Both parameters used to be discarded (`_from`, `_to`) in favour of three
+/// hardcoded entries stamped with the *current* version, so every range —
+/// including v3.29.0 → v3.29.0 — rendered the same three lines, one of them
+/// advertising a `cleanup-resources` command that does not exist in the binary.
 #[provable_contracts_macros::contract("pmat-core.yaml", equation = "check_compliance")]
-pub(crate) fn get_changelog_entries(_from: &str, _to: &str) -> Vec<ChangelogEntry> {
-    vec![
-        ChangelogEntry {
-            version: PMAT_VERSION.to_string(),
-            description: "Added qa-work command for Toyota Way validation".to_string(),
-            breaking: false,
-        },
-        ChangelogEntry {
-            version: PMAT_VERSION.to_string(),
-            description: "Added cleanup-resources command".to_string(),
-            breaking: false,
-        },
-        ChangelogEntry {
-            version: PMAT_VERSION.to_string(),
-            description: "Added comply command for compliance checking".to_string(),
-            breaking: false,
-        },
-    ]
+pub(crate) fn get_changelog_entries(from: &str, to: &str) -> Vec<ChangelogEntry> {
+    sections_in_range(from, to)
+        .into_iter()
+        .map(|s| ChangelogEntry {
+            version: s.version.to_string(),
+            description: s.description,
+            breaking: s.breaking,
+        })
+        .collect()
 }
 
 #[provable_contracts_macros::contract("pmat-core.yaml", equation = "path_exists")]
@@ -436,4 +536,98 @@ pub(crate) async fn determine_hook_action(
         return Ok(HookAction::Refresh);
     }
     Ok(HookAction::UpToDate)
+}
+
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg(test)]
+mod changelog_range_tests {
+    use super::*;
+
+    const SAMPLE: &str = "\
+# Changelog
+
+## [Unreleased]
+
+## [3.0.0] - 2026-01-01
+
+### Removed
+
+- Dropped the old API.
+
+## [2.1.0] - 2025-06-01
+
+- Added a widget.
+
+## [1.5.0] - 2024-01-01
+
+- First widget.
+";
+
+    /// A range must contain only the versions inside it. Both parameters used to
+    /// be discarded, so every range printed the same three canned entries.
+    #[test]
+    fn range_filters_by_version() {
+        let sections = parse_changelog(SAMPLE);
+        let versions: Vec<String> = sections.iter().map(|s| s.version.to_string()).collect();
+        assert_eq!(versions, vec!["3.0.0", "2.1.0", "1.5.0"]);
+
+        let in_range: Vec<String> = sections
+            .iter()
+            .filter(|s| {
+                s.version > semver::Version::parse("1.5.0").unwrap()
+                    && s.version <= semver::Version::parse("2.1.0").unwrap()
+            })
+            .map(|s| s.version.to_string())
+            .collect();
+        assert_eq!(in_range, vec!["2.1.0"]);
+    }
+
+    /// `### Removed` and `BREAKING` mark a release as breaking.
+    #[test]
+    fn breaking_sections_are_detected() {
+        let sections = parse_changelog(SAMPLE);
+        assert!(sections[0].breaking, "3.0.0 removes an API");
+        assert!(!sections[1].breaking);
+    }
+
+    /// An empty range must be empty. `--from X --to X` used to print three
+    /// entries stamped with the current version.
+    #[test]
+    fn identical_from_and_to_yields_nothing() {
+        assert!(get_changelog_entries(PMAT_VERSION, PMAT_VERSION).is_empty());
+    }
+
+    /// A range that ends before this project's first release must not report
+    /// entries from the current version.
+    #[test]
+    fn ancient_range_does_not_report_current_version() {
+        let entries = get_changelog_entries("1.0.0", "2.0.0");
+        assert!(
+            entries.iter().all(|e| e.version != PMAT_VERSION),
+            "entries outside the requested range leaked in: {:?}",
+            entries
+        );
+        assert!(
+            !entries
+                .iter()
+                .any(|e| e.description.contains("cleanup-resources")),
+            "the canned entry advertising a nonexistent command is still emitted"
+        );
+    }
+
+    /// Entries must come from the shipped changelog, so a wide range finds the
+    /// releases that are actually in it.
+    #[test]
+    fn wide_range_reads_the_embedded_changelog() {
+        let entries = get_changelog_entries("2.0.0", PMAT_VERSION);
+        assert!(
+            entries.len() > 3,
+            "expected the real changelog, got {} entries",
+            entries.len()
+        );
+        assert!(
+            entries.iter().any(|e| e.version == PMAT_VERSION),
+            "the current release must be inside (2.0.0, {PMAT_VERSION}]"
+        );
+    }
 }

--- a/src/cli/handlers/comply_handlers/comply_handlers_tests.rs
+++ b/src/cli/handlers/comply_handlers/comply_handlers_tests.rs
@@ -131,27 +131,41 @@ mod property_tests {
             prop_assert_eq!(deserialized.description, description);
         }
 
+        // These two properties were the stub written down as invariants: every
+        // entry carried PMAT_VERSION because `get_changelog_entries` ignored its
+        // range and stamped the current version on three canned rows, and
+        // `get_breaking_changes_since` returned `[]` unconditionally. Both now
+        // read CHANGELOG.md, so the properties assert what should actually hold
+        // of a version range.
+
         #[test]
-        fn test_changelog_entries_always_have_current_version(_seed in 0u32..1000) {
+        fn test_changelog_entries_are_distinct_real_versions(_seed in 0u32..1000) {
             let entries = get_changelog_entries("0.0.0", "999.999.999");
             prop_assert!(!entries.is_empty());
 
-            // All entries should have version matching PMAT_VERSION
+            let mut seen = std::collections::HashSet::new();
             for entry in &entries {
-                prop_assert_eq!(&entry.version, PMAT_VERSION);
+                prop_assert!(!entry.version.is_empty());
+                // A repeated version means the range is not being read.
+                prop_assert!(seen.insert(entry.version.clone()));
             }
+            prop_assert!(seen.len() > 1, "the changelog holds more than one release");
         }
 
         #[test]
-        fn test_breaking_changes_returns_empty_for_any_version(
+        fn test_breaking_changes_never_predate_the_version_asked_for(
             major in 0u32..100,
             minor in 0u32..1000,
             patch in 0u32..100
         ) {
             let version = format!("{}.{}.{}", major, minor, patch);
             let changes = get_breaking_changes_since(&version);
-            // Current implementation always returns empty
-            prop_assert!(changes.is_empty());
+            // Whatever comes back must be strictly newer than the floor given,
+            // and must name a version.
+            for change in &changes {
+                prop_assert!(!change.version.is_empty());
+                prop_assert_ne!(&change.version, &version);
+            }
         }
     }
 

--- a/src/cli/handlers/comply_handlers/coverage_part2_config.rs
+++ b/src/cli/handlers/comply_handlers/coverage_part2_config.rs
@@ -1,38 +1,62 @@
     // get_breaking_changes_since Tests
 
+    // These four tests asserted the STUB: `get_breaking_changes_since` returned
+    // `[]` for every version and `get_changelog_entries` returned a canned
+    // 3-entry list regardless of the range asked for. Two of them even said so
+    // ("Current implementation always returns empty"). Both functions now read
+    // the real CHANGELOG.md, so the tests assert against it instead.
+
     #[test]
-    fn test_get_breaking_changes_since_returns_empty() {
+    fn test_get_breaking_changes_since_finds_real_major_releases() {
+        // pmat's changelog starts at 2.172.0, so everything in it is "since 1.0.0".
         let changes = get_breaking_changes_since("1.0.0");
-        assert!(changes.is_empty());
+        assert!(
+            !changes.is_empty(),
+            "the changelog contains major releases after 1.0.0; an empty result \
+             means the stub is back"
+        );
     }
 
     #[test]
-    fn test_get_breaking_changes_since_any_version() {
-        let changes = get_breaking_changes_since("0.0.1");
-        assert!(changes.is_empty());
+    fn test_get_breaking_changes_since_is_bounded_by_the_version_given() {
+        // Nothing was released after the version currently being built.
+        let changes = get_breaking_changes_since(PMAT_VERSION);
+        assert!(
+            changes.is_empty(),
+            "nothing can be breaking *since* the current version, got {changes:?}"
+        );
     }
 
     // get_changelog_entries Tests
 
     #[test]
-    fn test_get_changelog_entries_returns_entries() {
-        let entries = get_changelog_entries("1.0.0", "2.0.0");
-        assert!(!entries.is_empty());
+    fn test_get_changelog_entries_covers_a_real_range() {
+        let entries = get_changelog_entries("2.172.0", PMAT_VERSION);
+        assert!(
+            !entries.is_empty(),
+            "2.172.0..{PMAT_VERSION} spans the whole changelog"
+        );
     }
 
     #[test]
-    fn test_get_changelog_entries_contain_expected_features() {
-        let entries = get_changelog_entries("1.0.0", PMAT_VERSION);
-        let has_comply = entries.iter().any(|e| e.description.contains("comply"));
-        assert!(has_comply);
+    fn test_get_changelog_entries_is_empty_below_the_oldest_release() {
+        // The oldest section in CHANGELOG.md is 2.172.0, so this range holds
+        // nothing. The stub returned three canned entries for it.
+        let entries = get_changelog_entries("1.0.0", "2.0.0");
+        assert!(
+            entries.is_empty(),
+            "no release exists in 1.0.0..2.0.0, got {entries:?}"
+        );
     }
 
     #[test]
-    fn test_changelog_entry_breaking_flag() {
-        let entries = get_changelog_entries("1.0.0", "2.0.0");
-        // Current implementation has no breaking changes
-        let breaking_count = entries.iter().filter(|e| e.breaking).count();
-        assert_eq!(breaking_count, 0);
+    fn test_changelog_entries_report_the_version_they_came_from() {
+        let entries = get_changelog_entries("2.172.0", PMAT_VERSION);
+        assert!(entries.iter().all(|e| !e.version.is_empty()));
+        assert!(
+            entries.iter().any(|e| e.version != PMAT_VERSION),
+            "every entry carrying the current version is the stub's signature"
+        );
     }
 
     // load_or_create_project_config Tests

--- a/src/cli/handlers/comprehensive_analysis_handler/helpers.rs
+++ b/src/cli/handlers/comprehensive_analysis_handler/helpers.rs
@@ -135,14 +135,17 @@ pub(super) async fn enhance_with_additional_analyses(
     mut result: ComprehensiveAnalysisResult,
     config: AdditionalAnalysisConfig<'_>,
 ) -> Result<ComprehensiveAnalysisResult> {
-    // Add duplicate detection if requested
+    // Duplicate detection is NOT wired into comprehensive analysis. It used to
+    // announce "👥 Detecting duplicates..." and then push the developer note
+    // "Duplicate detection analysis requested - integrate with duplicate
+    // detector" into the user-facing recommendations, which reads as a finding
+    // about the codebase rather than a missing feature — and the flag defaults
+    // to on, so every run carried it. Say what is true, on stderr, and leave
+    // the report free of a result nothing measured.
     if config.include_duplicates {
-        eprintln!("👥 Detecting duplicates...");
-        // Would integrate with duplicate detector service
-        // For now, just note it in the summary
-        result.summary.recommendations.push(
-            "Duplicate detection analysis requested - integrate with duplicate detector"
-                .to_string(),
+        eprintln!(
+            "ℹ️  Duplicate detection is not part of comprehensive analysis; \
+             run `pmat analyze duplicates` for clone results."
         );
     }
 
@@ -172,19 +175,32 @@ pub(super) async fn enhance_with_additional_analyses(
         };
 
         if let Ok(defect_result) = facade.analyze_project(request).await {
-            result.summary.total_issues += defect_result.high_risk_files;
-            result.summary.critical_issues += defect_result.high_risk_files;
-
-            if defect_result.high_risk_files > 0 {
-                result.summary.recommendations.push(format!(
-                    "Focus on {} high-risk files identified by defect prediction",
-                    defect_result.high_risk_files
-                ));
-            }
+            record_defect_prediction(&mut result.summary, defect_result.high_risk_files);
         }
     }
 
     Ok(result)
+}
+
+/// Fold defect prediction's `high_risk_files` into the summary — as a
+/// recommendation only.
+///
+/// It used to be added to BOTH `total_issues` and `critical_issues`. That is a
+/// FILE count going into an ISSUE counter, and the two are not commensurable:
+/// this repo reported `total_files: 4355` with `total_issues: 50747` and
+/// `critical_issues: 49784`, of which 49498 were "high-risk files" — eleven
+/// times more issues than there are files, while the analyses actually present
+/// in the report summed to 1249. An issue count must stay bounded by what the
+/// listed analyses found.
+pub(super) fn record_defect_prediction(
+    summary: &mut crate::services::facades::analysis_orchestrator::AnalysisSummary,
+    high_risk_files: usize,
+) {
+    if high_risk_files > 0 {
+        summary.recommendations.push(format!(
+            "Focus on {high_risk_files} high-risk files identified by defect prediction"
+        ));
+    }
 }
 
 /// Print performance breakdown
@@ -270,6 +286,46 @@ mod additional_config_scope_tests {
             additional.project_path,
             Path::new("."),
             "passing \".\" here is what made the issue counts depend on the caller's cwd"
+        );
+    }
+
+    /// `high_risk_files` is a FILE count from defect prediction; it used to be
+    /// added to `total_issues` AND `critical_issues`, so a 4,355-file project
+    /// reported 50,747 issues of which 49,498 were files.
+    #[test]
+    fn test_defect_prediction_does_not_inflate_the_issue_counters() {
+        use super::record_defect_prediction;
+        use crate::services::facades::analysis_orchestrator::AnalysisSummary;
+
+        let mut summary = AnalysisSummary {
+            total_files: 4355,
+            total_issues: 1249,
+            critical_issues: 286,
+            quality_score: 97.0,
+            recommendations: Vec::new(),
+        };
+
+        record_defect_prediction(&mut summary, 49498);
+
+        assert_eq!(
+            summary.total_issues, 1249,
+            "a file count must not be added to the issue count"
+        );
+        assert_eq!(
+            summary.critical_issues, 286,
+            "a file count must not be added to the critical-issue count"
+        );
+        assert!(
+            summary.total_issues <= summary.total_files * 100,
+            "issue counts must stay bounded by the analyzed corpus"
+        );
+        assert!(
+            summary
+                .recommendations
+                .iter()
+                .any(|r| r.contains("49498 high-risk files")),
+            "the figure is still reported, as its own recommendation: {:?}",
+            summary.recommendations
         );
     }
 

--- a/src/cli/handlers/comprehensive_analysis_handler/helpers.rs
+++ b/src/cli/handlers/comprehensive_analysis_handler/helpers.rs
@@ -6,7 +6,7 @@ use crate::services::facades::analysis_orchestrator::{
 };
 use crate::services::service_registry::ServiceRegistry;
 use anyhow::Result;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::Arc;
 
 pub(super) fn init_timing(perf: bool) -> Option<std::time::Instant> {
@@ -68,11 +68,20 @@ pub(super) async fn enhance_results_if_needed(
     }
 }
 
+/// Build the config for the sub-analyses the orchestrator does not cover.
+///
+/// The scope is `determine_analysis_path(config)` — the same path the
+/// orchestrated analysis uses — NOT `config.project_path`. Handing these
+/// sub-analyses the project path (default ".") meant `analyze comprehensive
+/// --file <one file>` ran defect prediction over the caller's *current
+/// directory* and attributed the result to that single file: identical
+/// commands reported `total_issues: 49498` from inside this repo and `0` from
+/// an empty cwd, and stderr leaked the tell ("churn not measured for .").
 pub(super) fn create_additional_config(
     config: &ComprehensiveAnalysisConfig,
 ) -> AdditionalAnalysisConfig<'_> {
     AdditionalAnalysisConfig {
-        project_path: &config.project_path,
+        project_path: determine_analysis_path(config),
         include_duplicates: config.include_duplicates,
         include_defects: config.include_defects,
         confidence_threshold: config.confidence_threshold,
@@ -108,7 +117,10 @@ pub(super) fn report_completion_and_performance(
 
 /// Configuration for additional analyses
 pub(super) struct AdditionalAnalysisConfig<'a> {
-    pub(super) project_path: &'a Path,
+    /// The path these sub-analyses must scan. This is the *resolved* analysis
+    /// scope from `determine_analysis_path`, so under `--file` it is that one
+    /// file — it is not necessarily `config.project_path`.
+    pub(super) project_path: PathBuf,
     pub(super) include_duplicates: bool,
     pub(super) include_defects: bool,
     pub(super) confidence_threshold: f32,
@@ -148,7 +160,7 @@ pub(super) async fn enhance_with_additional_analyses(
         let facade = DefectPredictionFacade::new(registry);
 
         let request = DefectPredictionRequest {
-            project_path: config.project_path.to_path_buf(),
+            project_path: config.project_path.clone(),
             confidence_threshold: config.confidence_threshold,
             min_lines: config.min_lines,
             include_low_confidence: false,
@@ -207,5 +219,73 @@ pub(super) fn print_performance_breakdown(result: &ComprehensiveAnalysisResult, 
             c_::label("Average time per file"),
             c_::number(&format!("{ms_per_file:.2}"))
         );
+    }
+}
+
+#[cfg(test)]
+mod additional_config_scope_tests {
+    //! Regression tests for `--file` scoping. The duplicates/defect-prediction
+    //! enhancement used to receive `config.project_path` (default ".") while
+    //! the orchestrated analysis received the `--file` path, so the sub-analysis
+    //! scanned the caller's current directory and its counts were attributed to
+    //! the single file.
+    use super::{create_additional_config, determine_analysis_path};
+    use crate::cli::handlers::comprehensive_analysis_handler::types::ComprehensiveAnalysisConfig;
+    use crate::cli::ComprehensiveOutputFormat;
+    use std::path::{Path, PathBuf};
+
+    fn config_with_file(project_path: &str, file: Option<&str>) -> ComprehensiveAnalysisConfig {
+        ComprehensiveAnalysisConfig {
+            project_path: PathBuf::from(project_path),
+            file: file.map(PathBuf::from),
+            files: Vec::new(),
+            format: ComprehensiveOutputFormat::Json,
+            include_duplicates: false,
+            include_dead_code: false,
+            include_defects: true,
+            include_complexity: false,
+            include_tdg: false,
+            confidence_threshold: 0.5,
+            min_lines: 10,
+            include: None,
+            exclude: None,
+            output: None,
+            perf: false,
+            executive_summary: false,
+            top_files: 10,
+        }
+    }
+
+    #[test]
+    fn test_single_file_scopes_the_additional_analyses_to_that_file() {
+        let config = config_with_file(".", Some("/corpus/tiny/src/lib.rs"));
+        let additional = create_additional_config(&config);
+
+        assert_eq!(
+            additional.project_path,
+            Path::new("/corpus/tiny/src/lib.rs"),
+            "--file must scope defect prediction to that file, not to the cwd"
+        );
+        assert_ne!(
+            additional.project_path,
+            Path::new("."),
+            "passing \".\" here is what made the issue counts depend on the caller's cwd"
+        );
+    }
+
+    #[test]
+    fn test_scope_matches_the_orchestrated_analysis_path() {
+        for (project, file) in [
+            (".", Some("src/lib.rs")),
+            ("/some/project", None),
+            ("/some/project", Some("/other/file.rs")),
+        ] {
+            let config = config_with_file(project, file);
+            assert_eq!(
+                create_additional_config(&config).project_path,
+                determine_analysis_path(&config),
+                "every sub-analysis must use the same resolved path as the orchestrator"
+            );
+        }
     }
 }

--- a/src/cli/handlers/config_command_handlers.rs
+++ b/src/cli/handlers/config_command_handlers.rs
@@ -6,26 +6,36 @@
 //! docs/specifications/pre-commit-hooks-spec.md
 
 use crate::cli::commands::{ConfigCommands, ConfigFormat};
-use crate::services::configuration_service::{configuration, PmatConfig};
+use crate::services::configuration_service::{configuration, ConfigurationService, PmatConfig};
 use anyhow::Result;
 use std::path::PathBuf;
 
 /// Configuration command interface implementation
-pub struct ConfigCommand {}
+pub struct ConfigCommand {
+    config_path: PathBuf,
+}
 
 impl ConfigCommand {
     /// Create new config command with specified config file
     #[must_use]
     #[provable_contracts_macros::contract("pmat-core.yaml", equation = "path_exists")]
-    pub fn new(_config_path: PathBuf) -> Self {
-        Self {}
+    pub fn new(config_path: PathBuf) -> Self {
+        Self { config_path }
+    }
+
+    /// Configuration as read from the file this command was pointed at.
+    ///
+    /// The path used to be dropped on the floor (`_config_path`) and every
+    /// reader went to the global service, so `--config-path` and the values
+    /// written by `config --set` had no effect on what was reported.
+    fn config(&self) -> Result<PmatConfig> {
+        ConfigurationService::new(Some(self.config_path.clone())).get_config()
     }
 
     /// Show complete configuration in specified format
     #[provable_contracts_macros::contract("pmat-core.yaml", equation = "check_compliance")]
     pub async fn show(&self, format: ConfigFormat) -> Result<String> {
-        let config_service = configuration();
-        let config = config_service.get_config()?;
+        let config = self.config()?;
 
         match format {
             ConfigFormat::Json => Ok(serde_json::to_string_pretty(&config)?),
@@ -37,8 +47,7 @@ impl ConfigCommand {
     /// Get specific configuration value by key path
     #[provable_contracts_macros::contract("pmat-core.yaml", equation = "check_compliance")]
     pub async fn get(&self, key: &str) -> Result<String> {
-        let config_service = configuration();
-        let config = config_service.get_config()?;
+        let config = self.config()?;
 
         self.get_config_value(&config, key)
     }
@@ -46,8 +55,7 @@ impl ConfigCommand {
     /// Validate configuration file
     #[provable_contracts_macros::contract("pmat-core.yaml", equation = "check_compliance")]
     pub async fn validate(&self) -> Result<ValidationResult> {
-        let config_service = configuration();
-        let config = config_service.get_config()?;
+        let config = self.config()?;
 
         let mut errors = Vec::new();
         let warnings = Vec::new();
@@ -358,6 +366,33 @@ request_timeout_seconds = 30
         // Test Env format
         let env_result = config_cmd.show(ConfigFormat::Env).await;
         assert!(env_result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_config_reads_the_file_it_was_given() {
+        // Regression: the path handed to ConfigCommand::new was discarded and
+        // every reader answered from the global default config, so a value
+        // persisted by `config --set` was never reported back.
+        let temp_dir = tempfile::tempdir().unwrap();
+        let config_path = temp_dir.path().join("pmat.toml");
+        let mut on_disk =
+            crate::services::configuration_service::ConfigurationService::default_config();
+        on_disk.quality.max_complexity = 5;
+        std::fs::write(&config_path, toml::to_string_pretty(&on_disk).unwrap()).unwrap();
+
+        let config_cmd = ConfigCommand::new(config_path);
+
+        let value = config_cmd
+            .get("hooks.quality_gates.max_cyclomatic_complexity")
+            .await
+            .unwrap();
+        assert_eq!(value, "5");
+
+        let shown = config_cmd.show(ConfigFormat::Env).await.unwrap();
+        assert!(
+            shown.contains("PMAT_MAX_CYCLOMATIC_COMPLEXITY=5"),
+            "show() must report the on-disk value, got:\n{shown}"
+        );
     }
 
     #[tokio::test]

--- a/src/cli/handlers/config_command_handlers.rs
+++ b/src/cli/handlers/config_command_handlers.rs
@@ -115,23 +115,47 @@ impl ConfigCommand {
     }
 
     /// Get specific configuration value by dot notation path
+    ///
+    /// The read-by-key surface used to be five hardcoded `hooks.*` slices, none of
+    /// which `config show` ever emits — so every key a user could actually see in the
+    /// dump (`quality.max_complexity`, …) answered "not found". The lookup now walks
+    /// the same serialization `show` prints, and the legacy `hooks.*` names are kept
+    /// as aliases so existing callers keep working.
     fn get_config_value(&self, config: &PmatConfig, key: &str) -> Result<String> {
         let parts: Vec<&str> = key.split('.').collect();
 
         match parts.as_slice() {
-            ["hooks", "auto_install"] => Ok("true".to_string()),
+            ["hooks", "auto_install"] => return Ok("true".to_string()),
             ["hooks", "quality_gates", "max_cyclomatic_complexity"] => {
-                Ok(config.quality.max_complexity.to_string())
+                return Ok(config.quality.max_complexity.to_string())
             }
             ["hooks", "quality_gates", "max_cognitive_complexity"] => {
-                Ok(config.quality.max_cognitive_complexity.to_string())
+                return Ok(config.quality.max_cognitive_complexity.to_string())
             }
             ["hooks", "quality_gates", "min_test_coverage"] => {
-                Ok(config.quality.min_coverage.to_string())
+                return Ok(config.quality.min_coverage.to_string())
             }
-            ["hooks", "documentation", "task_id_pattern"] => Ok("PMAT-[0-9]{4}".to_string()),
-            _ => Err(anyhow::anyhow!("Configuration key '{key}' not found")),
+            ["hooks", "documentation", "task_id_pattern"] => return Ok("PMAT-[0-9]{4}".to_string()),
+            _ => {}
         }
+
+        let root = serde_json::to_value(config)?;
+        let mut cursor = &root;
+        for part in &parts {
+            let next = match cursor {
+                serde_json::Value::Object(map) => map.get(*part),
+                serde_json::Value::Array(items) => {
+                    part.parse::<usize>().ok().and_then(|i| items.get(i))
+                }
+                _ => None,
+            };
+            cursor = next.ok_or_else(|| anyhow::anyhow!("Configuration key '{key}' not found"))?;
+        }
+
+        Ok(match cursor {
+            serde_json::Value::String(s) => s.clone(),
+            other => other.to_string(),
+        })
     }
 }
 
@@ -405,6 +429,42 @@ request_timeout_seconds = 30
             .get("hooks.quality_gates.max_cyclomatic_complexity")
             .await;
         assert!(result.is_ok());
+    }
+
+    /// Every key `config show` prints must be readable with `config get`; the
+    /// old hardcoded `hooks.*` match answered "not found" for all of them.
+    #[tokio::test]
+    async fn test_config_get_resolves_keys_visible_in_show() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let config_path = temp_dir.path().join("pmat.toml");
+        let mut on_disk =
+            crate::services::configuration_service::ConfigurationService::default_config();
+        on_disk.quality.max_complexity = 7;
+        on_disk.quality.max_cognitive_complexity = 9;
+        on_disk.system.project_name = "fixture".to_string();
+        std::fs::write(&config_path, toml::to_string_pretty(&on_disk).unwrap()).unwrap();
+
+        let config_cmd = ConfigCommand::new(config_path);
+
+        // Exactly the keys `config show` prints.
+        let shown = config_cmd.show(ConfigFormat::Json).await.unwrap();
+        assert!(shown.contains("\"max_complexity\""), "{shown}");
+
+        assert_eq!(config_cmd.get("quality.max_complexity").await.unwrap(), "7");
+        assert_eq!(
+            config_cmd
+                .get("quality.max_cognitive_complexity")
+                .await
+                .unwrap(),
+            "9"
+        );
+        assert_eq!(
+            config_cmd.get("system.project_name").await.unwrap(),
+            "fixture"
+        );
+
+        // A key that is genuinely absent must still be an error, not a fabricated value.
+        assert!(config_cmd.get("quality.no_such_key").await.is_err());
     }
 
     #[tokio::test]

--- a/src/cli/handlers/configuration_handlers.rs
+++ b/src/cli/handlers/configuration_handlers.rs
@@ -17,6 +17,18 @@ pub async fn handle_configuration(
     set: Vec<String>,
     config_path: Option<PathBuf>,
 ) -> Result<()> {
+    // An explicit --config-path that does not exist used to fall through to the
+    // built-in defaults and exit 0, byte-identical to a run with no flag at all, so
+    // a mistyped path silently ignored every setting the user asked for. Reads must
+    // fail loudly; only the implicit ./pmat.toml may be absent, and the writing
+    // operations (--set / --reset) are still allowed to create a new file.
+    let creates_config = reset || !set.is_empty();
+    if let Some(path) = config_path.as_ref() {
+        if !path.exists() && !creates_config {
+            anyhow::bail!("config file not found: {}", path.display());
+        }
+    }
+
     let config_service = create_config_service(config_path);
     execute_configuration_command(
         &config_service,
@@ -91,6 +103,50 @@ include!("configuration_handlers_operations.rs");
 mod tests {
     use super::*;
     use tempfile::tempdir;
+
+    /// `--config-path` naming a file that does not exist must be an error: silently
+    /// substituting the built-in defaults means the user's settings are ignored with
+    /// no signal at all.
+    #[tokio::test]
+    async fn test_handle_configuration_errors_on_missing_explicit_config_path() {
+        let result = handle_configuration(
+            true,
+            false,
+            false,
+            false,
+            None,
+            vec![],
+            Some(PathBuf::from("/does/not/exist/pmat-config-test.toml")),
+        )
+        .await;
+        assert!(
+            result.is_err(),
+            "missing --config-path must not use defaults"
+        );
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("not found"), "got: {msg}");
+    }
+
+    /// …but --set may still create a config file that does not exist yet.
+    #[tokio::test]
+    async fn test_handle_configuration_set_may_create_missing_config_path() {
+        let temp_dir = tempdir().unwrap();
+        let config_path = temp_dir.path().join("new_config.toml");
+        let result = handle_configuration(
+            false,
+            false,
+            false,
+            false,
+            None,
+            vec!["quality.max_complexity=25".to_string()],
+            Some(config_path.clone()),
+        )
+        .await;
+        assert!(
+            result.is_ok(),
+            "set must still be able to create: {result:?}"
+        );
+    }
 
     #[tokio::test]
     async fn test_configuration_overview() {

--- a/src/cli/handlers/cuda_tdg_handlers.rs
+++ b/src/cli/handlers/cuda_tdg_handlers.rs
@@ -119,6 +119,24 @@ fn report_if_unmeasured(result: &CudaSimdTdgResult, config: &CudaTdgCommandConfi
     Ok(true)
 }
 
+/// Resolve which path a subcommand analyses.
+///
+/// `pmat cuda-tdg [PATH] <SUBCOMMAND>` accepted the top-level positional and
+/// then threw it away: every subcommand carried its own
+/// `#[arg(default_value = ".")]`, so `pmat cuda-tdg /does/not/exist score`
+/// graded the CURRENT DIRECTORY and exited 0 — 81.0/100 "Gateway: PASSED" from
+/// the pmat repo, 56.5/100 from a small corpus, for the same nonexistent
+/// argument. A path the user typed must never be silently replaced by the cwd.
+///
+/// An explicit path after the subcommand still wins (`cuda-tdg score /path`);
+/// otherwise the top-level path is honoured, which itself defaults to `.`.
+fn resolve_subcommand_path<'a>(
+    path: Option<&'a PathBuf>,
+    config: &'a CudaTdgCommandConfig,
+) -> &'a PathBuf {
+    path.unwrap_or(&config.path)
+}
+
 /// Handle CUDA-TDG subcommands
 async fn handle_cuda_tdg_subcommand(
     cmd: &CudaTdgCommand,
@@ -126,12 +144,27 @@ async fn handle_cuda_tdg_subcommand(
 ) -> Result<()> {
     match cmd {
         CudaTdgCommand::Analyze { path } => handle_analyze(path, config).await,
-        CudaTdgCommand::Score { path, breakdown } => handle_score(path, *breakdown, config).await,
+        CudaTdgCommand::Score { path, breakdown } => {
+            handle_score(
+                resolve_subcommand_path(path.as_ref(), config),
+                *breakdown,
+                config,
+            )
+            .await
+        }
         CudaTdgCommand::Report {
             path,
             format,
             output,
-        } => handle_report(path, format, output.as_ref(), config).await,
+        } => {
+            handle_report(
+                resolve_subcommand_path(path.as_ref(), config),
+                format,
+                output.as_ref(),
+                config,
+            )
+            .await
+        }
         CudaTdgCommand::BarrierCheck { path } => handle_barrier_check(path, config).await,
         CudaTdgCommand::ValidateTiles {
             head_dim,
@@ -142,9 +175,22 @@ async fn handle_cuda_tdg_subcommand(
             path,
             min_score,
             fail_on_p0,
-        } => handle_gate(path, *min_score, *fail_on_p0, config).await,
+        } => {
+            handle_gate(
+                resolve_subcommand_path(path.as_ref(), config),
+                *min_score,
+                *fail_on_p0,
+                config,
+            )
+            .await
+        }
         CudaTdgCommand::Kaizen { path, since } => {
-            handle_kaizen(path, since.as_deref(), config).await
+            handle_kaizen(
+                resolve_subcommand_path(path.as_ref(), config),
+                since.as_deref(),
+                config,
+            )
+            .await
         }
         CudaTdgCommand::Taxonomy => handle_taxonomy(config).await,
     }

--- a/src/cli/handlers/cuda_tdg_handlers_gate_kaizen.rs
+++ b/src/cli/handlers/cuda_tdg_handlers_gate_kaizen.rs
@@ -79,12 +79,38 @@ fn format_gate_text(result: &CudaSimdTdgResult, passes: bool, min_score: f64) ->
     output
 }
 
+/// Render a kaizen metric that the analyzer does not measure.
+///
+/// MTTD/MTTF/escape rate/regression rate have no defect-lifecycle source
+/// behind them (see `build_kaizen_metrics`), so they arrive here as NaN and
+/// must be shown as "not measured" rather than as a number.
+fn kaizen_metric(value: f64, unit: &str) -> String {
+    if value.is_finite() {
+        format!("{:.1}{}", value, unit)
+    } else {
+        "not measured".to_string()
+    }
+}
+
+fn kaizen_percentage(value: f64) -> String {
+    kaizen_metric(value * 100.0, "%")
+}
+
 /// Handle kaizen subcommand
 async fn handle_kaizen(
     path: &PathBuf,
-    _since: Option<&str>,
+    since: Option<&str>,
     config: &CudaTdgCommandConfig,
 ) -> Result<()> {
+    // `--since` was bound to `_since` and dropped on the floor, so the flag
+    // silently changed nothing. Nothing this report emits is derived from a
+    // time window, so say so instead of pretending the filter applied.
+    if let Some(since) = since {
+        eprintln!(
+            "Warning: --since {since} ignored — cuda-tdg kaizen reports no history-derived metrics"
+        );
+    }
+
     let analyzer = CudaSimdAnalyzer::new();
     let result = analyzer.analyze(path)?;
 
@@ -108,20 +134,20 @@ fn format_kaizen_markdown(result: &CudaSimdTdgResult) -> String {
         result.kaizen.tickets_resolved
     ));
     md.push_str(&format!(
-        "- **Mean Time to Detect**: {:.1} hours\n",
-        result.kaizen.mttd
+        "- **Mean Time to Detect**: {}\n",
+        kaizen_metric(result.kaizen.mttd, " hours")
     ));
     md.push_str(&format!(
-        "- **Mean Time to Fix**: {:.1} hours\n",
-        result.kaizen.mttf
+        "- **Mean Time to Fix**: {}\n",
+        kaizen_metric(result.kaizen.mttf, " hours")
     ));
     md.push_str(&format!(
-        "- **Escape Rate**: {:.1}%\n",
-        result.kaizen.escape_rate * 100.0
+        "- **Escape Rate**: {}\n",
+        kaizen_percentage(result.kaizen.escape_rate)
     ));
     md.push_str(&format!(
-        "- **Regression Rate**: {:.1}%\n\n",
-        result.kaizen.regression_rate * 100.0
+        "- **Regression Rate**: {}\n\n",
+        kaizen_percentage(result.kaizen.regression_rate)
     ));
 
     if !result.kaizen.ticket_references.is_empty() {
@@ -142,22 +168,57 @@ fn format_kaizen_text(result: &CudaSimdTdgResult) -> String {
         result.kaizen.tickets_resolved
     ));
     output.push_str(&format!(
-        "Mean Time to Detect: {:.1} hours\n",
-        result.kaizen.mttd
+        "Mean Time to Detect: {}\n",
+        kaizen_metric(result.kaizen.mttd, " hours")
     ));
     output.push_str(&format!(
-        "Mean Time to Fix: {:.1} hours\n",
-        result.kaizen.mttf
+        "Mean Time to Fix: {}\n",
+        kaizen_metric(result.kaizen.mttf, " hours")
     ));
     output.push_str(&format!(
-        "Escape Rate: {:.1}%\n",
-        result.kaizen.escape_rate * 100.0
+        "Escape Rate: {}\n",
+        kaizen_percentage(result.kaizen.escape_rate)
     ));
     output.push_str(&format!(
-        "Regression Rate: {:.1}%\n",
-        result.kaizen.regression_rate * 100.0
+        "Regression Rate: {}\n",
+        kaizen_percentage(result.kaizen.regression_rate)
     ));
     output
+}
+
+#[cfg(test)]
+mod kaizen_honesty_tests {
+    use super::*;
+
+    #[test]
+    fn test_unmeasured_kaizen_metrics_render_as_not_measured() {
+        // Regression: these printed 24.0 hours / 48.0 hours / 5.0% / 2.0% for
+        // every input, from literals in build_kaizen_metrics.
+        assert_eq!(kaizen_metric(f64::NAN, " hours"), "not measured");
+        assert_eq!(kaizen_percentage(f64::NAN), "not measured");
+        assert_eq!(kaizen_metric(12.5, " hours"), "12.5 hours");
+        assert_eq!(kaizen_percentage(0.05), "5.0%");
+    }
+
+    #[test]
+    fn test_kaizen_report_does_not_quote_the_old_defaults() {
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(dir.path().join("lib.rs"), "pub fn f() {}\n").unwrap();
+
+        let result = CudaSimdAnalyzer::new().analyze(dir.path()).unwrap();
+        let text = format_kaizen_text(&result);
+
+        assert!(
+            text.contains("Mean Time to Detect: not measured"),
+            "MTTD must not be a hardcoded estimate: {text}"
+        );
+        assert!(
+            text.contains("Escape Rate: not measured"),
+            "escape rate must not be a hardcoded estimate: {text}"
+        );
+        assert!(!text.contains("24.0 hours"), "{text}");
+        assert!(!text.contains("5.0%"), "{text}");
+    }
 }
 
 /// Handle taxonomy subcommand

--- a/src/cli/handlers/cuda_tdg_handlers_subcommands.rs
+++ b/src/cli/handlers/cuda_tdg_handlers_subcommands.rs
@@ -98,19 +98,26 @@ async fn handle_validate_tiles(
     shared_memory: usize,
     config: &CudaTdgCommandConfig,
 ) -> Result<()> {
+    let shared_required = tile_kv.saturating_mul(head_dim).saturating_mul(2);
+    let overflows = shared_required > shared_memory;
+    let undersized = tile_kv < head_dim;
+
     let output = match config.format {
         CudaTdgOutputFormat::Json => {
+            let mut issues: Vec<&str> = Vec::new();
+            if undersized {
+                issues.push("PAR-041: tile_kv < head_dim causes shared memory overflow");
+            }
+            if overflows {
+                issues.push("Shared memory overflow: required exceeds the limit");
+            }
             let result = serde_json::json!({
                 "head_dim": head_dim,
                 "tile_kv": tile_kv,
                 "shared_memory_limit": shared_memory,
-                "valid": tile_kv >= head_dim,
-                "shared_memory_required": tile_kv * head_dim * 2,
-                "issues": if tile_kv < head_dim {
-                    vec!["PAR-041: tile_kv < head_dim causes shared memory overflow"]
-                } else {
-                    vec![]
-                }
+                "valid": issues.is_empty(),
+                "shared_memory_required": shared_required,
+                "issues": issues
             });
             serde_json::to_string_pretty(&result)?
         }
@@ -119,11 +126,25 @@ async fn handle_validate_tiles(
 
     write_output(&output, config)?;
 
-    if tile_kv < head_dim {
+    // The printed verdict and the exit status used to be computed from
+    // different conditions: the text renderer required `tile_kv >= head_dim`
+    // AND the configuration to fit in shared memory, while the only error
+    // return was the PAR-041 check. `--head-dim 99999 --tile-kv 99999` printed
+    // "Status: INVALID / Issue: Shared memory overflow" and exited 0, so CI
+    // gating on this command passed a configuration overflowing shared memory
+    // by ~400,000x. One verdict now drives both.
+    if undersized {
         return Err(anyhow!(
             "PAR-041: tile_kv ({}) < head_dim ({})",
             tile_kv,
             head_dim
+        ));
+    }
+    if overflows {
+        return Err(anyhow!(
+            "Shared memory overflow: {} bytes required, {} bytes available",
+            shared_required,
+            shared_memory
         ));
     }
 
@@ -132,7 +153,7 @@ async fn handle_validate_tiles(
 
 fn format_validate_tiles_text(head_dim: usize, tile_kv: usize, shared_memory: usize) -> String {
     let valid = tile_kv >= head_dim;
-    let shared_required = tile_kv * head_dim * 2; // FP16
+    let shared_required = tile_kv.saturating_mul(head_dim).saturating_mul(2); // FP16
 
     let mut output = String::new();
     output.push_str("Tile Dimension Validation\n");
@@ -162,4 +183,77 @@ fn format_validate_tiles_text(head_dim: usize, tile_kv: usize, shared_memory: us
         }
     }
     output
+}
+
+#[cfg(test)]
+mod validate_tiles_verdict_tests {
+    use super::*;
+
+    fn config(output: Option<PathBuf>) -> CudaTdgCommandConfig {
+        CudaTdgCommandConfig {
+            path: PathBuf::from("."),
+            command: None,
+            format: CudaTdgOutputFormat::Terminal,
+            min_score: 0.0,
+            fail_on_p0: false,
+            simd: false,
+            wgpu: false,
+            output,
+            quiet: true,
+        }
+    }
+
+    fn rendered_status(head_dim: usize, tile_kv: usize, shared_memory: usize) -> String {
+        let text = format_validate_tiles_text(head_dim, tile_kv, shared_memory);
+        if text.contains("Status: VALID") {
+            "VALID".to_string()
+        } else {
+            "INVALID".to_string()
+        }
+    }
+
+    async fn exits_ok(head_dim: usize, tile_kv: usize, shared_memory: usize) -> bool {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cfg = config(Some(dir.path().join("out.txt")));
+        handle_validate_tiles(head_dim, tile_kv, shared_memory, &cfg)
+            .await
+            .is_ok()
+    }
+
+    /// The printed verdict and the exit status came from different conditions:
+    /// a shared-memory overflow printed "Status: INVALID" and still returned
+    /// Ok(()), so a CI job gating on this command passed the overflowing
+    /// configuration. Every INVALID verdict must exit nonzero.
+    #[tokio::test]
+    async fn every_invalid_verdict_is_an_error() {
+        // (head_dim, tile_kv, shared_memory)
+        let cases = [
+            (64usize, 64usize, 49152usize),   // valid
+            (128, 128, 49152),                // valid
+            (128, 64, 49152),                 // PAR-041: tile_kv < head_dim
+            (99999, 99999, 49152),            // shared memory overflow
+            (128, 256, 1024),                 // overflow only
+        ];
+
+        for (head_dim, tile_kv, shared_memory) in cases {
+            let status = rendered_status(head_dim, tile_kv, shared_memory);
+            let ok = exits_ok(head_dim, tile_kv, shared_memory).await;
+            assert_eq!(
+                status == "VALID",
+                ok,
+                "head_dim={head_dim} tile_kv={tile_kv} shared_memory={shared_memory}: \
+                 printed {status} but exit was {}",
+                if ok { "0" } else { "nonzero" }
+            );
+        }
+    }
+
+    /// The overflow case specifically: it used to be the silent one.
+    #[tokio::test]
+    async fn shared_memory_overflow_is_an_error() {
+        assert!(
+            !exits_ok(99999, 99999, 49152).await,
+            "a configuration overflowing shared memory must not exit 0"
+        );
+    }
 }

--- a/src/cli/handlers/cuda_tdg_handlers_subcommands.rs
+++ b/src/cli/handlers/cuda_tdg_handlers_subcommands.rs
@@ -101,10 +101,18 @@ async fn handle_validate_tiles(
     let shared_required = tile_kv.saturating_mul(head_dim).saturating_mul(2);
     let overflows = shared_required > shared_memory;
     let undersized = tile_kv < head_dim;
+    // A zero dimension is not a tile. `--head-dim 0 --tile-kv 0` satisfied both
+    // of the checks above (0 >= 0, and 0 bytes fit in any budget) and was
+    // reported "Status: VALID" with exit 0, so a CI job gating on this command
+    // passed a kernel configuration that cannot exist.
+    let degenerate = head_dim == 0 || tile_kv == 0;
 
     let output = match config.format {
         CudaTdgOutputFormat::Json => {
             let mut issues: Vec<&str> = Vec::new();
+            if degenerate {
+                issues.push("Degenerate tile: head_dim and tile_kv must both be > 0");
+            }
             if undersized {
                 issues.push("PAR-041: tile_kv < head_dim causes shared memory overflow");
             }
@@ -133,6 +141,13 @@ async fn handle_validate_tiles(
     // "Status: INVALID / Issue: Shared memory overflow" and exited 0, so CI
     // gating on this command passed a configuration overflowing shared memory
     // by ~400,000x. One verdict now drives both.
+    if degenerate {
+        return Err(anyhow!(
+            "Degenerate tile: head_dim ({}) and tile_kv ({}) must both be > 0",
+            head_dim,
+            tile_kv
+        ));
+    }
     if undersized {
         return Err(anyhow!(
             "PAR-041: tile_kv ({}) < head_dim ({})",
@@ -152,7 +167,10 @@ async fn handle_validate_tiles(
 }
 
 fn format_validate_tiles_text(head_dim: usize, tile_kv: usize, shared_memory: usize) -> String {
-    let valid = tile_kv >= head_dim;
+    // `head_dim > 0` is part of the verdict: a zero dimension satisfies
+    // `tile_kv >= head_dim` and needs 0 bytes, so it used to print VALID.
+    let degenerate = head_dim == 0 || tile_kv == 0;
+    let valid = !degenerate && tile_kv >= head_dim;
     let shared_required = tile_kv.saturating_mul(head_dim).saturating_mul(2); // FP16
 
     let mut output = String::new();
@@ -170,6 +188,13 @@ fn format_validate_tiles_text(head_dim: usize, tile_kv: usize, shared_memory: us
         output.push_str("Status: VALID\n");
     } else {
         output.push_str("Status: INVALID\n\n");
+        if degenerate {
+            output.push_str("Issue: Degenerate tile - head_dim and tile_kv must both be > 0\n");
+            output.push_str(&format!(
+                "Fix: Set head_dim > 0 (currently {}) and tile_kv > 0 (currently {})\n",
+                head_dim, tile_kv
+            ));
+        }
         if tile_kv < head_dim {
             output.push_str("Issue: PAR-041 - tile_kv < head_dim\n");
             output.push_str(&format!(
@@ -244,6 +269,24 @@ mod validate_tiles_verdict_tests {
                 "head_dim={head_dim} tile_kv={tile_kv} shared_memory={shared_memory}: \
                  printed {status} but exit was {}",
                 if ok { "0" } else { "nonzero" }
+            );
+        }
+    }
+
+    /// A zero dimension is not a tile. `--head-dim 0 --tile-kv 0` passed both
+    /// existing checks (0 >= 0, 0 bytes fits) and printed "Status: VALID" with
+    /// exit 0.
+    #[tokio::test]
+    async fn degenerate_dimensions_are_invalid() {
+        for (head_dim, tile_kv) in [(0usize, 0usize), (0, 64), (64, 0)] {
+            let text = format_validate_tiles_text(head_dim, tile_kv, 49152);
+            assert!(
+                text.contains("Status: INVALID"),
+                "head_dim={head_dim} tile_kv={tile_kv} must render INVALID, got:\n{text}"
+            );
+            assert!(
+                !exits_ok(head_dim, tile_kv, 49152).await,
+                "head_dim={head_dim} tile_kv={tile_kv} must exit nonzero"
             );
         }
     }

--- a/src/cli/handlers/cuda_tdg_handlers_tests.rs
+++ b/src/cli/handlers/cuda_tdg_handlers_tests.rs
@@ -869,7 +869,7 @@ mod coverage_tests {
         let temp_dir = TempDir::new().unwrap();
         let config = create_config_with_format(CudaTdgOutputFormat::Terminal);
         let cmd = CudaTdgCommand::Score {
-            path: temp_dir.path().to_path_buf(),
+            path: Some(temp_dir.path().to_path_buf()),
             breakdown: true,
         };
 
@@ -882,7 +882,7 @@ mod coverage_tests {
         let temp_dir = TempDir::new().unwrap();
         let config = create_config_with_format(CudaTdgOutputFormat::Terminal);
         let cmd = CudaTdgCommand::Report {
-            path: temp_dir.path().to_path_buf(),
+            path: Some(temp_dir.path().to_path_buf()),
             format: "markdown".to_string(),
             output: None,
         };
@@ -921,7 +921,7 @@ mod coverage_tests {
         let temp_dir = TempDir::new().unwrap();
         let config = create_config_with_format(CudaTdgOutputFormat::Terminal);
         let cmd = CudaTdgCommand::Gate {
-            path: temp_dir.path().to_path_buf(),
+            path: Some(temp_dir.path().to_path_buf()),
             min_score: 0.0,
             fail_on_p0: false,
         };
@@ -935,7 +935,7 @@ mod coverage_tests {
         let temp_dir = TempDir::new().unwrap();
         let config = create_config_with_format(CudaTdgOutputFormat::Terminal);
         let cmd = CudaTdgCommand::Kaizen {
-            path: temp_dir.path().to_path_buf(),
+            path: Some(temp_dir.path().to_path_buf()),
             since: Some("2025-01-01".to_string()),
         };
 
@@ -1335,5 +1335,67 @@ fn test_barrier_convergence() {{
         assert!(config.analyze_wgpu);
         assert_eq!(config.shared_memory_limit, 49152);
         assert_eq!(config.register_limit, 64);
+    }
+}
+
+/// `pmat cuda-tdg [PATH] <SUBCOMMAND>` used to discard the top-level positional:
+/// each subcommand re-defaulted its own path to `"."`, so
+/// `pmat cuda-tdg /does/not/exist score` graded the current directory (81.0/100,
+/// "Gateway: PASSED", exit 0) instead of the path it was given.
+mod top_level_path_is_honoured_tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn config_for(path: PathBuf) -> CudaTdgCommandConfig {
+        CudaTdgCommandConfig {
+            path,
+            command: None,
+            format: CudaTdgOutputFormat::Terminal,
+            min_score: 85.0,
+            fail_on_p0: false,
+            simd: true,
+            wgpu: true,
+            output: None,
+            quiet: true,
+        }
+    }
+
+    #[test]
+    fn subcommand_without_a_path_falls_back_to_the_top_level_path() {
+        let config = config_for(PathBuf::from("/top/level"));
+        assert_eq!(
+            resolve_subcommand_path(None, &config),
+            &PathBuf::from("/top/level")
+        );
+    }
+
+    #[test]
+    fn an_explicit_subcommand_path_still_wins() {
+        let config = config_for(PathBuf::from("/top/level"));
+        let explicit = PathBuf::from("/explicit");
+        assert_eq!(resolve_subcommand_path(Some(&explicit), &config), &explicit);
+    }
+
+    #[tokio::test]
+    async fn score_over_a_missing_top_level_path_fails_instead_of_grading_the_cwd() {
+        let dir = TempDir::new().expect("tempdir");
+        let missing = dir.path().join("no-such-tree");
+        let config = config_for(missing.clone());
+
+        let err = handle_cuda_tdg_subcommand(
+            &CudaTdgCommand::Score {
+                path: None,
+                breakdown: false,
+            },
+            &config,
+        )
+        .await
+        .expect_err("a missing path must not be scored as the current directory");
+
+        let rendered = format!("{err:#}");
+        assert!(
+            rendered.contains(&missing.display().to_string()),
+            "the error must name the path that was given, got: {rendered}"
+        );
     }
 }

--- a/src/cli/handlers/cuda_tdg_handlers_tests.rs
+++ b/src/cli/handlers/cuda_tdg_handlers_tests.rs
@@ -587,10 +587,24 @@ mod coverage_tests {
     async fn test_handle_validate_tiles_shared_memory_overflow() {
         let config = create_config_with_format(CudaTdgOutputFormat::Terminal);
 
-        // Large dimensions with small shared memory
+        // Large dimensions with small shared memory: 256 * 128 * 2 = 65536 bytes
+        // required against a 1024 byte limit.
+        //
+        // This used to assert `is_ok()` ("should succeed (tile_kv >= head_dim) but
+        // show warning"). That encoded the defect: the printed verdict said
+        // "Status: INVALID / Issue: Shared memory overflow" while the command still
+        // exited 0, so CI gating on `validate-tiles` passed an overflowing
+        // configuration. An INVALID verdict must exit nonzero.
         let result = handle_validate_tiles(128, 256, 1024, &config).await;
-        // This should succeed (tile_kv >= head_dim) but show warning
-        assert!(result.is_ok());
+        assert!(
+            result.is_err(),
+            "a configuration overflowing shared memory must not exit 0"
+        );
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("Shared memory overflow"),
+            "unexpected error: {err}"
+        );
     }
 
     // Tests for handle_taxonomy

--- a/src/cli/handlers/dead_code_handlers.rs
+++ b/src/cli/handlers/dead_code_handlers.rs
@@ -59,7 +59,7 @@ pub async fn handle_analyze_dead_code(
 
     // Run analysis with timeout
     let timeout_duration = tokio::time::Duration::from_secs(timeout);
-    let result = tokio::time::timeout(timeout_duration, async {
+    let outcome = tokio::time::timeout(timeout_duration, async {
         run_dead_code_analysis_with_filters(
             &path,
             DeadCodeAnalysisFilters {
@@ -77,6 +77,8 @@ pub async fn handle_analyze_dead_code(
     .await
     .map_err(|_| anyhow::anyhow!("Dead code analysis timed out after {timeout} seconds"))??;
 
+    let result = outcome.report;
+
     eprintln!(
         "📊 Analysis complete: {} files analyzed, {} with dead code",
         result.summary.total_files_analyzed, result.summary.files_with_dead_code
@@ -88,18 +90,61 @@ pub async fn handle_analyze_dead_code(
     // Write output
     write_dead_code_output(formatted_output, output).await?;
 
-    // Check for violations and exit with error code if requested
+    // Check for violations and exit with error code if requested.
+    //
+    // The gate used to read `result.summary.dead_percentage`, which is scoped to
+    // the REPORTED list — `--top-files 5` shrinks it, `--top-files 10000` grows
+    // it — so the same project passed or failed `--max-dead-code` depending on
+    // how many files the user asked to see. It compares the project-wide figure
+    // now, and refuses to render a verdict when there is no project-wide figure
+    // to compare: a threshold that cannot be evaluated must not report a pass.
     if fail_on_violation {
-        let dead_code_percentage = result.summary.dead_percentage;
-        if dead_code_percentage > max_percentage as f32 {
-            eprintln!(
-                "\n❌ Dead code violations found: {dead_code_percentage:.1}% exceeds threshold of {max_percentage:.1}%"
-            );
-            std::process::exit(1);
+        match dead_code_gate_verdict(outcome.project_dead_percentage, max_percentage) {
+            DeadCodeGateVerdict::Pass => {}
+            DeadCodeGateVerdict::Violation(dead_code_percentage) => {
+                eprintln!(
+                    "\n❌ Dead code violations found: {dead_code_percentage:.1}% exceeds threshold of {max_percentage:.1}%"
+                );
+                std::process::exit(1);
+            }
+            DeadCodeGateVerdict::Unmeasurable => anyhow::bail!(
+                "--fail-on-violation cannot be enforced here: no project-wide dead-code \
+                 percentage was measured for this project (the multi-language analyzer \
+                 does not count total project lines). Re-run without --fail-on-violation \
+                 to see the report."
+            ),
         }
     }
 
     Ok(())
+}
+
+/// What `--fail-on-violation` decides.
+#[derive(Debug, PartialEq)]
+enum DeadCodeGateVerdict {
+    Pass,
+    Violation(f32),
+    /// No project-wide percentage exists, so the threshold cannot be evaluated.
+    Unmeasurable,
+}
+
+/// Compare the PROJECT-wide dead-code percentage against `--max-dead-code`.
+///
+/// Takes `Option` deliberately: an analyzer that cannot produce a project-wide
+/// figure yields no verdict at all, rather than a pass.
+fn dead_code_gate_verdict(
+    project_dead_percentage: Option<f32>,
+    max_percentage: f64,
+) -> DeadCodeGateVerdict {
+    let Some(pct) = project_dead_percentage else {
+        return DeadCodeGateVerdict::Unmeasurable;
+    };
+    #[allow(clippy::cast_possible_truncation)]
+    if pct > max_percentage as f32 {
+        DeadCodeGateVerdict::Violation(pct)
+    } else {
+        DeadCodeGateVerdict::Pass
+    }
 }
 
 // --- Submodule includes ---
@@ -574,7 +619,9 @@ mod multi_language_percentage_tests {
         )
         .unwrap();
 
-        let result = run_multi_language_dead_code(temp.path(), &filters(), "python").unwrap();
+        let result = run_multi_language_dead_code(temp.path(), &filters(), "python")
+            .unwrap()
+            .report;
 
         for f in &result.files {
             assert!(
@@ -620,7 +667,9 @@ mod multi_language_percentage_tests {
         )
         .unwrap();
 
-        let result = run_multi_language_dead_code(temp.path(), &filters(), "python").unwrap();
+        let result = run_multi_language_dead_code(temp.path(), &filters(), "python")
+            .unwrap()
+            .report;
 
         // Two .py files on disk. This was 4 -- the function count.
         assert_eq!(result.total_files, 2, "total_files must be the file count");
@@ -628,6 +677,111 @@ mod multi_language_percentage_tests {
         assert_eq!(
             result.total_files, result.summary.total_files_analyzed,
             "the headline file count must agree with the summary beneath it"
+        );
+    }
+}
+
+/// `--fail-on-violation` used to compare `summary.dead_percentage`, which is
+/// scoped to the REPORTED list, so the verdict moved with `--top-files`.
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg(test)]
+mod gate_scope_tests {
+    use super::*;
+    use crate::models::dead_code::{DeadCodeSummary, FileDeadCodeMetrics};
+
+    fn dead_file(path: &str, dead_lines: usize) -> FileDeadCodeMetrics {
+        let mut f = FileDeadCodeMetrics::new(path.to_string());
+        f.dead_lines = dead_lines;
+        f.total_lines = 1_000;
+        f.dead_functions = 1;
+        f
+    }
+
+    fn blank_summary() -> DeadCodeSummary {
+        DeadCodeSummary {
+            total_files_analyzed: 5,
+            files_with_dead_code: 0,
+            total_dead_lines: 0,
+            dead_percentage: 0.0,
+            dead_functions: 0,
+            dead_classes: 0,
+            dead_modules: 0,
+            unreachable_blocks: 0,
+        }
+    }
+
+    /// The number the gate used to read moves when `--top-files` truncates the
+    /// list — which is exactly why it must not be the number the gate reads.
+    #[test]
+    fn summary_percentage_shrinks_with_top_files_so_it_cannot_gate() {
+        let files: Vec<FileDeadCodeMetrics> = (0..5)
+            .map(|i| dead_file(&format!("f{i}.rs"), 200))
+            .collect();
+
+        let mut summary = blank_summary();
+        resummarize_from_listed_files(&mut summary, &files, 10_000);
+        let with_all_files = summary.dead_percentage;
+
+        // What `--top-files 1` leaves behind.
+        let mut summary = blank_summary();
+        resummarize_from_listed_files(&mut summary, &files[..1], 10_000);
+        let with_top_1 = summary.dead_percentage;
+
+        assert!(
+            with_top_1 < with_all_files,
+            "the summary percentage is list-scoped ({with_top_1} vs {with_all_files})"
+        );
+    }
+
+    /// The project-wide figure the gate now reads does not move with the cap,
+    /// so the same project gets the same verdict at any `--top-files`.
+    #[test]
+    fn the_gate_verdict_is_the_same_at_every_top_files_value() {
+        // 12% dead over the whole project, whatever the list was cut down to.
+        let measured = Some(12.0_f32);
+
+        assert_eq!(
+            dead_code_gate_verdict(measured, 10.0),
+            DeadCodeGateVerdict::Violation(12.0)
+        );
+        assert_eq!(
+            dead_code_gate_verdict(measured, 12.0),
+            DeadCodeGateVerdict::Pass
+        );
+    }
+
+    /// The gate must not be re-wired back to the list-scoped figure.
+    ///
+    /// The verdict function itself cannot see where its argument came from, and
+    /// `handle_analyze_dead_code` calls `std::process::exit` so it cannot be
+    /// driven from a unit test. The wiring is therefore pinned against this
+    /// module's own source, the same way `entropy_semantic.rs` pins its banners
+    /// to stderr.
+    #[test]
+    fn the_gate_is_not_wired_to_the_list_scoped_summary() {
+        let src = include_str!("dead_code_handlers.rs");
+        let call = src
+            .lines()
+            .find(|l| l.contains("dead_code_gate_verdict(") && !l.contains("fn "))
+            .expect("the gate must call dead_code_gate_verdict");
+        assert!(
+            !call.contains("summary.dead_percentage"),
+            "--fail-on-violation must not compare the list-scoped percentage: {call}"
+        );
+        assert!(
+            call.contains("project_dead_percentage"),
+            "--fail-on-violation must compare the project-wide percentage: {call}"
+        );
+    }
+
+    /// An analyzer that never measured a project-wide percentage must not have
+    /// its threshold silently reported as met.
+    #[test]
+    fn an_unmeasured_percentage_is_not_a_pass() {
+        assert_eq!(
+            dead_code_gate_verdict(None, 10.0),
+            DeadCodeGateVerdict::Unmeasurable,
+            "no measurement means no verdict, not a pass"
         );
     }
 }

--- a/src/cli/handlers/dead_code_handlers_analysis.rs
+++ b/src/cli/handlers/dead_code_handlers_analysis.rs
@@ -1,11 +1,25 @@
 // Dead code analysis logic - included from dead_code_handlers.rs
 // NO `use` imports or `#!` inner attributes allowed here.
 
+/// Dead code analysis output: the report, plus the one figure that describes
+/// the PROJECT rather than the reported list.
+///
+/// `report.summary.dead_percentage` is scoped to the files actually listed —
+/// it has to be, a count must agree with the list it heads — so it is not a
+/// number a threshold can be enforced against: it shrinks as `--top-files`
+/// asks for fewer files. `project_dead_percentage` is measured over every line
+/// walked, before `--min-dead-lines` and `--top-files` cut the list down, and
+/// is `None` when the analyzer cannot measure one.
+struct DeadCodeAnalysisOutcome {
+    report: crate::models::dead_code::DeadCodeResult,
+    project_dead_percentage: Option<f32>,
+}
+
 /// Run dead code analysis with include/exclude filters
 async fn run_dead_code_analysis_with_filters(
     path: &Path,
     filters: DeadCodeAnalysisFilters,
-) -> Result<crate::models::dead_code::DeadCodeResult> {
+) -> Result<DeadCodeAnalysisOutcome> {
     use crate::models::dead_code::DeadCodeAnalysisConfig;
     use crate::utils::file_filter::FileFilter;
 
@@ -49,6 +63,11 @@ async fn run_dead_code_analysis_with_filters(
     // the pre-filter number — 26 files claimed above a 4-entry array.
     let files_with_dead_code_found = accurate_report.files_with_dead_code.len();
     let project_total_lines = accurate_report.total_lines;
+    // Measured over every line the analyzer walked, before any filter. This is
+    // the only figure `--fail-on-violation` may compare against; the summary's
+    // is scoped to the list that survived `--top-files`/`--min-dead-lines`.
+    #[allow(clippy::cast_possible_truncation)]
+    let project_dead_percentage = Some(accurate_report.dead_code_percentage as f32);
     let mut analysis_result =
         create_dead_code_ranking_result(accurate_report, filters.min_dead_lines, config);
 
@@ -78,13 +97,16 @@ async fn run_dead_code_analysis_with_filters(
     );
 
     // Convert to DeadCodeResult
-    Ok(crate::models::dead_code::DeadCodeResult {
-        summary: analysis_result.summary.clone(),
-        files: analysis_result.ranked_files,
-        total_files: analysis_result.summary.total_files_analyzed,
-        analyzed_files: analysis_result.summary.total_files_analyzed,
-        files_with_dead_code_found,
-        files_truncated,
+    Ok(DeadCodeAnalysisOutcome {
+        report: crate::models::dead_code::DeadCodeResult {
+            summary: analysis_result.summary.clone(),
+            files: analysis_result.ranked_files,
+            total_files: analysis_result.summary.total_files_analyzed,
+            analyzed_files: analysis_result.summary.total_files_analyzed,
+            files_with_dead_code_found,
+            files_truncated,
+        },
+        project_dead_percentage,
     })
 }
 
@@ -119,7 +141,7 @@ fn run_multi_language_dead_code(
     path: &Path,
     filters: &DeadCodeAnalysisFilters,
     language: &str,
-) -> Result<crate::models::dead_code::DeadCodeResult> {
+) -> Result<DeadCodeAnalysisOutcome> {
     use crate::models::dead_code::{
         ConfidenceLevel, DeadCodeItem, DeadCodeSummary, DeadCodeType, FileDeadCodeMetrics,
     };
@@ -199,18 +221,25 @@ fn run_multi_language_dead_code(
     // summary always agrees with the list that follows it.
     let summary = DeadCodeSummary::from_files(&files);
 
-    Ok(crate::models::dead_code::DeadCodeResult {
-        summary,
-        // MEASURED file count (#720). These were `total_functions.max(1)` -- a
-        // FUNCTION count under a FILE label, which made a 2-file Python fixture
-        // with 4 functions print "Files Analyzed | 4" directly above a summary
-        // that correctly said 2, and `.max(1)` invented one file for an empty
-        // project.
-        total_files: ml_result.total_files,
-        analyzed_files: ml_result.total_files,
-        files,
-        files_with_dead_code_found,
-        files_truncated,
+    Ok(DeadCodeAnalysisOutcome {
+        report: crate::models::dead_code::DeadCodeResult {
+            summary,
+            // MEASURED file count (#720). These were `total_functions.max(1)` --
+            // a FUNCTION count under a FILE label, which made a 2-file Python
+            // fixture with 4 functions print "Files Analyzed | 4" directly above
+            // a summary that correctly said 2, and `.max(1)` invented one file
+            // for an empty project.
+            total_files: ml_result.total_files,
+            analyzed_files: ml_result.total_files,
+            files,
+            files_with_dead_code_found,
+            files_truncated,
+        },
+        // The multi-language analyzer never counts the project's total lines,
+        // only the lines of the files it flagged, so there is no project-wide
+        // ratio to report. `--fail-on-violation` refuses rather than comparing
+        // the list-scoped figure and calling the result a pass.
+        project_dead_percentage: None,
     })
 }
 

--- a/src/cli/handlers/debug_handlers.rs
+++ b/src/cli/handlers/debug_handlers.rs
@@ -160,16 +160,23 @@ mod coverage_tests {
     #[test]
     fn serve_and_replay_are_labelled_not_implemented() {
         use clap::Subcommand;
-        let cmd =
-            crate::cli::commands::DebugCommands::augment_subcommands(clap::Command::new("debug"));
-        for name in ["serve", "replay"] {
-            let about = cmd
-                .get_subcommands()
-                .find(|s| s.get_name() == name)
-                .unwrap_or_else(|| panic!("{name} subcommand must exist"))
-                .get_about()
-                .map(std::string::ToString::to_string)
-                .unwrap_or_default();
+        let abouts = crate::cli::commands::on_big_stack(|| {
+            let cmd = crate::cli::commands::DebugCommands::augment_subcommands(clap::Command::new(
+                "debug",
+            ));
+            ["serve", "replay"]
+                .into_iter()
+                .map(|name| {
+                    cmd.get_subcommands()
+                        .find(|s| s.get_name() == name)
+                        .unwrap_or_else(|| panic!("{name} subcommand must exist"))
+                        .get_about()
+                        .map(std::string::ToString::to_string)
+                        .unwrap_or_default()
+                })
+                .collect::<Vec<_>>()
+        });
+        for (name, about) in ["serve", "replay"].into_iter().zip(abouts) {
             assert!(
                 about.contains("NOT IMPLEMENTED"),
                 "`debug {name}` must be labelled unimplemented in the command list, got: {about}"

--- a/src/cli/handlers/debug_handlers.rs
+++ b/src/cli/handlers/debug_handlers.rs
@@ -1,25 +1,71 @@
 // Debug Adapter Protocol (DAP) handlers - Sprint 74
 //
 // Stub: Not yet implemented
+//
+// Honest-failure policy: these exit with
+// [`DEBUG_UNIMPLEMENTED_EXIT_CODE`] (2, "misuse"), the same code `pmat serve`
+// uses for the same situation (utility_serve_handlers). They used to
+// `anyhow::bail!`, which surfaced as exit 1 — the code reserved for "the
+// command ran and found a problem" — so a CI script could not tell "this
+// subcommand does not exist yet" from "the DAP server failed to start".
+
+/// Exit code for a `pmat debug` subcommand that is not implemented.
+///
+/// Kept numerically in step with
+/// [`crate::cli::handlers::utility_serve_handlers::SERVE_UNIMPLEMENTED_EXIT_CODE`].
+pub const DEBUG_UNIMPLEMENTED_EXIT_CODE: i32 = 2;
+
+/// Emit the honest-failure diagnostic for an unimplemented `debug` subcommand.
+///
+/// Extracted so tests can assert on the exact bytes without the process exit.
+pub fn write_debug_unimplemented_message<W: std::io::Write>(
+    mut out: W,
+    subcommand: &str,
+    ticket: &str,
+    requested: &str,
+) -> std::io::Result<()> {
+    writeln!(
+        out,
+        "error: pmat debug {subcommand} is not implemented ({ticket})"
+    )?;
+    writeln!(out, "  requested: {requested}")?;
+    writeln!(
+        out,
+        "hint: no DAP socket is bound and no recording is read — nothing is running"
+    )?;
+    Ok(())
+}
 
 // Placeholder for DAP server handler
 #[provable_contracts_macros::contract("pmat-core.yaml", equation = "path_exists")]
 pub async fn handle_debug_serve(
-    _port: u16,
-    _host: String,
-    _record_dir: Option<std::path::PathBuf>,
+    port: u16,
+    host: String,
+    record_dir: Option<std::path::PathBuf>,
 ) -> anyhow::Result<()> {
-    anyhow::bail!("Debug serve command not yet implemented (DEBUG-002)")
+    let _ = write_debug_unimplemented_message(
+        std::io::stderr(),
+        "serve",
+        "DEBUG-002",
+        &format!("host={host} port={port} record_dir={record_dir:?}"),
+    );
+    std::process::exit(DEBUG_UNIMPLEMENTED_EXIT_CODE);
 }
 
 // Placeholder for DAP replay handler
 #[provable_contracts_macros::contract("pmat-core.yaml", equation = "path_exists")]
 pub async fn handle_debug_replay(
-    _recording: std::path::PathBuf,
-    _position: Option<usize>,
-    _interactive: bool,
+    recording: std::path::PathBuf,
+    position: Option<usize>,
+    interactive: bool,
 ) -> anyhow::Result<()> {
-    anyhow::bail!("Debug replay command not yet implemented (DEBUG-003)")
+    let _ = write_debug_unimplemented_message(
+        std::io::stderr(),
+        "replay",
+        "DEBUG-003",
+        &format!("recording={recording:?} position={position:?} interactive={interactive}"),
+    );
+    std::process::exit(DEBUG_UNIMPLEMENTED_EXIT_CODE);
 }
 
 // Placeholder for DAP compare handler
@@ -38,67 +84,97 @@ pub async fn handle_debug_timeline() -> anyhow::Result<()> {
 #[cfg(test)]
 mod coverage_tests {
     use super::*;
-    use std::path::PathBuf;
 
-    /// Test that handle_debug_serve returns the expected error
-    #[tokio::test]
-    async fn test_handle_debug_serve_returns_not_implemented() {
-        let result = handle_debug_serve(8080, "localhost".to_string(), None).await;
-        assert!(result.is_err());
-        let err = result.unwrap_err();
-        assert!(err.to_string().contains("DEBUG-002"));
-        assert!(err.to_string().contains("not yet implemented"));
+    // The serve/replay tests below used to call the handlers and assert
+    // `result.is_err()`. Those handlers now exit(2) like `pmat serve` does, so
+    // they are exercised through the message writer instead — same coverage
+    // intent (the diagnostic names the ticket and says it is not implemented),
+    // without killing the test process.
+
+    /// The `debug serve` diagnostic still names DEBUG-002 and says so plainly.
+    #[test]
+    fn serve_message_states_not_implemented_and_names_the_ticket() {
+        let mut buf = Vec::new();
+        write_debug_unimplemented_message(
+            &mut buf,
+            "serve",
+            "DEBUG-002",
+            "host=localhost port=8080 record_dir=None",
+        )
+        .unwrap();
+        let s = String::from_utf8(buf).unwrap();
+        assert!(s.contains("DEBUG-002"), "got: {s}");
+        assert!(s.contains("not implemented"), "got: {s}");
     }
 
-    /// Test handle_debug_serve with various port values
-    #[tokio::test]
-    async fn test_handle_debug_serve_with_different_ports() {
-        // Test with port 0
-        let result = handle_debug_serve(0, "localhost".to_string(), None).await;
-        assert!(result.is_err());
-
-        // Test with max port
-        let result = handle_debug_serve(65535, "127.0.0.1".to_string(), None).await;
-        assert!(result.is_err());
+    /// The diagnostic echoes what was requested, so logs show the port/host.
+    #[test]
+    fn serve_message_echoes_the_request() {
+        let mut buf = Vec::new();
+        write_debug_unimplemented_message(
+            &mut buf,
+            "serve",
+            "DEBUG-002",
+            "host=0.0.0.0 port=65535 record_dir=Some(\"/tmp/debug-recordings\")",
+        )
+        .unwrap();
+        let s = String::from_utf8(buf).unwrap();
+        assert!(s.contains("0.0.0.0"), "got: {s}");
+        assert!(s.contains("65535"), "got: {s}");
+        assert!(s.contains("/tmp/debug-recordings"), "got: {s}");
     }
 
-    /// Test handle_debug_serve with record_dir
-    #[tokio::test]
-    async fn test_handle_debug_serve_with_record_dir() {
-        let record_dir = Some(PathBuf::from("/tmp/debug-recordings"));
-        let result = handle_debug_serve(8080, "0.0.0.0".to_string(), record_dir).await;
-        assert!(result.is_err());
-        let err = result.unwrap_err();
-        assert!(err.to_string().contains("DEBUG-002"));
+    /// The `debug replay` diagnostic still names DEBUG-003.
+    #[test]
+    fn replay_message_states_not_implemented_and_names_the_ticket() {
+        let mut buf = Vec::new();
+        write_debug_unimplemented_message(
+            &mut buf,
+            "replay",
+            "DEBUG-003",
+            "recording=\"/tmp/recording.dap\" position=Some(42) interactive=true",
+        )
+        .unwrap();
+        let s = String::from_utf8(buf).unwrap();
+        assert!(s.contains("DEBUG-003"), "got: {s}");
+        assert!(s.contains("not implemented"), "got: {s}");
+        assert!(s.contains("/tmp/recording.dap"), "got: {s}");
     }
 
-    /// Test that handle_debug_replay returns the expected error
-    #[tokio::test]
-    async fn test_handle_debug_replay_returns_not_implemented() {
-        let recording = PathBuf::from("/tmp/recording.dap");
-        let result = handle_debug_replay(recording, None, false).await;
-        assert!(result.is_err());
-        let err = result.unwrap_err();
-        assert!(err.to_string().contains("DEBUG-003"));
-        assert!(err.to_string().contains("not yet implemented"));
+    /// `debug serve` must exit 2 ("misuse"), not 1, and must match `pmat serve`.
+    ///
+    /// Exit 1 is the code a command uses when it ran and found a problem; using
+    /// it for "this subcommand does not exist yet" made the two indistinguishable.
+    #[test]
+    fn unimplemented_exit_code_matches_serve() {
+        assert_eq!(DEBUG_UNIMPLEMENTED_EXIT_CODE, 2);
+        assert_eq!(
+            DEBUG_UNIMPLEMENTED_EXIT_CODE,
+            crate::cli::handlers::utility_serve_handlers::SERVE_UNIMPLEMENTED_EXIT_CODE
+        );
     }
 
-    /// Test handle_debug_replay with position and interactive flags
-    #[tokio::test]
-    async fn test_handle_debug_replay_with_options() {
-        let recording = PathBuf::from("/tmp/recording.dap");
-
-        // With position
-        let result = handle_debug_replay(recording.clone(), Some(42), false).await;
-        assert!(result.is_err());
-
-        // With interactive
-        let result = handle_debug_replay(recording.clone(), None, true).await;
-        assert!(result.is_err());
-
-        // With both
-        let result = handle_debug_replay(recording, Some(100), true).await;
-        assert!(result.is_err());
+    /// The `debug` subcommand help must carry the `[NOT IMPLEMENTED]` marker
+    /// that `pmat serve` carries. Without it the only way to learn that
+    /// `debug serve` binds no socket was to run it.
+    #[test]
+    fn serve_and_replay_are_labelled_not_implemented() {
+        use clap::Subcommand;
+        let cmd =
+            crate::cli::commands::DebugCommands::augment_subcommands(clap::Command::new("debug"));
+        for name in ["serve", "replay"] {
+            let about = cmd
+                .get_subcommands()
+                .find(|s| s.get_name() == name)
+                .unwrap_or_else(|| panic!("{name} subcommand must exist"))
+                .get_about()
+                .map(std::string::ToString::to_string)
+                .unwrap_or_default();
+            assert!(
+                about.contains("NOT IMPLEMENTED"),
+                "`debug {name}` must be labelled unimplemented in the command list, got: {about}"
+            );
+        }
     }
 
     /// Test that handle_debug_compare returns the expected error

--- a/src/cli/handlers/deps_audit_handlers/handler.rs
+++ b/src/cli/handlers/deps_audit_handlers/handler.rs
@@ -11,6 +11,22 @@ use super::pareto::run_pareto_analysis;
 use super::parser::{parse_cargo_lock, parse_cargo_toml};
 use super::types::{DepCategory, DepsAuditReport, SortMode};
 
+/// Derive the (total, direct, transitive) headline counts from one population.
+///
+/// These three used to be computed from three different populations — the
+/// analyzed (de-duplicated) direct set, the raw `deps + dev_deps` sum which
+/// double-counts a dev-dependency that repeats a regular one, and the Cargo.lock
+/// package set — so the report could print a Total *smaller* than its own Direct
+/// (116 < 119 on this repo). The invariant `total == direct + transitive` now
+/// holds by construction.
+pub(super) fn summary_counts(
+    direct_analyzed: usize,
+    lock_packages: usize,
+) -> (usize, usize, usize) {
+    let total = lock_packages.max(direct_analyzed);
+    (total, direct_analyzed, total - direct_analyzed)
+}
+
 /// Handle the deps-audit command
 #[provable_contracts_macros::contract("pmat-core.yaml", equation = "path_exists")]
 pub fn handle_deps_audit(
@@ -197,12 +213,13 @@ pub fn handle_deps_audit(
         return Ok(());
     }
 
+    let (total_count, direct_count, transitive_count) =
+        summary_counts(all_deps.len(), all_packages.len());
+
     let report = DepsAuditReport {
-        total_deps: all_deps.len(),
-        direct_deps: deps.len() + dev_deps.len(),
-        transitive_deps: all_packages
-            .len()
-            .saturating_sub(deps.len() + dev_deps.len()),
+        total_deps: total_count,
+        direct_deps: direct_count,
+        transitive_deps: transitive_count,
         sovereign_deps: sovereign_count,
         replaceable_deps: replaceable_count,
         removable_deps: removable_count,

--- a/src/cli/handlers/deps_audit_handlers/output.rs
+++ b/src/cli/handlers/deps_audit_handlers/output.rs
@@ -150,8 +150,10 @@ pub fn print_text_report(report: &DepsAuditReport) {
         report.transitive_deps,
         colors::RESET
     );
+    // Labelled by its source: this is the Cargo.lock package set, and it is
+    // exactly direct + transitive (it used to be a third, smaller population).
     println!(
-        "  Total (graph nodes):   {}{}{}",
+        "  Total (Cargo.lock):    {}{}{}",
         colors::BOLD_WHITE,
         report.total_deps,
         colors::RESET

--- a/src/cli/handlers/deps_audit_handlers/pareto.rs
+++ b/src/cli/handlers/deps_audit_handlers/pareto.rs
@@ -1,6 +1,5 @@
 #![cfg_attr(coverage_nightly, coverage(off))]
 
-use std::collections::HashSet;
 use std::path::Path;
 
 use super::types::{DepAnalysis, DepCategory, ParetoEffort, ParetoEntry};
@@ -44,9 +43,22 @@ pub fn estimate_effort(name: &str, category: DepCategory) -> ParetoEffort {
     }
 }
 
-/// Run Pareto analysis using cargo tree for accurate transitive counts
+/// Run Pareto analysis over the transitive counts already on `deps`.
+///
+/// These counts used to be re-derived here by spawning `cargo tree -p <dep>`
+/// per candidate, which contradicted the same command's `-f json` output: that
+/// path reports [`DepAnalysis::transitive_count`], computed by BFS over the
+/// Cargo.lock graph. `cargo tree -p` fails for any name that is not a unique
+/// package spec in the workspace (ambiguous or renamed packages), and the
+/// failure arm returned **0** rather than an error — so `--pareto` printed
+/// "octocrab 0 transitive deps, ROI 0.0" while `-f json` printed 250 for the
+/// same dependency in the same run, and the ROI ranking that decides what to
+/// remove first was inverted. One graph, one count.
+///
+/// `_path` is retained so the call site does not change; nothing here shells
+/// out any more.
 #[provable_contracts_macros::contract("pmat-core.yaml", equation = "path_exists")]
-pub fn run_pareto_analysis(deps: &[DepAnalysis], path: &Path) -> Vec<ParetoEntry> {
+pub fn run_pareto_analysis(deps: &[DepAnalysis], _path: &Path) -> Vec<ParetoEntry> {
     let mut entries = Vec::new();
 
     // Only analyze removable, heavy, and replaceable deps
@@ -61,8 +73,8 @@ pub fn run_pareto_analysis(deps: &[DepAnalysis], path: &Path) -> Vec<ParetoEntry
         .collect();
 
     for dep in candidates {
-        // Get actual transitive count from cargo tree
-        let transitive = get_transitive_count(&dep.name, path);
+        // Same number the JSON report prints for this dependency.
+        let transitive = dep.transitive_count;
 
         let effort = estimate_effort(&dep.name, dep.category);
         let roi = transitive as f32 / effort.multiplier();
@@ -87,33 +99,27 @@ pub fn run_pareto_analysis(deps: &[DepAnalysis], path: &Path) -> Vec<ParetoEntry
     entries
 }
 
-/// Get transitive dependency count using cargo tree
-#[provable_contracts_macros::contract("pmat-core.yaml", equation = "path_exists")]
-pub fn get_transitive_count(dep_name: &str, path: &Path) -> usize {
-    use std::process::Command;
-
-    let output = Command::new("cargo")
-        .args(["tree", "-p", dep_name, "--prefix", "none", "-e", "no-dev"])
-        .current_dir(path)
-        .output();
-
-    match output {
-        Ok(o) if o.status.success() => {
-            let stdout = String::from_utf8_lossy(&o.stdout);
-            // Count unique lines (each is a transitive dep)
-            let count: HashSet<_> = stdout.lines().collect();
-            count.len().saturating_sub(1) // Don't count self
-        }
-        _ => 0,
-    }
-}
+// `get_transitive_count` (a `cargo tree -p <dep>` spawn whose every failure mode
+// returned 0) is gone: it was the second, disagreeing source of transitive
+// counts. See [`run_pareto_analysis`].
 
 #[cfg(test)]
 mod pareto_tests {
     //! Covers estimate_effort + run_pareto_analysis filtering/sorting in
     //! deps_audit_handlers/pareto.rs (9 uncov on broad, 0% cov).
-    //! Skips get_transitive_count (spawns `cargo tree`).
     use super::*;
+
+    fn dep_with_transitive(
+        name: &str,
+        category: DepCategory,
+        reason: &str,
+        transitive_count: usize,
+    ) -> DepAnalysis {
+        DepAnalysis {
+            transitive_count,
+            ..dep(name, category, reason)
+        }
+    }
 
     fn dep(name: &str, category: DepCategory, reason: &str) -> DepAnalysis {
         DepAnalysis {
@@ -247,12 +253,35 @@ mod pareto_tests {
         assert!(entries.is_empty());
     }
 
-    // ── get_transitive_count: only the cargo-failure arm (no project at /tmp) ──
+    // ── transitive counts: one graph, one number ──
 
+    /// This replaces `test_get_transitive_count_cargo_failure_returns_zero`,
+    /// which pinned the defect: it asserted that a failed `cargo tree` spawn
+    /// silently yields 0 transitive deps. That zero reached the report, so
+    /// `--pareto` printed "octocrab 0 / ROI 0.0" against `-f json`'s 250 for the
+    /// same dependency in the same run. The Pareto table must report the counts
+    /// already computed from the Cargo.lock graph, never re-derive them.
     #[test]
-    fn test_get_transitive_count_cargo_failure_returns_zero() {
-        // /tmp has no Cargo project → cargo tree fails → unwrap_or(0).
-        let count = get_transitive_count("nonexistent_dep_xyz", std::path::Path::new("/tmp"));
-        assert_eq!(count, 0);
+    fn test_run_pareto_analysis_reports_the_analysed_transitive_counts() {
+        let deps = vec![
+            dep_with_transitive("octocrab", DepCategory::Heavy, "GitHub API", 250),
+            dep_with_transitive("reqwest", DepCategory::Heavy, "HTTP client", 192),
+            dep_with_transitive("sourcemap", DepCategory::Removable, "debug maps", 91),
+        ];
+        let entries = run_pareto_analysis(&deps, std::path::Path::new("/nonexistent-project"));
+
+        let by_name = |n: &str| {
+            entries
+                .iter()
+                .find(|e| e.name == n)
+                .unwrap_or_else(|| panic!("{n} missing from the Pareto table"))
+        };
+        assert_eq!(by_name("octocrab").transitive_deps, 250);
+        assert_eq!(by_name("reqwest").transitive_deps, 192);
+        assert_eq!(by_name("sourcemap").transitive_deps, 91);
+
+        // ROI = transitive / effort multiplier, so a real count must also
+        // produce a nonzero ranking signal.
+        assert!(by_name("octocrab").roi > 0.0);
     }
 }

--- a/src/cli/handlers/deps_audit_handlers/tests.rs
+++ b/src/cli/handlers/deps_audit_handlers/tests.rs
@@ -413,4 +413,29 @@ mod coverage_instrumented_tests {
         assert!(!deps[0].is_orphan);
         assert_eq!(deps[0].transitive_count, 10);
     }
+
+    // ── Summary count invariant (round-5 dogfood: Total 116 < Direct 119) ──
+
+    #[test]
+    fn test_summary_counts_total_is_direct_plus_transitive() {
+        use super::super::handler::summary_counts;
+        // 853 packages in Cargo.lock, 116 de-duplicated direct+dev deps.
+        let (total, direct, transitive) = summary_counts(116, 853);
+        assert_eq!(total, 853);
+        assert_eq!(direct, 116);
+        assert_eq!(transitive, 737);
+        assert_eq!(total, direct + transitive);
+        assert!(total >= direct, "Total must never be below Direct");
+    }
+
+    #[test]
+    fn test_summary_counts_never_reports_total_below_direct() {
+        use super::super::handler::summary_counts;
+        // Degenerate: no/short Cargo.lock. Total still cannot undercut Direct.
+        let (total, direct, transitive) = summary_counts(119, 0);
+        assert_eq!(total, 119);
+        assert_eq!(direct, 119);
+        assert_eq!(transitive, 0);
+        assert!(total >= direct);
+    }
 }

--- a/src/cli/handlers/doc_validate_handlers.rs
+++ b/src/cli/handlers/doc_validate_handlers.rs
@@ -66,8 +66,24 @@ impl ValidateDocsCmd {
             eprintln!("⚡ Max concurrent: {}", config.max_concurrent_requests);
         }
 
-        let validator = DocValidator::new(config);
+        // Only text/plain, json and junit are actually rendered. Every other
+        // clap value used to fall through a catch-all to coloured human text,
+        // so `validate-docs -o yaml | yq` was fed ANSI escapes. Refuse the
+        // formats we cannot produce instead of silently downgrading them.
+        check_output_format_supported(&self.output)?;
+
         let root = self.root.clone().unwrap_or_else(|| PathBuf::from("."));
+        // A nonexistent --root used to walk to zero files and print
+        // "All documentation links are valid!" with exit 0 even under
+        // --fail-on-error: a gate that passes because it measured nothing.
+        if !root.is_dir() {
+            anyhow::bail!(
+                "path does not exist or is not a directory: {}",
+                root.display()
+            );
+        }
+
+        let validator = DocValidator::new(config);
         let summary = validator.validate_directory(&root).await?;
 
         // Output results
@@ -75,7 +91,10 @@ impl ValidateDocsCmd {
             OutputFormat::Text | OutputFormat::Plain => self.print_text_summary(&summary),
             OutputFormat::Json => self.print_json_summary(&summary)?,
             OutputFormat::Junit => self.print_junit_summary(&summary)?,
-            _ => self.print_text_summary(&summary),
+            ref other => {
+                // Unreachable: check_output_format_supported rejects these above.
+                anyhow::bail!("unsupported output format for validate-docs: {other}")
+            }
         }
 
         // Exit with error code if broken links found and fail_on_error is true
@@ -319,6 +338,22 @@ impl ValidateDocsCmd {
     }
 }
 
+/// Reject the `--output` values `validate-docs` has no renderer for.
+///
+/// The shared `OutputFormat` enum advertises nine values; this command
+/// implements four. yaml/markdown/csv/summary/table used to be accepted and
+/// rendered as coloured text, so machine consumers silently got ANSI escapes.
+pub(crate) fn check_output_format_supported(format: &OutputFormat) -> Result<()> {
+    match format {
+        OutputFormat::Text | OutputFormat::Plain | OutputFormat::Json | OutputFormat::Junit => {
+            Ok(())
+        }
+        other => anyhow::bail!(
+            "validate-docs does not support --output {other}; supported: text, plain, json, junit"
+        ),
+    }
+}
+
 fn xml_escape(s: &str) -> String {
     s.replace('&', "&amp;")
         .replace('<', "&lt;")
@@ -371,6 +406,78 @@ mod tests {
             .exclude_patterns
             .contains(&"custom_exclude".to_string()));
         assert_eq!(config.exclude_patterns.len(), 5);
+    }
+
+    fn cmd_with(root: Option<PathBuf>, output: OutputFormat) -> ValidateDocsCmd {
+        ValidateDocsCmd {
+            root,
+            config: None,
+            fail_on_error: true,
+            output,
+            max_concurrent: 1,
+            timeout: 1,
+            max_retries: 0,
+            exclude: vec![],
+            verbose: false,
+        }
+    }
+
+    // Regression: a nonexistent --root walked zero files and printed
+    // "All documentation links are valid!" with exit 0.
+    #[tokio::test]
+    async fn test_execute_nonexistent_root_is_an_error() {
+        let cmd = cmd_with(
+            Some(PathBuf::from("/does/not/exist/pmat-doc-validate")),
+            OutputFormat::Text,
+        );
+        let err = cmd.execute().await.expect_err("missing root must not pass");
+        assert!(
+            err.to_string().contains("does not exist"),
+            "unexpected error: {err}"
+        );
+    }
+
+    // Regression: yaml/markdown/csv/summary/table were accepted and rendered
+    // as ANSI-coloured text by a catch-all match arm.
+    #[tokio::test]
+    async fn test_execute_rejects_unimplemented_output_format() {
+        let dir = tempfile::tempdir().unwrap();
+        let cmd = cmd_with(Some(dir.path().to_path_buf()), OutputFormat::Yaml);
+        let err = cmd
+            .execute()
+            .await
+            .expect_err("yaml has no renderer and must be rejected");
+        assert!(
+            err.to_string().contains("does not support --output yaml"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_check_output_format_supported_matrix() {
+        for ok in [
+            OutputFormat::Text,
+            OutputFormat::Plain,
+            OutputFormat::Json,
+            OutputFormat::Junit,
+        ] {
+            assert!(
+                check_output_format_supported(&ok).is_ok(),
+                "{ok} must render"
+            );
+        }
+        for bad in [
+            OutputFormat::Yaml,
+            OutputFormat::Markdown,
+            OutputFormat::Csv,
+            OutputFormat::Summary,
+            OutputFormat::Table,
+        ] {
+            assert!(
+                check_output_format_supported(&bad).is_err(),
+                "{bad} has no renderer and must be refused, not downgraded to text"
+            );
+        }
     }
 
     #[test]

--- a/src/cli/handlers/enforce_coverage_part1.rs
+++ b/src/cli/handlers/enforce_coverage_part1.rs
@@ -484,10 +484,19 @@ mod tests {
         }
 
         #[test]
-        fn test_load_quality_profile_default() {
-            let profile = load_quality_profile("default", None).unwrap();
-            // Should return extreme profile as default
-            assert_eq!(profile.coverage_min, 80.0);
+        fn test_load_quality_profile_unknown_name_is_rejected() {
+            // Every arm of `load_quality_profile` used to return the extreme
+            // profile, so an unrecognised name — like the "default" this test
+            // used to assert on — silently enforced the extreme thresholds.
+            assert!(load_quality_profile("default", None).is_err());
+        }
+
+        #[test]
+        fn test_load_quality_profile_standard_is_looser_than_extreme() {
+            let standard = load_quality_profile("standard", None).unwrap();
+            let extreme = load_quality_profile("extreme", None).unwrap();
+            assert!(standard.coverage_min < extreme.coverage_min);
+            assert!(standard.complexity_max > extreme.complexity_max);
         }
 
         #[test]

--- a/src/cli/handlers/enforce_coverage_part2_checks.rs
+++ b/src/cli/handlers/enforce_coverage_part2_checks.rs
@@ -176,14 +176,23 @@
         #[tokio::test]
         async fn test_run_coverage_analysis() {
             let temp_dir = create_test_project();
+            // Was asserting a violation against a project with no coverage data
+            // at all, which only held while the handler returned the literal
+            // "simulated" 65.0. The percentage is measured now, so the report
+            // has to exist for there to be anything to compare.
+            std::fs::write(
+                temp_dir.path().join("lcov.info"),
+                "TN:\nSF:src/lib.rs\nLF:100\nLH:65\nend_of_record\n",
+            )
+            .expect("write lcov");
             let profile = make_test_profile();
 
             let violations = run_coverage_analysis(temp_dir.path(), &profile)
                 .await
                 .unwrap();
 
-            // Should have at least one coverage violation (simulated at 65%)
             assert!(!violations.is_empty());
             assert_eq!(violations[0].violation_type, "coverage");
+            assert_eq!(violations[0].current, 65.0);
         }
     }

--- a/src/cli/handlers/enforce_coverage_part3.rs
+++ b/src/cli/handlers/enforce_coverage_part3.rs
@@ -132,16 +132,44 @@
 
         #[test]
         fn test_initialize_enforcement_environment_default_profile() {
-            let result = initialize_enforcement_environment("default", None, &None, false).unwrap();
-            assert_eq!(result.coverage_min, 80.0);
+            // Used to assert that the name "default" resolved successfully to
+            // coverage_min == 80.0. That only held because every arm of
+            // `load_quality_profile` returned `QualityProfile::default()`, so any
+            // string produced the extreme thresholds. "default" is not one of the
+            // documented profiles; the *default* profile is the CLI default,
+            // `extreme`, and that is what must carry the default thresholds.
+            assert!(
+                initialize_enforcement_environment("default", None, &None, false).is_err(),
+                "\"default\" is not a documented profile name"
+            );
+
+            let extreme = initialize_enforcement_environment("extreme", None, &None, false).unwrap();
+            assert_eq!(extreme.coverage_min, QualityProfile::default().coverage_min);
+
+            // A named non-default profile must not come back with the default
+            // thresholds — that was the whole defect.
+            let standard =
+                initialize_enforcement_environment("standard", None, &None, false).unwrap();
+            assert!(standard.coverage_min < extreme.coverage_min);
         }
 
         #[test]
         fn test_initialize_enforcement_environment_unknown_profile() {
-            let result =
-                initialize_enforcement_environment("unknown-profile", None, &None, false).unwrap();
-            // Should return default profile
-            assert_eq!(result.coverage_min, 80.0);
+            // Used to assert an unknown name silently succeeded and yielded the
+            // extreme profile (coverage_min 80.0) — a typo'd `--profile` then
+            // enforced thresholds the user never asked for. It must now be a hard
+            // error that names the valid profiles.
+            let err = initialize_enforcement_environment("unknown-profile", None, &None, false)
+                .unwrap_err()
+                .to_string();
+            assert!(
+                err.contains("unknown-profile"),
+                "error must echo the bad name, got {err}"
+            );
+            assert!(
+                err.contains("standard") && err.contains("strict") && err.contains("extreme"),
+                "error must list the valid profiles, got {err}"
+            );
         }
     }
 

--- a/src/cli/handlers/enforce_coverage_part4.rs
+++ b/src/cli/handlers/enforce_coverage_part4.rs
@@ -385,16 +385,32 @@
     mod coverage_analysis_tests {
         use super::*;
 
+        /// Write an lcov report with a known line-coverage percentage.
+        ///
+        /// These tests used to assert `current == 65.0` against a bare temp
+        /// directory, which pinned the literal `let coverage = 65.0; //
+        /// Simulated coverage` the handler has now lost: every project on earth,
+        /// including an empty one, was reported 15 points under the 80% floor.
+        /// The percentage now has to come from a real report, so the tests
+        /// supply one.
+        fn write_lcov(dir: &std::path::Path, hit: u64, found: u64) {
+            std::fs::write(
+                dir.join("lcov.info"),
+                format!("TN:\nSF:src/lib.rs\nLF:{found}\nLH:{hit}\nend_of_record\n"),
+            )
+            .expect("write lcov");
+        }
+
         #[tokio::test]
         async fn test_run_coverage_analysis_below_threshold() {
             let temp_dir = create_test_project();
+            write_lcov(temp_dir.path(), 65, 100); // 65%
             let profile = make_test_profile(); // 80% min coverage
 
             let violations = run_coverage_analysis(temp_dir.path(), &profile)
                 .await
                 .unwrap();
 
-            // Simulated coverage is 65%, so should have violation
             assert!(!violations.is_empty());
             assert_eq!(violations[0].violation_type, "coverage");
             assert_eq!(violations[0].current, 65.0);
@@ -404,6 +420,7 @@
         #[tokio::test]
         async fn test_run_coverage_analysis_above_threshold() {
             let temp_dir = create_test_project();
+            write_lcov(temp_dir.path(), 65, 100); // 65%
             let mut profile = make_test_profile();
             profile.coverage_min = 50.0; // Lower threshold
 
@@ -411,7 +428,23 @@
                 .await
                 .unwrap();
 
-            // Simulated coverage is 65%, above 50% threshold
             assert!(violations.is_empty());
+        }
+
+        /// No lcov report ⇒ nothing measured ⇒ no violation invented.
+        #[tokio::test]
+        async fn test_run_coverage_analysis_reports_nothing_when_unmeasured() {
+            let temp_dir = create_test_project();
+            let profile = make_test_profile(); // 80% min coverage
+
+            let violations = run_coverage_analysis(temp_dir.path(), &profile)
+                .await
+                .unwrap();
+
+            assert!(
+                violations.is_empty(),
+                "a project with no coverage report must not be reported as failing a \
+                 coverage floor; got {violations:?}"
+            );
         }
     }

--- a/src/cli/handlers/enforce_handlers/analysis.rs
+++ b/src/cli/handlers/enforce_handlers/analysis.rs
@@ -73,6 +73,42 @@ impl AnalysisScope {
     }
 }
 
+/// Scratch path used to capture a printing analysis handler's JSON report.
+///
+/// `enforce` used to invoke these handlers purely for their side effects and
+/// then push a hardcoded `QualityViolation`. The consequence was that
+/// `enforce extreme --list-violations` returned the SAME cast of violations
+/// for an empty directory as for this repository — pointing at
+/// `server/src/cli/handlers/enforce_handlers.rs`, a path that exists in no
+/// project — and a literal `coverage 65.0`. A violation must come from the
+/// analysis that was actually run, so the handler's own JSON is captured and
+/// parsed instead of discarded.
+fn capture_path(tag: &str) -> PathBuf {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |d| d.as_nanos());
+    std::env::temp_dir().join(format!(
+        "pmat-enforce-{tag}-{}-{nanos}.json",
+        std::process::id()
+    ))
+}
+
+/// Read and delete a captured JSON report.
+///
+/// `None` means the analysis produced nothing readable — the caller must then
+/// report no violations rather than substitute a constant.
+fn take_captured_json(path: &Path) -> Option<serde_json::Value> {
+    let text = std::fs::read_to_string(path).ok();
+    let _ = std::fs::remove_file(path);
+    serde_json::from_str(&text?).ok()
+}
+
+/// Report that a signal could not be produced. A phase that measured nothing
+/// must say so; it must not fall through to a plausible-looking number.
+fn warn_not_measured(kind: &str, path: &Path, reason: &str) {
+    eprintln!("⚠️  {kind} not measured for {}: {reason}", path.display());
+}
+
 /// Run complexity analysis - extracted from `list_all_violations` (complexity: ≤10)
 #[provable_contracts_macros::contract("pmat-core.yaml", equation = "path_exists")]
 pub async fn run_complexity_analysis(
@@ -80,44 +116,66 @@ pub async fn run_complexity_analysis(
     profile: &QualityProfile,
     specific_file: Option<&Path>,
 ) -> Result<Vec<QualityViolation>> {
-    use crate::cli::handlers::complexity_handlers::handle_analyze_complexity;
-    use crate::cli::ComplexityOutputFormat;
-
-    let mut violations = Vec::new();
-
-    match handle_analyze_complexity(
-        project_path.to_path_buf(),
-        specific_file.map(Path::to_path_buf), // file: restricts analysis to one file
-        vec![],                               // files
-        None,                                 // toolchain
-        ComplexityOutputFormat::Json,
-        None,                         // output
-        Some(profile.complexity_max), // max_cyclomatic
-        None,                         // max_cognitive
-        vec![],                       // include
-        false,                        // watch
-        10,                           // top_files
-        false,                        // fail_on_violation
-        60,                           // timeout
-    )
-    .await
-    {
-        Ok(()) => {
-            // NOTE: Would parse JSON output and extract violations
-            // For now, add sample violation based on known complexity issues
-            violations.push(QualityViolation {
-                violation_type: "complexity".to_string(),
-                severity: "high".to_string(),
-                location: "server/src/cli/handlers/enforce_handlers.rs:run_enforcement_step"
-                    .to_string(),
-                current: 62.0,
-                target: f64::from(profile.complexity_max),
-                suggestion: "Extract method pattern - split match statement into handler functions"
-                    .to_string(),
-            });
+    // The complexity service is called directly rather than through the
+    // printing CLI handler: the handler returns `()`, so its result had to be
+    // thrown away and a sample violation invented in its place.
+    let file_metrics = match specific_file {
+        Some(file) => {
+            match crate::services::complexity::analyze_file_complexity_uncached(file, None).await {
+                Ok(m) => vec![m],
+                Err(e) => {
+                    warn_not_measured("complexity", file, &e.to_string());
+                    return Ok(Vec::new());
+                }
+            }
         }
-        Err(_) => {} // Ignore failures in analysis
+        None => {
+            match crate::cli::analysis_utilities::analyze_project_files(
+                project_path,
+                None,
+                &[],
+                profile.complexity_max,
+                profile.complexity_max,
+            )
+            .await
+            {
+                Ok(m) => m,
+                Err(e) => {
+                    warn_not_measured("complexity", project_path, &e.to_string());
+                    return Ok(Vec::new());
+                }
+            }
+        }
+    };
+
+    let severe = profile.complexity_max.saturating_mul(2);
+    let mut violations = Vec::new();
+    for file in &file_metrics {
+        for func in &file.functions {
+            if func.metrics.cyclomatic > profile.complexity_max {
+                violations.push(QualityViolation {
+                    violation_type: "complexity".to_string(),
+                    severity: if func.metrics.cyclomatic > severe {
+                        "high".to_string()
+                    } else {
+                        "medium".to_string()
+                    },
+                    location: format!("{}:{}:{}", file.path, func.line_start, func.name),
+                    current: f64::from(func.metrics.cyclomatic),
+                    target: f64::from(profile.complexity_max),
+                    suggestion: "Extract method pattern - split the function into smaller units"
+                        .to_string(),
+                });
+            }
+        }
     }
+
+    // Deterministic order: worst first, then by location.
+    violations.sort_by(|a, b| {
+        b.current
+            .total_cmp(&a.current)
+            .then_with(|| a.location.cmp(&b.location))
+    });
 
     Ok(violations)
 }
@@ -168,37 +226,61 @@ pub async fn run_tdg_analysis(
     project_path: &Path,
     profile: &QualityProfile,
 ) -> Result<Vec<QualityViolation>> {
-    use crate::cli::handlers::advanced_analysis_handlers::handle_analyze_tdg;
-    use crate::cli::TdgOutputFormat;
+    use crate::services::tdg_calculator::TDGCalculator;
 
+    // `TDGCalculator` is the analyser whose scale `profile.tdg_max` is written
+    // against (0.0-5.0, lower is better). The previous code called the
+    // printing `analyze tdg` handler, dropped its `()` result and pushed a
+    // literal `2.3` for a file that does not exist in any checkout.
+    let calculator = TDGCalculator::new();
     let mut violations = Vec::new();
 
-    match handle_analyze_tdg(
-        project_path.to_path_buf(),
-        Some(profile.tdg_max), // threshold
-        Some(10),              // top
-        TdgOutputFormat::Json,
-        true,  // include_components
-        None,  // output
-        false, // critical_only
-        false, // verbose
-    )
-    .await
-    {
-        Ok(()) => {
-            // NOTE: Would parse JSON and check TDG scores
-            // Adding sample violation for demonstration
-            violations.push(QualityViolation {
-                violation_type: "tdg".to_string(),
-                severity: "medium".to_string(),
-                location: "server/src/cli/handlers/enforce_handlers.rs".to_string(),
-                current: 2.3,
-                target: profile.tdg_max,
-                suggestion: "Refactor high-complexity functions to reduce technical debt"
-                    .to_string(),
-            });
+    if project_path.is_dir() {
+        match calculator.analyze_directory(project_path).await {
+            Ok(summary) => {
+                for hotspot in &summary.hotspots {
+                    if hotspot.tdg_score > profile.tdg_max {
+                        violations.push(QualityViolation {
+                            violation_type: "tdg".to_string(),
+                            severity: if hotspot.tdg_score > profile.tdg_max * 2.0 {
+                                "high".to_string()
+                            } else {
+                                "medium".to_string()
+                            },
+                            location: hotspot.path.clone(),
+                            current: hotspot.tdg_score,
+                            target: profile.tdg_max,
+                            suggestion: format!(
+                                "Reduce technical debt - primary factor: {}",
+                                hotspot.primary_factor
+                            ),
+                        });
+                    }
+                }
+            }
+            Err(e) => warn_not_measured("tdg", project_path, &e.to_string()),
         }
-        Err(_) => {} // Ignore failures in analysis
+    } else {
+        match calculator.calculate_file(project_path).await {
+            Ok(score) => {
+                if score.value > profile.tdg_max {
+                    violations.push(QualityViolation {
+                        violation_type: "tdg".to_string(),
+                        severity: if score.value > profile.tdg_max * 2.0 {
+                            "high".to_string()
+                        } else {
+                            "medium".to_string()
+                        },
+                        location: project_path.display().to_string(),
+                        current: score.value,
+                        target: profile.tdg_max,
+                        suggestion: "Refactor high-complexity functions to reduce technical debt"
+                            .to_string(),
+                    });
+                }
+            }
+            Err(e) => warn_not_measured("tdg", project_path, &e.to_string()),
+        }
     }
 
     Ok(violations)
@@ -215,35 +297,60 @@ pub async fn run_dead_code_analysis(
 
     let mut violations = Vec::new();
 
-    match handle_analyze_dead_code(
+    // The handler's JSON is captured to a scratch file and parsed. Discarding
+    // it and pushing a literal is what made every project report dead code in
+    // `server/src/services/ast_typescript_dispatch.rs:9`, a file no checkout
+    // contains.
+    let capture = capture_path("dead-code");
+    let ran = handle_analyze_dead_code(
         project_path.to_path_buf(),
         DeadCodeOutputFormat::Json,
-        Some(10),   // top_files
-        true,       // include_unreachable
-        5,          // min_dead_lines
-        false,      // include_tests
-        None,       // output
-        false,      // fail_on_violation
-        15.0,       // max_percentage
-        60,         // timeout
-        Vec::new(), // include
-        Vec::new(), // exclude
-        8,          // max_depth
+        Some(10),              // top_files
+        true,                  // include_unreachable
+        5,                     // min_dead_lines
+        false,                 // include_tests
+        Some(capture.clone()), // output
+        false,                 // fail_on_violation
+        15.0,                  // max_percentage
+        60,                    // timeout
+        Vec::new(),            // include
+        Vec::new(),            // exclude
+        8,                     // max_depth
     )
-    .await
-    {
-        Ok(()) => {
-            // NOTE: Would parse JSON and extract dead code violations
-            violations.push(QualityViolation {
-                violation_type: "dead_code".to_string(),
-                severity: "low".to_string(),
-                location: "server/src/services/ast_typescript_dispatch.rs:9".to_string(),
-                current: 1.0,
-                target: 0.0,
-                suggestion: "Remove dead code attributes and unused functions".to_string(),
-            });
+    .await;
+
+    match ran {
+        Ok(()) => match take_captured_json(&capture) {
+            Some(report) => {
+                let files = report.get("files").and_then(serde_json::Value::as_array);
+                for file in files.into_iter().flatten() {
+                    let dead_lines = file
+                        .get("dead_lines")
+                        .and_then(serde_json::Value::as_f64)
+                        .unwrap_or(0.0);
+                    if dead_lines <= 0.0 {
+                        continue;
+                    }
+                    let path = file
+                        .get("path")
+                        .and_then(serde_json::Value::as_str)
+                        .unwrap_or("<unknown>");
+                    violations.push(QualityViolation {
+                        violation_type: "dead_code".to_string(),
+                        severity: "low".to_string(),
+                        location: path.to_string(),
+                        current: dead_lines,
+                        target: 0.0,
+                        suggestion: "Remove dead code attributes and unused functions".to_string(),
+                    });
+                }
+            }
+            None => warn_not_measured("dead code", project_path, "no parsable JSON report"),
+        },
+        Err(e) => {
+            let _ = std::fs::remove_file(&capture);
+            warn_not_measured("dead code", project_path, &e.to_string());
         }
-        Err(_) => {} // Ignore failures in analysis
     }
 
     Ok(violations)
@@ -262,6 +369,10 @@ pub async fn run_duplication_analysis(
 
     let mut violations = Vec::new();
 
+    // Capture the detector's own JSON. The literal `current: 15.0` that used to
+    // be pushed here was reported for an empty directory as readily as for a
+    // real tree, which is the same defect as the complexity/TDG samples above.
+    let capture = capture_path("duplication");
     let dup_config = DuplicateAnalysisConfig {
         project_path: project_path.to_path_buf(),
         detection_type: DuplicateType::Exact,
@@ -272,40 +383,99 @@ pub async fn run_duplication_analysis(
         perf: false,
         include: None,
         exclude: None,
-        output: None,
+        output: Some(capture.clone()),
         top_files: 0, // 0 = all files
     };
 
     match handle_analyze_duplicates(dup_config).await {
-        Ok(()) => {
-            if profile.duplication_max_lines == 0 {
-                violations.push(QualityViolation {
-                    violation_type: "duplication".to_string(),
-                    severity: "low".to_string(),
-                    location: "multiple files".to_string(),
-                    current: 15.0,
-                    target: 0.0,
-                    suggestion: "Extract common code into shared utilities".to_string(),
-                });
+        Ok(()) => match take_captured_json(&capture) {
+            Some(report) => {
+                let duplicate_lines = report
+                    .get("duplicate_lines")
+                    .and_then(serde_json::Value::as_f64)
+                    .unwrap_or(0.0);
+                if duplicate_lines > profile.duplication_max_lines as f64 {
+                    let percentage = report
+                        .get("duplication_percentage")
+                        .and_then(serde_json::Value::as_f64)
+                        .unwrap_or(0.0);
+                    violations.push(QualityViolation {
+                        violation_type: "duplication".to_string(),
+                        severity: if percentage >= 10.0 { "medium" } else { "low" }.to_string(),
+                        location: format!("{} ({percentage:.1}% of lines)", project_path.display()),
+                        current: duplicate_lines,
+                        target: profile.duplication_max_lines as f64,
+                        suggestion: "Extract common code into shared utilities".to_string(),
+                    });
+                }
             }
+            None => warn_not_measured("duplication", project_path, "no parsable JSON report"),
+        },
+        Err(e) => {
+            let _ = std::fs::remove_file(&capture);
+            warn_not_measured("duplication", project_path, &e.to_string());
         }
-        Err(_) => {} // Ignore failures in analysis
     }
 
     Ok(violations)
 }
 
+/// Overall line coverage the project has already measured, if any.
+///
+/// pmat does not run a coverage tool itself, so the only honest source is an
+/// lcov report the project produced (`cargo llvm-cov --lcov --output-path
+/// lcov.info`). `None` means nothing was measured.
+fn read_measured_line_coverage(project_path: &Path) -> Option<f64> {
+    const CANDIDATES: [&str; 5] = [
+        "lcov.info",
+        "coverage/lcov.info",
+        "target/coverage/lcov.info",
+        "target/llvm-cov/lcov.info",
+        "target/llvm-cov-target/lcov.info",
+    ];
+
+    for rel in CANDIDATES {
+        let Ok(text) = std::fs::read_to_string(project_path.join(rel)) else {
+            continue;
+        };
+        let mut lines_found: u64 = 0;
+        let mut lines_hit: u64 = 0;
+        for line in text.lines() {
+            if let Some(v) = line.trim().strip_prefix("LF:") {
+                lines_found += v.trim().parse::<u64>().unwrap_or(0);
+            } else if let Some(v) = line.trim().strip_prefix("LH:") {
+                lines_hit += v.trim().parse::<u64>().unwrap_or(0);
+            }
+        }
+        if lines_found > 0 {
+            return Some(lines_hit as f64 / lines_found as f64 * 100.0);
+        }
+    }
+
+    None
+}
+
 /// Run coverage analysis - extracted from `list_all_violations` (complexity: ≤10)
 #[provable_contracts_macros::contract("pmat-core.yaml", equation = "path_exists")]
 pub async fn run_coverage_analysis(
-    _project_path: &Path,
+    project_path: &Path,
     profile: &QualityProfile,
 ) -> Result<Vec<QualityViolation>> {
-    let mut violations = Vec::new();
+    // This function used to read `let coverage = 65.0; // Simulated coverage`,
+    // so every project on earth was reported 15 points short of the 80% floor —
+    // including an empty directory with no tests and no source. A gate that
+    // cannot measure a signal must say it did not measure it, not report a
+    // failure it invented.
+    let Some(coverage) = read_measured_line_coverage(project_path) else {
+        warn_not_measured(
+            "coverage",
+            project_path,
+            "no lcov report found (run `cargo llvm-cov --lcov --output-path lcov.info`)",
+        );
+        return Ok(Vec::new());
+    };
 
-    // NOTE: Would use external tool like cargo llvm-cov
-    // For now, simulate coverage check
-    let coverage = 65.0; // Simulated coverage
+    let mut violations = Vec::new();
 
     if coverage < profile.coverage_min {
         violations.push(QualityViolation {
@@ -315,13 +485,135 @@ pub async fn run_coverage_analysis(
             current: coverage,
             target: profile.coverage_min,
             suggestion: format!(
-                "Increase test coverage by {}%",
+                "Increase test coverage by {:.1}%",
                 profile.coverage_min - coverage
             ),
         });
     }
 
     Ok(violations)
+}
+
+#[cfg(test)]
+mod measured_violation_tests {
+    //! Regression tests for the fabricated `--list-violations` output: every
+    //! phase used to push a literal violation (paths that exist in no project,
+    //! `coverage 65.0`) regardless of what it had just analysed.
+    use super::{
+        read_measured_line_coverage, run_complexity_analysis, run_coverage_analysis,
+        run_duplication_analysis, run_tdg_analysis, QualityProfile,
+    };
+
+    #[tokio::test]
+    async fn test_empty_directory_yields_no_violations() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let profile = QualityProfile::default();
+        let root = temp.path();
+
+        assert!(
+            run_complexity_analysis(root, &profile, None)
+                .await
+                .unwrap()
+                .is_empty(),
+            "an empty directory has no functions, so it can have no complexity violations"
+        );
+        assert!(
+            run_tdg_analysis(root, &profile).await.unwrap().is_empty(),
+            "an empty directory has no files, so it can have no TDG hotspots"
+        );
+        assert!(
+            run_duplication_analysis(root, &profile)
+                .await
+                .unwrap()
+                .is_empty(),
+            "an empty directory has no duplicated lines"
+        );
+        assert!(
+            run_coverage_analysis(root, &profile)
+                .await
+                .unwrap()
+                .is_empty(),
+            "no coverage report exists, so coverage is not measured and cannot be a violation"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_complexity_violation_points_at_the_analysed_file() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let src = temp.path().join("hot.rs");
+        let mut body = String::from("pub fn tangled(n: i32) -> i32 {\n    let mut acc = 0;\n");
+        for i in 0..30 {
+            body.push_str(&format!("    if n == {i} {{ acc += {i}; }}\n"));
+        }
+        body.push_str("    acc\n}\n");
+        std::fs::write(&src, body).unwrap();
+
+        let profile = QualityProfile::default();
+        let violations = run_complexity_analysis(temp.path(), &profile, Some(&src))
+            .await
+            .unwrap();
+
+        assert!(
+            !violations.is_empty(),
+            "a 31-branch function must exceed the default max of {}",
+            profile.complexity_max
+        );
+        let v = &violations[0];
+        assert_eq!(v.violation_type, "complexity");
+        assert!(
+            v.location.contains("hot.rs"),
+            "violation must name the analysed file, got {:?}",
+            v.location
+        );
+        assert!(
+            !v.location
+                .contains("server/src/cli/handlers/enforce_handlers.rs"),
+            "the hardcoded sample location must be gone"
+        );
+        assert!(
+            v.current > f64::from(profile.complexity_max),
+            "reported complexity {} must be the measured value",
+            v.current
+        );
+    }
+
+    #[test]
+    fn test_coverage_is_read_from_an_lcov_report() {
+        let temp = tempfile::TempDir::new().unwrap();
+        assert_eq!(read_measured_line_coverage(temp.path()), None);
+
+        std::fs::write(
+            temp.path().join("lcov.info"),
+            "SF:src/a.rs\nLF:100\nLH:90\nend_of_record\nSF:src/b.rs\nLF:100\nLH:80\nend_of_record\n",
+        )
+        .unwrap();
+
+        let measured = read_measured_line_coverage(temp.path()).unwrap();
+        assert!(
+            (measured - 85.0).abs() < 1e-9,
+            "expected the lcov totals (170/200), got {measured}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_coverage_violation_uses_the_measured_value() {
+        let temp = tempfile::TempDir::new().unwrap();
+        std::fs::write(
+            temp.path().join("lcov.info"),
+            "SF:src/a.rs\nLF:100\nLH:42\nend_of_record\n",
+        )
+        .unwrap();
+
+        let profile = QualityProfile::default();
+        let violations = run_coverage_analysis(temp.path(), &profile).await.unwrap();
+
+        assert_eq!(violations.len(), 1);
+        assert!(
+            (violations[0].current - 42.0).abs() < 1e-9,
+            "coverage must be the measured 42.0, not the old simulated 65.0; got {}",
+            violations[0].current
+        );
+    }
 }
 
 #[cfg(test)]

--- a/src/cli/handlers/enforce_handlers/config.rs
+++ b/src/cli/handlers/enforce_handlers/config.rs
@@ -22,17 +22,58 @@ pub struct EnforcementConfig {
     pub ci_mode: bool,
 }
 
+/// The `--profile standard` thresholds: the loosest of the three.
+///
+/// `--help` advertises three profiles, but every arm of `load_quality_profile`
+/// used to return `QualityProfile::default()` ("For now, return default extreme
+/// profile"), so `--profile standard`, `--profile strict` and `--profile
+/// extreme` enforced byte-identical thresholds. A flag that changes nothing is
+/// worse than no flag: it reports a pass under "standard" that was actually
+/// measured against the extreme limits.
+fn standard_profile() -> QualityProfile {
+    QualityProfile {
+        coverage_min: 60.0,
+        complexity_max: 30,
+        complexity_target: 15,
+        tdg_max: 2.5,
+        satd_allowed: 20,
+        duplication_max_lines: 200,
+        big_o_max: "O(n^2)".to_string(),
+        provability_min: 0.5,
+    }
+}
+
+/// The `--profile strict` thresholds: between standard and extreme.
+fn strict_profile() -> QualityProfile {
+    QualityProfile {
+        coverage_min: 70.0,
+        complexity_max: 25,
+        complexity_target: 12,
+        tdg_max: 1.5,
+        satd_allowed: 5,
+        duplication_max_lines: 50,
+        big_o_max: "O(n log n)".to_string(),
+        provability_min: 0.7,
+    }
+}
+
 /// Load quality profile from name or config file
 #[provable_contracts_macros::contract("pmat-core.yaml", equation = "path_exists")]
 pub fn load_quality_profile(
     profile_name: &str,
     _config_path: Option<PathBuf>,
 ) -> Result<QualityProfile> {
-    // In real implementation, would load from .pmat-extreme.toml
-    // For now, return default extreme profile
+    // TODO(config): `.pmat-extreme.toml` overrides are not read yet; the named
+    // profiles below are the whole story, and an unknown name is an error
+    // rather than a silent fall-through to `extreme`.
     match profile_name {
+        "standard" => Ok(standard_profile()),
+        "strict" => Ok(strict_profile()),
+        // `extreme` is the RIGID profile `--help` describes, and is the default.
         "extreme" => Ok(QualityProfile::default()),
-        _ => Ok(QualityProfile::default()),
+        other => anyhow::bail!(
+            "Unknown quality profile: {other}. Valid profiles: standard, strict, extreme"
+        ),
     }
 }
 
@@ -59,5 +100,61 @@ pub fn clear_enforcement_cache(cache_dir: &Option<PathBuf>) {
     if let Some(cache_path) = cache_dir {
         eprintln!("🧹 Clearing cache at: {}", cache_path.display());
         // In real implementation, would clear cache
+    }
+}
+
+#[cfg(test)]
+mod profile_selection_tests {
+    //! Regression tests for `--profile` being a no-op: `load_quality_profile`
+    //! matched on the name and returned `QualityProfile::default()` in every
+    //! arm, so all three documented profiles enforced the same thresholds.
+    use super::load_quality_profile;
+
+    #[test]
+    fn test_named_profiles_have_distinct_thresholds() {
+        let standard = load_quality_profile("standard", None).unwrap();
+        let strict = load_quality_profile("strict", None).unwrap();
+        let extreme = load_quality_profile("extreme", None).unwrap();
+
+        // Ordered from loosest to strictest on every threshold the enforcement
+        // phases actually read.
+        assert!(
+            standard.complexity_max > strict.complexity_max
+                && strict.complexity_max > extreme.complexity_max,
+            "complexity_max must tighten: {} / {} / {}",
+            standard.complexity_max,
+            strict.complexity_max,
+            extreme.complexity_max
+        );
+        assert!(
+            standard.tdg_max > strict.tdg_max && strict.tdg_max > extreme.tdg_max,
+            "tdg_max must tighten"
+        );
+        assert!(
+            standard.coverage_min < strict.coverage_min
+                && strict.coverage_min < extreme.coverage_min,
+            "coverage_min must rise"
+        );
+        assert!(
+            standard.satd_allowed > strict.satd_allowed
+                && strict.satd_allowed > extreme.satd_allowed,
+            "satd_allowed must tighten"
+        );
+        assert!(
+            standard.duplication_max_lines > strict.duplication_max_lines
+                && strict.duplication_max_lines > extreme.duplication_max_lines,
+            "duplication_max_lines must tighten"
+        );
+    }
+
+    #[test]
+    fn test_unknown_profile_is_an_error_not_a_silent_extreme() {
+        let err = load_quality_profile("toyota", None)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("standard") && err.contains("strict") && err.contains("extreme"),
+            "the error must name the valid profiles, got {err}"
+        );
     }
 }

--- a/src/cli/handlers/enforce_handlers/states.rs
+++ b/src/cli/handlers/enforce_handlers/states.rs
@@ -45,22 +45,51 @@ pub async fn handle_analyzing_state(
     let satd_violations = run_satd_analysis(scope.walk_root(), profile).await?;
     let tdg_violations = run_tdg_analysis(scope.file_or_root(), profile).await?;
 
+    // Composite score, derived from the analyses that were just run.
+    //
+    // These four lines used to be
+    //   let complexity_score = 0.8;  // Would calculate from actual results
+    //   let satd_score = if profile.satd_allowed == 0 { 1.0 } else { 0.5 };
+    //   let tdg_score = 0.7;         // Would calculate from actual TDG
+    //   let coverage_score = 0.65;   // Would parse from coverage tool
+    // whose mean is 0.7875, so `pmat enforce extreme` printed
+    // `Score: 0.79/1.00` verbatim for an empty directory, a three-line crate
+    // and this repository alike. A score that cannot tell an empty directory
+    // from a 3252-file repo measures nothing.
+    //
+    // Each phase that ran contributes one dimension. Coverage is deliberately
+    // absent: nothing in this state machine measures it, and the 0.65 stand-in
+    // is exactly the kind of invented number this replaces.
+    //
+    // Caveat worth keeping in view: a phase whose analysis FAILED also returns
+    // no violations and so scores 1.0 here — `run_*_analysis` swallows its own
+    // errors (it warns "not measured" and returns an empty vec) rather than
+    // reporting them upwards. Telling "clean" from "not measured" needs those
+    // functions to return that distinction.
+    let phase_scores = [
+        phase_score(&complexity_violations),
+        phase_score(&satd_violations),
+        phase_score(&tdg_violations),
+    ];
+    let total_score = phase_scores.iter().sum::<f64>() / phase_scores.len() as f64;
+
     violations.extend(complexity_violations);
     violations.extend(satd_violations);
     violations.extend(tdg_violations);
-
-    // Calculate composite score
-    let complexity_score = 0.8; // Would calculate from actual results
-    let satd_score = if profile.satd_allowed == 0 { 1.0 } else { 0.5 };
-    let tdg_score = 0.7; // Would calculate from actual TDG
-    let coverage_score = 0.65; // Would parse from coverage tool
-    let total_score = (complexity_score + satd_score + tdg_score + coverage_score) / 4.0;
 
     // Determine next state
     let next_state = if violations.is_empty() {
         EnforcementState::Complete
     } else {
         EnforcementState::Violating
+    };
+
+    // `100` used to be reported here for every project, empty directories
+    // included; count the files that actually carry a violation instead.
+    let files_remaining = if single_file_mode {
+        usize::from(!violations.is_empty())
+    } else {
+        distinct_violation_files(&violations)
     };
 
     Ok(EnforcementResult {
@@ -76,10 +105,40 @@ pub async fn handle_analyzing_state(
         },
         progress: EnforcementProgress {
             files_completed: 0,
-            files_remaining: if single_file_mode { 1 } else { 100 },
+            files_remaining,
             estimated_iterations: ((1.0 - total_score) * 10.0) as u32,
         },
     })
+}
+
+/// Score one analysis phase in `[0.0, 1.0]`: 1.0 when the phase found nothing
+/// to report, otherwise how close its worst violation sits to the limit the
+/// profile allows (a function at twice the allowed complexity scores 0.5).
+fn phase_score(violations: &[QualityViolation]) -> f64 {
+    violations
+        .iter()
+        .map(|v| {
+            if v.current <= v.target {
+                1.0
+            } else if v.target > 0.0 {
+                (v.target / v.current).clamp(0.0, 1.0)
+            } else {
+                // A zero-tolerance dimension (e.g. satd_allowed = 0) that was
+                // nevertheless violated.
+                0.0
+            }
+        })
+        .fold(1.0_f64, f64::min)
+}
+
+/// Number of distinct files named by the violations, used for progress
+/// reporting. Locations are `path:line:name` or a bare path.
+fn distinct_violation_files(violations: &[QualityViolation]) -> usize {
+    violations
+        .iter()
+        .map(|v| v.location.split(':').next().unwrap_or(&v.location))
+        .collect::<std::collections::BTreeSet<_>>()
+        .len()
 }
 
 /// Handle violating state - extracted from `run_enforcement_step` (complexity: ≤10)
@@ -256,4 +315,121 @@ pub async fn handle_analyzing_enforcement_state(
 #[provable_contracts_macros::contract("pmat-core.yaml", equation = "check_compliance")]
 pub fn handle_complete_enforcement_state() -> Result<EnforcementResult> {
     handle_complete_state()
+}
+
+/// Regression tests for the composite enforcement score.
+///
+/// The score used to be the mean of four hardcoded constants, so
+/// `pmat enforce extreme -p <anything> --dry-run` printed `Score: 0.79/1.00`
+/// for an empty directory and for a 3252-file repository alike.
+#[cfg(test)]
+mod composite_score_regression_tests {
+    use super::*;
+
+    fn strict_profile() -> QualityProfile {
+        QualityProfile {
+            // Isolate the complexity dimension: every function in the fixture
+            // exceeds this, while TDG is given headroom it cannot breach.
+            complexity_max: 1,
+            complexity_target: 1,
+            tdg_max: 1000.0,
+            ..QualityProfile::default()
+        }
+    }
+
+    fn write_project(dir: &Path, source: &str) {
+        std::fs::write(
+            dir.join("Cargo.toml"),
+            "[package]\nname = \"fixture\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+        )
+        .expect("write Cargo.toml");
+        std::fs::create_dir_all(dir.join("src")).expect("create src");
+        std::fs::write(dir.join("src").join("lib.rs"), source).expect("write lib.rs");
+    }
+
+    #[tokio::test]
+    async fn score_distinguishes_an_empty_directory_from_a_violating_project() {
+        let empty = tempfile::tempdir().expect("tempdir");
+        let profile = strict_profile();
+
+        let empty_result = handle_analyzing_state(empty.path(), &profile, false, true, None)
+            .await
+            .expect("analyze empty directory");
+
+        assert!(
+            empty_result.violations.is_empty(),
+            "an empty directory violates nothing: {:?}",
+            empty_result.violations
+        );
+        assert!(
+            (empty_result.score - 1.0).abs() < f64::EPSILON,
+            "empty directory scored {} — the score is not derived from the analysis",
+            empty_result.score
+        );
+
+        let violating = tempfile::tempdir().expect("tempdir");
+        write_project(
+            violating.path(),
+            "pub fn branchy(a: i32, b: i32) -> i32 {\n\
+             \x20   if a > 0 {\n\
+             \x20       if b > 0 {\n\
+             \x20           return 1;\n\
+             \x20       }\n\
+             \x20       return 2;\n\
+             \x20   }\n\
+             \x20   match a {\n\
+             \x20       1 => 3,\n\
+             \x20       2 => 4,\n\
+             \x20       3 => 5,\n\
+             \x20       _ => 6,\n\
+             \x20   }\n\
+             }\n",
+        );
+
+        let violating_result =
+            handle_analyzing_state(violating.path(), &profile, false, true, None)
+                .await
+                .expect("analyze violating project");
+
+        assert!(
+            !violating_result.violations.is_empty(),
+            "fixture must breach complexity_max = 1"
+        );
+        assert!(
+            violating_result.score < empty_result.score,
+            "a violating project ({}) must not score the same as an empty directory ({})",
+            violating_result.score,
+            empty_result.score
+        );
+    }
+
+    #[test]
+    fn phase_score_is_clean_when_nothing_was_reported() {
+        assert!((phase_score(&[]) - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn phase_score_scales_with_the_worst_overshoot() {
+        let violations = vec![
+            QualityViolation {
+                violation_type: "complexity".to_string(),
+                severity: "medium".to_string(),
+                location: "a.rs:1:f".to_string(),
+                current: 20.0,
+                target: 10.0,
+                suggestion: String::new(),
+            },
+            QualityViolation {
+                violation_type: "complexity".to_string(),
+                severity: "high".to_string(),
+                location: "b.rs:1:g".to_string(),
+                current: 40.0,
+                target: 10.0,
+                suggestion: String::new(),
+            },
+        ];
+
+        assert!((phase_score(&violations) - 0.25).abs() < 1e-9);
+        assert_eq!(distinct_violation_files(&violations), 2);
+    }
 }

--- a/src/cli/handlers/enforce_handlers/tests.rs
+++ b/src/cli/handlers/enforce_handlers/tests.rs
@@ -179,9 +179,11 @@ mod tests {
     }
 
     #[test]
-    fn test_load_quality_profile_default_is_extreme() {
-        let profile = load_quality_profile("default", None).unwrap();
-        assert_eq!(profile.coverage_min, 80.0);
+    fn test_load_quality_profile_rejects_unknown_name() {
+        // "default" is not one of the three profiles clap accepts. It used to
+        // return the extreme profile, which is how every name — including the
+        // ones `--help` documents as looser — enforced the extreme thresholds.
+        assert!(load_quality_profile("default", None).is_err());
     }
 
     #[test]

--- a/src/cli/handlers/enhanced_reporting_handlers.rs
+++ b/src/cli/handlers/enhanced_reporting_handlers.rs
@@ -96,7 +96,7 @@ use tracing::info;
 ///     false, // not text format
 ///     false, // not markdown shortcut
 ///     false, // not csv shortcut
-///     true,  // include visualizations
+///     false, // include visualizations (rejected: not implemented for any format)
 ///     true,  // include executive summary
 ///     true,  // include recommendations
 ///     vec![AnalysisType::Complexity, AnalysisType::TechnicalDebt],
@@ -141,7 +141,7 @@ use tracing::info;
 /// ```bash
 /// # Comprehensive executive report
 /// pmat generate report /path/to/project --format markdown \
-///   --include-visualizations --include-executive-summary \
+///   --include-executive-summary \
 ///   --include-recommendations --output project-health.md
 ///
 /// # Quick CSV export for data analysis
@@ -155,7 +155,7 @@ use tracing::info;
 ///
 /// # Management dashboard (legacy HTML format)
 /// pmat generate report /path/to/project --format dashboard \
-///   --include-visualizations --include-executive-summary
+///   --include-executive-summary
 /// ```ignore
 ///
 /// # Integration Examples
@@ -183,7 +183,7 @@ pub async fn handle_generate_report(
     text: bool,
     markdown: bool,
     csv: bool,
-    _include_visualizations: bool,
+    include_visualizations: bool,
     _include_executive_summary: bool,
     _include_recommendations: bool,
     _analyses: Vec<AnalysisType>,
@@ -200,6 +200,7 @@ pub async fn handle_generate_report(
     let start_time = Instant::now();
 
     let actual_format = determine_output_format(output_format, text, markdown, csv);
+    reject_unimplemented_visualizations(include_visualizations)?;
     log_report_generation_start(&project_path, &actual_format);
 
     let service = DefectReportService::new();
@@ -262,6 +263,26 @@ fn convert_to_service_format(actual_format: ReportOutputFormat) -> Result<Report
             format!("{unsupported:?}").to_lowercase(),
         ),
     })
+}
+
+/// Refuse `--include-visualizations` rather than accepting it and doing nothing.
+///
+/// The flag was taken as `_include_visualizations` and dropped: `pmat report -f
+/// markdown` and `pmat report -f markdown --include-visualizations` produced
+/// byte-identical output, and the same held for json, csv and text. The three
+/// formats that could plausibly carry a chart (html, pdf, dashboard) are
+/// themselves rejected by `convert_to_service_format` (#672), so there is no
+/// format left for this flag to affect. Same rule as that rejection: a declared
+/// option must do what it says or be refused, never silently no-op.
+fn reject_unimplemented_visualizations(include_visualizations: bool) -> Result<()> {
+    if include_visualizations {
+        anyhow::bail!(
+            "--include-visualizations is not implemented for `pmat report`: it changed \
+             nothing in json, csv, markdown or text, and the formats that could embed \
+             charts (html, pdf, dashboard) are not implemented either. Re-run without it."
+        );
+    }
+    Ok(())
 }
 
 /// Format report using service (cognitive complexity ≤4)
@@ -430,6 +451,51 @@ mod tests {
         let err = result.expect_err("a nonexistent project path must be an error");
         assert!(
             err.to_string().contains("not found"),
+            "unexpected error: {err}"
+        );
+    }
+
+    /// `--include-visualizations` was taken as `_include_visualizations` and
+    /// dropped, so `-f markdown` and `-f markdown --include-visualizations`
+    /// produced byte-identical output. A flag that cannot do anything must say
+    /// so, like `--format html` already does.
+    #[test]
+    fn test_include_visualizations_is_rejected_not_silently_ignored() {
+        assert!(reject_unimplemented_visualizations(false).is_ok());
+
+        let err = reject_unimplemented_visualizations(true)
+            .expect_err("--include-visualizations affects no format and must be refused");
+        assert!(
+            err.to_string().contains("--include-visualizations"),
+            "the error must name the flag: {err}"
+        );
+    }
+
+    /// End-to-end on the handler: the flag must never reach a successful run.
+    #[tokio::test]
+    async fn test_generate_report_refuses_the_visualizations_flag() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join("lib.rs"), "fn main() {}").expect("write");
+
+        let result = handle_generate_report(
+            dir.path().to_path_buf(),
+            ReportOutputFormat::Markdown,
+            false,
+            false,
+            false,
+            true, // --include-visualizations
+            false,
+            false,
+            vec![],
+            50,
+            None,
+            false,
+        )
+        .await;
+
+        let err = result.expect_err("--include-visualizations must not succeed as a no-op");
+        assert!(
+            err.to_string().contains("not implemented"),
             "unexpected error: {err}"
         );
     }

--- a/src/cli/handlers/enhanced_reporting_handlers.rs
+++ b/src/cli/handlers/enhanced_reporting_handlers.rs
@@ -191,6 +191,12 @@ pub async fn handle_generate_report(
     output: Option<PathBuf>,
     perf: bool,
 ) -> Result<()> {
+    // A nonexistent --project-path used to produce a green 0-defect report with
+    // exit 0, shape-identical to a real report on an empty project: nothing in
+    // the pipeline can tell "no defects" from "no such directory". Fail like
+    // deps-audit and five-whys already do.
+    crate::cli::ensure_analysis_path_exists(&project_path)?;
+
     let start_time = Instant::now();
 
     let actual_format = determine_output_format(output_format, text, markdown, csv);
@@ -395,6 +401,36 @@ mod tests {
             before.len(),
             after.len(),
             "report must not drop an artifact into the tree it measures (before={before:?}, after={after:?})"
+        );
+    }
+
+    /// `pmat report -p /does/not/exist -f json` used to print a clean
+    /// 0-defect document and exit 0 — shape-identical to a real report on an
+    /// empty project, with nothing on stderr. A path that is not there is an
+    /// error, not a clean bill of health.
+    #[tokio::test]
+    async fn test_generate_report_rejects_a_nonexistent_project_path() {
+        let missing = PathBuf::from("/does/not/exist-9f3a-pmat");
+        let result = handle_generate_report(
+            missing,
+            ReportOutputFormat::Json,
+            false,
+            false,
+            false,
+            false,
+            false,
+            false,
+            vec![],
+            0,
+            None,
+            false,
+        )
+        .await;
+
+        let err = result.expect_err("a nonexistent project path must be an error");
+        assert!(
+            err.to_string().contains("not found"),
+            "unexpected error: {err}"
         );
     }
 

--- a/src/cli/handlers/health_handler.rs
+++ b/src/cli/handlers/health_handler.rs
@@ -137,7 +137,12 @@ pub async fn run_health_checks_internal(
 
     let summary = calculate_summary(&checks);
     let report = HealthReport {
-        healthy: summary.failed == 0,
+        // `failed == 0` also holds when every check SKIPPED, so a run that
+        // measured nothing at all reported "✨ Project is healthy!" and exited
+        // 0 — `pmat maintain health` in an empty directory (Build: "No
+        // Cargo.toml found", 1 skipped, 0 of everything else) passed. Health
+        // has to be observed: at least one check must have reached a verdict.
+        healthy: summary.total_checks > summary.skipped && summary.failed == 0,
         checks,
         summary,
     };

--- a/src/cli/handlers/health_handler_output.rs
+++ b/src/cli/handlers/health_handler_output.rs
@@ -114,6 +114,14 @@ fn print_health_table(report: &HealthReport) {
             colors::BOLD_GREEN,
             colors::RESET
         );
+    } else if report.summary.failed == 0 {
+        // Every check skipped. This used to print the healthy banner (see
+        // run_health_checks_internal); "we could not look" is not a pass.
+        eprintln!(
+            "\n⚠️  {}Project health was not measured — every check was skipped{}",
+            colors::YELLOW,
+            colors::RESET
+        );
     } else {
         eprintln!(
             "\n⚠️  {}Project has {} issue(s){}",

--- a/src/cli/handlers/health_handler_tests.rs
+++ b/src/cli/handlers/health_handler_tests.rs
@@ -536,4 +536,26 @@ mod r5_classifier_tests {
         assert_eq!(violations, 2);
         assert_eq!(max, 500);
     }
+
+    /// An all-skipped run measured nothing, but `healthy` was `failed == 0`,
+    /// so `pmat maintain health` in an empty directory printed
+    /// "✨ Project is healthy!" and exited 0 off a single skipped Build check.
+    #[tokio::test]
+    async fn an_all_skipped_run_is_not_reported_healthy() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        // quick => Build only, and with no Cargo.toml the Build check skips.
+        let config = HealthCheckConfig::new(true, false, false, false, false, false, false);
+
+        let report = run_health_checks_internal(&tmp.path().to_path_buf(), &config)
+            .await
+            .expect("health run");
+
+        assert_eq!(report.summary.total_checks, 1);
+        assert_eq!(report.summary.skipped, 1);
+        assert_eq!(report.summary.failed, 0);
+        assert!(
+            !report.healthy,
+            "a run in which every check was skipped measured nothing and must not pass"
+        );
+    }
 }

--- a/src/cli/handlers/hooks_command_handlers/hooks_command.rs
+++ b/src/cli/handlers/hooks_command_handlers/hooks_command.rs
@@ -103,12 +103,24 @@ impl HooksCommand {
         let hook_path = self.hooks_dir.join("pre-commit");
         let backup_path = self.hooks_dir.join("pre-commit.pmat-backup");
 
+        // `install` writes pre-commit AND pre-push, but uninstall only ever
+        // touched pre-commit: users who uninstalled were told "Pre-commit hook
+        // uninstalled successfully" (and `hooks status` then said "Installed:
+        // ✗ No") while the PMAT pre-push gate kept firing on every push, with
+        // no command that reported or removed it. Remove every hook install
+        // writes.
+        let pre_push_removed = self.remove_pre_push_hook()?;
+
         if !hook_path.exists() {
             return Ok(HookUninstallResult {
                 success: true,
-                hook_removed: false,
+                hook_removed: pre_push_removed,
                 backup_restored: false,
-                message: "No hook to uninstall".to_string(),
+                message: if pre_push_removed {
+                    "Pre-push hook uninstalled successfully (no pre-commit hook)".to_string()
+                } else {
+                    "No hook to uninstall".to_string()
+                },
             });
         }
 
@@ -116,7 +128,7 @@ impl HooksCommand {
         if !self.is_pmat_managed(&hook_path)? {
             return Ok(HookUninstallResult {
                 success: false,
-                hook_removed: false,
+                hook_removed: pre_push_removed,
                 backup_restored: false,
                 message: "Hook is not PMAT-managed".to_string(),
             });
@@ -135,8 +147,27 @@ impl HooksCommand {
             success: true,
             hook_removed: true,
             backup_restored,
-            message: "Pre-commit hook uninstalled successfully".to_string(),
+            message: if pre_push_removed {
+                "Pre-commit and pre-push hooks uninstalled successfully".to_string()
+            } else {
+                "Pre-commit hook uninstalled successfully".to_string()
+            },
         })
+    }
+
+    /// Remove the PMAT-managed pre-push hook, if that is what is there.
+    ///
+    /// Returns whether a hook was removed. A pre-push hook PMAT did not write
+    /// is left alone.
+    fn remove_pre_push_hook(&self) -> Result<bool> {
+        let hook_path = self.hooks_dir.join("pre-push");
+
+        if !hook_path.exists() || !self.is_pmat_managed(&hook_path)? {
+            return Ok(false);
+        }
+
+        fs::remove_file(&hook_path)?;
+        Ok(true)
     }
 
     /// Show hook installation status
@@ -382,5 +413,58 @@ echo "✅ Pre-push gate passed"
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod uninstall_tests {
+    //! `hooks install` writes two hooks; uninstall used to remove one.
+    use super::HooksCommand;
+
+    fn managed_hook(label: &str) -> String {
+        format!(
+            "#!/usr/bin/env bash\n# PMAT {label}\n# auto-managed by PMAT — DO NOT EDIT\nexit 0\n"
+        )
+    }
+
+    #[tokio::test]
+    async fn test_uninstall_removes_the_pre_push_hook_install_wrote() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let hooks_dir = dir.path().join("hooks");
+        std::fs::create_dir_all(&hooks_dir).expect("create hooks dir");
+        std::fs::write(hooks_dir.join("pre-commit"), managed_hook("pre-commit"))
+            .expect("write pre-commit");
+        std::fs::write(hooks_dir.join("pre-push"), managed_hook("pre-push"))
+            .expect("write pre-push");
+
+        let cmd = HooksCommand::new(hooks_dir.clone(), dir.path().join("pmat.toml"));
+        let result = cmd.uninstall(false).await.expect("uninstall");
+
+        assert!(result.success, "{}", result.message);
+        assert!(!hooks_dir.join("pre-commit").exists());
+        assert!(
+            !hooks_dir.join("pre-push").exists(),
+            "uninstall reported \"{}\" but the PMAT pre-push gate is still installed",
+            result.message
+        );
+    }
+
+    #[tokio::test]
+    async fn test_uninstall_leaves_a_foreign_pre_push_hook_alone() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let hooks_dir = dir.path().join("hooks");
+        std::fs::create_dir_all(&hooks_dir).expect("create hooks dir");
+        std::fs::write(hooks_dir.join("pre-commit"), managed_hook("pre-commit"))
+            .expect("write pre-commit");
+        std::fs::write(hooks_dir.join("pre-push"), "#!/bin/sh\n# mine\nexit 0\n")
+            .expect("write pre-push");
+
+        let cmd = HooksCommand::new(hooks_dir.clone(), dir.path().join("pmat.toml"));
+        cmd.uninstall(false).await.expect("uninstall");
+
+        assert!(
+            hooks_dir.join("pre-push").exists(),
+            "a pre-push hook PMAT did not write must survive uninstall"
+        );
     }
 }

--- a/src/cli/handlers/infra_score_handlers.rs
+++ b/src/cli/handlers/infra_score_handlers.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(coverage_nightly, coverage(off))]
 //! CLI handler for `pmat infra-score` command
 //!
-//! Calculates Infrastructure Score (0-100 + 10 bonus) for CI/CD,
+//! Calculates Infrastructure Score (0-100 + 12 bonus) for CI/CD,
 //! build reliability, quality pipeline, deployment, supply chain,
 //! and provable contracts.
 
@@ -123,11 +123,16 @@ fn write_infra_summary(out: &mut String, result: &InfraScore) {
             "  Bonus: \x1b[36m+{:.1}\x1b[0m (provable contracts)",
             bonus
         );
+        // Denominator is derived, not hardcoded: the bonus category is worth 12
+        // (PV-01..PV-05), so a hardcoded "/110.0" could print a total above its
+        // own maximum.
         let _ = writeln!(
             out,
-            "  Total with bonus: {}{:.1}\x1b[0m/110.0",
+            "  Total with bonus: {}{:.1}\x1b[0m/{:.1}",
             score_color,
-            result.categories.total_with_bonus()
+            result.categories.total_with_bonus(),
+            crate::services::infra_score::models::INFRA_SCORE_MAX_POINTS
+                + result.categories.provable_contracts.max_score
         );
     }
 }
@@ -487,6 +492,43 @@ mod format_text_tests {
         let r = make_score(95.0, InfraGrade::APlus, false);
         let out = format_text_output(&r, false, false);
         assert!(!out.contains("\x1b[1mRecommendations\x1b[0m"));
+    }
+
+    // ── Bonus denominator ──
+
+    #[test]
+    fn test_bonus_denominator_matches_bonus_category_max() {
+        use crate::services::infra_score::models::{
+            INFRA_SCORE_BONUS_MAX_POINTS, INFRA_SCORE_MAX_POINTS,
+        };
+        let mut r = make_score(99.0, InfraGrade::APlus, false);
+        // A perfect bonus run: the denominator printed must not be smaller than
+        // the bonus the same output claims to have awarded.
+        r.categories.provable_contracts.score = INFRA_SCORE_BONUS_MAX_POINTS;
+        let out = format_text_output(&r, false, false);
+        let expected = format!(
+            "/{:.1}",
+            INFRA_SCORE_MAX_POINTS + INFRA_SCORE_BONUS_MAX_POINTS
+        );
+        assert!(
+            out.contains(&expected),
+            "expected bonus denominator {expected} in:\n{out}"
+        );
+        assert!(!out.contains("/110.0"), "hardcoded /110.0 denominator");
+    }
+
+    #[test]
+    fn test_bonus_category_default_max_matches_scorer_max() {
+        use crate::services::infra_score::scorers::InfraScorer;
+        let scorer =
+            crate::services::infra_score::scorers::provable_contracts::ProvableContractsScorer::new(
+            );
+        let defaults = InfraCategoryScores::default();
+        assert_eq!(
+            defaults.provable_contracts.max_score,
+            scorer.max_score(),
+            "model default and scorer disagree on the bonus maximum"
+        );
     }
 
     // ── Header always present ──

--- a/src/cli/handlers/kaizen_handler/scanning_analysis.rs
+++ b/src/cli/handlers/kaizen_handler/scanning_analysis.rs
@@ -26,41 +26,74 @@ fn scan_comply(path: &Path) -> Result<Vec<KaizenFinding>> {
         Err(_) => return Ok(Vec::new()),
     };
 
+    Ok(comply_findings_from_json(&json))
+}
+
+/// Turn a `pmat comply check -f json` report into kaizen findings.
+///
+/// The report's checks carry `name`, `status` and `severity` — there is no `id`
+/// field, and the statuses are capitalised (`Pass`/`Warn`/`Fail`/`Skip`).
+/// Reading `id` and comparing the status against lowercase `"pass"`/`"skip"`
+/// meant every passing check came back as a HIGH finding called
+/// `comply::CB-???`: 154 of them on an empty directory, which kaizen (without
+/// `--dry-run`) would then commit and file as GitHub issues.
+fn comply_findings_from_json(json: &serde_json::Value) -> Vec<KaizenFinding> {
     let mut findings = Vec::new();
 
-    if let Some(checks) = json.get("checks").and_then(|c| c.as_array()) {
-        for check in checks {
-            let status = check.get("status").and_then(|s| s.as_str()).unwrap_or("");
-            if status == "pass" || status == "skip" {
-                continue;
-            }
+    let Some(checks) = json.get("checks").and_then(|c| c.as_array()) else {
+        return findings;
+    };
 
-            let id = check.get("id").and_then(|s| s.as_str()).unwrap_or("CB-???");
-            let msg = check
-                .get("message")
-                .and_then(|s| s.as_str())
-                .unwrap_or("Compliance violation");
-
-            findings.push(KaizenFinding {
-                source: FindingSource::Comply,
-                severity: FindingSeverity::High,
-                category: format!("comply::{id}"),
-                message: msg.to_string(),
-                file: None,
-                auto_fixable: false,
-                agent_fixable: true,
-                fix_applied: false,
-                agent_prompt: Some(format!(
-                    "Fix PMAT compliance violation {id}: {msg}. \
-                     Run `pmat comply check` after fixing to verify."
-                )),
-                suspiciousness_score: None,
-                crate_name: None,
-            });
+    for check in checks {
+        let status = check.get("status").and_then(|s| s.as_str()).unwrap_or("");
+        if status.eq_ignore_ascii_case("pass") || status.eq_ignore_ascii_case("skip") {
+            continue;
         }
+
+        // A check we cannot name is a check nobody can act on — skip it rather
+        // than emit a placeholder rule id.
+        let Some(id) = check.get("name").and_then(|s| s.as_str()) else {
+            continue;
+        };
+        let msg = check
+            .get("message")
+            .and_then(|s| s.as_str())
+            .unwrap_or("Compliance violation");
+
+        // Report the severity comply itself assigned instead of calling
+        // everything High.
+        let severity = match check
+            .get("severity")
+            .and_then(|s| s.as_str())
+            .unwrap_or("")
+            .to_ascii_lowercase()
+            .as_str()
+        {
+            "critical" => FindingSeverity::Critical,
+            "error" => FindingSeverity::High,
+            "info" => FindingSeverity::Low,
+            _ => FindingSeverity::Medium,
+        };
+
+        findings.push(KaizenFinding {
+            source: FindingSource::Comply,
+            severity,
+            category: format!("comply::{id}"),
+            message: msg.to_string(),
+            file: None,
+            auto_fixable: false,
+            agent_fixable: true,
+            fix_applied: false,
+            agent_prompt: Some(format!(
+                "Fix PMAT compliance violation {id}: {msg}. \
+                 Run `pmat comply check` after fixing to verify."
+            )),
+            suspiciousness_score: None,
+            crate_name: None,
+        });
     }
 
-    Ok(findings)
+    findings
 }
 
 /// Scan for known defect patterns (batuta bug-hunt: unwrap, panic, unsafe, etc.)
@@ -319,4 +352,73 @@ fn scan_custom_scores(path: &Path) -> Vec<KaizenFinding> {
     }
 
     findings
+}
+
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg(test)]
+mod comply_json_tests {
+    use super::*;
+
+    /// Shaped exactly like `pmat comply check -f json` output: capitalised
+    /// statuses, a `name` (never an `id`), and a per-check severity.
+    fn comply_report() -> serde_json::Value {
+        serde_json::json!({
+            "checks": [
+                {"name": "version-compliance", "status": "Pass",
+                 "message": "up to date", "severity": "Info"},
+                {"name": "hooks-installed", "status": "Skip",
+                 "message": "no .git dir", "severity": "Info"},
+                {"name": "CB-125-B binding scope", "status": "Warn",
+                 "message": "2 contracts unbound", "severity": "Warning"},
+                {"name": "quality-gate", "status": "Fail",
+                 "message": "complexity over budget", "severity": "Error"},
+            ]
+        })
+    }
+
+    #[test]
+    fn test_comply_findings_skip_passing_and_skipped_checks() {
+        // Regression: statuses are capitalised, so the lowercase comparison
+        // turned Pass/Skip checks into findings.
+        let findings = comply_findings_from_json(&comply_report());
+        assert_eq!(findings.len(), 2);
+        assert!(findings
+            .iter()
+            .all(|f| !f.category.contains("version-compliance")));
+        assert!(findings
+            .iter()
+            .all(|f| !f.category.contains("hooks-installed")));
+    }
+
+    #[test]
+    fn test_comply_findings_use_the_check_name_not_a_placeholder() {
+        let findings = comply_findings_from_json(&comply_report());
+        assert!(findings.iter().all(|f| !f.category.contains("CB-???")));
+        assert!(findings
+            .iter()
+            .any(|f| f.category == "comply::CB-125-B binding scope"));
+    }
+
+    #[test]
+    fn test_comply_findings_carry_the_reports_own_severity() {
+        let findings = comply_findings_from_json(&comply_report());
+        let warn = findings
+            .iter()
+            .find(|f| f.category.contains("binding scope"))
+            .expect("Warn check must produce a finding");
+        assert_eq!(warn.severity, FindingSeverity::Medium);
+        let fail = findings
+            .iter()
+            .find(|f| f.category.contains("quality-gate"))
+            .expect("Fail check must produce a finding");
+        assert_eq!(fail.severity, FindingSeverity::High);
+    }
+
+    #[test]
+    fn test_comply_findings_drop_unnamed_checks() {
+        let json = serde_json::json!({
+            "checks": [{"status": "Fail", "message": "boom", "severity": "Error"}]
+        });
+        assert!(comply_findings_from_json(&json).is_empty());
+    }
 }

--- a/src/cli/handlers/lint_hotspot_handlers/mod.rs
+++ b/src/cli/handlers/lint_hotspot_handlers/mod.rs
@@ -41,22 +41,22 @@ use std::path::{Path, PathBuf};
 /// Handle analyze lint-hotspot command
 ///
 /// This function analyzes a Rust project to find lint violations and can enforce
-/// quality standards. When the `--enforce` flag is set, the command will exit
-/// with a non-zero status code if ANY violations are found.
+/// quality standards. `--enforce` reports the breach and makes the exit code
+/// follow the quality gate; it does not lower the threshold.
 ///
 /// # Exit Status
 ///
-/// The command exits with status code 1 in the following cases:
-/// - Quality gate fails (defect density exceeds `max_density` threshold)
-/// - When `--enforce` flag is set AND there are any violations
+/// The command exits with status code 1 when the quality gate fails, i.e. when
+/// the measured defect density exceeds `max_density` (or a single file carries
+/// more than 50 violations) — with or without `--enforce`.
 ///
 /// # Example
 ///
 /// ```bash
-/// # Without enforce flag - only exits non-zero if quality gate fails
+/// # Exits non-zero only if the measured density exceeds --max-density
 /// pmat analyze lint-hotspot --max-density 5.0
 ///
-/// # With enforce flag - exits non-zero if ANY violations exist
+/// # Same gate, plus the enforcement metadata and refactor chain in the report
 /// pmat analyze lint-hotspot --enforce
 /// ```ignore
 #[allow(clippy::too_many_arguments)]
@@ -338,11 +338,31 @@ async fn output_results(
     write_output(&output_content, params).await
 }
 
-/// Execute enforcement if requested and conditions are met
+/// Report that the gate is blocking.
+///
+/// This used to announce "executing refactor chain..." and then admit
+/// "Enforcement execution not yet implemented": a released command advertising
+/// a step it never took. `--enforce` is a gate — it reports the breach and sets
+/// the exit code; the refactor chain it computes is printed in the report for a
+/// human or tool to apply.
 fn execute_enforcement_if_needed(final_result: &LintHotspotResult, params: &LintHotspotParams) {
+    if let Some(notice) = enforcement_notice(final_result, params) {
+        eprintln!("{notice}");
+    }
+}
+
+/// The message `--enforce` prints when the gate is blocking, or `None`.
+///
+/// Split out so the released text can be asserted: it must describe what the
+/// command actually did, never a step it does not perform.
+fn enforcement_notice(
+    final_result: &LintHotspotResult,
+    params: &LintHotspotParams,
+) -> Option<String> {
     if params.enforce && !params.dry_run && final_result.quality_gate.blocking {
-        eprintln!("🚨 Enforcement required - executing refactor chain...");
-        eprintln!("⚠️  Enforcement execution not yet implemented");
+        Some("🚨 Quality gate is blocking - see the refactor chain in the report above".to_string())
+    } else {
+        None
     }
 }
 
@@ -355,21 +375,26 @@ fn check_exit_conditions(final_result: &LintHotspotResult, params: &LintHotspotP
 }
 
 /// Check if we should exit with error code
-fn should_exit_with_error(final_result: &LintHotspotResult, params: &LintHotspotParams) -> bool {
+///
+/// The exit code follows the quality gate, which is what applies
+/// `--max-density`. `--enforce` used to OR in "any violation at all", so
+/// `--max-density 100` still exited 1 on a project measured at 0.72 while the
+/// same run's `enforcement-json` reported `quality_gate.passed = true`. The
+/// exit code and the machine-readable report now come from the same decision.
+fn should_exit_with_error(final_result: &LintHotspotResult, _params: &LintHotspotParams) -> bool {
     !final_result.quality_gate.passed
-        || (params.enforce && final_result.total_project_violations > 0)
 }
 
 /// Log enforcement failure message if conditions are met
 fn log_enforcement_failure_if_needed(final_result: &LintHotspotResult, params: &LintHotspotParams) {
-    if params.enforce
-        && final_result.total_project_violations > 0
-        && final_result.quality_gate.passed
-    {
-        eprintln!(
-            "\n❌ Enforcement failed: {} violations found",
-            final_result.total_project_violations
-        );
+    if params.enforce && !final_result.quality_gate.passed {
+        eprintln!("\n❌ Enforcement failed: quality gate breached");
+        for violation in &final_result.quality_gate.violations {
+            eprintln!(
+                "   {}: {:.2} exceeds {:.2}",
+                violation.rule, violation.actual, violation.threshold
+            );
+        }
     }
 }
 
@@ -518,11 +543,26 @@ mod pure_helper_tests {
     }
 
     #[test]
-    fn test_should_exit_enforce_with_violations() {
-        // PIN: enforce=true AND total_project_violations > 0 forces exit
-        // even when quality_gate passes.
+    fn test_should_exit_enforce_with_violations_under_threshold_passes() {
+        // Regression: `--enforce` used to OR in "any violation at all", so a
+        // project measured well under --max-density still exited 1 while the
+        // same run's enforcement-json said quality_gate.passed = true. This
+        // test previously PINNED that contradiction.
         let mut result = make_result(make_hotspot("src/foo.rs", 100, 5), vec![]);
         result.total_project_violations = 3;
+        let mut params = make_params(vec![], vec![]);
+        params.enforce = true;
+        assert!(
+            !should_exit_with_error(&result, &params),
+            "exit code must follow quality_gate.passed, which already applies --max-density"
+        );
+    }
+
+    #[test]
+    fn test_should_exit_enforce_follows_failing_gate() {
+        let mut result = make_result(make_hotspot("src/foo.rs", 100, 5), vec![]);
+        result.total_project_violations = 3;
+        result.quality_gate.passed = false;
         let mut params = make_params(vec![], vec![]);
         params.enforce = true;
         assert!(should_exit_with_error(&result, &params));
@@ -535,6 +575,29 @@ mod pure_helper_tests {
         let mut params = make_params(vec![], vec![]);
         params.enforce = true;
         assert!(!should_exit_with_error(&result, &params));
+    }
+
+    // ── enforcement_notice ──────────────────────────────────────────────────
+
+    #[test]
+    fn test_enforcement_notice_never_announces_an_unimplemented_step() {
+        // Regression: --enforce printed "executing refactor chain..." followed
+        // by "Enforcement execution not yet implemented" in the shipped binary.
+        let mut result = make_result(make_hotspot("src/foo.rs", 100, 5), vec![]);
+        result.quality_gate.blocking = true;
+        let mut params = make_params(vec![], vec![]);
+        params.enforce = true;
+        let notice = enforcement_notice(&result, &params).expect("blocking gate must be reported");
+        assert!(!notice.contains("not yet implemented"), "{notice}");
+        assert!(!notice.contains("executing refactor chain"), "{notice}");
+    }
+
+    #[test]
+    fn test_enforcement_notice_silent_when_gate_not_blocking() {
+        let result = make_result(make_hotspot("src/foo.rs", 100, 5), vec![]);
+        let mut params = make_params(vec![], vec![]);
+        params.enforce = true;
+        assert!(enforcement_notice(&result, &params).is_none());
     }
 
     // ── generate_enforcement_metadata_if_needed ─────────────────────────────

--- a/src/cli/handlers/lint_hotspot_handlers/output.rs
+++ b/src/cli/handlers/lint_hotspot_handlers/output.rs
@@ -409,27 +409,53 @@ fn format_json(result: &LintHotspotResult, enforcement: bool) -> Result<String> 
 ///
 /// Returns an error if the operation fails
 fn format_sarif(result: &LintHotspotResult) -> Result<String> {
-    let results = result
-        .quality_gate
-        .violations
+    // SARIF used to be built from `quality_gate.violations` — the handful of
+    // threshold breaches — so whenever the gate passed the document was
+    // `"results": []` even though `-f detailed` listed 13 located clippy findings
+    // for the same run, and CI consuming the SARIF saw a clean project. The located
+    // findings in `all_violations` are the results; the gate breaches ride along
+    // after them without a region, since they describe the project, not a line.
+    let mut results: Vec<serde_json::Value> = result
+        .all_violations
         .iter()
         .map(|v| {
             serde_json::json!({
-                "ruleId": v.rule,
-                "level": if v.severity == "blocking" { "error" } else { "warning" },
-                "message": {
-                    "text": format!("{} exceeded: {:.2} > {:.2}", v.rule, v.actual, v.threshold)
-                },
+                "ruleId": v.lint_name,
+                "level": if v.severity == "error" { "error" } else { "warning" },
+                "message": { "text": v.message },
                 "locations": [{
                     "physicalLocation": {
                         "artifactLocation": {
-                            "uri": result.hotspot.file.to_string_lossy()
+                            "uri": v.file.to_string_lossy()
+                        },
+                        "region": {
+                            "startLine": v.line.max(1),
+                            "startColumn": v.column.max(1),
+                            "endLine": v.end_line.max(v.line).max(1),
+                            "endColumn": v.end_column.max(1)
                         }
                     }
                 }]
             })
         })
-        .collect::<Vec<_>>();
+        .collect();
+
+    results.extend(result.quality_gate.violations.iter().map(|v| {
+        serde_json::json!({
+            "ruleId": v.rule,
+            "level": if v.severity == "blocking" { "error" } else { "warning" },
+            "message": {
+                "text": format!("{} exceeded: {:.2} > {:.2}", v.rule, v.actual, v.threshold)
+            },
+            "locations": [{
+                "physicalLocation": {
+                    "artifactLocation": {
+                        "uri": result.hotspot.file.to_string_lossy()
+                    }
+                }
+            }]
+        })
+    }));
 
     serde_json::to_string_pretty(&sarif_envelope(results)).context("Failed to serialize to SARIF")
 }
@@ -610,6 +636,52 @@ mod lint_hotspot_output_tests {
         assert!(
             obj.contains_key("version") || obj.contains_key("runs"),
             "SARIF envelope missing"
+        );
+    }
+
+    /// A located clippy finding must appear as a SARIF result even when the quality
+    /// gate passes — SARIF used to serialise only the gate's threshold breaches, so a
+    /// project with 13 located violations handed CI `"results": []`.
+    #[test]
+    fn test_sarif_emits_located_violations_when_gate_passes() {
+        let mut result = empty_result();
+        result.all_violations.push(ViolationDetail {
+            file: "src/lib.rs".into(),
+            line: 17,
+            column: 40,
+            end_line: 17,
+            end_column: 52,
+            lint_name: "clippy::clone_on_copy".to_string(),
+            message: "using `clone` on type `i32` which implements the `Copy` trait".to_string(),
+            severity: "warning".to_string(),
+            suggestion: None,
+            machine_applicable: true,
+        });
+        // Gate passes: no threshold breaches at all.
+        assert!(result.quality_gate.passed);
+
+        let out = format_output(
+            &result,
+            LintHotspotOutputFormat::Sarif,
+            false,
+            std::time::Duration::from_millis(10),
+            5,
+        )
+        .unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        let results = parsed["runs"][0]["results"].as_array().unwrap();
+        assert_eq!(
+            results.len(),
+            1,
+            "located violation missing from SARIF: {out}"
+        );
+        assert_eq!(results[0]["ruleId"], "clippy::clone_on_copy");
+        let region = &results[0]["locations"][0]["physicalLocation"]["region"];
+        assert_eq!(region["startLine"], 17);
+        assert_eq!(region["startColumn"], 40);
+        assert_eq!(
+            results[0]["locations"][0]["physicalLocation"]["artifactLocation"]["uri"],
+            "src/lib.rs"
         );
     }
 

--- a/src/cli/handlers/memory_display.rs
+++ b/src/cli/handlers/memory_display.rs
@@ -29,10 +29,37 @@ fn build_pool_stats_output(
     pool_stats_output
 }
 
+/// True when the in-process pool manager has recorded nothing at all.
+///
+/// `pmat memory` inspects `global_memory_manager()`, which is created fresh per
+/// process and is never exercised by the `memory` subcommand itself, so every
+/// counter is structurally zero on every invocation. Zeros from a manager that
+/// was never used are not a measurement of this machine's memory.
+fn nothing_was_recorded(stats: &crate::services::memory_manager::MemoryStats) -> bool {
+    stats.total_allocated == 0
+        && stats.peak_usage == 0
+        && stats
+            .pool_stats
+            .values()
+            .all(|p| p.allocation_count == 0 && p.reuse_count == 0)
+}
+
+/// The honest line to print instead of tuning advice derived from zeros.
+const NO_MEMORY_DATA_NOTE: &str =
+    "No allocations were recorded in this process: `pmat memory` reads the in-process pool \
+     manager, which starts empty, so these counters measure nothing.";
+
 /// Generate memory usage recommendations
 fn generate_memory_recommendations(
     stats: &crate::services::memory_manager::MemoryStats,
 ) -> Vec<String> {
+    // The zeros used to produce five "Pool X has low reuse efficiency (0.0%).
+    // Consider adjusting pool size." lines on every run — tuning advice
+    // synthesised from a pool that had never been asked for a buffer.
+    if nothing_was_recorded(stats) {
+        return vec![NO_MEMORY_DATA_NOTE.to_string()];
+    }
+
     let mut recommendations = Vec::new();
 
     add_pressure_recommendations(&mut recommendations, stats.allocation_pressure);
@@ -66,6 +93,11 @@ fn add_pool_efficiency_recommendations(
     >,
 ) {
     for (pool_type, pool_stats) in pool_stats {
+        // A pool that was never asked for a buffer has no reuse efficiency to
+        // be low: its 0.0% is the absence of a measurement, not a finding.
+        if pool_stats.allocation_count == 0 {
+            continue;
+        }
         if pool_stats.reuse_ratio < 0.3 {
             recommendations.push(format!(
                 "Pool {:?} has low reuse efficiency ({:.1}%). Consider adjusting pool size.",
@@ -209,4 +241,72 @@ fn calculate_pool_efficiency_rating(reuse_ratio: f64) -> &'static str {
 /// Format bytes in human-readable format (delegates to batuta-common)
 fn format_bytes(bytes: usize) -> String {
     batuta_common::fmt::format_bytes(bytes as u64)
+}
+
+#[cfg(test)]
+mod unrecorded_memory_tests {
+    //! Regression tests for `pmat memory stats`: the pool manager is fresh per
+    //! process and the subcommand never allocates through it, so every counter
+    //! was zero — and five "Pool X has low reuse efficiency (0.0%)" tuning
+    //! recommendations were synthesised from those zeros on every run.
+    use super::{generate_memory_recommendations, nothing_was_recorded};
+    use crate::services::memory_manager::{MemoryStats, PoolStats, PoolType};
+
+    fn stats_with(pool: PoolStats, total_allocated: usize) -> MemoryStats {
+        let mut pool_stats = rustc_hash::FxHashMap::default();
+        pool_stats.insert(PoolType::AstParsing, pool);
+        MemoryStats {
+            total_allocated,
+            pool_stats,
+            string_intern_size: 0,
+            peak_usage: total_allocated,
+            allocation_pressure: 0.0,
+        }
+    }
+
+    fn empty_pool() -> PoolStats {
+        PoolStats {
+            buffer_count: 0,
+            total_size: 0,
+            allocation_count: 0,
+            reuse_count: 0,
+            reuse_ratio: 0.0,
+        }
+    }
+
+    #[test]
+    fn test_untouched_pools_yield_a_not_measured_note_not_tuning_advice() {
+        let stats = stats_with(empty_pool(), 0);
+        assert!(nothing_was_recorded(&stats));
+
+        let recommendations = generate_memory_recommendations(&stats);
+        assert_eq!(recommendations.len(), 1);
+        assert!(
+            !recommendations[0].contains("low reuse efficiency"),
+            "a pool that was never used cannot have low reuse efficiency: {:?}",
+            recommendations[0]
+        );
+        assert!(recommendations[0].contains("measure nothing"));
+    }
+
+    #[test]
+    fn test_a_used_pool_with_poor_reuse_still_gets_advice() {
+        let used = PoolStats {
+            buffer_count: 4,
+            total_size: 4096,
+            allocation_count: 100,
+            reuse_count: 5,
+            reuse_ratio: 0.05,
+        };
+        let stats = stats_with(used, 4096);
+        assert!(!nothing_was_recorded(&stats));
+
+        let recommendations = generate_memory_recommendations(&stats);
+        assert!(
+            recommendations
+                .iter()
+                .any(|r| r.contains("low reuse efficiency")),
+            "measured poor reuse must still be reported: {recommendations:?}"
+        );
+    }
 }

--- a/src/cli/handlers/memory_operations.rs
+++ b/src/cli/handlers/memory_operations.rs
@@ -110,6 +110,13 @@ async fn handle_memory_pools(pool: &Option<String>, efficiency: bool) -> Result<
 
     print_pool_statistics_header();
 
+    // Five pools of all-zero counters used to be printed as if they were a
+    // reading of this machine; say plainly that nothing was recorded.
+    if nothing_was_recorded(&stats) {
+        println!("{}", crate::cli::colors::dim(NO_MEMORY_DATA_NOTE));
+        println!();
+    }
+
     for (pool_type, pool_stats) in &stats.pool_stats {
         let pool_name = format!("{pool_type:?}");
 
@@ -225,6 +232,20 @@ async fn handle_memory_pressure(threshold: f64, watch: &Option<u64>) -> Result<(
         }
     } else {
         let stats = manager.stats();
+
+        // "Current memory pressure: 0.0% / Threshold 80.0% / OK" was printed on
+        // every invocation: the pool manager is fresh per process and the
+        // `memory` subcommand allocates nothing through it, so the 0.0% is an
+        // unmeasured value and the OK is a pass on a check that never ran.
+        if nothing_was_recorded(&stats) {
+            println!(
+                "{}: {}",
+                c::label("Current memory pressure"),
+                c::dim("not measured")
+            );
+            println!("{}", c::dim(NO_MEMORY_DATA_NOTE));
+            return Ok(());
+        }
 
         println!(
             "{}: {}",

--- a/src/cli/handlers/new_tdg_handler.rs
+++ b/src/cli/handlers/new_tdg_handler.rs
@@ -122,8 +122,35 @@ async fn run_tdg_analysis(config: TdgAnalysisConfig, enforce_threshold: bool) ->
     // nothing: -n 5 / -n 10 / -n 100000 all emitted the same file list.
     let top_files = config.top_files.unwrap_or(10);
 
+    // `--threshold` is a documented result FILTER for `analyze tdg`, but its
+    // default (1.5) and its help text are phrased for the retired 0-5 debt
+    // gradient; scores are now 0-100 where higher is better, so there is no
+    // filter direction that both honours the flag and leaves the default
+    // invocation showing anything at all. It is enforced as a gate by
+    // `analyze build-tdg` and by nothing else — say so instead of accepting the
+    // value and silently discarding it, which is what `let _threshold = ...`
+    // used to do.
+    if !enforce_threshold {
+        if let Some(t) = threshold {
+            if (t - 1.5).abs() > f64::EPSILON {
+                eprintln!(
+                    "⚠️  --threshold {t} was not applied: `analyze tdg` reports every analysed \
+                     file (see -n/--top-files and --critical-only). --threshold gates \
+                     `analyze build-tdg` only."
+                );
+            }
+        }
+    }
+
     let (result, measured_score) = if config.path.is_dir() {
-        analyze_project_path(&analyzer, &config.path, &config.format, top_files).await?
+        analyze_project_path(
+            &analyzer,
+            &config.path,
+            &config.format,
+            top_files,
+            config.critical_only,
+        )
+        .await?
     } else {
         analyze_single_file(&analyzer, &config.path, &config.format).await?
     };
@@ -172,11 +199,21 @@ async fn analyze_project_path(
     path: &Path,
     format: &TdgOutputFormat,
     top_files: usize,
+    critical_only: bool,
 ) -> Result<(String, f32)> {
     let mut project_score = analyzer.analyze_project(path).await?;
     // Honour --top-files for every renderer; aggregates stay whole-project and
     // the truncation is disclosed (files_reported / files_truncated).
     project_score.limit_to_worst_files(top_files);
+    // `--critical-only` had no reader at all: on a tree whose worst file graded
+    // A it still listed all 9 files and called them critical. A "critical" file
+    // is an F-grade file — the same definition `f_grade_count` documents — so
+    // filter to those and let the count fall to zero when there are none.
+    // Applied after the --top-files cap so the reported/truncated bookkeeping
+    // reflects the list actually printed.
+    if critical_only {
+        retain_critical_files(&mut project_score);
+    }
     let average_score = project_score.average_score;
     // `root` is the analysed path, not the process CWD -- that distinction is
     // the #680-round-3 fix for grades depending on the caller's directory.
@@ -184,6 +221,20 @@ async fn analyze_project_path(
         format_project_result(&project_score, path, format)?,
         average_score,
     ))
+}
+
+/// Keep only the critical (F-grade) files in the reported list.
+///
+/// Whole-project aggregates (`total_files`, `average_score`, `grade_distribution`,
+/// `f_grade_count`) are deliberately left untouched, exactly as `--top-files`
+/// truncation leaves them, so the reported subset can never be mistaken for the
+/// analysed population.
+fn retain_critical_files(project_score: &mut crate::tdg::ProjectScore) {
+    project_score
+        .files
+        .retain(|file| file.grade == crate::tdg::Grade::F);
+    project_score.files_reported = project_score.files.len();
+    project_score.files_truncated = project_score.files_reported < project_score.total_files;
 }
 
 async fn analyze_single_file(
@@ -568,5 +619,56 @@ mod tests {
         // ...while the ungated `analyze tdg` path stays a report.
         assert!(handle_analyze_tdg(cfg(1000.0)).await.is_ok());
         Ok(())
+    }
+
+    // ── --critical-only actually filters ────────────────────────────────────
+
+    fn graded(path: &str, total: f32, grade: crate::tdg::Grade) -> crate::tdg::TdgScore {
+        crate::tdg::TdgScore {
+            total,
+            grade,
+            file_path: Some(PathBuf::from(path)),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn critical_only_keeps_nothing_when_no_file_is_critical() {
+        // The reported defect: `analyze tdg --critical-only` on a tree whose
+        // worst file graded A still listed all 9 files as critical.
+        let mut project = crate::tdg::ProjectScore::aggregate(vec![
+            graded("src/a.rs", 98.0, crate::tdg::Grade::APlus),
+            graded("src/b.rs", 91.0, crate::tdg::Grade::A),
+        ]);
+
+        retain_critical_files(&mut project);
+
+        assert!(
+            project.files.is_empty(),
+            "no F-grade file exists, so --critical-only must report none"
+        );
+        assert_eq!(project.files_reported, 0);
+        assert!(project.files_truncated, "the subset must be disclosed");
+        // Whole-project aggregates are never rewritten by a display filter.
+        assert_eq!(project.total_files, 2);
+    }
+
+    #[test]
+    fn critical_only_keeps_exactly_the_f_grade_files() {
+        let mut project = crate::tdg::ProjectScore::aggregate(vec![
+            graded("src/a.rs", 98.0, crate::tdg::Grade::APlus),
+            graded("src/bad.rs", 12.0, crate::tdg::Grade::F),
+            graded("src/b.rs", 91.0, crate::tdg::Grade::A),
+        ]);
+
+        retain_critical_files(&mut project);
+
+        assert_eq!(project.files.len(), 1);
+        assert_eq!(
+            project.files[0].file_path,
+            Some(PathBuf::from("src/bad.rs"))
+        );
+        assert_eq!(project.files_reported, 1);
+        assert_eq!(project.total_files, 3);
     }
 }

--- a/src/cli/handlers/new_tdg_handler.rs
+++ b/src/cli/handlers/new_tdg_handler.rs
@@ -142,6 +142,21 @@ async fn run_tdg_analysis(config: TdgAnalysisConfig, enforce_threshold: bool) ->
         }
     }
 
+    // `--include-components` adds sections to the human renderers; the machine
+    // ones serialise every component of every reported file unconditionally, so
+    // say that rather than let the flag look inert.
+    if config.include_components
+        && matches!(
+            config.format,
+            TdgOutputFormat::Json | TdgOutputFormat::Sarif
+        )
+    {
+        eprintln!(
+            "ℹ️  --include-components: -f json/sarif already carry every per-file component; \
+             the flag adds breakdown sections to -f table and -f markdown."
+        );
+    }
+
     let (result, measured_score) = if config.path.is_dir() {
         analyze_project_path(
             &analyzer,
@@ -149,6 +164,7 @@ async fn run_tdg_analysis(config: TdgAnalysisConfig, enforce_threshold: bool) ->
             &config.format,
             top_files,
             config.critical_only,
+            config.include_components,
         )
         .await?
     } else {
@@ -200,6 +216,7 @@ async fn analyze_project_path(
     format: &TdgOutputFormat,
     top_files: usize,
     critical_only: bool,
+    include_components: bool,
 ) -> Result<(String, f32)> {
     let mut project_score = analyzer.analyze_project(path).await?;
     // Honour --top-files for every renderer; aggregates stay whole-project and
@@ -218,7 +235,7 @@ async fn analyze_project_path(
     // `root` is the analysed path, not the process CWD -- that distinction is
     // the #680-round-3 fix for grades depending on the caller's directory.
     Ok((
-        format_project_result(&project_score, path, format)?,
+        format_project_result(&project_score, path, format, include_components)?,
         average_score,
     ))
 }
@@ -251,17 +268,171 @@ fn format_project_result(
     project_score: &crate::tdg::ProjectScore,
     root: &Path,
     format: &TdgOutputFormat,
+    include_components: bool,
 ) -> Result<String> {
     let result = match format {
-        TdgOutputFormat::Table => format_project(project_score),
+        TdgOutputFormat::Table => {
+            let mut out = format_project(project_score);
+            if include_components {
+                out.push_str(&components_text(project_score));
+            }
+            out
+        }
         TdgOutputFormat::Json => serde_json::to_string_pretty(project_score)?,
-        TdgOutputFormat::Markdown => format_project(project_score),
+        // `-f markdown` used to dispatch to `format_project`, i.e. the SAME
+        // box-drawing table `-f table` prints (`md5sum` of the two outputs
+        // matched byte for byte). Markdown now gets markdown.
+        TdgOutputFormat::Markdown => project_markdown(project_score, include_components),
         TdgOutputFormat::Sarif => {
             let sarif = create_sarif_output(project_score, root);
             serde_json::to_string_pretty(&sarif)?
         }
     };
     Ok(result)
+}
+
+/// Percentage of `total`, or 0.0 when nothing was analysed (never NaN).
+fn percent_of(count: usize, total: usize) -> f32 {
+    if total == 0 {
+        0.0
+    } else {
+        (count as f32 / total as f32) * 100.0
+    }
+}
+
+/// Render a whole-project TDG score as Markdown.
+///
+/// `-f markdown` shared `format_project` with `-f table`, so it emitted
+/// U+2500/U+2502 box drawing that no Markdown renderer turns into a table.
+fn project_markdown(project: &crate::tdg::ProjectScore, include_components: bool) -> String {
+    use std::fmt::Write;
+    let mut out = String::new();
+    let w = &mut out;
+
+    let _ = writeln!(w, "# Project TDG Score Report\n");
+    let _ = writeln!(
+        w,
+        "**Average Score:** {:.1}/100 ({})",
+        project.average_score, project.average_grade
+    );
+    let _ = writeln!(w, "**Total Files:** {}", project.total_files);
+    // A truncated list says so, exactly as the box-drawing renderer does.
+    if project.files_truncated {
+        let _ = writeln!(
+            w,
+            "**Files Listed:** {} of {} (--top-files)",
+            project.files_reported, project.total_files
+        );
+    }
+    if project.grade_capped {
+        let _ = writeln!(
+            w,
+            "**Grade Capped:** yes ({} F-grade file(s))",
+            project.f_grade_count
+        );
+    }
+
+    let _ = writeln!(w, "\n## Language Distribution\n");
+    let _ = writeln!(w, "| Language | Files | Share |");
+    let _ = writeln!(w, "|---|---:|---:|");
+    for (language, count) in &project.language_distribution {
+        let _ = writeln!(
+            w,
+            "| {} | {} | {:.1}% |",
+            language,
+            count,
+            percent_of(*count, project.total_files)
+        );
+    }
+
+    let _ = writeln!(w, "\n## Grade Distribution\n");
+    let _ = writeln!(w, "| Grade | Files | Share |");
+    let _ = writeln!(w, "|---|---:|---:|");
+    for (grade, count) in &project.grade_distribution {
+        let _ = writeln!(
+            w,
+            "| {} | {} | {:.1}% |",
+            grade,
+            count,
+            percent_of(*count, project.total_files)
+        );
+    }
+
+    let _ = writeln!(w, "\n## Files\n");
+    let _ = writeln!(w, "| File | Score | Grade |");
+    let _ = writeln!(w, "|---|---:|---|");
+    for file in &project.files {
+        let _ = writeln!(
+            w,
+            "| `{}` | {:.1} | {} |",
+            file_label(file),
+            file.total,
+            file.grade
+        );
+    }
+
+    if include_components {
+        let _ = writeln!(w, "\n## Component Breakdown\n");
+        let _ = writeln!(
+            w,
+            "| File | Structural | Semantic | Duplication | Coupling | Documentation | Consistency |"
+        );
+        let _ = writeln!(w, "|---|---:|---:|---:|---:|---:|---:|");
+        for file in &project.files {
+            let _ = writeln!(
+                w,
+                "| `{}` | {:.1} | {:.1} | {:.1} | {:.1} | {:.1} | {:.1} |",
+                file_label(file),
+                file.structural_complexity,
+                file.semantic_complexity,
+                file.duplication_ratio,
+                file.coupling_score,
+                file.doc_coverage,
+                file.consistency_score
+            );
+        }
+    }
+
+    out
+}
+
+/// The per-file component breakdown for the box-drawing (`-f table`) renderer.
+///
+/// `--include-components` had no reader at all on `analyze tdg`
+/// (`NewTdgConfig.include_components` was dead), so passing it produced
+/// byte-identical output while the top-level `pmat tdg` honoured the same flag.
+fn components_text(project: &crate::tdg::ProjectScore) -> String {
+    use std::fmt::Write;
+    let mut out = String::new();
+    let _ = writeln!(
+        out,
+        "\nComponent Breakdown (--include-components; points earned per metric):"
+    );
+    if project.files.is_empty() {
+        let _ = writeln!(out, "  (no files reported)");
+        return out;
+    }
+    for file in &project.files {
+        let _ = writeln!(
+            out,
+            "  {:<48} structural {:>5.1}  semantic {:>5.1}  duplication {:>5.1}  \
+             coupling {:>5.1}  documentation {:>5.1}  consistency {:>5.1}",
+            file_label(file),
+            file.structural_complexity,
+            file.semantic_complexity,
+            file.duplication_ratio,
+            file.coupling_score,
+            file.doc_coverage,
+            file.consistency_score
+        );
+    }
+    out
+}
+
+fn file_label(file: &crate::tdg::TdgScore) -> String {
+    file.file_path
+        .as_ref()
+        .map_or_else(|| "unknown".to_string(), |p| p.display().to_string())
 }
 
 fn format_file_result(score: &crate::tdg::TdgScore, format: &TdgOutputFormat) -> Result<String> {
@@ -670,5 +841,71 @@ mod tests {
         );
         assert_eq!(project.files_reported, 1);
         assert_eq!(project.total_files, 3);
+    }
+
+    // ── -f markdown is markdown, and --include-components is read ───────────
+
+    fn two_file_project() -> crate::tdg::ProjectScore {
+        let mut a = graded("src/a.rs", 98.0, crate::tdg::Grade::APlus);
+        a.structural_complexity = 24.0;
+        a.semantic_complexity = 19.5;
+        a.duplication_ratio = 20.0;
+        a.coupling_score = 14.5;
+        a.doc_coverage = 9.0;
+        a.consistency_score = 10.0;
+        crate::tdg::ProjectScore::aggregate(vec![a, graded("src/b.rs", 91.0, crate::tdg::Grade::A)])
+    }
+
+    /// The reported defect: `-f markdown` dispatched to `format_project`, the
+    /// box-drawing renderer, so `md5sum` of the `-f table` and `-f markdown`
+    /// outputs matched byte for byte.
+    #[test]
+    fn markdown_is_not_the_box_drawing_table() {
+        let project = two_file_project();
+        let root = Path::new("/tmp/x");
+
+        let table = format_project_result(&project, root, &TdgOutputFormat::Table, false).unwrap();
+        let markdown =
+            format_project_result(&project, root, &TdgOutputFormat::Markdown, false).unwrap();
+
+        assert_ne!(
+            table, markdown,
+            "-f markdown must not re-emit the -f table rendering"
+        );
+        assert!(
+            !markdown.contains('\u{2500}') && !markdown.contains('\u{2502}'),
+            "markdown must not contain box-drawing characters: {markdown}"
+        );
+        assert!(markdown.starts_with("# Project TDG Score Report"));
+        assert!(
+            markdown.contains("| File | Score | Grade |"),
+            "markdown must carry a real pipe table: {markdown}"
+        );
+        assert!(markdown.contains("`src/a.rs`"));
+    }
+
+    /// The reported defect: `NewTdgConfig.include_components` had no reader, so
+    /// `--include-components` produced byte-identical output.
+    #[test]
+    fn include_components_changes_the_human_renderings() {
+        let project = two_file_project();
+        let root = Path::new("/tmp/x");
+
+        for format in [TdgOutputFormat::Table, TdgOutputFormat::Markdown] {
+            let without = format_project_result(&project, root, &format, false).unwrap();
+            let with = format_project_result(&project, root, &format, true).unwrap();
+            assert_ne!(
+                without, with,
+                "--include-components must change -f {format:?} output"
+            );
+            assert!(
+                !without.contains("24.0"),
+                "components must be absent without the flag: {without}"
+            );
+            assert!(
+                with.contains("24.0") && with.contains("19.5"),
+                "components must be present with the flag: {with}"
+            );
+        }
     }
 }

--- a/src/cli/handlers/new_tdg_handler.rs
+++ b/src/cli/handlers/new_tdg_handler.rs
@@ -24,7 +24,7 @@ pub struct TdgAnalysisConfig {
 /// Auto-fails TDG analysis if critical defects are found
 async fn check_for_critical_defects(path: &Path) -> Result<()> {
     use crate::services::defect_detector::{RustDefectDetector, Severity};
-    use walkdir::WalkDir;
+    use ignore::WalkBuilder;
 
     let detector = RustDefectDetector::new();
     let mut critical_defects_found = false;
@@ -32,11 +32,21 @@ async fn check_for_critical_defects(path: &Path) -> Result<()> {
 
     eprintln!("🔍 Checking for critical defects...");
 
-    // Scan Rust files in the project
-    for entry in WalkDir::new(path)
-        .follow_links(true)
-        .into_iter()
-        .filter_map(|e| e.ok())
+    // Scan Rust files in the project. Gitignore-aware: the bare `WalkDir`
+    // this replaces also descended into gitignored trees — on this repo the
+    // ephemeral `.claude/worktrees/` checkouts, which are copies of the very
+    // files being scanned, so the same defect was counted once per copy.
+    // `follow_links` stays off for the same reason.
+    for entry in WalkBuilder::new(path)
+        .follow_links(false)
+        .hidden(false)
+        .parents(true)
+        .ignore(true)
+        .git_ignore(true)
+        .git_global(true)
+        .git_exclude(true)
+        .build()
+        .filter_map(std::result::Result::ok)
     {
         let file_path = entry.path();
 
@@ -91,15 +101,28 @@ async fn check_for_critical_defects(path: &Path) -> Result<()> {
 
 #[provable_contracts_macros::contract("pmat-core.yaml", equation = "check_compliance")]
 pub async fn handle_analyze_tdg(config: TdgAnalysisConfig) -> Result<()> {
+    run_tdg_analysis(config, false).await
+}
+
+/// `analyze build-tdg`: the same analysis, plus the documented quality gate.
+///
+/// Kept separate from `handle_analyze_tdg` because `analyze tdg`'s `--threshold`
+/// is documented as a result filter, not a gate; only `build-tdg` promises to
+/// "fail fast" on it.
+pub async fn handle_analyze_tdg_gated(config: TdgAnalysisConfig) -> Result<()> {
+    run_tdg_analysis(config, true).await
+}
+
+async fn run_tdg_analysis(config: TdgAnalysisConfig, enforce_threshold: bool) -> Result<()> {
     eprintln!("🔍 Starting TDG (Technical Debt Grading) analysis...");
 
     let analyzer = TdgAnalyzer::new()?;
-    let _threshold = config.threshold.unwrap_or(1.5);
+    let threshold = config.threshold;
     // `-n/--top-files` was read into a discarded binding, so it truncated
     // nothing: -n 5 / -n 10 / -n 100000 all emitted the same file list.
     let top_files = config.top_files.unwrap_or(10);
 
-    let result = if config.path.is_dir() {
+    let (result, measured_score) = if config.path.is_dir() {
         analyze_project_path(&analyzer, &config.path, &config.format, top_files).await?
     } else {
         analyze_single_file(&analyzer, &config.path, &config.format).await?
@@ -111,6 +134,36 @@ pub async fn handle_analyze_tdg(config: TdgAnalysisConfig) -> Result<()> {
     check_for_critical_defects(&config.path).await?;
 
     eprintln!("✅ TDG analysis complete");
+
+    if enforce_threshold {
+        enforce_tdg_threshold(measured_score, threshold.unwrap_or(2.0))?;
+    }
+    Ok(())
+}
+
+/// The Jidoka gate `analyze build-tdg --help` promises.
+///
+/// The threshold used to be bound to `_threshold` and never compared, so on a
+/// deliberately pathological crate every value from 0.0 to 1000 exited 0 — a
+/// gate that cannot fail is not a gate. It is now enforced against the ONE
+/// number the command just printed.
+///
+/// The flag's help text ("fail if exceeded", defaults 1.5/2.0) is phrased for
+/// the retired 0–5 debt-gradient scale. TDG now scores quality on 0–100 where
+/// HIGHER IS BETTER, so comparing "exceeds" against it would fail every healthy
+/// project; the threshold is enforced as a minimum score instead, and the
+/// comparison is printed in full so the gate is never silent about what it
+/// measured or which way round it read the number.
+fn enforce_tdg_threshold(measured: f32, threshold: f64) -> Result<()> {
+    eprintln!(
+        "🚦 TDG gate: measured {measured:.1}/100 against required minimum {threshold:.1} \
+         (--threshold, on the 0-100 scale where higher is better)"
+    );
+    if f64::from(measured) < threshold {
+        anyhow::bail!(
+            "TDG gate failed: score {measured:.1}/100 is below the required minimum of {threshold:.1} (--threshold)"
+        );
+    }
     Ok(())
 }
 
@@ -119,23 +172,28 @@ async fn analyze_project_path(
     path: &Path,
     format: &TdgOutputFormat,
     top_files: usize,
-) -> Result<String> {
+) -> Result<(String, f32)> {
     let mut project_score = analyzer.analyze_project(path).await?;
     // Honour --top-files for every renderer; aggregates stay whole-project and
     // the truncation is disclosed (files_reported / files_truncated).
     project_score.limit_to_worst_files(top_files);
+    let average_score = project_score.average_score;
     // `root` is the analysed path, not the process CWD -- that distinction is
     // the #680-round-3 fix for grades depending on the caller's directory.
-    format_project_result(&project_score, path, format)
+    Ok((
+        format_project_result(&project_score, path, format)?,
+        average_score,
+    ))
 }
 
 async fn analyze_single_file(
     analyzer: &TdgAnalyzer,
     path: &Path,
     format: &TdgOutputFormat,
-) -> Result<String> {
+) -> Result<(String, f32)> {
     let score = analyzer.analyze_file(path).await?;
-    format_file_result(&score, format)
+    let total = score.total;
+    Ok((format_file_result(&score, format)?, total))
 }
 
 fn format_project_result(
@@ -456,6 +514,59 @@ mod tests {
         let result = handle_analyze_tdg(config).await;
 
         assert!(result.is_ok());
+        Ok(())
+    }
+
+    // ── --threshold is a gate, not a discarded binding ──────────────────────
+
+    #[test]
+    fn threshold_gate_fails_when_the_measured_score_is_below_it() {
+        let err = enforce_tdg_threshold(85.0, 90.0)
+            .expect_err("85.0/100 must not satisfy a required minimum of 90.0");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("85.0"),
+            "gate must state what it measured: {msg}"
+        );
+        assert!(
+            msg.contains("90.0"),
+            "gate must state what it required: {msg}"
+        );
+    }
+
+    #[test]
+    fn threshold_gate_passes_when_the_measured_score_meets_it() {
+        assert!(enforce_tdg_threshold(85.0, 2.0).is_ok());
+        assert!(enforce_tdg_threshold(85.0, 85.0).is_ok());
+    }
+
+    #[tokio::test]
+    async fn build_tdg_gate_rejects_a_project_below_the_threshold() -> Result<()> {
+        // The whole point of the defect: every threshold used to exit 0.
+        let dir = tempfile::tempdir()?;
+        std::fs::write(
+            dir.path().join("lib.rs"),
+            "pub fn a() -> i32 { 1 }\npub fn b() -> i32 { 2 }\n",
+        )?;
+
+        let cfg = |threshold: f64| TdgAnalysisConfig {
+            path: dir.path().to_path_buf(),
+            threshold: Some(threshold),
+            top_files: Some(10),
+            format: TdgOutputFormat::Json,
+            include_components: false,
+            output: Some(dir.path().join("out.json")),
+            critical_only: false,
+            verbose: false,
+        };
+
+        // A minimum nothing can reach must fail the build...
+        assert!(
+            handle_analyze_tdg_gated(cfg(1000.0)).await.is_err(),
+            "--threshold 1000 must fail: no project scores above 100/100"
+        );
+        // ...while the ungated `analyze tdg` path stays a report.
+        assert!(handle_analyze_tdg(cfg(1000.0)).await.is_ok());
         Ok(())
     }
 }

--- a/src/cli/handlers/oracle_handlers_commands.rs
+++ b/src/cli/handlers/oracle_handlers_commands.rs
@@ -101,14 +101,165 @@ async fn handle_oracle_status(path: &Path, format: OracleOutputFormat) -> Result
 
     let targets = ConvergenceTargets::default();
 
-    // Collect current metrics (simplified for now - would integrate with actual PMAT commands)
-    let metrics = collect_project_metrics(path).await?;
-    let status = targets.check(&metrics);
+    if banner_enabled(format) {
+        println!("   Collecting signals (cargo build / clippy / test)...");
+        println!();
+    }
 
-    let formatted = format_status(&metrics, &targets, &status, format)?;
+    let collected = collect_project_metrics(path).await?;
+    let status = convergence_status_with_gaps(&targets, &collected);
+
+    let formatted = format_status(&collected.metrics, &targets, &status, format)?;
     println!("{}", formatted);
 
     Ok(())
+}
+
+/// Metrics plus the names of the targets nothing actually measured.
+///
+/// `ProjectMetrics` has no "unknown" state — every field is a plain number —
+/// so an unmeasured target reads as a perfect 0. Carrying the gaps alongside
+/// lets the status report say so instead.
+struct CollectedMetrics {
+    metrics: ProjectMetrics,
+    unmeasured: Vec<&'static str>,
+}
+
+/// Convergence cannot be declared over targets that were never measured, so
+/// every gap is folded into the "remaining" list and Converged is suppressed.
+fn convergence_status_with_gaps(
+    targets: &ConvergenceTargets,
+    collected: &CollectedMetrics,
+) -> crate::services::oracle::ConvergenceStatus {
+    use crate::services::oracle::ConvergenceStatus;
+
+    let checked = targets.check(&collected.metrics);
+    if collected.unmeasured.is_empty() {
+        return checked;
+    }
+
+    let mut remaining = match checked {
+        ConvergenceStatus::Converged => Vec::new(),
+        ConvergenceStatus::NotConverged { remaining } => remaining,
+    };
+    for gap in &collected.unmeasured {
+        remaining.push(format!("{}: not measured", gap));
+    }
+    ConvergenceStatus::NotConverged { remaining }
+}
+
+/// Collect project metrics from the same signal collectors `oracle single`
+/// runs.
+///
+/// This was `async fn collect_project_metrics(_path: &Path) -> ... {
+/// Ok(ProjectMetrics::default()) }` — the path was discarded, so an empty
+/// directory, a crate that does not compile, and this 4000-file repo all
+/// reported "Compiler Errors: 0 (target: ≤0)" in an identical 10 ms. A crate
+/// that fails to build must never be able to reach a green compiler-error
+/// line. Coverage, mutation score, TDG and the Rust project score still have
+/// no collector behind them here; they are reported as gaps rather than as 0.
+async fn collect_project_metrics(path: &Path) -> Result<CollectedMetrics> {
+    use crate::services::oracle::{AggregatedCollector, SignalSource};
+
+    let mut metrics = ProjectMetrics::default();
+    let mut unmeasured = vec![
+        "test coverage",
+        "mutation score",
+        "TDG score",
+        "rust project score",
+        "SATD markers",
+        "dead code",
+        "complexity",
+    ];
+
+    // Without a manifest cargo cannot run at all; reporting its silence as
+    // "0 errors" is exactly the fabrication this replaced.
+    if !path.join("Cargo.toml").exists() {
+        unmeasured.push("compiler errors");
+        unmeasured.push("clippy warnings");
+        unmeasured.push("test failures");
+        return Ok(CollectedMetrics {
+            metrics,
+            unmeasured,
+        });
+    }
+
+    let signals = AggregatedCollector::new().collect_all(path).await?;
+    metrics.compiler_errors = signals
+        .iter()
+        .filter(|s| s.source == SignalSource::Rustc)
+        .count();
+    metrics.clippy_warnings = signals
+        .iter()
+        .filter(|s| s.source == SignalSource::Clippy)
+        .count();
+    metrics.test_failures = signals
+        .iter()
+        .filter(|s| s.source == SignalSource::CargoTest)
+        .count();
+
+    Ok(CollectedMetrics {
+        metrics,
+        unmeasured,
+    })
+}
+
+#[cfg(test)]
+mod oracle_status_metric_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_collect_project_metrics_reports_gaps_without_a_manifest() {
+        // Regression: this returned ProjectMetrics::default() for every path,
+        // so a directory cargo cannot even be pointed at reported a clean
+        // "Compiler Errors: 0".
+        let dir = tempfile::TempDir::new().unwrap();
+        let collected = collect_project_metrics(dir.path()).await.unwrap();
+
+        assert!(
+            collected.unmeasured.contains(&"compiler errors"),
+            "cargo cannot run without a manifest: {:?}",
+            collected.unmeasured
+        );
+        assert!(collected.unmeasured.contains(&"test coverage"));
+    }
+
+    #[test]
+    fn test_unmeasured_targets_block_convergence() {
+        use crate::services::oracle::ConvergenceStatus;
+
+        // A metrics block that satisfies every default target on paper.
+        let targets = ConvergenceTargets::default();
+        let metrics = ProjectMetrics {
+            test_coverage: 1.0,
+            mutation_score: 1.0,
+            tdg_score: 100.0,
+            rust_project_score: 100,
+            ..Default::default()
+        };
+
+        let all_measured = CollectedMetrics {
+            metrics: metrics.clone(),
+            unmeasured: Vec::new(),
+        };
+        assert!(matches!(
+            convergence_status_with_gaps(&targets, &all_measured),
+            ConvergenceStatus::Converged
+        ));
+
+        let with_gap = CollectedMetrics {
+            metrics,
+            unmeasured: vec!["TDG score"],
+        };
+        match convergence_status_with_gaps(&targets, &with_gap) {
+            ConvergenceStatus::Converged => {
+                panic!("must not declare convergence over a target nothing measured")
+            }
+            ConvergenceStatus::NotConverged { remaining } => {
+                assert!(remaining.iter().any(|r| r.contains("TDG score: not measured")));
+            }
+        }
+    }
 }
 
 /// Handle `pmat oracle single` - Run single PDCA iteration
@@ -143,18 +294,3 @@ async fn handle_oracle_single(
     Ok(())
 }
 
-/// Collect project metrics (simplified implementation)
-///
-/// Returns default metrics. Full implementation would run:
-/// - `pmat tdg` for TDG score
-/// - `pmat analyze complexity` for cyclomatic/cognitive complexity
-/// - `pmat analyze satd` for SATD markers
-/// - `pmat analyze dead-code` for dead code items
-/// - `cargo test` for test coverage/failures
-///
-/// Oracle-driven convergence uses these metrics to guide iterative improvements.
-async fn collect_project_metrics(_path: &Path) -> Result<ProjectMetrics> {
-    // Stub implementation - full metrics collection would be expensive
-    // and is meant for CI/CD pipelines, not interactive use.
-    Ok(ProjectMetrics::default())
-}

--- a/src/cli/handlers/org_handlers.rs
+++ b/src/cli/handlers/org_handlers.rs
@@ -24,6 +24,30 @@ use std::path::{Path, PathBuf};
 #[cfg(feature = "org-intelligence")]
 use tracing::info;
 
+/// The error a build without `org-intelligence` must return for `pmat org …`.
+///
+/// The `#[cfg(not(feature = "org-intelligence"))]` dispatch arms used to bail
+/// with "Rebuild with --features org-intelligence" for every subcommand. For
+/// `org analyze` that hint is known-wrong at build time: the feature-enabled arm
+/// bails too, because the upstream organizational-analysis API was removed. The
+/// rebuild cost the user minutes and delivered a second, different error. Only
+/// `org localize` is genuinely gated by the feature.
+pub fn org_not_enabled_error(org_cmd: &crate::cli::commands::OrgCommands) -> anyhow::Result<()> {
+    match org_cmd {
+        crate::cli::commands::OrgCommands::Analyze { .. } => anyhow::bail!(
+            "`pmat org analyze` is no longer available: the upstream \
+organizational-intelligence-plugin (aprender-orchestrate) crate removed its \
+organizational-analysis API (GitHub mining, defect-pattern analysis, and report \
+generation) in 0.41 with no replacement. Rebuilding with --features \
+org-intelligence will not bring it back. Use `pmat org localize` for native \
+Tarantula fault localization, which is unaffected."
+        ),
+        _ => anyhow::bail!(
+            "Organizational intelligence feature is not enabled. Rebuild with --features org-intelligence"
+        ),
+    }
+}
+
 /// Handle organizational intelligence commands
 #[cfg(feature = "org-intelligence")]
 #[provable_contracts_macros::contract("pmat-core.yaml", equation = "check_compliance")]
@@ -262,5 +286,68 @@ mod tests {
         // This will fail (org doesn't exist) but proves the function signature is correct
         let result = handle_org_command(cmd).await;
         assert!(result.is_err(), "Expected error for nonexistent org");
+    }
+}
+
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg(test)]
+mod org_not_enabled_tests {
+    use crate::cli::commands::OrgCommands;
+    use std::path::PathBuf;
+
+    /// Without the feature, `org analyze` used to be told to rebuild with
+    /// `--features org-intelligence` — but the enabled arm bails too, because
+    /// the upstream analysis API was removed. The hint cost a multi-minute
+    /// rebuild and delivered a second, different error.
+    #[test]
+    fn analyze_is_reported_as_removed_not_as_a_missing_feature() {
+        let cmd = OrgCommands::Analyze {
+            org: "paiml".to_string(),
+            output: PathBuf::from("/tmp/org.json"),
+            max_concurrent: 1,
+            summarize: false,
+            strip_pii: false,
+            top_n: 10,
+            min_frequency: 3,
+        };
+
+        let err = super::org_not_enabled_error(&cmd).unwrap_err().to_string();
+        assert!(
+            err.contains("no longer available"),
+            "must state the command is gone, got: {err}"
+        );
+        assert!(
+            err.contains("org localize"),
+            "must point at the surviving command, got: {err}"
+        );
+        assert!(
+            !err.starts_with("Organizational intelligence feature is not enabled"),
+            "must not send the user off on a rebuild that cannot help: {err}"
+        );
+    }
+
+    /// `org localize` genuinely is feature-gated, so it keeps the rebuild hint.
+    #[test]
+    fn localize_keeps_the_rebuild_hint() {
+        let cmd = OrgCommands::Localize {
+            passed_coverage: PathBuf::from("p.info"),
+            failed_coverage: PathBuf::from("f.info"),
+            passed_count: 1,
+            failed_count: 1,
+            formula: "tarantula".to_string(),
+            top_n: 10,
+            output: None,
+            ensemble: false,
+            calibrated: false,
+            confidence_threshold: 0.5,
+            enrich_tdg: false,
+            repo: PathBuf::from("."),
+        };
+
+        let err = super::org_not_enabled_error(&cmd).unwrap_err().to_string();
+        assert!(
+            err.contains("--features org-intelligence"),
+            "localize really is gated by the feature, got: {err}"
+        );
     }
 }

--- a/src/cli/handlers/perfection_score_handlers.rs
+++ b/src/cli/handlers/perfection_score_handlers.rs
@@ -18,6 +18,15 @@ pub async fn handle_perfection_score(
     output: Option<&Path>,
     fast: bool,
 ) -> anyhow::Result<()> {
+    // The `path_exists` contract annotation above was decorative: nothing ever
+    // checked the path, so `perfection-score -p /does/not/exist` ran every
+    // category against an absent tree, each fell back to its zero-files
+    // default, and the run printed 95.2/200 with Technical Debt Grade 40.0/40.0
+    // (A+) and exit 0 — outscoring a real crate. Every peer scoring command
+    // (repo-score, rust-project-score, demo-score, brick-score, popper-score)
+    // exits 1 here; this one now does too.
+    crate::cli::ensure_analysis_path_exists(path)?;
+
     let calculator = PerfectionScoreCalculator::new().fast_mode(fast);
     let mut result = calculator.calculate(path).await?;
 
@@ -217,6 +226,28 @@ mod tests {
 
         assert!(md.contains("# PMAT Perfection Score Report"));
         assert!(md.contains("| Category |"));
+    }
+
+    /// A nonexistent tree used to score 95.2/200 with a perfect TDG 40/40 and
+    /// exit 0, because nothing validated the path before scoring.
+    #[tokio::test]
+    async fn test_perfection_score_rejects_missing_path() {
+        let missing = Path::new("/nonexistent/pmat/perfection/score/path");
+        let err = handle_perfection_score(
+            missing,
+            false,
+            None,
+            PerfectionScoreOutputFormat::Json,
+            None,
+            true,
+        )
+        .await
+        .expect_err("a path that does not exist must not produce a score");
+
+        assert!(
+            err.to_string().contains("Path not found"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/src/cli/handlers/predict_quality_handlers.rs
+++ b/src/cli/handlers/predict_quality_handlers.rs
@@ -84,38 +84,42 @@ pub async fn handle_predict_quality(
         }
     }
 
-    if predictions.is_empty() {
-        println!(
-            "\n{}",
-            c::pass("No metrics to predict (all metrics safe or insufficient data)")
-        );
-        return Ok(());
-    }
-
-    // Output results
-    match format {
-        OutputFormat::Json => {
-            println!("{}", serde_json::to_string_pretty(&predictions)?);
-        }
-        OutputFormat::Yaml => {
-            println!("{}", serde_yaml_ng::to_string(&predictions)?);
-        }
-        _ => {
-            print_predictions_table(&predictions);
-        }
-    }
+    println!("{}", render_predictions(&predictions, format)?);
 
     Ok(())
 }
 
-/// Print predictions in table format
-fn print_predictions_table(predictions: &[PredictionResult]) {
-    println!("\n{}\n", c::header("Quality Metrics Predictions"));
+/// Render predictions in the DECLARED format.
+///
+/// The empty case used to `println!` a prose line and return before this match
+/// ever ran, so on any fresh checkout — where no metric has the 7 observations a
+/// prediction needs — `predict-quality --all --format json` wrote
+/// `✓ No metrics to predict …` to stdout and every `| jq` consumer failed. A
+/// declared machine format has to produce that format on every path, and the
+/// honest empty answer in JSON is `[]`.
+fn render_predictions(predictions: &[PredictionResult], format: OutputFormat) -> Result<String> {
+    Ok(match format {
+        OutputFormat::Json => serde_json::to_string_pretty(predictions)?,
+        OutputFormat::Yaml => serde_yaml_ng::to_string(predictions)?,
+        _ if predictions.is_empty() => format!(
+            "\n{}",
+            c::pass("No metrics to predict (all metrics safe or insufficient data)")
+        ),
+        _ => format_predictions_table(predictions),
+    })
+}
+
+/// Render predictions in table format
+fn format_predictions_table(predictions: &[PredictionResult]) -> String {
+    use std::fmt::Write;
+    let mut out = String::new();
+
+    let _ = writeln!(out, "\n{}\n", c::header("Quality Metrics Predictions"));
 
     for pred in predictions {
-        println!("{}", c::subheader(&pred.metric));
-        println!("  {}: {:.1}ms", c::dim("Current"), pred.current_value);
-        println!("  {}: {:.1}ms", c::dim("Threshold"), pred.threshold);
+        let _ = writeln!(out, "{}", c::subheader(&pred.metric));
+        let _ = writeln!(out, "  {}: {:.1}ms", c::dim("Current"), pred.current_value);
+        let _ = writeln!(out, "  {}: {:.1}ms", c::dim("Threshold"), pred.threshold);
 
         if let Some(days) = pred.breach_in_days {
             if let Some(value) = pred.predicted_value {
@@ -127,14 +131,16 @@ fn print_predictions_table(predictions: &[PredictionResult]) {
                     format!("{}INFO{}", c::BOLD_BLUE, c::RESET)
                 };
 
-                println!(
+                let _ = writeln!(
+                    out,
                     "  {}: {} in {} days (predicted: {:.1}ms)",
                     c::dim("Breach"),
                     urgency,
                     c::number(&days.to_string()),
                     value
                 );
-                println!(
+                let _ = writeln!(
+                    out,
                     "  {}: {} (R²={:.3})",
                     c::dim("Confidence"),
                     c::pct(pred.confidence * 100.0, 80.0, 50.0),
@@ -142,8 +148,14 @@ fn print_predictions_table(predictions: &[PredictionResult]) {
                 );
             }
         } else {
-            println!("  {}: {}", c::dim("Breach"), c::pass("No breach predicted"));
-            println!(
+            let _ = writeln!(
+                out,
+                "  {}: {}",
+                c::dim("Breach"),
+                c::pass("No breach predicted")
+            );
+            let _ = writeln!(
+                out,
                 "  {}: {} (R²={:.3})",
                 c::dim("Confidence"),
                 c::pct(pred.confidence * 100.0, 80.0, 50.0),
@@ -153,20 +165,40 @@ fn print_predictions_table(predictions: &[PredictionResult]) {
 
         // Print recommendations
         if !pred.recommendations.is_empty() {
-            println!("  {}:", c::dim("Recommendations"));
+            let _ = writeln!(out, "  {}:", c::dim("Recommendations"));
             for rec in &pred.recommendations {
-                println!("    {} {}", c::dim("•"), rec);
+                let _ = writeln!(out, "    {} {}", c::dim("•"), rec);
             }
         }
 
-        println!();
+        let _ = writeln!(out);
     }
+
+    out
 }
 
 #[cfg_attr(coverage_nightly, coverage(off))]
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A fresh checkout has no metric with the 7 observations a prediction
+    /// needs, so this is the ordinary case, not an edge case: `--format json`
+    /// printed `✓ No metrics to predict …` on stdout and broke every `| jq`.
+    #[test]
+    fn empty_predictions_still_produce_the_declared_format() {
+        let json = render_predictions(&[], OutputFormat::Json).expect("json");
+        let parsed: serde_json::Value = serde_json::from_str(&json).expect("valid json");
+        assert_eq!(parsed, serde_json::json!([]));
+
+        let yaml = render_predictions(&[], OutputFormat::Yaml).expect("yaml");
+        let parsed: serde_yaml_ng::Value = serde_yaml_ng::from_str(&yaml).expect("valid yaml");
+        assert_eq!(parsed, serde_yaml_ng::Value::Sequence(vec![]));
+
+        // The human formats keep the prose.
+        let table = render_predictions(&[], OutputFormat::Table).expect("table");
+        assert!(table.contains("No metrics to predict"), "{table:?}");
+    }
 
     #[tokio::test]
     #[ignore] // Flaky - requires specific environment
@@ -181,7 +213,7 @@ mod tests {
 
 #[cfg(test)]
 mod predict_quality_print_tests {
-    //! Covers print_predictions_table in predict_quality_handlers.rs
+    //! Covers format_predictions_table in predict_quality_handlers.rs
     //! (46 uncov on broad, 0% cov). Drives all four urgency arms,
     //! the no-breach arm, and the recommendations arm.
     use super::*;
@@ -204,39 +236,39 @@ mod predict_quality_print_tests {
     fn test_print_predictions_table_no_breach_arm() {
         // breach_in_days=None → "No breach predicted" arm fires.
         let p = pred("lint_p99", None, vec![]);
-        print_predictions_table(&[p]);
+        format_predictions_table(&[p]);
     }
 
     #[test]
     fn test_print_predictions_table_urgent_arm() {
         // days <= 7 → URGENT.
         let p = pred("test_p99", Some(3), vec![]);
-        print_predictions_table(&[p]);
+        format_predictions_table(&[p]);
     }
 
     #[test]
     fn test_print_predictions_table_warning_arm() {
         // 7 < days <= 14 → WARNING.
         let p = pred("test_p99", Some(10), vec![]);
-        print_predictions_table(&[p]);
+        format_predictions_table(&[p]);
     }
 
     #[test]
     fn test_print_predictions_table_info_arm() {
         // days > 14 → INFO.
         let p = pred("test_p99", Some(30), vec![]);
-        print_predictions_table(&[p]);
+        format_predictions_table(&[p]);
     }
 
     #[test]
     fn test_print_predictions_table_with_recommendations() {
         let p = pred("complexity", Some(5), vec!["Refactor X", "Extract Y"]);
-        print_predictions_table(&[p]);
+        format_predictions_table(&[p]);
     }
 
     #[test]
     fn test_print_predictions_table_empty_input_no_panic() {
-        print_predictions_table(&[]);
+        format_predictions_table(&[]);
     }
 
     #[test]
@@ -246,6 +278,6 @@ mod predict_quality_print_tests {
             pred("b", Some(3), vec!["fix it"]),
             pred("c", Some(20), vec![]),
         ];
-        print_predictions_table(&preds);
+        format_predictions_table(&preds);
     }
 }

--- a/src/cli/handlers/prompt_handlers_core.rs
+++ b/src/cli/handlers/prompt_handlers_core.rs
@@ -40,13 +40,38 @@ fn list_prompts() {
 
     println!();
     println!("Usage:");
-    println!("  pmat prompt <name>                       Show prompt in YAML format");
-    println!("  pmat prompt <name> --format json         Show prompt in JSON format");
-    println!("  pmat prompt <name> --format text         Show just the prompt text");
-    println!("  pmat prompt <name> --show-variables      Show available variables");
-    println!("  pmat prompt <name> --set VAR=value       Override prompt variables");
+    for (invocation, description) in LIST_PROMPTS_USAGE {
+        println!("  {invocation:<41} {description}");
+    }
     println!();
 }
+
+/// The invocations advertised by the `--list` footer.
+///
+/// These used to read `pmat prompt <name> …`. `prompt` takes a subcommand, so
+/// every one of them was a command clap rejects with "unrecognized subcommand"
+/// and exit 2 — the footer of a working `pmat prompt show --list` told the
+/// reader to run five things that cannot run. The working form is
+/// `pmat prompt show <name>`.
+const LIST_PROMPTS_USAGE: &[(&str, &str)] = &[
+    ("pmat prompt show <name>", "Show prompt in YAML format"),
+    (
+        "pmat prompt show <name> --format json",
+        "Show prompt in JSON format",
+    ),
+    (
+        "pmat prompt show <name> --format text",
+        "Show just the prompt text",
+    ),
+    (
+        "pmat prompt show <name> --show-variables",
+        "Show available variables",
+    ),
+    (
+        "pmat prompt show <name> --set VAR=value",
+        "Override prompt variables",
+    ),
+];
 
 /// Substitute `${VAR}` placeholders and put object keys in a stable order.
 ///
@@ -277,8 +302,43 @@ mod variable_substitution_tests {
     //! `show_prompt` dropped the variable map, so `--title MYBOOK` emitted ten
     //! literal `${BOOK_TITLE}`s. The HashMap-backed model also gave a different
     //! key order — and so different bytes — on every run.
-    use super::{render_prompt_value, show_prompt, PromptOutputFormat, Value, WorkflowPrompt, PROMPTS};
+    use super::{
+        render_prompt_value, show_prompt, PromptOutputFormat, Value, WorkflowPrompt,
+        LIST_PROMPTS_USAGE, PROMPTS,
+    };
     use std::collections::HashMap;
+
+    /// Every invocation the `--list` footer advertises must be one clap accepts.
+    /// The footer used to print `pmat prompt <name>`, which exits 2 with
+    /// "unrecognized subcommand" — advice that cannot be followed, printed by
+    /// the command that is meant to teach the interface.
+    #[test]
+    fn test_list_usage_lines_are_invocations_clap_accepts() {
+        // 8MB stack: the `Cli` enum overflows the default test stack, the same
+        // reason the other clap parsing tests spawn their own thread.
+        std::thread::Builder::new()
+            .stack_size(8 * 1024 * 1024)
+            .spawn(|| {
+                use clap::Parser;
+
+                for (invocation, _) in LIST_PROMPTS_USAGE {
+                    // Substitute the placeholders for a concrete prompt and
+                    // assignment so the line can go to the parser verbatim.
+                    let concrete = invocation
+                        .replace("<name>", "book-documentation")
+                        .replace("VAR=value", "TITLE=x");
+                    let argv: Vec<&str> = concrete.split_whitespace().collect();
+
+                    assert!(
+                        crate::cli::Cli::try_parse_from(&argv).is_ok(),
+                        "advertised usage `{invocation}` is not a runnable command"
+                    );
+                }
+            })
+            .expect("spawn")
+            .join()
+            .expect("advertised usage lines must all parse");
+    }
 
     #[test]
     fn test_show_prompt_substitutes_on_the_yaml_path() {

--- a/src/cli/handlers/prompt_handlers_core.rs
+++ b/src/cli/handlers/prompt_handlers_core.rs
@@ -48,6 +48,46 @@ fn list_prompts() {
     println!();
 }
 
+/// Substitute `${VAR}` placeholders and put object keys in a stable order.
+///
+/// Substituting on the serialised *value* rather than on the emitted text keeps
+/// YAML/JSON escaping correct, and covers the placeholders that live outside
+/// the main `prompt` field (quality gates, validation tools, …).
+///
+/// The same walk rebuilds every object with sorted keys: the prompt model holds
+/// `HashMap` fields, so four identical `pmat prompt book --title MYBOOK`
+/// invocations produced four different md5s.
+fn render_prompt_value(value: &Value, variables: &HashMap<String, String>) -> Value {
+    match value {
+        Value::String(s) => {
+            let mut rendered = s.clone();
+            for (key, replacement) in variables {
+                rendered = rendered.replace(&format!("${{{key}}}"), replacement);
+            }
+            Value::String(rendered)
+        }
+        Value::Array(items) => Value::Array(
+            items
+                .iter()
+                .map(|item| render_prompt_value(item, variables))
+                .collect(),
+        ),
+        Value::Object(map) => {
+            let mut keys: Vec<&String> = map.keys().collect();
+            keys.sort();
+            let mut ordered = serde_json::Map::with_capacity(map.len());
+            for key in keys {
+                ordered.insert(
+                    key.clone(),
+                    render_prompt_value(&map[key.as_str()], variables),
+                );
+            }
+            Value::Object(ordered)
+        }
+        other => other.clone(),
+    }
+}
+
 /// Show a specific prompt
 fn show_prompt(
     name: &str,
@@ -93,10 +133,22 @@ fn show_prompt(
         variables.insert(key, value_str);
     }
 
-    // Render output in requested format
+    // Render output in requested format.
+    //
+    // Only the Text arm used to receive `variables`; Yaml and Json called
+    // to_yaml()/to_json() and dropped the map on the floor. Since
+    // `prompt book` and `prompt comply` hardcode Yaml, no flag could ever
+    // substitute anything: `--title MYBOOK` left ten literal `${BOOK_TITLE}`s
+    // in the emitted prompt.
     let output_str = match format {
-        PromptOutputFormat::Yaml => prompt.to_yaml()?,
-        PromptOutputFormat::Json => prompt.to_json()?,
+        PromptOutputFormat::Yaml => {
+            let rendered = render_prompt_value(&serde_json::to_value(&prompt)?, &variables);
+            serde_yaml_ng::to_string(&rendered)?
+        }
+        PromptOutputFormat::Json => {
+            let rendered = render_prompt_value(&serde_json::to_value(&prompt)?, &variables);
+            serde_json::to_string_pretty(&rendered)?
+        }
         PromptOutputFormat::Text => prompt.to_text(&variables),
     };
 
@@ -214,5 +266,100 @@ pub async fn handle_prompt_command(prompt_cmd: PromptCommands) -> Result<()> {
             )
             .await
         }
+    }
+}
+
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg(test)]
+mod variable_substitution_tests {
+    //! Regression tests for `pmat prompt book` / `pmat prompt comply`: both
+    //! hardcode the Yaml output format, and the Yaml and Json arms of
+    //! `show_prompt` dropped the variable map, so `--title MYBOOK` emitted ten
+    //! literal `${BOOK_TITLE}`s. The HashMap-backed model also gave a different
+    //! key order — and so different bytes — on every run.
+    use super::{render_prompt_value, show_prompt, PromptOutputFormat, Value, WorkflowPrompt, PROMPTS};
+    use std::collections::HashMap;
+
+    #[test]
+    fn test_show_prompt_substitutes_on_the_yaml_path() {
+        // `prompt book` / `prompt comply` hardcode Yaml, and that arm dropped
+        // the variable map entirely — this pins the call site, not just the
+        // renderer. `--output` is used because the alternative is stdout.
+        let temp = tempfile::TempDir::new().unwrap();
+        let out = temp.path().join("book.yaml");
+
+        show_prompt(
+            "book-documentation",
+            false,
+            vec![(
+                "BOOK_TITLE".to_string(),
+                Value::String("MYBOOK".to_string()),
+            )],
+            PromptOutputFormat::Yaml,
+            Some(out.clone()),
+        )
+        .unwrap();
+
+        let written = std::fs::read_to_string(&out).unwrap();
+        assert!(
+            written.contains("MYBOOK"),
+            "--title must reach the YAML that show_prompt writes"
+        );
+        assert!(
+            !written.contains("${BOOK_TITLE}"),
+            "the Yaml arm must not emit unsubstituted placeholders"
+        );
+    }
+
+    fn yaml_of(name: &str, variables: &HashMap<String, String>) -> String {
+        let raw = PROMPTS
+            .iter()
+            .find(|(n, _)| *n == name)
+            .map(|(_, y)| *y)
+            .expect("prompt must exist");
+        let prompt = WorkflowPrompt::from_yaml(raw).expect("prompt must parse");
+        let value = serde_json::to_value(&prompt).expect("prompt must serialize");
+        serde_yaml_ng::to_string(&render_prompt_value(&value, variables)).expect("yaml")
+    }
+
+    #[test]
+    fn test_book_variables_are_substituted_in_yaml_output() {
+        let mut variables = HashMap::new();
+        variables.insert("BOOK_TITLE".to_string(), "MYBOOK".to_string());
+        variables.insert("MIN_PASS_RATE".to_string(), "42".to_string());
+
+        let yaml = yaml_of("book-documentation", &variables);
+
+        assert!(
+            yaml.contains("MYBOOK"),
+            "--title must reach the emitted prompt"
+        );
+        assert!(
+            !yaml.contains("${BOOK_TITLE}"),
+            "no ${{BOOK_TITLE}} placeholder may survive substitution"
+        );
+        assert!(!yaml.contains("${MIN_PASS_RATE}"));
+    }
+
+    #[test]
+    fn test_identical_input_gives_identical_bytes() {
+        let variables = HashMap::new();
+        // Parsed afresh each time, as two separate invocations would: the
+        // model's HashMap fields otherwise serialise in a different order per
+        // parse.
+        for (name, _) in PROMPTS {
+            let first = yaml_of(name, &variables);
+            let second = yaml_of(name, &variables);
+            assert_eq!(first, second, "prompt {name} is not byte-stable");
+        }
+    }
+
+    #[test]
+    fn test_object_keys_are_emitted_in_sorted_order() {
+        let value = serde_json::json!({"zulu": 1, "alpha": {"yankee": 2, "bravo": 3}});
+        let rendered =
+            serde_json::to_string(&render_prompt_value(&value, &HashMap::new())).unwrap();
+        assert!(rendered.find("alpha").unwrap() < rendered.find("zulu").unwrap());
+        assert!(rendered.find("bravo").unwrap() < rendered.find("yankee").unwrap());
     }
 }

--- a/src/cli/handlers/proof_annotations_handler.rs
+++ b/src/cli/handlers/proof_annotations_handler.rs
@@ -4,7 +4,8 @@
 
 use crate::cli::proof_annotation_helpers::{
     collect_and_filter_annotations, format_as_full, format_as_json, format_as_markdown,
-    format_as_sarif, format_as_summary, setup_proof_annotator, ProofAnnotationFilter,
+    format_as_sarif, format_as_summary, incomplete_analysis_note, setup_proof_annotator,
+    ProofAnnotationFilter,
 };
 use crate::cli::{ProofAnnotationOutputFormat, PropertyTypeFilter, VerificationMethodFilter};
 use crate::models::unified_ast::{Location, ProofAnnotation};
@@ -64,6 +65,9 @@ pub async fn handle_analyze_proof_annotations(
         elapsed.as_millis(),
         chrono::Utc::now().to_rfc3339()
     );
+    if let Some(note) = incomplete_analysis_note(annotator.collection_errors()) {
+        eprint!("⚠️{note}");
+    }
 
     // Format output using helpers
     let content = format_proof_annotations(
@@ -95,17 +99,34 @@ fn format_proof_annotations(
     project_path: &Path,
     include_evidence: bool,
 ) -> Result<String> {
-    match format {
-        ProofAnnotationOutputFormat::Json => format_as_json(annotations, elapsed, annotator),
-        ProofAnnotationOutputFormat::Summary => format_as_summary(annotations, elapsed),
+    let mut content = match format {
+        ProofAnnotationOutputFormat::Json => format_as_json(annotations, elapsed, annotator)?,
+        ProofAnnotationOutputFormat::Summary => format_as_summary(annotations, elapsed)?,
         ProofAnnotationOutputFormat::Full => {
-            format_as_full(annotations, project_path, include_evidence)
+            format_as_full(annotations, project_path, include_evidence)?
         }
         ProofAnnotationOutputFormat::Markdown => {
-            format_as_markdown(annotations, project_path, include_evidence)
+            format_as_markdown(annotations, project_path, include_evidence)?
         }
-        ProofAnnotationOutputFormat::Sarif => format_as_sarif(annotations, project_path),
+        ProofAnnotationOutputFormat::Sarif => format_as_sarif(annotations, project_path)?,
+    };
+
+    // Files the collector could not parse contributed no annotations, and that
+    // fact stopped at one `warn!` line on stderr — the report said "Total
+    // proofs: 38050" as though it had seen the whole tree, while 31 files had
+    // been skipped. The human-readable renderers get the disclosure appended
+    // here; the JSON document already carries `summary.files_not_analyzed`, and
+    // SARIF has no free-text slot for it.
+    if !matches!(
+        format,
+        ProofAnnotationOutputFormat::Json | ProofAnnotationOutputFormat::Sarif
+    ) {
+        if let Some(note) = incomplete_analysis_note(annotator.collection_errors()) {
+            content.push_str(&note);
+        }
     }
+
+    Ok(content)
 }
 
 #[cfg_attr(coverage_nightly, coverage(off))]
@@ -130,6 +151,98 @@ mod active_tests {
         )
         .await;
         assert!(result.is_ok());
+    }
+
+    /// A tree with one file the collector cannot parse. On the pmat repo 31
+    /// such files were skipped, their failure logged once at `warn!` and
+    /// dropped: the report still said "Total proofs: N" with nothing to say it
+    /// had been computed over a subset. Both renderings must disclose the gap.
+    #[tokio::test]
+    async fn test_unparseable_files_are_disclosed_in_the_report() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        std::fs::write(
+            temp_dir.path().join("good.rs"),
+            "pub fn good(x: &str) -> usize { x.len() }\n",
+        )
+        .expect("write");
+        std::fs::write(temp_dir.path().join("broken.rs"), "fn ((( <<< not rust\n").expect("write");
+
+        // Summary (and every other human-readable format) gets a note.
+        let summary_out = temp_dir.path().join("summary.txt");
+        handle_analyze_proof_annotations(
+            temp_dir.path().to_path_buf(),
+            ProofAnnotationOutputFormat::Summary,
+            false,
+            false,
+            None,
+            None,
+            Some(summary_out.clone()),
+            false,
+            true,
+        )
+        .await
+        .expect("summary run");
+
+        let summary = std::fs::read_to_string(&summary_out).expect("read summary");
+        assert!(
+            summary.contains("INCOMPLETE"),
+            "the summary must disclose the file it could not parse, got:\n{summary}"
+        );
+
+        // The JSON document carries the same fact as a field, not prose.
+        let json_out = temp_dir.path().join("out.json");
+        handle_analyze_proof_annotations(
+            temp_dir.path().to_path_buf(),
+            ProofAnnotationOutputFormat::Json,
+            false,
+            false,
+            None,
+            None,
+            Some(json_out.clone()),
+            false,
+            true,
+        )
+        .await
+        .expect("json run");
+
+        let doc: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&json_out).expect("read json"))
+                .expect("valid json");
+        assert_eq!(
+            doc["summary"]["files_not_analyzed"].as_u64(),
+            Some(1),
+            "the JSON summary must report the skipped file, got: {doc}"
+        );
+    }
+
+    /// A tree the collector reads completely must read exactly as before — the
+    /// disclosure is only for a partial analysis.
+    #[tokio::test]
+    async fn test_complete_analysis_carries_no_incomplete_note() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        std::fs::write(
+            temp_dir.path().join("good.rs"),
+            "pub fn good(x: &str) -> usize { x.len() }\n",
+        )
+        .expect("write");
+
+        let out = temp_dir.path().join("summary.txt");
+        handle_analyze_proof_annotations(
+            temp_dir.path().to_path_buf(),
+            ProofAnnotationOutputFormat::Summary,
+            false,
+            false,
+            None,
+            None,
+            Some(out.clone()),
+            false,
+            true,
+        )
+        .await
+        .expect("summary run");
+
+        let summary = std::fs::read_to_string(&out).expect("read summary");
+        assert!(!summary.contains("INCOMPLETE"), "got:\n{summary}");
     }
 
     #[tokio::test]

--- a/src/cli/handlers/provability_handler_core.rs
+++ b/src/cli/handlers/provability_handler_core.rs
@@ -63,17 +63,31 @@ pub async fn handle_analyze_provability(config: ProvabilityConfig) -> Result<()>
 async fn resolve_function_targets(
     config: &ProvabilityConfig,
 ) -> Result<Vec<crate::services::lightweight_provability_analyzer::FunctionId>> {
-    use crate::cli::provability_helpers::{discover_project_functions, parse_function_spec};
+    use crate::cli::provability_helpers::{discover_project_functions, match_function_spec};
+
+    let discovered = discover_project_functions(&config.project_path).await?;
 
     if config.functions.is_empty() {
-        discover_project_functions(&config.project_path).await
-    } else {
-        let mut ids = Vec::new();
-        for spec in &config.functions {
-            ids.push(parse_function_spec(spec, &config.project_path)?);
-        }
-        Ok(ids)
+        return Ok(discovered);
     }
+
+    // Every --functions spec used to be handed to parse_function_spec, which
+    // built a FunctionId out of the argument string with no lookup at all — so
+    // `--functions ghost` against an EMPTY directory still printed "✓ Analyzed
+    // 1 functions" and scored it 20.0%. A name that is not in the tree has to
+    // come back as an error, not as a result row.
+    let mut ids = Vec::new();
+    for spec in &config.functions {
+        let matches = match_function_spec(spec, &discovered);
+        if matches.is_empty() {
+            anyhow::bail!(
+                "no function named `{spec}` found under {}",
+                config.project_path.display()
+            );
+        }
+        ids.extend(matches);
+    }
+    Ok(ids)
 }
 
 /// Run provability analysis on function targets (cognitive complexity ≤3)

--- a/src/cli/handlers/provability_handler_core.rs
+++ b/src/cli/handlers/provability_handler_core.rs
@@ -118,8 +118,8 @@ fn format_provability_output(
     config: &ProvabilityConfig,
 ) -> Result<String> {
     use crate::cli::provability_helpers::{
-        format_provability_detailed, format_provability_json, format_provability_sarif,
-        format_provability_summary,
+        format_provability_detailed, format_provability_json, format_provability_markdown,
+        format_provability_sarif, format_provability_summary,
     };
 
     match config.format {
@@ -133,8 +133,11 @@ fn format_provability_output(
             format_provability_detailed(function_ids, summaries, config.include_evidence)
         }
         ProvabilityOutputFormat::Sarif => format_provability_sarif(function_ids, summaries),
+        // `markdown` used to call `format_provability_detailed` — the terminal
+        // renderer — so `-f markdown` and `-f full` produced byte-identical,
+        // ANSI-decorated output containing no markdown at all.
         ProvabilityOutputFormat::Markdown => {
-            format_provability_detailed(function_ids, summaries, config.include_evidence)
+            format_provability_markdown(function_ids, summaries, config.include_evidence)
         }
     }
 }

--- a/src/cli/handlers/provability_handler_tests.rs
+++ b/src/cli/handlers/provability_handler_tests.rs
@@ -375,28 +375,63 @@ async fn test_resolve_function_targets_with_empty_functions() {
     assert!(result.is_ok() || result.is_err());
 }
 
-#[tokio::test]
-async fn test_resolve_function_targets_with_specific_functions() {
-    // This tests the branch where specific functions are provided
-    let temp_dir = TempDir::new().unwrap();
-    let config = ProvabilityConfig {
-        project_path: temp_dir.path().to_path_buf(),
-        functions: vec!["main".to_string(), "src/lib.rs:helper".to_string()],
+fn provability_config_for(path: &std::path::Path, functions: Vec<String>) -> ProvabilityConfig {
+    ProvabilityConfig {
+        project_path: path.to_path_buf(),
+        functions,
         analysis_depth: 3,
         format: ProvabilityOutputFormat::Summary,
         high_confidence_only: false,
         include_evidence: false,
         output: None,
         top_files: 5,
-    };
+    }
+}
 
-    let result = resolve_function_targets(&config).await;
-    assert!(result.is_ok());
+#[tokio::test]
+async fn test_resolve_function_targets_with_specific_functions() {
+    // Specs must resolve against functions that are really in the tree. This
+    // test used to point at an EMPTY temp dir and assert two ids came back,
+    // which is precisely the fabrication being fixed.
+    let temp_dir = TempDir::new().unwrap();
+    std::fs::create_dir_all(temp_dir.path().join("src")).unwrap();
+    std::fs::write(temp_dir.path().join("src/main.rs"), "pub fn main() {}\n").unwrap();
+    std::fs::write(temp_dir.path().join("src/lib.rs"), "pub fn helper() {}\n").unwrap();
 
-    let ids = result.unwrap();
+    let config = provability_config_for(
+        temp_dir.path(),
+        vec!["main".to_string(), "src/lib.rs:helper".to_string()],
+    );
+
+    let ids = resolve_function_targets(&config).await.unwrap();
     assert_eq!(ids.len(), 2);
     assert_eq!(ids[0].function_name, "main");
+    assert_eq!(ids[0].file_path, "src/main.rs");
     assert_eq!(ids[1].function_name, "helper");
+    assert_eq!(ids[1].file_path, "src/lib.rs");
+}
+
+/// `--functions ghost` against an empty directory used to report
+/// "✓ Analyzed 1 functions / Average provability score: 20.0%" — a result row
+/// manufactured from the argument string. A name with nothing behind it must
+/// be an error.
+#[tokio::test]
+async fn test_resolve_function_targets_rejects_unknown_function_name() {
+    let temp_dir = TempDir::new().unwrap();
+
+    let config = provability_config_for(temp_dir.path(), vec!["ghost".to_string()]);
+    let err = resolve_function_targets(&config)
+        .await
+        .expect_err("a function that is not in the tree must not be analyzed");
+    assert!(err.to_string().contains("ghost"), "unexpected: {err}");
+
+    // Same for a file-qualified spec whose file exists but whose function does not.
+    std::fs::write(temp_dir.path().join("real.rs"), "pub fn present() {}\n").unwrap();
+    let config = provability_config_for(temp_dir.path(), vec!["real.rs:absent".to_string()]);
+    assert!(resolve_function_targets(&config).await.is_err());
+
+    let config = provability_config_for(temp_dir.path(), vec!["real.rs:present".to_string()]);
+    assert_eq!(resolve_function_targets(&config).await.unwrap().len(), 1);
 }
 
 // ============================================================

--- a/src/cli/handlers/provability_handler_tests.rs
+++ b/src/cli/handlers/provability_handler_tests.rs
@@ -305,9 +305,27 @@ fn test_format_provability_output_markdown() {
     let result = format_provability_output(&function_ids, &summaries, &config);
     assert!(result.is_ok());
 
-    // Markdown format uses format_provability_detailed
+    // Was: `// Markdown format uses format_provability_detailed` +
+    // `assert!(content.contains("Detailed Provability Analysis"))` — the comment
+    // documented the defect. `-f markdown` fell through to the detailed
+    // renderer, so it emitted ANSI-escaped plain text byte-identical to
+    // `-f full` and nothing a Markdown consumer could use. It has its own
+    // renderer now, so assert actual Markdown.
     let content = result.unwrap();
-    assert!(content.contains("Detailed Provability Analysis"));
+    assert!(
+        content.starts_with("# Provability Analysis"),
+        "markdown must open with an H1, got: {}",
+        content.lines().next().unwrap_or("")
+    );
+    assert!(content.contains("## `src/main.rs`"), "{content}");
+    assert!(
+        content.contains("| Function | Line | Provability | Verified | Missing |"),
+        "{content}"
+    );
+    assert!(
+        !content.contains('\u{1b}'),
+        "markdown must not carry ANSI escapes"
+    );
 }
 
 // ============================================================

--- a/src/cli/handlers/provability_handler_tests_part2.rs
+++ b/src/cli/handlers/provability_handler_tests_part2.rs
@@ -5,6 +5,25 @@
 // Full handler integration tests
 // ============================================================
 
+/// Write a project containing exactly the named functions.
+///
+/// These tests used to pass an EMPTY `TempDir` together with `--functions
+/// <name>` and assert `is_ok()`. That asserted the fabrication the handler was
+/// fixed for: every spec was turned into a `FunctionId` with no lookup, so
+/// `--functions ghost` against an empty directory printed "✓ Analyzed 1
+/// functions" and scored it 20.0%. Naming a function that does not exist is now
+/// an error, so each format test gets a project where its function really does
+/// exist — which is what these tests were always meant to exercise.
+fn project_with_functions(temp: &TempDir, names: &[&str]) {
+    let src = temp.path().join("src");
+    std::fs::create_dir_all(&src).unwrap();
+    let body: String = names
+        .iter()
+        .map(|n| format!("pub fn {n}(x: i32) -> i32 {{ if x > 0 {{ x }} else {{ -x }} }}\n"))
+        .collect();
+    std::fs::write(src.join("lib.rs"), body).unwrap();
+}
+
 #[tokio::test]
 async fn test_handle_analyze_provability_with_output_file() {
     let temp_dir = TempDir::new().unwrap();
@@ -34,6 +53,7 @@ async fn test_handle_analyze_provability_with_output_file() {
 #[tokio::test]
 async fn test_handle_analyze_provability_summary_format() {
     let temp_dir = TempDir::new().unwrap();
+    project_with_functions(&temp_dir, &["test_func"]);
 
     let config = ProvabilityConfig {
         project_path: temp_dir.path().to_path_buf(),
@@ -53,6 +73,7 @@ async fn test_handle_analyze_provability_summary_format() {
 #[tokio::test]
 async fn test_handle_analyze_provability_sarif_format() {
     let temp_dir = TempDir::new().unwrap();
+    project_with_functions(&temp_dir, &["main"]);
     let output_path = temp_dir.path().join("analysis.sarif");
 
     let config = ProvabilityConfig {
@@ -76,6 +97,7 @@ async fn test_handle_analyze_provability_sarif_format() {
 #[tokio::test]
 async fn test_handle_analyze_provability_full_format_with_evidence() {
     let temp_dir = TempDir::new().unwrap();
+    project_with_functions(&temp_dir, &["complex_fn"]);
 
     let config = ProvabilityConfig {
         project_path: temp_dir.path().to_path_buf(),
@@ -95,6 +117,7 @@ async fn test_handle_analyze_provability_full_format_with_evidence() {
 #[tokio::test]
 async fn test_handle_analyze_provability_markdown_format() {
     let temp_dir = TempDir::new().unwrap();
+    project_with_functions(&temp_dir, &["test"]);
     let output_path = temp_dir.path().join("analysis.md");
 
     let config = ProvabilityConfig {
@@ -115,6 +138,7 @@ async fn test_handle_analyze_provability_markdown_format() {
 #[tokio::test]
 async fn test_handle_analyze_provability_high_confidence_filter() {
     let temp_dir = TempDir::new().unwrap();
+    project_with_functions(&temp_dir, &["fn1", "fn2"]);
 
     let config = ProvabilityConfig {
         project_path: temp_dir.path().to_path_buf(),

--- a/src/cli/handlers/qa_mcp_sweep.rs
+++ b/src/cli/handlers/qa_mcp_sweep.rs
@@ -50,6 +50,13 @@ pub struct ToolSweepResult {
     /// Present when non-conformant: what went wrong.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub anomaly: Option<String>,
+    /// Digest of the response payload with volatile fields normalised — the
+    /// only thing that can tell one pass's answer from another's. Without it
+    /// the advertised "replay determinism" check compared nothing but the
+    /// `conformant` boolean, so a server returning a fresh random nonce on
+    /// every call swept clean.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub response_digest: Option<String>,
 }
 
 /// A framing/concurrency anomaly not tied to a single tool.
@@ -203,13 +210,25 @@ pub fn is_conformant_response(frame: &serde_json::Value) -> bool {
     obj.contains_key("result") ^ obj.contains_key("error")
 }
 
-/// Locate the pmat binary to spawn (release preferred, then debug, then PATH).
+/// Locate the pmat binary to spawn (release preferred, then debug, then the
+/// running executable, then PATH).
+///
+/// The candidates used to be returned as the RELATIVE paths they were tested
+/// as (`target/release/pmat`), while `run_sweep_once` spawns with
+/// `.current_dir(<swept path>)` — so the existence check and the execution
+/// referred to different directories. Sweeping any directory from a built tree
+/// executed `<swept path>/target/release/pmat`, i.e. whatever binary happened
+/// to sit there, and a swept path with no `target/` failed to spawn even with
+/// pmat on PATH. Candidates are now absolutised against the caller's cwd
+/// before they are handed to `Command`.
 fn resolve_pmat_binary() -> PathBuf {
     for candidate in ["target/release/pmat", "target/debug/pmat"] {
-        let p = PathBuf::from(candidate);
-        if p.exists() {
-            return p;
+        if let Ok(abs) = std::fs::canonicalize(candidate) {
+            return abs;
         }
+    }
+    if let Ok(exe) = std::env::current_exe() {
+        return exe;
     }
     PathBuf::from("pmat")
 }
@@ -250,7 +269,13 @@ fn run_sweep_once(
         Ok(c) => c,
         Err(e) => {
             std::fs::remove_dir_all(&fixture).ok();
-            return Err(anyhow::Error::from(e).context("spawn MCP server (MCP_VERSION=1 pmat)"));
+            // Name the binary we actually tried: the message used to say
+            // "pmat" while spawning a relative path resolved against the
+            // swept directory.
+            return Err(anyhow::Error::from(e).context(format!(
+                "spawn MCP server (MCP_VERSION=1 {})",
+                binary.display()
+            )));
         }
     };
 
@@ -316,7 +341,7 @@ fn run_sweep_once(
     let _ = child.wait();
     std::fs::remove_dir_all(&fixture).ok();
 
-    let results = correlate_results(&expected_ids, &frames);
+    let results = correlate_results(&expected_ids, &frames, &arg_target);
     let (anomalies, framing_pure) = framing_anomalies(&raw_stdout, tools.is_empty());
     Ok((results, anomalies, framing_pure))
 }
@@ -426,6 +451,7 @@ fn drain_responses(
 fn correlate_results(
     expected_ids: &[(u64, String)],
     frames: &[serde_json::Value],
+    arg_target: &str,
 ) -> Vec<ToolSweepResult> {
     expected_ids
         .iter()
@@ -442,9 +468,73 @@ fn correlate_results(
                 name: name.clone(),
                 conformant: anomaly.is_none(),
                 anomaly,
+                response_digest: frame.map(|f| response_digest(f, arg_target)),
             }
         })
         .collect()
+}
+
+/// Digest of a tool response's payload, used for the cross-pass replay check.
+///
+/// Only the `result`/`error` payload is hashed (the JSON-RPC envelope's `id`
+/// is per-pass bookkeeping), and fields that legitimately differ between two
+/// identical requests — wall-clock, durations, pids, session ids, and the
+/// per-pass fixture path — are normalised away first, so a mismatch means the
+/// server really did answer the same question differently.
+fn response_digest(frame: &serde_json::Value, arg_target: &str) -> String {
+    let mut payload = frame
+        .get("result")
+        .or_else(|| frame.get("error"))
+        .cloned()
+        .unwrap_or(serde_json::Value::Null);
+    normalize_volatile(&mut payload, arg_target);
+    // serde_json serialises object keys in sorted order, so the canonical form
+    // is stable without any extra ordering pass.
+    let canonical = serde_json::to_string(&payload).unwrap_or_default();
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    std::hash::Hash::hash(&canonical, &mut hasher);
+    format!("{:016x}", std::hash::Hasher::finish(&hasher))
+}
+
+/// Key fragments whose values vary between two identical requests by design.
+const VOLATILE_KEY_FRAGMENTS: &[&str] = &[
+    "timestamp",
+    "time",
+    "duration",
+    "elapsed",
+    "started",
+    "finished",
+    "generated",
+    "session",
+    "pid",
+    "uuid",
+    "seed",
+    "_ms",
+];
+
+/// Null out volatile values and mask the per-pass fixture path in-place.
+fn normalize_volatile(value: &mut serde_json::Value, arg_target: &str) {
+    match value {
+        serde_json::Value::Object(map) => {
+            for (key, val) in map.iter_mut() {
+                let key_lc = key.to_lowercase();
+                if VOLATILE_KEY_FRAGMENTS.iter().any(|f| key_lc.contains(f)) {
+                    *val = serde_json::Value::Null;
+                } else {
+                    normalize_volatile(val, arg_target);
+                }
+            }
+        }
+        serde_json::Value::Array(items) => {
+            for item in items {
+                normalize_volatile(item, arg_target);
+            }
+        }
+        serde_json::Value::String(s) if !arg_target.is_empty() && s.contains(arg_target) => {
+            *s = s.replace(arg_target, "<TARGET>");
+        }
+        _ => {}
+    }
 }
 
 /// Build framing anomalies (stray non-JSON stdout lines) + purity flag.
@@ -499,6 +589,54 @@ fn scratch_snapshot(target: &std::path::Path) -> std::collections::BTreeSet<Stri
     names
 }
 
+/// Cross-pass invariants: every pass must agree on tool conformance (no
+/// lock-error-induced divergence) AND on the payload each tool returned.
+///
+/// The payload half is what `--help` calls "replay determinism", and it was
+/// missing: the only comparison built a `name -> conformant` map from pass 0,
+/// so a server answering every `tools/call` with a fresh random nonce swept
+/// clean with ok:true. `conformant` only means "a well-formed JSON-RPC frame
+/// came back" — eight passes can return eight different documents and still
+/// agree on that boolean.
+fn cross_pass_anomalies(pass_reports: &[Vec<ToolSweepResult>]) -> Vec<SweepAnomaly> {
+    let mut anomalies = Vec::new();
+    let Some(first) = pass_reports.first() else {
+        return anomalies;
+    };
+    let baseline: std::collections::BTreeMap<&str, &ToolSweepResult> =
+        first.iter().map(|t| (t.name.as_str(), t)).collect();
+
+    for (pass, report) in pass_reports.iter().enumerate().skip(1) {
+        for t in report {
+            let Some(base) = baseline.get(t.name.as_str()) else {
+                continue;
+            };
+            if base.conformant != t.conformant {
+                anomalies.push(SweepAnomaly {
+                    id: format!("concurrency-divergence-{}-pass{pass:02}", t.name),
+                    detail: format!(
+                        "tool {} conformance differs across passes (possible lock error)",
+                        t.name
+                    ),
+                });
+            }
+            if base.response_digest.is_some() && base.response_digest != t.response_digest {
+                anomalies.push(SweepAnomaly {
+                    id: format!("replay-nondeterminism-{}-pass{pass:02}", t.name),
+                    detail: format!(
+                        "tool {} answered the identical request with a different payload \
+                         (pass00 digest {}, pass{pass:02} digest {})",
+                        t.name,
+                        base.response_digest.as_deref().unwrap_or("none"),
+                        t.response_digest.as_deref().unwrap_or("none"),
+                    ),
+                });
+            }
+        }
+    }
+    anomalies
+}
+
 /// `pmat qa-work mcp-sweep` entry point (MACS-011).
 pub async fn handle_mcp_sweep(opts: SweepOpts) -> Result<()> {
     let binary = resolve_pmat_binary();
@@ -545,27 +683,7 @@ pub async fn handle_mcp_sweep(opts: SweepOpts) -> Result<()> {
         }
     }
 
-    // Concurrency invariant: every pass must agree on tool conformance
-    // (no lock-error-induced divergence across passes).
-    if let Some(first) = pass_reports.first() {
-        let baseline: std::collections::BTreeMap<&str, bool> = first
-            .iter()
-            .map(|t| (t.name.as_str(), t.conformant))
-            .collect();
-        for (pass, report) in pass_reports.iter().enumerate().skip(1) {
-            for t in report {
-                if baseline.get(t.name.as_str()) != Some(&t.conformant) {
-                    all_anomalies.push(SweepAnomaly {
-                        id: format!("concurrency-divergence-{}-pass{pass:02}", t.name),
-                        detail: format!(
-                            "tool {} conformance differs across passes (possible lock error)",
-                            t.name
-                        ),
-                    });
-                }
-            }
-        }
-    }
+    all_anomalies.extend(cross_pass_anomalies(&pass_reports));
 
     // Scratch-leftover invariant.
     let scratch_after = scratch_snapshot(&opts.path);
@@ -775,11 +893,13 @@ mod tests {
                         name: "b_tool".into(),
                         conformant: true,
                         anomaly: None,
+                        response_digest: None,
                     },
                     ToolSweepResult {
                         name: "a_tool".into(),
                         conformant: true,
                         anomaly: None,
+                        response_digest: None,
                     },
                 ],
                 vec![],
@@ -803,6 +923,7 @@ mod tests {
                 name: "t".into(),
                 conformant: true,
                 anomaly: None,
+                response_digest: None,
             }],
             vec![],
             false,
@@ -814,6 +935,7 @@ mod tests {
                 name: "t".into(),
                 conformant: true,
                 anomaly: None,
+                response_digest: None,
             }],
             vec![SweepAnomaly {
                 id: "x".into(),
@@ -828,6 +950,7 @@ mod tests {
                 name: "t".into(),
                 conformant: false,
                 anomaly: Some("bad".into()),
+                response_digest: None,
             }],
             vec![],
             true,
@@ -844,11 +967,13 @@ mod tests {
                     name: "good".into(),
                     conformant: true,
                     anomaly: None,
+                    response_digest: None,
                 },
                 ToolSweepResult {
                     name: "bad".into(),
                     conformant: false,
                     anomaly: Some("no response".into()),
+                    response_digest: None,
                 },
             ],
             vec![],
@@ -859,6 +984,61 @@ mod tests {
         assert!(xml.contains("<testcase name=\"good\"/>"));
         assert!(xml.contains("<testcase name=\"bad\"><failure>no response</failure>"));
         assert!(xml.contains("failures=\"1\""));
+    }
+
+    fn frame(id: u64, text: &str) -> serde_json::Value {
+        serde_json::json!({"jsonrpc":"2.0","id":id,
+            "result":{"content":[{"type":"text","text":text}]}})
+    }
+
+    #[test]
+    fn replay_nondeterminism_is_an_anomaly() {
+        // A server whose every tools/call answers with a fresh nonce used to
+        // sweep clean: only the `conformant` boolean was compared across
+        // passes, and eight different payloads all set it to true.
+        let expected = vec![(100u64, "alpha_tool".to_string())];
+        let pass0 = correlate_results(&expected, &[frame(100, "NONCE-1-111")], "/tmp/fixture");
+        let pass1 = correlate_results(&expected, &[frame(100, "NONCE-2-222")], "/tmp/fixture");
+        assert!(
+            pass0[0].conformant && pass1[0].conformant,
+            "both well-formed"
+        );
+
+        let anomalies = cross_pass_anomalies(&[pass0, pass1]);
+        assert_eq!(anomalies.len(), 1, "got: {anomalies:?}");
+        assert!(anomalies[0]
+            .id
+            .starts_with("replay-nondeterminism-alpha_tool"));
+    }
+
+    #[test]
+    fn identical_payloads_and_volatile_fields_are_not_anomalies() {
+        let expected = vec![(100u64, "alpha_tool".to_string())];
+        // Same answer, different wall-clock/duration and a different per-pass
+        // fixture path: neither is the server answering differently.
+        let a = serde_json::json!({"jsonrpc":"2.0","id":100,
+            "result":{"files":1,"timestamp":"2026-01-01T00:00:00Z","duration_ms":7,
+                      "root":"/tmp/pmat-mcp-sweep-1-0"}});
+        let b = serde_json::json!({"jsonrpc":"2.0","id":100,
+            "result":{"files":1,"timestamp":"2026-01-01T00:00:09Z","duration_ms":9,
+                      "root":"/tmp/pmat-mcp-sweep-2-1"}});
+        let pass0 = correlate_results(&expected, &[a], "/tmp/pmat-mcp-sweep-1-0");
+        let pass1 = correlate_results(&expected, &[b], "/tmp/pmat-mcp-sweep-2-1");
+        assert_eq!(pass0[0].response_digest, pass1[0].response_digest);
+        assert!(cross_pass_anomalies(&[pass0, pass1]).is_empty());
+    }
+
+    #[test]
+    fn resolved_binary_is_absolute_so_cwd_and_spawn_dir_agree() {
+        // `run_sweep_once` spawns with `.current_dir(<swept path>)`, so a
+        // relative "target/release/pmat" was re-resolved against the SWEPT
+        // directory and executed whatever binary sat there.
+        let binary = resolve_pmat_binary();
+        assert!(
+            binary.is_absolute() || binary == std::path::Path::new("pmat"),
+            "candidate must be absolute (or the bare PATH name), got {}",
+            binary.display()
+        );
     }
 
     #[test]

--- a/src/cli/handlers/qa_work_handler/impl_print.rs
+++ b/src/cli/handlers/qa_work_handler/impl_print.rs
@@ -117,11 +117,20 @@ async fn handle_report(
     format: QaOutputFormat,
 ) -> Result<()> {
     use crate::cli::colors as c;
-    println!("{} {}", c::label("Generating QA report for task:"), task_id);
+    // Same defect as `qa-work validate`: this banner used to land on STDOUT
+    // ahead of the JSON/YAML document, so `-f json | jq` never parsed.
+    if qa_format_owns_stdout(&format) {
+        eprintln!("Generating QA report for task: {}", task_id);
+    } else {
+        println!("{} {}", c::label("Generating QA report for task:"), task_id);
+    }
 
     // First run validation
     let mut categories: HashMap<String, CategoryResult> = HashMap::new();
 
+    // Report and validate must score the same checklist: Safety & Ethics is
+    // part of the 25-point checklist, so it belongs in the audit trail too.
+    categories.insert("safety_ethics".into(), run_safety_ethics_checks());
     categories.insert(
         "code_quality".into(),
         run_code_quality_checks(project_path).await,

--- a/src/cli/handlers/qa_work_handler/impl_print.rs
+++ b/src/cli/handlers/qa_work_handler/impl_print.rs
@@ -84,6 +84,30 @@ fn print_validation_markdown(result: &QaValidationResult) {
     }
 }
 
+/// Build the report artefact from the category results.
+///
+/// `handle_report` used to initialise `passed: true` in the struct literal and
+/// never recompute it, so the audit-trail report said PASSED for a run that
+/// `qa-work validate` failed at the identical score (20.0% scored PASSED in the
+/// report and FAILED in validate, back to back, on the same `.pmat-qa` state).
+/// Pass/fail now comes from the same `determine_pass` the validate path uses,
+/// so the two surfaces cannot disagree.
+fn build_report_result(
+    task_id: &str,
+    categories: HashMap<String, CategoryResult>,
+) -> QaValidationResult {
+    let overall_score = calculate_overall_score(&categories);
+    QaValidationResult {
+        task_id: task_id.to_string(),
+        timestamp: Utc::now(),
+        categories,
+        overall_score,
+        // `report` has no --strict flag, so it matches plain `qa-work validate`.
+        passed: determine_pass(overall_score, false),
+        manual_checks_required: vec![],
+    }
+}
+
 /// Generate QA report for audit trail
 async fn handle_report(
     task_id: &str,
@@ -96,41 +120,23 @@ async fn handle_report(
     println!("{} {}", c::label("Generating QA report for task:"), task_id);
 
     // First run validation
-    let mut result = QaValidationResult {
-        task_id: task_id.to_string(),
-        timestamp: Utc::now(),
-        categories: HashMap::new(),
-        overall_score: 0.0,
-        passed: true,
-        manual_checks_required: vec![],
-    };
+    let mut categories: HashMap<String, CategoryResult> = HashMap::new();
 
-    result.categories.insert(
+    categories.insert(
         "code_quality".into(),
         run_code_quality_checks(project_path).await,
     );
-    result
-        .categories
-        .insert("testing".into(), run_testing_checks(project_path).await);
-    result.categories.insert(
+    categories.insert("testing".into(), run_testing_checks(project_path).await);
+    categories.insert(
         "documentation".into(),
         run_documentation_checks(project_path, task_id).await,
     );
-    result.categories.insert(
+    categories.insert(
         "process".into(),
         run_process_checks(project_path, task_id).await,
     );
 
-    // Calculate score
-    let (total_passed, total_items) = result
-        .categories
-        .values()
-        .fold((0, 0), |(p, t), cat| (p + cat.passed, t + cat.total));
-    result.overall_score = if total_items > 0 {
-        (total_passed as f64 / total_items as f64) * 100.0
-    } else {
-        0.0
-    };
+    let result = build_report_result(task_id, categories);
 
     // Generate report content
     let report = match format {
@@ -194,6 +200,12 @@ async fn handle_report(
         println!("{} Report saved to: {}", c::pass(""), c::path(&output_path.display().to_string()));
     } else {
         println!("{}", report);
+    }
+
+    // The report is still written/printed first, but a failing audit must not
+    // exit 0 while `qa-work validate` exits 1 on the very same score.
+    if !result.passed {
+        std::process::exit(1);
     }
 
     Ok(())
@@ -410,6 +422,63 @@ mod print_tests {
             ],
         };
         print_validation_markdown(&r);
+    }
+
+    // ── build_report_result ──
+    // Regression: `handle_report` hardcoded `passed: true`, so the audit report
+    // said PASSED for a task `qa-work validate` failed at the same score.
+
+    #[test]
+    fn test_build_report_result_low_score_is_not_passed() {
+        let mut cats = HashMap::new();
+        cats.insert(
+            "code_quality".to_string(),
+            category(
+                "Code Quality",
+                vec![
+                    item("C1", "ok", ValidationStatus::Passed),
+                    item("C2", "bad", ValidationStatus::Failed),
+                    item("C3", "bad", ValidationStatus::Failed),
+                    item("C4", "bad", ValidationStatus::Failed),
+                    item("C5", "bad", ValidationStatus::Failed),
+                ],
+            ),
+        );
+        let r = build_report_result("T-1", cats);
+        assert!((r.overall_score - 20.0).abs() < f64::EPSILON);
+        assert!(
+            !r.passed,
+            "20.0% must be a fail in the report exactly as it is in validate"
+        );
+    }
+
+    #[test]
+    fn test_build_report_result_high_score_passes() {
+        let mut cats = HashMap::new();
+        cats.insert(
+            "code_quality".to_string(),
+            category(
+                "Code Quality",
+                vec![
+                    item("C1", "ok", ValidationStatus::Passed),
+                    item("C2", "ok", ValidationStatus::Passed),
+                    item("C3", "ok", ValidationStatus::Passed),
+                    item("C4", "ok", ValidationStatus::Passed),
+                    item("C5", "bad", ValidationStatus::Failed),
+                ],
+            ),
+        );
+        let r = build_report_result("T-1", cats);
+        assert!((r.overall_score - 80.0).abs() < f64::EPSILON);
+        assert!(r.passed);
+    }
+
+    #[test]
+    fn test_build_report_result_empty_categories_is_not_passed() {
+        // No checks ran at all: nothing was measured, so nothing passed.
+        let r = build_report_result("T-1", HashMap::new());
+        assert!((r.overall_score - 0.0).abs() < f64::EPSILON);
+        assert!(!r.passed);
     }
 
     #[test]

--- a/src/cli/handlers/qa_work_handler/impl_spec.rs
+++ b/src/cli/handlers/qa_work_handler/impl_spec.rs
@@ -40,6 +40,32 @@ fn print_task_status(task_id: &str, task_dir: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Credit a claim earns for its validation status: `(proven, manual_unverified)`.
+///
+/// A MANUAL claim used to be added to the same counter as a PROVEN one, so a spec
+/// whose claims were all unverified scored 100% in every category and the
+/// Falsifiability gateway could never fail. Unverified is not verified: MANUAL is
+/// tallied and reported, but scores nothing.
+fn claim_credit(status: &crate::services::spec_parser::ValidationStatus) -> (u32, u32) {
+    use crate::services::spec_parser::ValidationStatus as S;
+    match status {
+        S::Proven => (1, 0),
+        S::ManualRequired => (0, 1),
+        _ => (0, 0),
+    }
+}
+
+/// The Falsifiability gateway: the category must clear the threshold *and* contain
+/// at least one claim we actually proved. A gateway satisfied by unverified claims
+/// is not a gateway.
+fn falsifiability_gateway_passed(
+    gateway_score: f64,
+    gateway_threshold: u32,
+    gateway_proven: u32,
+) -> bool {
+    gateway_score >= gateway_threshold as f64 && gateway_proven > 0
+}
+
 /// Handle spec validation command (Part D & E: pmat qa spec)
 ///
 /// Implements 100-point Popperian falsifiability scoring:
@@ -96,7 +122,11 @@ async fn handle_spec(
     println!("{}", c::header("Validation Results (Popperian: FALSE until PROVEN)"));
     println!();
 
-    let mut category_scores: HashMap<String, (u32, u32)> = HashMap::new();
+    // (proven, manual_unverified, total) per category. A MANUAL claim used to be
+    // added to the same counter as a PROVEN one ("Count as passed"), so every
+    // category with only unverified claims scored 100% and the Falsifiability
+    // gateway could never fail. Unverified is not verified: only PROVEN earns points.
+    let mut category_scores: HashMap<String, (u32, u32, u32)> = HashMap::new();
 
     // Initialize categories
     for cat in &[
@@ -107,14 +137,14 @@ async fn handle_spec(
         ClaimCategory::Integration,
     ] {
         let cat_name = format!("{:?}", cat);
-        category_scores.insert(cat_name, (0, 0));
+        category_scores.insert(cat_name, (0, 0, 0));
     }
 
     // Validate each claim
     for claim in &spec.claims {
         let cat_name = format!("{:?}", claim.category);
-        let entry = category_scores.entry(cat_name.clone()).or_insert((0, 0));
-        entry.1 += 1; // total
+        let entry = category_scores.entry(cat_name.clone()).or_insert((0, 0, 0));
+        entry.2 += 1; // total
 
         // Try to validate
         let (status, evidence) = if claim.automatable {
@@ -144,15 +174,12 @@ async fn handle_spec(
             (SpecValidationStatus::ManualRequired, None)
         };
 
-        // Update score
-        // Proven claims get full credit, Manual claims get partial credit (claim exists but unverified)
-        if status == SpecValidationStatus::Proven {
-            entry.0 += 1;
-        } else if status == SpecValidationStatus::ManualRequired {
-            // Give 50% credit for having a falsifiable claim (it CAN be tested)
-            // This rewards specs that have testable claims even if not auto-validated
-            entry.0 += 1; // Count as passed - having falsifiable claims is the goal
-        }
+        // Update score. Only a claim we actually verified scores; MANUAL claims are
+        // tallied separately and reported, but they earn nothing — counting them as
+        // passed is what let an all-unverified spec show 100% in every category.
+        let (proven_credit, manual_credit) = claim_credit(&status);
+        entry.0 += proven_credit;
+        entry.1 += manual_credit;
 
         // Print result
         let status_str = match status {
@@ -188,6 +215,7 @@ async fn handle_spec(
 
     let mut total_score: f64 = 0.0;
     let mut gateway_score: f64 = 0.0;
+    let mut gateway_proven: u32 = 0;
 
     for cat in &[
         ClaimCategory::Falsifiability,
@@ -197,36 +225,42 @@ async fn handle_spec(
         ClaimCategory::Integration,
     ] {
         let cat_name = format!("{:?}", cat);
-        let (passed, total) = category_scores.get(&cat_name).unwrap_or(&(0, 0));
+        let (proven, manual, total) = category_scores.get(&cat_name).unwrap_or(&(0, 0, 0));
         let max_pts = cat.max_points();
 
         let cat_score = if *total > 0 {
-            (*passed as f64 / *total as f64) * max_pts as f64
+            (*proven as f64 / *total as f64) * max_pts as f64
         } else {
             0.0
         };
 
         let pct = if *total > 0 {
-            (*passed as f64 / *total as f64) * 100.0
+            (*proven as f64 / *total as f64) * 100.0
         } else {
             0.0
         };
 
         if *cat == ClaimCategory::Falsifiability {
             gateway_score = cat_score;
+            gateway_proven = *proven;
             print!("  {} ", c::label("GATE"));
         } else {
             print!("     ");
         }
 
         println!(
-            "{:<15} {}/{} pts ({:.0}%) - {}/{} claims",
+            "{:<15} {}/{} pts ({:.0}%) - {}/{} claims proven{}",
             cat_name,
             c::number(&format!("{:.1}", cat_score)),
             max_pts,
             pct,
-            passed,
-            total
+            proven,
+            total,
+            if *manual > 0 {
+                format!(" ({} manual, unverified)", manual)
+            } else {
+                String::new()
+            }
         );
 
         total_score += cat_score;
@@ -235,13 +269,16 @@ async fn handle_spec(
     println!();
     println!("{}", c::rule());
 
-    // Gateway check (Falsifiability category must meet threshold)
-    let gateway_passed = gateway_score >= gateway_threshold as f64;
+    // Gateway check (Falsifiability category must meet threshold AND have at least
+    // one claim we actually proved — a gateway satisfied by unverified claims is no
+    // gateway at all).
+    let gateway_passed =
+        falsifiability_gateway_passed(gateway_score, gateway_threshold, gateway_proven);
     let final_score = if gateway_passed { total_score } else { 0.0 };
 
     if !gateway_passed {
         println!(
-            "{} GATEWAY FAILED: Falsifiability score {:.1} < {} (total score forced to 0)",
+            "{} GATEWAY FAILED: Falsifiability score {:.1} < {} or no claim proven (total score forced to 0)",
             c::fail(""),
             gateway_score,
             gateway_threshold
@@ -260,9 +297,12 @@ async fn handle_spec(
     }
 
     println!();
+    // Named "claim falsifiability score", not "total score": `pmat spec score`
+    // reports a different 100-point number for the same file (artefact completeness,
+    // ≥95 bar) and the two were indistinguishable in the output.
     println!(
         "{}: {}/100 (threshold: {})",
-        c::label("Total Score"),
+        c::label("Claim falsifiability score"),
         c::number(&format!("{:.1}", final_score)),
         threshold
     );
@@ -443,4 +483,56 @@ fn format_spec_result_markdown(result: &serde_json::Value) -> String {
             "✗"
         },
     )
+}
+
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg(test)]
+mod impl_spec_scoring_tests {
+    use super::{claim_credit, falsifiability_gateway_passed};
+    use crate::services::spec_parser::ValidationStatus as S;
+
+    /// A MANUAL (unverified) claim must earn no points. It used to be counted as
+    /// passed, which is why every category read 100% on a spec with 9 MANUAL claims.
+    #[test]
+    fn test_manual_claims_earn_no_score() {
+        assert_eq!(claim_credit(&S::Proven), (1, 0));
+        assert_eq!(claim_credit(&S::ManualRequired), (0, 1));
+        assert_eq!(claim_credit(&S::Falsified), (0, 0));
+        assert_eq!(claim_credit(&S::Unfalsified), (0, 0));
+        assert_eq!(claim_credit(&S::Skipped), (0, 0));
+    }
+
+    /// 9 MANUAL + 1 PROVEN in Implementation scores 1/10 of the category, not 100%.
+    #[test]
+    fn test_category_score_uses_proven_only() {
+        let statuses = [
+            S::Proven,
+            S::ManualRequired,
+            S::ManualRequired,
+            S::ManualRequired,
+        ];
+        let (proven, manual) = statuses.iter().fold((0u32, 0u32), |(p, m), s| {
+            let (pc, mc) = claim_credit(s);
+            (p + pc, m + mc)
+        });
+        assert_eq!((proven, manual), (1, 3));
+        let score = proven as f64 / statuses.len() as f64 * 25.0;
+        assert!((score - 6.25).abs() < 1e-9, "got {score}");
+    }
+
+    /// The gateway must fail when its only falsifiability claim is unverified,
+    /// however many claims exist.
+    #[test]
+    fn test_gateway_fails_without_a_proven_claim() {
+        assert!(
+            !falsifiability_gateway_passed(0.0, 15, 0),
+            "no proven claim must not satisfy the gateway"
+        );
+        assert!(
+            !falsifiability_gateway_passed(25.0, 15, 0),
+            "a score without a proven claim must not satisfy the gateway"
+        );
+        assert!(falsifiability_gateway_passed(25.0, 15, 1));
+        assert!(!falsifiability_gateway_passed(10.0, 15, 1));
+    }
 }

--- a/src/cli/handlers/qa_work_handler/impl_validation.rs
+++ b/src/cli/handlers/qa_work_handler/impl_validation.rs
@@ -32,6 +32,16 @@ fn format_checklist_text(checklist: &QaChecklist) -> String {
     output
 }
 
+/// True for formats a tool parses rather than a human reads.
+///
+/// `qa-work validate -f json` used to print `Running QA validation for task: …`
+/// to STDOUT ahead of the document, so piping it to `jq` failed on the very
+/// first byte. Machine formats own stdout exclusively; progress chatter belongs
+/// on stderr.
+pub(crate) fn qa_format_owns_stdout(format: &QaOutputFormat) -> bool {
+    matches!(format, QaOutputFormat::Json | QaOutputFormat::Yaml)
+}
+
 /// Run automated QA validation
 async fn handle_validate(
     task_id: &str,
@@ -39,8 +49,12 @@ async fn handle_validate(
     strict: bool,
     format: QaOutputFormat,
 ) -> Result<()> {
-    println!("Running QA validation for task: {}", task_id);
-    println!();
+    if qa_format_owns_stdout(&format) {
+        eprintln!("Running QA validation for task: {}", task_id);
+    } else {
+        println!("Running QA validation for task: {}", task_id);
+        println!();
+    }
 
     let mut result = QaValidationResult {
         task_id: task_id.to_string(),
@@ -50,6 +64,16 @@ async fn handle_validate(
         passed: true,
         manual_checks_required: vec![],
     };
+
+    // Safety & Ethics (A1-A5) was silently absent from validate while
+    // generate-checklist and the checklist model both list it, so validate
+    // scored 20 items against a 25-item checklist and the one security
+    // category was the one that vanished. It is now always present; the items
+    // report as unverified rather than as passes nobody measured.
+    let safety_ethics = run_safety_ethics_checks();
+    result
+        .categories
+        .insert("safety_ethics".into(), safety_ethics);
 
     // Run code quality checks
     let code_quality = run_code_quality_checks(project_path).await;
@@ -182,6 +206,47 @@ pub(crate) fn calculate_overall_score(
 #[provable_contracts_macros::contract("pmat-core.yaml", equation = "check_compliance")]
 pub(crate) fn determine_pass(overall_score: f64, strict: bool) -> bool {
     overall_score >= 80.0 && !strict || overall_score >= 95.0
+}
+
+/// Build the Safety & Ethics (A1-A5) category.
+///
+/// The five items mirror `generate-checklist` exactly so validate's denominator
+/// is the checklist's 25, not 20. pmat has no implemented secret/injection/log
+/// scanner behind A1/A3/A4, so they are reported as requiring review rather
+/// than as automated passes — an unmeasured check must never count as a pass.
+fn run_safety_ethics_checks() -> CategoryResult {
+    let specs = [
+        ("A1", "No hardcoded secrets or credentials"),
+        ("A2", "Error handling covers all failure modes"),
+        ("A3", "Input validation prevents injection attacks"),
+        ("A4", "Logging doesn't expose sensitive data"),
+        ("A5", "Rate limiting considered for APIs"),
+    ];
+
+    let items: Vec<ValidationItem> = specs
+        .iter()
+        .map(|(id, description)| ValidationItem {
+            id: (*id).to_string(),
+            description: (*description).to_string(),
+            status: ValidationStatus::Manual,
+            value: None,
+            threshold: None,
+            evidence: Some("No automated safety check is implemented; review manually".into()),
+        })
+        .collect();
+
+    let passed = items
+        .iter()
+        .filter(|i| i.status == ValidationStatus::Passed)
+        .count() as u32;
+    let total = items.len() as u32;
+
+    CategoryResult {
+        name: "Safety & Ethics".into(),
+        passed,
+        total,
+        items,
+    }
 }
 
 /// Run code quality validation checks
@@ -502,3 +567,58 @@ async fn run_process_checks(project_path: &Path, task_id: &str) -> CategoryResul
     }
 }
 
+
+#[cfg(test)]
+mod validation_shape_tests {
+    //! Regressions for two ways `qa-work validate` misreported itself: the
+    //! banner stole stdout from `-f json`, and the Safety & Ethics category was
+    //! dropped so 25 checklist items were scored as 20.
+    use super::*;
+
+    #[test]
+    fn test_machine_formats_own_stdout() {
+        assert!(qa_format_owns_stdout(&QaOutputFormat::Json));
+        assert!(qa_format_owns_stdout(&QaOutputFormat::Yaml));
+        assert!(!qa_format_owns_stdout(&QaOutputFormat::Text));
+        assert!(!qa_format_owns_stdout(&QaOutputFormat::Markdown));
+    }
+
+    #[test]
+    fn test_safety_ethics_category_covers_a1_to_a5() {
+        let cat = run_safety_ethics_checks();
+        assert_eq!(cat.name, "Safety & Ethics");
+        let ids: Vec<&str> = cat.items.iter().map(|i| i.id.as_str()).collect();
+        assert_eq!(ids, vec!["A1", "A2", "A3", "A4", "A5"]);
+        assert_eq!(cat.total, 5);
+    }
+
+    #[test]
+    fn test_safety_ethics_claims_no_unmeasured_passes() {
+        let cat = run_safety_ethics_checks();
+        assert_eq!(
+            cat.passed, 0,
+            "no automated safety check is implemented, so none of A1-A5 may count as passed"
+        );
+        assert!(cat
+            .items
+            .iter()
+            .all(|i| i.status == ValidationStatus::Manual));
+    }
+
+    #[test]
+    fn test_validate_denominator_matches_the_25_point_checklist() {
+        // handle_validate is async and shells out to cargo/git, so the
+        // denominator is asserted over the category constructors it inserts:
+        // safety_ethics(5) + code_quality(5) + testing(5) + documentation(5)
+        // + process(5) = 25, the size of generate-checklist's output. It was
+        // 20 while safety_ethics was silently absent.
+        let checklist = generate_checklist("T-1", QaTaskType::Feature);
+        let checklist_items = checklist.categories.safety_ethics.len()
+            + checklist.categories.code_quality.len()
+            + checklist.categories.testing.len()
+            + checklist.categories.documentation.len()
+            + checklist.categories.process.len();
+        assert_eq!(checklist_items, 25);
+        assert_eq!(run_safety_ethics_checks().total as usize, checklist.categories.safety_ethics.len());
+    }
+}

--- a/src/cli/handlers/qdd_handlers.rs
+++ b/src/cli/handlers/qdd_handlers.rs
@@ -151,40 +151,56 @@ async fn execute_create_operation(
 }
 
 /// Display creation results
+///
+/// The four numbers here used to be printed as measurements: "Quality Score: 98.0,
+/// Complexity: 1, Coverage: 100.0%, TDG Score: 1" — identical for `add two numbers`
+/// and for `a distributed consensus engine with retries and backoff`, over a body
+/// that is `todo!("Implementation needed")`. Coverage is a literal 100 that no test
+/// run ever produced and TDG is a constant, so they are reported as not measured;
+/// the complexity/quality figures are labelled as the template estimates they are.
 fn display_create_results(profile: QddQualityProfile, result: &QddResult) {
-    println!("{}", c::header("QDD Code Creation Successful!"));
+    println!("{}", c::header("QDD Template Generated"));
     println!("{}", c::pass(&format!("Quality Profile: {profile:?}")));
+
+    let is_stub = result.code.contains("todo!");
+    if is_stub {
+        println!(
+            "  {}",
+            c::warn("Template only: the generated body is `todo!()` — nothing is implemented yet")
+        );
+    }
+
     println!(
-        "  {} {}",
-        c::label("Quality Score:"),
-        c::number(&format!("{:.1}", result.quality_score.overall))
+        "  {} {} {}",
+        c::label("Template complexity (estimated):"),
+        c::number(&format!("{}", result.quality_score.complexity)),
+        c::dim("(keyword heuristic over the template)")
     );
     println!(
-        "  {} {}",
-        c::label("Complexity:"),
-        c::number(&format!("{}", result.quality_score.complexity))
+        "  {} {} {}",
+        c::label("Template quality score (estimated):"),
+        c::number(&format!("{:.1}", result.quality_score.overall)),
+        c::dim("(derived from the estimate above, not an analysis of your code)")
     );
     println!(
         "  {} {}",
         c::label("Coverage:"),
-        c::pct(result.quality_score.coverage, 80.0, 60.0)
+        c::dim("not measured (no tests were executed)")
     );
-    println!(
-        "  {} {}",
-        c::label("TDG Score:"),
-        c::number(&format!("{}", result.quality_score.tdg))
-    );
+    println!("  {} {}", c::label("TDG Score:"), c::dim("not measured"));
     println!();
 }
 
 /// Output generated code to file or stdout
 fn output_generated_code(output_file: Option<PathBuf>, result: &QddResult) -> Result<()> {
     if let Some(output_path) = output_file {
-        let full_content = format!(
-            "{}\n\n{}\n\n{}",
-            result.code, result.tests, result.documentation
-        );
-        std::fs::write(&output_path, full_content)?;
+        // The documentation is Markdown. It used to be concatenated onto the end of
+        // the same file as the code and the tests, so `-o add.rs` produced a file
+        // that carried "# add_two", "## Returns" and a ```rust fence after
+        // `mod tests` — the emitted .rs could not parse. Rust goes in the source
+        // file; the prose goes in a sibling .md.
+        let source = format!("{}\n\n{}\n", result.code, result.tests);
+        std::fs::write(&output_path, source)?;
         println!(
             "{}",
             c::pass(&format!(
@@ -192,6 +208,21 @@ fn output_generated_code(output_file: Option<PathBuf>, result: &QddResult) -> Re
                 c::path(&output_path.display().to_string())
             ))
         );
+
+        if !result.documentation.trim().is_empty() {
+            let mut doc_path = output_path.with_extension("md");
+            if doc_path == output_path {
+                doc_path = output_path.with_extension("doc.md");
+            }
+            std::fs::write(&doc_path, format!("{}\n", result.documentation))?;
+            println!(
+                "{}",
+                c::pass(&format!(
+                    "Generated documentation written to: {}",
+                    c::path(&doc_path.display().to_string())
+                ))
+            );
+        }
     } else {
         println!("{}", c::subheader("Generated Code:"));
         println!("{}", result.code);
@@ -778,3 +809,64 @@ fn build_validation_json(
 
 // Tests extracted to qdd_handlers_tests.rs for file health (CB-040).
 include!("qdd_handlers_tests.rs");
+
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg(test)]
+mod qdd_output_tests {
+    use super::*;
+    use crate::qdd::{QualityMetrics, QualityScore, RollbackPlan};
+
+    fn sample_result() -> QddResult {
+        QddResult {
+            code:
+                "pub fn add_two(a: i32, b: i32) -> i32 {\n    todo!(\"Implementation needed\")\n}\n"
+                    .to_string(),
+            tests: "#[cfg(test)]\nmod tests {\n    use super::*;\n}\n".to_string(),
+            documentation:
+                "# add_two\n\nadd two numbers\n\n## Returns\n\n```rust\nlet x = 1;\n```\n"
+                    .to_string(),
+            quality_score: QualityScore {
+                overall: 98.0,
+                complexity: 1,
+                coverage: 100.0,
+                tdg: 1,
+            },
+            metrics: QualityMetrics::default(),
+            rollback_plan: RollbackPlan {
+                original: String::new(),
+                checkpoints: vec![],
+            },
+        }
+    }
+
+    /// The Markdown documentation used to be appended to the generated .rs, leaving
+    /// a source file that cannot parse. The .rs must contain Rust only.
+    #[test]
+    fn test_documentation_is_not_appended_to_the_rust_file() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let rs_path = tmp.path().join("add.rs");
+
+        output_generated_code(Some(rs_path.clone()), &sample_result()).unwrap();
+
+        let source = std::fs::read_to_string(&rs_path).unwrap();
+        assert!(source.contains("pub fn add_two"), "code missing: {source}");
+        assert!(source.contains("mod tests"), "tests missing: {source}");
+        assert!(
+            !source.contains("# add_two"),
+            "markdown heading leaked into the .rs: {source}"
+        );
+        assert!(
+            !source.contains("## Returns"),
+            "markdown heading leaked into the .rs: {source}"
+        );
+        assert!(
+            !source.contains("```"),
+            "markdown fence leaked into the .rs: {source}"
+        );
+        // The .rs must be parseable Rust.
+        syn::parse_file(&source).expect("generated .rs must parse as Rust");
+
+        let doc = std::fs::read_to_string(tmp.path().join("add.md")).unwrap();
+        assert!(doc.contains("## Returns"), "docs missing: {doc}");
+    }
+}

--- a/src/cli/handlers/qdd_handlers.rs
+++ b/src/cli/handlers/qdd_handlers.rs
@@ -390,6 +390,9 @@ async fn handle_qdd_validate(
     output: Option<PathBuf>,
     strict: bool,
 ) -> Result<()> {
+    // `qdd validate -p /does/not/exist.rs` printed "✓ PASSED" and exited 0.
+    crate::cli::ensure_analysis_path_exists(&path)?;
+
     let quality_profile = match profile {
         QddQualityProfile::Extreme => QualityProfile::extreme(),
         QddQualityProfile::Standard => QualityProfile::standard(),
@@ -402,59 +405,56 @@ async fn handle_qdd_validate(
         print_validation_header(&path, profile, &quality_profile);
     }
 
-    // Simple validation placeholder
-    let validation_passed = true; // Would implement actual validation
+    // This used to be `let validation_passed = true; // Would implement actual
+    // validation`, and the Detailed arm printed four hardcoded PASSED lines with
+    // no check behind any of them — so every input passed, including a path that
+    // did not exist and this repository, whose own printed thresholds
+    // ("Max Complexity: 10, Zero SATD: true") it violates. The verdict is now
+    // derived from checks that actually run, and the two thresholds this command
+    // cannot measure say so instead of passing.
+    let outcome = run_validation_checks(&path, &quality_profile).await;
+    let validation_passed = outcome.passed();
 
     match format {
         QddOutputFormat::Summary => {
             println!("\n{}", c::subheader("Validation Summary:"));
-            println!(
-                "{}",
-                if validation_passed {
-                    c::pass("PASSED")
-                } else {
-                    c::fail("FAILED")
-                }
-            );
+            println!("{}", render_status(&outcome));
+            for (name, check) in &outcome.checks {
+                println!("  {} {}", c::label(&format!("{name}:")), check.describe());
+            }
         }
         QddOutputFormat::Detailed => {
             println!("\n{}", c::subheader("Detailed Validation Results:"));
-            println!("{}", c::pass("Quality checks: PASSED"));
-            println!("{}", c::pass("Complexity check: PASSED"));
-            println!("{}", c::pass("Coverage check: PASSED"));
-            println!("{}", c::pass("Technical debt: PASSED"));
+            for (name, check) in &outcome.checks {
+                println!("{}", check.render(name));
+            }
+            println!("{}", render_status(&outcome));
         }
         QddOutputFormat::Json => {
-            let json_result = build_validation_json(validation_passed, profile, &path);
+            let json_result = build_validation_json(&outcome, profile, &path);
             println!("{}", serde_json::to_string_pretty(&json_result)?);
         }
         QddOutputFormat::Markdown => {
             println!("# QDD Validation Report");
             println!();
-            println!(
-                "**Status:** {}",
-                if validation_passed {
-                    "✅ PASSED"
-                } else {
-                    "❌ FAILED"
-                }
-            );
+            println!("**Status:** {}", markdown_status(&outcome));
             println!("**Profile:** {profile:?}");
             println!("**Path:** {}", path.display());
             println!(
                 "**Date:** {}",
                 chrono::Utc::now().format("%Y-%m-%d %H:%M:%S UTC")
             );
+            println!();
+            for (name, check) in &outcome.checks {
+                println!("- **{name}:** {}", check.describe());
+            }
         }
     }
 
     if let Some(output_path) = output {
         // Write the report before claiming it was written
-        let report = serde_json::to_string_pretty(&build_validation_json(
-            validation_passed,
-            profile,
-            &path,
-        ))?;
+        let report =
+            serde_json::to_string_pretty(&build_validation_json(&outcome, profile, &path))?;
         std::fs::write(&output_path, report)
             .with_context(|| format!("Failed to write report: {}", output_path.display()))?;
         let message = c::pass(&format!(
@@ -469,10 +469,249 @@ async fn handle_qdd_validate(
     }
 
     if strict && !validation_passed {
-        return Err(anyhow::anyhow!("Quality validation failed (strict mode)"));
+        return Err(anyhow::anyhow!(
+            "Quality validation did not pass (strict mode): {}",
+            outcome.strict_reason()
+        ));
     }
 
     Ok(())
+}
+
+/// The result of one threshold this command claims to enforce.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum CheckOutcome {
+    Passed(String),
+    Failed(String),
+    /// The threshold is printed by the header but nothing here measures it.
+    /// An unmeasured check is never a pass — see the `cuda-tdg` "not measured"
+    /// reports for the same rule.
+    NotMeasured(String),
+}
+
+impl CheckOutcome {
+    fn describe(&self) -> String {
+        match self {
+            Self::Passed(detail) | Self::Failed(detail) | Self::NotMeasured(detail) => {
+                detail.clone()
+            }
+        }
+    }
+
+    fn verdict(&self) -> &'static str {
+        match self {
+            Self::Passed(_) => "passed",
+            Self::Failed(_) => "failed",
+            Self::NotMeasured(_) => "not measured",
+        }
+    }
+
+    fn render(&self, name: &str) -> String {
+        let line = format!(
+            "{name}: {} ({})",
+            self.verdict().to_uppercase(),
+            self.describe()
+        );
+        match self {
+            Self::Passed(_) => c::pass(&line),
+            Self::Failed(_) => c::fail(&line),
+            Self::NotMeasured(_) => c::warn(&line),
+        }
+    }
+}
+
+/// Every check this run performed, in the order the header prints them.
+struct ValidationOutcome {
+    checks: Vec<(&'static str, CheckOutcome)>,
+}
+
+impl ValidationOutcome {
+    /// `failed` beats `incomplete` beats `passed`: a run that could not measure
+    /// a threshold it prints must not report a pass.
+    fn status(&self) -> &'static str {
+        if self.has(|c| matches!(c, CheckOutcome::Failed(_))) {
+            "failed"
+        } else if self.has(|c| matches!(c, CheckOutcome::NotMeasured(_))) {
+            "incomplete"
+        } else {
+            "passed"
+        }
+    }
+
+    fn has(&self, pred: impl Fn(&CheckOutcome) -> bool) -> bool {
+        self.checks.iter().any(|(_, c)| pred(c))
+    }
+
+    fn passed(&self) -> bool {
+        self.status() == "passed"
+    }
+
+    fn strict_reason(&self) -> String {
+        self.checks
+            .iter()
+            .filter(|(_, c)| !matches!(c, CheckOutcome::Passed(_)))
+            .map(|(name, c)| format!("{name} {}: {}", c.verdict(), c.describe()))
+            .collect::<Vec<_>>()
+            .join("; ")
+    }
+
+    fn violations(&self) -> Vec<serde_json::Value> {
+        self.checks
+            .iter()
+            .filter(|(_, c)| matches!(c, CheckOutcome::Failed(_)))
+            .map(|(name, c)| serde_json::json!({ "check": name, "detail": c.describe() }))
+            .collect()
+    }
+
+    fn unmeasured(&self) -> Vec<serde_json::Value> {
+        self.checks
+            .iter()
+            .filter(|(_, c)| matches!(c, CheckOutcome::NotMeasured(_)))
+            .map(|(name, c)| serde_json::json!({ "check": name, "reason": c.describe() }))
+            .collect()
+    }
+}
+
+fn render_status(outcome: &ValidationOutcome) -> String {
+    match outcome.status() {
+        "passed" => c::pass("PASSED"),
+        "failed" => c::fail("FAILED"),
+        other => c::warn(&other.to_uppercase()),
+    }
+}
+
+fn markdown_status(outcome: &ValidationOutcome) -> &'static str {
+    match outcome.status() {
+        "passed" => "✅ PASSED",
+        "failed" => "❌ FAILED",
+        _ => "⚠️ INCOMPLETE (some thresholds were not measured)",
+    }
+}
+
+/// Run the checks behind the thresholds the header prints.
+async fn run_validation_checks(path: &Path, profile: &QualityProfile) -> ValidationOutcome {
+    let thresholds = &profile.thresholds;
+    ValidationOutcome {
+        checks: vec![
+            ("complexity", check_complexity(path, thresholds.max_complexity).await),
+            ("technical debt", check_satd(path, thresholds.zero_satd).await),
+            (
+                "coverage",
+                CheckOutcome::NotMeasured(format!(
+                    "min {}% required; coverage needs an instrumented test run (cargo llvm-cov), which this command does not perform",
+                    thresholds.min_coverage
+                )),
+            ),
+            (
+                "tdg",
+                CheckOutcome::NotMeasured(format!(
+                    "max {} allowed; run `pmat tdg` — this command does not compute TDG",
+                    thresholds.max_tdg
+                )),
+            ),
+        ],
+    }
+}
+
+/// Source files this command can analyse under `path`.
+fn collect_analysable_files(path: &Path) -> Vec<PathBuf> {
+    use crate::cli::language_analyzer::Language;
+
+    let candidates = if path.is_file() {
+        vec![path.to_path_buf()]
+    } else {
+        crate::services::file_discovery::ProjectFileDiscovery::new(path.to_path_buf())
+            .discover_files()
+            .unwrap_or_default()
+    };
+
+    candidates
+        .into_iter()
+        .filter(|p| {
+            !matches!(
+                Language::from_path(p),
+                Language::Unknown | Language::Markdown | Language::Yaml
+            )
+        })
+        .collect()
+}
+
+/// Worst cyclomatic complexity under `path` against the profile threshold.
+async fn check_complexity(path: &Path, max_complexity: u32) -> CheckOutcome {
+    let files = collect_analysable_files(path);
+    let mut worst: Option<(String, u16)> = None;
+    let mut analyzed = 0usize;
+
+    for file in &files {
+        let Ok(metrics) =
+            crate::services::complexity::analyze_file_complexity_uncached(file, None).await
+        else {
+            continue;
+        };
+        analyzed += 1;
+        for func in &metrics.functions {
+            if worst
+                .as_ref()
+                .is_none_or(|(_, c)| func.metrics.cyclomatic > *c)
+            {
+                worst = Some((
+                    format!("{}::{}", metrics.path, func.name),
+                    func.metrics.cyclomatic,
+                ));
+            }
+        }
+    }
+
+    match worst {
+        // Nothing read means nothing measured; a clean pass over zero files is
+        // the fabrication this whole command was guilty of.
+        None => CheckOutcome::NotMeasured(format!(
+            "no functions were read under {} ({analyzed} file(s) analysed)",
+            path.display()
+        )),
+        Some((name, cyclomatic)) if u32::from(cyclomatic) > max_complexity => CheckOutcome::Failed(
+            format!("{name} has cyclomatic complexity {cyclomatic}, over the limit of {max_complexity} ({analyzed} file(s) analysed)"),
+        ),
+        Some((name, cyclomatic)) => CheckOutcome::Passed(format!(
+            "worst function {name} at cyclomatic {cyclomatic}, within {max_complexity} ({analyzed} file(s) analysed)"
+        )),
+    }
+}
+
+/// Self-admitted technical debt against the profile's `zero_satd` threshold.
+async fn check_satd(path: &Path, zero_satd: bool) -> CheckOutcome {
+    use crate::services::satd_detector::SATDDetector;
+
+    if !zero_satd {
+        return CheckOutcome::Passed("this profile does not require zero SATD".to_string());
+    }
+
+    let detector = SATDDetector::new();
+    let debts = if path.is_file() {
+        match std::fs::read_to_string(path) {
+            Ok(content) => detector.extract_from_content(&content, path).ok(),
+            Err(_) => None,
+        }
+    } else {
+        detector.analyze_directory(path).await.ok()
+    };
+
+    match debts {
+        None => CheckOutcome::NotMeasured(format!("could not scan {} for SATD", path.display())),
+        Some(debts) if debts.is_empty() => {
+            CheckOutcome::Passed("no self-admitted technical debt found".to_string())
+        }
+        Some(debts) => {
+            let first = debts
+                .first()
+                .map(|d| format!("{}:{}", d.file.display(), d.line))
+                .unwrap_or_default();
+            CheckOutcome::Failed(format!(
+                "{} self-admitted debt marker(s), first at {first}",
+                debts.len()
+            ))
+        }
+    }
 }
 
 /// Print the validation header and thresholds (human formats only)
@@ -512,15 +751,27 @@ fn print_validation_header(
 }
 
 /// Build the JSON payload for validation results (stdout in JSON mode is this payload only)
+///
+/// The payload used to be `{status, profile, path, validation_time}` with no
+/// field able to carry a violation — status was always "passed" and there was
+/// nowhere for a failure to appear even if one had been found. `checks`,
+/// `violations` and `not_measured` make the verdict auditable.
 fn build_validation_json(
-    validation_passed: bool,
+    outcome: &ValidationOutcome,
     profile: QddQualityProfile,
     path: &Path,
 ) -> serde_json::Value {
     serde_json::json!({
-        "status": if validation_passed { "passed" } else { "failed" },
+        "status": outcome.status(),
         "profile": format!("{profile:?}").to_lowercase(),
         "path": path.display().to_string(),
+        "checks": outcome.checks.iter().map(|(name, check)| serde_json::json!({
+            "check": name,
+            "result": check.verdict(),
+            "detail": check.describe(),
+        })).collect::<Vec<_>>(),
+        "violations": outcome.violations(),
+        "not_measured": outcome.unmeasured(),
         "validation_time": chrono::Utc::now().to_rfc3339()
     })
 }

--- a/src/cli/handlers/qdd_handlers.rs
+++ b/src/cli/handlers/qdd_handlers.rs
@@ -350,43 +350,72 @@ async fn execute_refactoring(
 }
 
 /// Display refactoring results
+///
+/// Same defect as [`display_create_results`], one command over: "Coverage: 80.0%"
+/// came from `CodeAnalyzer::estimate_coverage`, which is `count("#[test]") * 10 /
+/// line_count` — no test was compiled, let alone run — and "TDG Score: 0" is a
+/// count of the literals `todo!` and `unwrap` in the text, not a TDG score. Both
+/// are reported as not measured; the two figures that ARE derived from the code
+/// (a keyword count of branching constructs, and the score computed from it) are
+/// labelled as the estimates they are. The estimates still drive the refactoring
+/// loop's stopping condition — they are just no longer printed as measurements.
 fn display_refactor_results(
     file: &Path,
     function: Option<String>,
     profile: QddQualityProfile,
     result: &QddResult,
 ) {
-    println!("{}", c::header("QDD Refactoring Successful!"));
-    println!(
-        "  {} {}",
+    print!(
+        "{}",
+        format_refactor_results(file, function, profile, result)
+    );
+}
+
+/// The text [`display_refactor_results`] prints, as a string so it can be
+/// asserted on.
+fn format_refactor_results(
+    file: &Path,
+    function: Option<String>,
+    profile: QddQualityProfile,
+    result: &QddResult,
+) -> String {
+    let mut out = String::new();
+    out.push_str(&format!("{}\n", c::header("QDD Refactoring Successful!")));
+    out.push_str(&format!(
+        "  {} {}\n",
         c::label("File:"),
         c::path(&file.display().to_string())
-    );
+    ));
     if let Some(func) = function {
-        println!("  {} {}", c::label("Function:"), func);
+        out.push_str(&format!("  {} {}\n", c::label("Function:"), func));
     }
-    println!("{}", c::pass(&format!("Quality Profile: {profile:?}")));
-    println!(
-        "  {} {}",
-        c::label("Quality Score:"),
-        c::number(&format!("{:.1}", result.quality_score.overall))
-    );
-    println!(
-        "  {} {}",
-        c::label("Complexity:"),
-        c::number(&format!("{}", result.quality_score.complexity))
-    );
-    println!(
-        "  {} {}",
+    out.push_str(&format!(
+        "{}\n",
+        c::pass(&format!("Quality Profile: {profile:?}"))
+    ));
+    out.push_str(&format!(
+        "  {} {} {}\n",
+        c::label("Quality score (estimated):"),
+        c::number(&format!("{:.1}", result.quality_score.overall)),
+        c::dim("(derived from the estimates below, not an analysis run)")
+    ));
+    out.push_str(&format!(
+        "  {} {} {}\n",
+        c::label("Complexity (estimated):"),
+        c::number(&format!("{}", result.quality_score.complexity)),
+        c::dim("(keyword heuristic over the refactored text)")
+    ));
+    out.push_str(&format!(
+        "  {} {}\n",
         c::label("Coverage:"),
-        c::pct(result.quality_score.coverage, 80.0, 60.0)
-    );
-    println!(
-        "  {} {}",
+        c::dim("not measured (no tests were executed)")
+    ));
+    out.push_str(&format!(
+        "  {} {}\n\n",
         c::label("TDG Score:"),
-        c::number(&format!("{}", result.quality_score.tdg))
-    );
-    println!();
+        c::dim("not measured")
+    ));
+    out
 }
 
 /// Save refactored code to file
@@ -837,6 +866,60 @@ mod qdd_output_tests {
                 checkpoints: vec![],
             },
         }
+    }
+
+    /// Strip ANSI SGR sequences so assertions see the words, not the colours.
+    fn plain(s: &str) -> String {
+        let mut out = String::new();
+        let mut chars = s.chars();
+        while let Some(ch) = chars.next() {
+            if ch == '\u{1b}' {
+                for c in chars.by_ref() {
+                    if c == 'm' {
+                        break;
+                    }
+                }
+            } else {
+                out.push(ch);
+            }
+        }
+        out
+    }
+
+    /// `pmat qdd refactor` printed "Coverage: 80.0%" and "TDG Score: 0" for
+    /// every run: coverage came from `#[test]` occurrences x 10 / line count
+    /// (no test was ever executed) and "TDG" was a count of the literals
+    /// `todo!` and `unwrap`. Neither may be printed as a measurement.
+    #[test]
+    fn refactor_results_do_not_print_a_coverage_measurement() {
+        let mut result = sample_result();
+        result.quality_score.coverage = 80.0;
+        result.quality_score.tdg = 0;
+
+        let text = plain(&format_refactor_results(
+            Path::new("src/lib.rs"),
+            None,
+            QddQualityProfile::Standard,
+            &result,
+        ));
+
+        assert!(
+            text.contains("Coverage: not measured"),
+            "coverage must be reported as not measured, got:\n{text}"
+        );
+        assert!(
+            text.contains("TDG Score: not measured"),
+            "TDG must be reported as not measured, got:\n{text}"
+        );
+        assert!(
+            !text.contains("80.0%"),
+            "the coverage guess must not be printed as a percentage:\n{text}"
+        );
+        // The figures that ARE derived from the code stay, labelled as estimates.
+        assert!(
+            text.contains("Complexity (estimated):"),
+            "the complexity estimate must say it is an estimate:\n{text}"
+        );
     }
 
     /// The Markdown documentation used to be appended to the generated .rs, leaving

--- a/src/cli/handlers/qdd_handlers_tests.rs
+++ b/src/cli/handlers/qdd_handlers_tests.rs
@@ -655,22 +655,101 @@ mod coverage_tests {
         assert!(result.is_ok());
     }
 
+    /// This test used to read "Since validation_passed is hardcoded to true,
+    /// strict mode should pass" — it asserted the defect. An EMPTY directory
+    /// measures nothing, and two of the four thresholds the header prints
+    /// (coverage, TDG) are not measured at all, so strict mode must refuse
+    /// rather than certify.
     #[tokio::test]
-    async fn test_handle_qdd_validate_strict_mode_passes() {
+    async fn test_handle_qdd_validate_strict_mode_refuses_unmeasured_thresholds() {
         let temp_dir = TempDir::new().unwrap();
         let path = temp_dir.path().to_path_buf();
 
-        // Since validation_passed is hardcoded to true, strict mode should pass
-        let result = handle_qdd_validate(
+        let err = handle_qdd_validate(
             path,
             QddQualityProfile::Extreme,
             QddOutputFormat::Summary,
             None,
             true,
         )
-        .await;
+        .await
+        .expect_err("strict mode cannot pass on thresholds nothing measured");
 
-        assert!(result.is_ok());
+        let rendered = format!("{err:#}");
+        assert!(
+            rendered.contains("not measured"),
+            "the error must say what was not measured, got: {rendered}"
+        );
+    }
+
+    /// The stub passed for a path that does not exist.
+    #[tokio::test]
+    async fn test_handle_qdd_validate_rejects_a_missing_path() {
+        let missing = PathBuf::from("/does/not/exist.rs");
+        let err = handle_qdd_validate(
+            missing.clone(),
+            QddQualityProfile::Standard,
+            QddOutputFormat::Summary,
+            None,
+            false,
+        )
+        .await
+        .expect_err("a path that does not exist must not be validated");
+        assert!(format!("{err:#}").contains("/does/not/exist.rs"));
+    }
+
+    /// A file that violates the thresholds the command prints must FAIL. The
+    /// stub reported "Validation Summary: PASSED" for this repository, whose own
+    /// printed limits ("Max Complexity: 10, Zero SATD: true") it breaks.
+    #[tokio::test]
+    async fn test_handle_qdd_validate_fails_on_real_violations() {
+        let temp_dir = TempDir::new().unwrap();
+        let file = temp_dir.path().join("hot.rs");
+        let mut body = String::from("// TODO: this is self-admitted debt\nfn hot(n: i32) -> i32 {\n    let mut acc = 0;\n");
+        for i in 0..30 {
+            body.push_str(&format!("    if n > {i} {{ acc += {i}; }}\n"));
+        }
+        body.push_str("    acc\n}\n");
+        std::fs::write(&file, body).unwrap();
+
+        let outcome = run_validation_checks(&file, &QualityProfile::standard()).await;
+        assert_eq!(outcome.status(), "failed", "{}", outcome.strict_reason());
+        assert!(!outcome.passed());
+
+        let json = build_validation_json(&outcome, QddQualityProfile::Standard, &file);
+        assert_eq!(json["status"], "failed");
+        let violations = json["violations"].as_array().expect("violations array");
+        assert!(
+            violations.len() >= 2,
+            "complexity and SATD must both be reported: {violations:?}"
+        );
+    }
+
+    /// Coverage and TDG are printed as thresholds but nothing here measures
+    /// them, so they must be reported as unmeasured rather than PASSED.
+    #[tokio::test]
+    async fn test_handle_qdd_validate_never_claims_unmeasured_checks_passed() {
+        let temp_dir = TempDir::new().unwrap();
+        let file = temp_dir.path().join("clean.rs");
+        std::fs::write(&file, "fn clean() -> i32 {\n    1\n}\n").unwrap();
+
+        let outcome = run_validation_checks(&file, &QualityProfile::standard()).await;
+        assert_eq!(
+            outcome.status(),
+            "incomplete",
+            "clean code with unmeasured thresholds is not a pass: {}",
+            outcome.strict_reason()
+        );
+
+        let json = build_validation_json(&outcome, QddQualityProfile::Standard, &file);
+        let unmeasured: Vec<String> = json["not_measured"]
+            .as_array()
+            .expect("not_measured array")
+            .iter()
+            .map(|v| v["check"].as_str().unwrap_or_default().to_string())
+            .collect();
+        assert!(unmeasured.contains(&"coverage".to_string()), "{unmeasured:?}");
+        assert!(unmeasured.contains(&"tdg".to_string()), "{unmeasured:?}");
     }
 
     // ===============================================================
@@ -1158,25 +1237,36 @@ mod coverage_tests {
     // Tests for build_validation_json (JSON purity)
     // ===============================================================
 
+    fn outcome_of(checks: Vec<(&'static str, CheckOutcome)>) -> ValidationOutcome {
+        ValidationOutcome { checks }
+    }
+
     #[test]
     fn test_build_validation_json_passed() {
         let path = PathBuf::from("src/utils/scratch.rs");
-        let json = build_validation_json(true, QddQualityProfile::Standard, &path);
+        let outcome = outcome_of(vec![("complexity", CheckOutcome::Passed("ok".into()))]);
+        let json = build_validation_json(&outcome, QddQualityProfile::Standard, &path);
 
         assert_eq!(json["status"], "passed");
         assert_eq!(json["profile"], "standard");
         assert_eq!(json["path"], "src/utils/scratch.rs");
         assert!(json["validation_time"].is_string());
+        assert!(json["violations"].as_array().unwrap().is_empty());
     }
 
     #[test]
     fn test_build_validation_json_failed() {
         let path = PathBuf::from("/some/dir");
-        let json = build_validation_json(false, QddQualityProfile::Extreme, &path);
+        let outcome = outcome_of(vec![(
+            "complexity",
+            CheckOutcome::Failed("a::b has cyclomatic complexity 31".into()),
+        )]);
+        let json = build_validation_json(&outcome, QddQualityProfile::Extreme, &path);
 
         assert_eq!(json["status"], "failed");
         assert_eq!(json["profile"], "extreme");
         assert_eq!(json["path"], "/some/dir");
+        assert_eq!(json["violations"][0]["check"], "complexity");
     }
 
     #[test]
@@ -1184,7 +1274,8 @@ mod coverage_tests {
         // Stdout in JSON mode is exactly this pretty-printed payload: it must
         // start with '{' (no ANSI header) and round-trip through a JSON parser.
         let path = PathBuf::from(".");
-        let json = build_validation_json(true, QddQualityProfile::Relaxed, &path);
+        let outcome = outcome_of(vec![("complexity", CheckOutcome::Passed("ok".into()))]);
+        let json = build_validation_json(&outcome, QddQualityProfile::Relaxed, &path);
         let pretty = serde_json::to_string_pretty(&json).unwrap();
 
         assert!(pretty.starts_with('{'));

--- a/src/cli/handlers/qdd_handlers_tests.rs
+++ b/src/cli/handlers/qdd_handlers_tests.rs
@@ -343,7 +343,7 @@ mod coverage_tests {
         let result = QddResult {
             code: "fn main() { println!(\"Hello\"); }".to_string(),
             tests: "#[test] fn test_main() { assert!(true); }".to_string(),
-            documentation: "/// Main function".to_string(),
+            documentation: "# main\n\nMain function\n".to_string(),
             quality_score: QualityScore {
                 overall: 80.0,
                 complexity: 3,
@@ -360,10 +360,22 @@ mod coverage_tests {
         let res = output_generated_code(Some(output_path.clone()), &result);
         assert!(res.is_ok());
 
+        // This used to assert the Markdown documentation was inside output.rs too.
+        // That encoded the defect: the generator emits Markdown ("# add_two",
+        // "## Returns", a ```rust fence), so concatenating it onto the source
+        // produced a .rs file that could not parse. Rust goes in the source file,
+        // the prose goes in a sibling .md.
         let content = fs::read_to_string(&output_path).unwrap();
         assert!(content.contains("fn main()"));
         assert!(content.contains("#[test]"));
-        assert!(content.contains("/// Main function"));
+        assert!(
+            !content.contains("# main"),
+            "Markdown documentation must not be concatenated into the .rs file: {content}"
+        );
+
+        let doc_content = fs::read_to_string(output_path.with_extension("md")).unwrap();
+        assert!(doc_content.contains("# main"));
+        assert!(doc_content.contains("Main function"));
     }
 
     #[test]

--- a/src/cli/handlers/query_handler/formatting.rs
+++ b/src/cli/handlers/query_handler/formatting.rs
@@ -46,6 +46,7 @@ pub(super) fn emit_query_output(
         after_context,
         before_context,
         merge_ctx,
+        format,
     )? {
         return Ok(());
     }
@@ -94,6 +95,20 @@ fn print_raw_results(raw_results: &[RawSearchResult], format: &QueryOutputFormat
     }
 }
 
+/// Colour code, or nothing when stdout is not a terminal.
+///
+/// `--files-with-matches`, `--count` and `-A/-B/-C` wrote raw CYAN/YELLOW
+/// escapes unconditionally, so redirecting them to a file produced a file full
+/// of `\e[36m`. Everything these three modes print goes through here.
+fn tint(code: &'static str) -> &'static str {
+    use std::io::IsTerminal;
+    if std::io::stdout().is_terminal() {
+        code
+    } else {
+        ""
+    }
+}
+
 /// Returns Ok(true) if handled, Ok(false) for standard output.
 #[allow(clippy::too_many_arguments)]
 fn try_special_output_modes_merged(
@@ -105,18 +120,22 @@ fn try_special_output_modes_merged(
     after_context: Option<usize>,
     before_context: Option<usize>,
     ctx: &MergeContext,
+    format: &QueryOutputFormat,
 ) -> anyhow::Result<bool> {
     if files_with_matches {
-        return handle_files_with_matches(results, raw_results, ctx);
+        return handle_files_with_matches(results, raw_results, ctx, format);
     }
     if count {
-        return handle_count_mode(results, ctx);
+        return handle_count_mode(results, ctx, format);
     }
     let ctx_after = context_lines.or(after_context).unwrap_or(0);
     let ctx_before = context_lines.or(before_context).unwrap_or(0);
     if ctx_after > 0 || ctx_before > 0 {
-        print_context_lines(results, ctx.project_path, ctx_before, ctx_after);
-        print_raw_results(raw_results, &QueryOutputFormat::Text);
+        // `--format json` used to be discarded on this path twice over: the
+        // context blocks were printed as ANSI text, and the raw matches were
+        // rendered with a hardcoded `QueryOutputFormat::Text`.
+        print_context_lines(results, ctx.project_path, ctx_before, ctx_after, format);
+        print_raw_results(raw_results, format);
         return Ok(true);
     }
     Ok(false)
@@ -126,6 +145,7 @@ fn handle_files_with_matches(
     results: &[QueryResult],
     raw_results: &[RawSearchResult],
     ctx: &MergeContext,
+    format: &QueryOutputFormat,
 ) -> anyhow::Result<bool> {
     let mut seen = std::collections::HashSet::new();
     for r in results {
@@ -150,13 +170,30 @@ fn handle_files_with_matches(
     }
     let mut sorted: Vec<String> = seen.into_iter().collect();
     sorted.sort();
-    for f in &sorted {
-        println!("{CYAN}{}{RESET}", f);
-    }
+    println!("{}", render_files_with_matches(&sorted, format)?);
     Ok(true)
 }
 
-fn handle_count_mode(results: &[QueryResult], ctx: &MergeContext) -> anyhow::Result<bool> {
+/// `--files-with-matches` in the declared format.
+fn render_files_with_matches(
+    files: &[String],
+    format: &QueryOutputFormat,
+) -> anyhow::Result<String> {
+    if matches!(format, QueryOutputFormat::Json) {
+        return Ok(serde_json::to_string_pretty(files)?);
+    }
+    Ok(files
+        .iter()
+        .map(|f| format!("{}{}{}", tint(CYAN), f, tint(RESET)))
+        .collect::<Vec<_>>()
+        .join("\n"))
+}
+
+fn handle_count_mode(
+    results: &[QueryResult],
+    ctx: &MergeContext,
+    format: &QueryOutputFormat,
+) -> anyhow::Result<bool> {
     let mut file_counts: std::collections::BTreeMap<String, usize> =
         std::collections::BTreeMap::new();
     for r in results {
@@ -177,10 +214,67 @@ fn handle_count_mode(results: &[QueryResult], ctx: &MergeContext) -> anyhow::Res
             *entry = (*entry).max(c.count);
         }
     }
-    for (file, cnt) in &file_counts {
-        println!("{CYAN}{}{RESET}:{YELLOW}{}{RESET}", file, cnt);
-    }
+    println!("{}", render_counts(&file_counts, format)?);
     Ok(true)
+}
+
+/// `--count` in the declared format. `--format json` used to emit
+/// `\e[36m<path>\e[0m:\e[33m1\e[0m`, which is not JSON by any reading.
+fn render_counts(
+    file_counts: &std::collections::BTreeMap<String, usize>,
+    format: &QueryOutputFormat,
+) -> anyhow::Result<String> {
+    if matches!(format, QueryOutputFormat::Json) {
+        let rows: Vec<serde_json::Value> = file_counts
+            .iter()
+            .map(|(file, count)| serde_json::json!({ "file": file, "count": count }))
+            .collect();
+        return Ok(serde_json::to_string_pretty(&rows)?);
+    }
+    Ok(file_counts
+        .iter()
+        .map(|(file, cnt)| {
+            format!(
+                "{}{}{}:{}{}{}",
+                tint(CYAN),
+                file,
+                tint(RESET),
+                tint(YELLOW),
+                cnt,
+                tint(RESET)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n"))
+}
+
+/// The lines a context block covers, or `None` when the file could not be read.
+fn context_block(
+    r: &QueryResult,
+    project_path: &std::path::Path,
+    ctx_before: usize,
+    ctx_after: usize,
+) -> Option<(usize, usize, Vec<String>)> {
+    let start = r.start_line.saturating_sub(ctx_before).max(1);
+    let file_path = project_path.join(&r.file_path);
+    let content = match std::fs::read_to_string(&file_path) {
+        Ok(c) => c,
+        Err(_) => {
+            // Workspace paths (e.g. "trueno/src/...") are siblings, try parent dir
+            let parent_path = project_path.join("..").join(&r.file_path);
+            std::fs::read_to_string(&parent_path).ok()?
+        }
+    };
+    let lines: Vec<&str> = content.lines().collect();
+    let end = (r.end_line + ctx_after).min(lines.len());
+    let body = lines
+        .iter()
+        .enumerate()
+        .skip(start.saturating_sub(1))
+        .take((end + 1).saturating_sub(start))
+        .map(|(_, line)| (*line).to_string())
+        .collect();
+    Some((start, end, body))
 }
 
 fn print_context_for_result(
@@ -189,42 +283,79 @@ fn print_context_for_result(
     ctx_before: usize,
     ctx_after: usize,
 ) {
-    let start = r.start_line.saturating_sub(ctx_before).max(1);
-    let file_path = project_path.join(&r.file_path);
-    let content = match std::fs::read_to_string(&file_path) {
-        Ok(c) => c,
-        Err(_) => {
-            // Workspace paths (e.g. "trueno/src/...") are siblings, try parent dir
-            let parent_path = project_path.join("..").join(&r.file_path);
-            match std::fs::read_to_string(&parent_path) {
-                Ok(c) => c,
-                Err(_) => return,
-            }
-        }
+    let Some((start, end, body)) = context_block(r, project_path, ctx_before, ctx_after) else {
+        return;
     };
-    let lines: Vec<&str> = content.lines().collect();
-    let end = (r.end_line + ctx_after).min(lines.len());
     let pv_display = r
         .contract_level
         .as_deref()
-        .map(|l| format!("  PV:{GREEN}{l}{RESET}"))
+        .map(|l| format!("  PV:{}{l}{}", tint(GREEN), tint(RESET)))
         .unwrap_or_default();
-    println!("{BOLD}{CYAN}{}{RESET}:{YELLOW}{}{RESET}-{YELLOW}{}{RESET}  {WHITE}{}{RESET}  TDG:{GREEN}{}{RESET}{pv_display}",
-        r.file_path, start, end, r.function_name, r.tdg_grade);
-    for (line_idx, line) in lines
-        .iter()
-        .enumerate()
-        .skip(start.saturating_sub(1))
-        .take(end - start + 1)
-    {
-        let line_num = line_idx + 1;
+    println!(
+        "{}{}{}{}:{}{}{}-{}{}{}  {}{}{}  TDG:{}{}{}{pv_display}",
+        tint(BOLD),
+        tint(CYAN),
+        r.file_path,
+        tint(RESET),
+        tint(YELLOW),
+        start,
+        tint(RESET),
+        tint(YELLOW),
+        end,
+        tint(RESET),
+        tint(WHITE),
+        r.function_name,
+        tint(RESET),
+        tint(GREEN),
+        r.tdg_grade,
+        tint(RESET)
+    );
+    for (offset, line) in body.iter().enumerate() {
+        let line_num = start + offset;
         if line_num >= r.start_line && line_num <= r.end_line {
-            println!("{GREEN}{:>4}{RESET} {}", line_num, line);
+            println!("{}{:>4}{} {}", tint(GREEN), line_num, tint(RESET), line);
         } else {
-            println!("{DIM}{:>4} {}{RESET}", line_num, line);
+            println!("{}{:>4} {}{}", tint(DIM), line_num, line, tint(RESET));
         }
     }
     println!();
+}
+
+/// Context blocks as JSON: one object per match, with the covered lines.
+fn context_blocks_json(
+    results: &[QueryResult],
+    project_path: &std::path::Path,
+    ctx_before: usize,
+    ctx_after: usize,
+) -> serde_json::Value {
+    let blocks: Vec<serde_json::Value> = results
+        .iter()
+        .filter_map(|r| {
+            let (start, end, body) = context_block(r, project_path, ctx_before, ctx_after)?;
+            let lines: Vec<serde_json::Value> = body
+                .iter()
+                .enumerate()
+                .map(|(offset, line)| {
+                    let line_num = start + offset;
+                    serde_json::json!({
+                        "line_number": line_num,
+                        "text": line,
+                        "is_match": line_num >= r.start_line && line_num <= r.end_line,
+                    })
+                })
+                .collect();
+            Some(serde_json::json!({
+                "file": r.file_path,
+                "function": r.function_name,
+                "tdg_grade": r.tdg_grade,
+                "contract_level": r.contract_level,
+                "start_line": start,
+                "end_line": end,
+                "lines": lines,
+            }))
+        })
+        .collect();
+    serde_json::json!({ "context_matches": blocks })
 }
 
 fn print_context_lines(
@@ -232,7 +363,16 @@ fn print_context_lines(
     project_path: &std::path::Path,
     ctx_before: usize,
     ctx_after: usize,
+    format: &QueryOutputFormat,
 ) {
+    if matches!(format, QueryOutputFormat::Json) {
+        let json = context_blocks_json(results, project_path, ctx_before, ctx_after);
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&json).unwrap_or_default()
+        );
+        return;
+    }
     for r in results {
         print_context_for_result(r, project_path, ctx_before, ctx_after);
     }
@@ -278,6 +418,98 @@ fn print_query_output(
                 all_commits,
             );
             println!("{}", git_output);
+        }
+    }
+}
+
+#[cfg(test)]
+mod declared_format_tests {
+    use super::*;
+
+    fn result_for(file: &str, start: usize, end: usize) -> QueryResult {
+        serde_json::from_value(serde_json::json!({
+            "file_path": file,
+            "function_name": "f",
+            "signature": "fn f()",
+            "doc_comment": null,
+            "start_line": start,
+            "end_line": end,
+            "language": "rust",
+            "tdg_score": 90.0,
+            "tdg_grade": "A",
+            "complexity": 1,
+            "big_o": "O(1)",
+            "satd_count": 0,
+            "loc": 3,
+            "relevance_score": 1.0,
+            "source": null
+        }))
+        .expect("QueryResult fixture")
+    }
+
+    /// `query --count --format json` emitted
+    /// `\e[36m<path>\e[0m:\e[33m1\e[0m` — ANSI text, not JSON, and not even
+    /// valid JSON to a `| jq` consumer.
+    #[test]
+    fn count_mode_honours_format_json() {
+        let counts = std::collections::BTreeMap::from([
+            ("src/a.rs".to_string(), 3usize),
+            ("src/b.rs".to_string(), 1usize),
+        ]);
+        let rendered = render_counts(&counts, &QueryOutputFormat::Json).expect("render");
+        assert!(
+            !rendered.contains('\u{1b}'),
+            "JSON must not carry ANSI escapes: {rendered:?}"
+        );
+        let value: serde_json::Value = serde_json::from_str(&rendered).expect("valid json");
+        assert_eq!(value[0]["file"], "src/a.rs");
+        assert_eq!(value[0]["count"], 3);
+        assert_eq!(value[1]["count"], 1);
+    }
+
+    /// Same defect on `--files-with-matches`.
+    #[test]
+    fn files_with_matches_honours_format_json() {
+        let files = vec!["src/a.rs".to_string(), "src/b.rs".to_string()];
+        let rendered = render_files_with_matches(&files, &QueryOutputFormat::Json).expect("render");
+        assert!(!rendered.contains('\u{1b}'), "{rendered:?}");
+        let value: serde_json::Value = serde_json::from_str(&rendered).expect("valid json");
+        assert_eq!(value, serde_json::json!(["src/a.rs", "src/b.rs"]));
+    }
+
+    /// ... and on `-A/-B/-C`, which additionally hardcoded
+    /// `print_raw_results(.., &QueryOutputFormat::Text)`.
+    #[test]
+    fn context_mode_honours_format_json() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join("a.rs"), "one\ntwo\nthree\nfour\n").expect("write");
+
+        let results = vec![result_for("a.rs", 2, 2)];
+        let value = context_blocks_json(&results, dir.path(), 1, 1);
+        let rendered = serde_json::to_string(&value).expect("serialize");
+        assert!(!rendered.contains('\u{1b}'), "{rendered:?}");
+
+        let block = &value["context_matches"][0];
+        assert_eq!(block["file"], "a.rs");
+        assert_eq!(block["start_line"], 1);
+        assert_eq!(block["end_line"], 3);
+        assert_eq!(block["lines"][0]["text"], "one");
+        assert_eq!(block["lines"][0]["is_match"], false);
+        assert_eq!(block["lines"][1]["text"], "two");
+        assert_eq!(block["lines"][1]["is_match"], true);
+    }
+
+    /// Text mode keeps its shape, minus the escapes when stdout is redirected —
+    /// these modes wrote raw CYAN/YELLOW into files.
+    #[test]
+    fn text_mode_is_plain_when_stdout_is_not_a_terminal() {
+        use std::io::IsTerminal;
+        let files = vec!["src/a.rs".to_string()];
+        let rendered = render_files_with_matches(&files, &QueryOutputFormat::Text).expect("render");
+        if std::io::stdout().is_terminal() {
+            assert!(rendered.contains("src/a.rs"));
+        } else {
+            assert_eq!(rendered, "src/a.rs");
         }
     }
 }

--- a/src/cli/handlers/query_handler/modes_docs.rs
+++ b/src/cli/handlers/query_handler/modes_docs.rs
@@ -39,9 +39,21 @@ pub(super) fn emit_docs_section(
 
     match format {
         QueryOutputFormat::Json => {
-            // For JSON, print a separate documents array
+            // Documents go to STDERR, not stdout.
+            //
+            // `--docs` is on by default, and this used to `println!` a second
+            // top-level JSON document after the code-results array. Two
+            // concatenated documents are not valid JSON, so the default output
+            // of `pmat query --format json` — the search command CLAUDE.md
+            // mandates over grep — could not be piped to `jq` at all; only
+            // `--no-docs` parsed. stdout now carries exactly one document.
+            //
+            // stderr is where the sibling `raw_matches` section already goes
+            // (`print_raw_results`), so this keeps the two supplementary
+            // sections consistent and loses no data. For documents as
+            // machine-readable stdout, use `--docs-only`.
             let json = serde_json::json!({ "documents": doc_results });
-            println!(
+            eprintln!(
                 "{}",
                 serde_json::to_string_pretty(&json)
                     .map_err(|e| anyhow::anyhow!("JSON serialize: {e}"))?

--- a/src/cli/handlers/repo_score_handlers.rs
+++ b/src/cli/handlers/repo_score_handlers.rs
@@ -33,12 +33,7 @@ pub async fn handle_repo_score(
     }
 
     // Create configuration
-    let config = ScorerConfig {
-        verbose,
-        timeout_seconds: 300,
-        skip_slow_checks: failures_only,
-        deep,
-    };
+    let config = build_scorer_config(verbose, failures_only, deep);
 
     // Run scoring
     let aggregator = ScoreAggregator::new();
@@ -72,6 +67,26 @@ pub async fn handle_repo_score(
     Ok(())
 }
 
+/// Build the configuration handed to the scorers.
+///
+/// `failures_only` is accepted and deliberately DISCARDED. It used to be wired
+/// straight into `skip_slow_checks`, so a flag documented as "show only
+/// failures and warnings" changed what was measured: the pre-commit hook
+/// performance check was skipped, and a skipped check awards a full 10/10
+/// "performance assumed" instead of the measured score. `repo-score` on this
+/// repo scored 96.0 plain and 99.0 with `--failures-only` — the same repository,
+/// two answers, and the higher one from the run that measured less. A
+/// presentation flag must never reach the measurement; filtering belongs in the
+/// formatters.
+fn build_scorer_config(verbose: bool, _failures_only: bool, deep: bool) -> ScorerConfig {
+    ScorerConfig {
+        verbose,
+        timeout_seconds: 300,
+        skip_slow_checks: false,
+        deep,
+    }
+}
+
 // Display/formatting functions (format_text, format_category, format_json, format_yaml, format_markdown)
 include!("repo_score_handlers_display.rs");
 
@@ -80,6 +95,32 @@ include!("repo_score_handlers_badge.rs");
 
 // Unit tests
 include!("repo_score_handlers_tests.rs");
+
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg(test)]
+mod failures_only_is_a_display_filter_tests {
+    use super::*;
+
+    /// `--failures-only` was wired to `ScorerConfig.skip_slow_checks`, which
+    /// skipped the pre-commit performance check and scored it 10/10 instead of
+    /// the measured 7.0 — total 96.0 without the flag, 99.0 with it. The scorer
+    /// configuration must not vary with a display flag.
+    #[test]
+    fn scorer_config_does_not_vary_with_failures_only() {
+        let plain = build_scorer_config(false, false, false);
+        let filtered = build_scorer_config(false, true, false);
+
+        assert!(
+            !filtered.skip_slow_checks,
+            "--failures-only must not skip checks: a skipped check is scored as a pass"
+        );
+        assert_eq!(
+            format!("{plain:?}"),
+            format!("{filtered:?}"),
+            "a display filter must not change what is measured"
+        );
+    }
+}
 
 // Design-by-contract specifications (Verus-style)
 // #[requires(project_path.is_dir())]

--- a/src/cli/handlers/satd_handler_analysis.rs
+++ b/src/cli/handlers/satd_handler_analysis.rs
@@ -9,6 +9,8 @@ pub async fn handle_analyze_satd(config: SatdAnalysisConfig) -> Result<()> {
     // from a genuinely debt-free repository.
     crate::cli::ensure_analysis_path_exists(&config.path)?;
 
+    reject_unimplemented_evolution(config.evolution)?;
+
     eprintln!("🔍 Analyzing Self-Admitted Technical Debt (SATD)...");
 
     // Delegate filter logging to extracted function
@@ -31,6 +33,29 @@ pub async fn handle_analyze_satd(config: SatdAnalysisConfig) -> Result<()> {
     // fail. (A working check existed in complexity_handlers/satd.rs, but on a
     // route nothing dispatches to.)
     enforce_fail_on_violation(&filtered_result, config.fail_on_violation)
+}
+
+/// Refuse `--evolution` rather than answering it with a placeholder sentence.
+///
+/// `--evolution` is documented as "Track debt evolution over time (requires git
+/// history)" and `--days` as the window. Nothing read git history: summary and
+/// SARIF ignored the flag entirely (`analyze satd -p .` and `analyze satd -p .
+/// --evolution --days 90` were byte-identical), JSON answered with
+/// `"evolution": {"message": "Evolution tracking would show SATD trends over
+/// time"}` and Markdown with a `## Evolution (Last N Days)` heading over that
+/// same sentence — so `--days` moved a number in a heading and nothing else.
+/// `DebtEvolution` exists as a type with no producer.
+///
+/// A flag that measures nothing must say so, not emit prose shaped like a
+/// result. Same rule `pmat report --format html` follows (#672).
+fn reject_unimplemented_evolution(evolution: bool) -> Result<()> {
+    if evolution {
+        anyhow::bail!(
+            "--evolution is not implemented for `analyze satd`: no debt history is \
+             computed, and --days selects nothing. Re-run without it."
+        );
+    }
+    Ok(())
 }
 
 /// Turn retained violations into a non-zero exit when the caller asked for one.
@@ -145,13 +170,7 @@ async fn write_satd_output(
     config: &SatdAnalysisConfig,
 ) -> Result<()> {
     // Format output
-    let content = format_output(
-        filtered_result,
-        config.format.clone(),
-        config.evolution,
-        config.days,
-        config.metrics,
-    );
+    let content = format_output(filtered_result, config.format.clone(), config.metrics);
 
     // Write to file or stdout
     if let Some(output_path) = &config.output {

--- a/src/cli/handlers/satd_handler_analysis.rs
+++ b/src/cli/handlers/satd_handler_analysis.rs
@@ -23,6 +23,30 @@ pub async fn handle_analyze_satd(config: SatdAnalysisConfig) -> Result<()> {
     // Delegate output formatting and writing to extracted function
     write_satd_output(&filtered_result, &config).await?;
 
+    // `--fail-on-violation` is documented as "Exit with non-zero code if
+    // violations are found", but this handler never read the flag off the
+    // config: `analyze satd --strict --fail-on-violation` on a crate with three
+    // TODO/FIXME/HACK markers printed "Total violations: 3" and exited 0, the
+    // same exit code as without the flag, so no CI gate built on it could ever
+    // fail. (A working check existed in complexity_handlers/satd.rs, but on a
+    // route nothing dispatches to.)
+    enforce_fail_on_violation(&filtered_result, config.fail_on_violation)
+}
+
+/// Turn retained violations into a non-zero exit when the caller asked for one.
+///
+/// The message deliberately avoids the word "violation": `bin/pmat.rs`
+/// `categorize_error` maps any error text containing it to exit code 3, and the
+/// documented behaviour of this flag — and the behaviour of the sibling
+/// implementation it replaces — is exit 1.
+fn enforce_fail_on_violation(result: &SatdAnalysisResult, fail_on_violation: bool) -> Result<()> {
+    if fail_on_violation && !result.violations.is_empty() {
+        anyhow::bail!(
+            "SATD gate failed: {} self-admitted technical debt items found in {} files",
+            result.violations.len(),
+            result.total_files
+        );
+    }
     Ok(())
 }
 
@@ -181,4 +205,89 @@ fn apply_filters(
     }
 
     result
+}
+
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg(test)]
+mod fail_on_violation_tests {
+    use super::*;
+    use crate::services::facades::satd_facade::{SatdSeverity as FacadeSeverity, SatdViolation};
+
+    fn result_with(n: usize) -> SatdAnalysisResult {
+        SatdAnalysisResult {
+            total_files: usize::from(n > 0),
+            violations: (0..n)
+                .map(|i| SatdViolation {
+                    file_path: "src/lib.rs".to_string(),
+                    line_number: i + 1,
+                    violation_type: "TODO".to_string(),
+                    message: "TODO: finish".to_string(),
+                    severity: FacadeSeverity::Medium,
+                })
+                .collect(),
+            summary: format!("Found {n} SATD violations in 1 files"),
+        }
+    }
+
+    #[test]
+    fn violations_plus_flag_is_an_error() {
+        let err = enforce_fail_on_violation(&result_with(3), true)
+            .expect_err("--fail-on-violation with 3 items must not succeed");
+        let message = err.to_string();
+        assert!(message.contains('3'), "{message}");
+        // Exit-code contract: `categorize_error` in bin/pmat.rs routes anything
+        // mentioning "violation" to exit 3; this gate must exit 1.
+        assert!(
+            !message.to_lowercase().contains("violation"),
+            "message would be categorised as exit 3: {message}"
+        );
+    }
+
+    #[test]
+    fn no_violations_or_no_flag_is_success() {
+        assert!(enforce_fail_on_violation(&result_with(0), true).is_ok());
+        assert!(enforce_fail_on_violation(&result_with(3), false).is_ok());
+    }
+
+    /// End-to-end: the routed handler never consulted `config.fail_on_violation`
+    /// at all, so this returned `Ok` (exit 0) on a tree full of TODOs whether or
+    /// not the flag was set.
+    #[tokio::test]
+    async fn handler_fails_when_fail_on_violation_is_set() {
+        let project = tempfile::TempDir::new().unwrap();
+        let out = tempfile::TempDir::new().unwrap();
+        std::fs::write(
+            project.path().join("lib.rs"),
+            "// TODO: implement this\nfn f() {}\n// FIXME: broken\nfn g() {}\n",
+        )
+        .unwrap();
+
+        let config = |fail_on_violation: bool| SatdAnalysisConfig {
+            path: project.path().to_path_buf(),
+            format: SatdOutputFormat::Summary,
+            severity: None,
+            critical_only: false,
+            include_tests: false,
+            strict: false,
+            evolution: false,
+            days: 30,
+            metrics: false,
+            output: Some(out.path().join("satd.txt")),
+            top_files: 0,
+            fail_on_violation,
+            timeout: 60,
+            include: vec![],
+            exclude: vec![],
+            extended: false,
+        };
+
+        assert!(
+            handle_analyze_satd(config(false)).await.is_ok(),
+            "without the flag the command reports and succeeds"
+        );
+        assert!(
+            handle_analyze_satd(config(true)).await.is_err(),
+            "--fail-on-violation must make a tree with TODO/FIXME exit non-zero"
+        );
+    }
 }

--- a/src/cli/handlers/satd_handler_formatting.rs
+++ b/src/cli/handlers/satd_handler_formatting.rs
@@ -1,16 +1,21 @@
 /// Format output based on format type
+///
+/// `evolution`/`days` are gone from this dispatcher: nothing measured debt over
+/// time. Summary and SARIF ignored the flag outright, JSON emitted the literal
+/// string "Evolution tracking would show SATD trends over time" and Markdown a
+/// "## Evolution (Last N Days)" heading over the same sentence, so `--days`
+/// only ever changed a heading. `handle_analyze_satd` now refuses `--evolution`
+/// instead of rendering a placeholder that looks like a measurement.
 fn format_output(
     result: &SatdAnalysisResult,
     format: SatdOutputFormat,
-    evolution: bool,
-    days: u32,
     metrics: bool,
 ) -> String {
     match format {
         SatdOutputFormat::Summary => format_summary(result),
-        SatdOutputFormat::Json => format_json(result, metrics, evolution),
+        SatdOutputFormat::Json => format_json(result, metrics),
         SatdOutputFormat::Sarif => format_sarif(result),
-        SatdOutputFormat::Markdown => format_markdown(result, evolution, days),
+        SatdOutputFormat::Markdown => format_markdown(result),
     }
 }
 
@@ -69,25 +74,37 @@ fn format_summary(result: &SatdAnalysisResult) -> String {
         })
         .count();
 
+    // `--color never` / NO_COLOR reached these lines and changed nothing: the
+    // raw `c::BOLD`/`c::RED`/`c::RESET` consts are unconditional, so
+    // `analyze satd ... --color never > out.txt` still wrote five escape-bearing
+    // lines. `c::seq` is the same sequence gated on `colors_enabled()`.
     output.push_str(&format!("\n{}\n", c::subheader("Severity Distribution")));
     output.push_str(&format!(
         "  {}{}Critical:{} {}\n",
-        c::BOLD, c::RED, c::RESET,
+        c::seq(c::BOLD),
+        c::seq(c::RED),
+        c::seq(c::RESET),
         c::number(&critical_count.to_string())
     ));
     output.push_str(&format!(
         "  {}{}High:{} {}\n",
-        c::BOLD, c::RED, c::RESET,
+        c::seq(c::BOLD),
+        c::seq(c::RED),
+        c::seq(c::RESET),
         c::number(&high_count.to_string())
     ));
     output.push_str(&format!(
         "  {}{}Medium:{} {}\n",
-        c::BOLD, c::YELLOW, c::RESET,
+        c::seq(c::BOLD),
+        c::seq(c::YELLOW),
+        c::seq(c::RESET),
         c::number(&medium_count.to_string())
     ));
     output.push_str(&format!(
         "  {}{}Low:{} {}\n",
-        c::BOLD, c::GREEN, c::RESET,
+        c::seq(c::BOLD),
+        c::seq(c::GREEN),
+        c::seq(c::RESET),
         c::number(&low_count.to_string())
     ));
 
@@ -106,9 +123,9 @@ fn format_summary(result: &SatdAnalysisResult) -> String {
                 c::path(&violation.file_path),
                 c::dim(&violation.line_number.to_string()),
                 violation.violation_type,
-                sev_color,
+                c::seq(sev_color),
                 violation.severity,
-                c::RESET
+                c::seq(c::RESET)
             ));
         }
     }
@@ -117,7 +134,7 @@ fn format_summary(result: &SatdAnalysisResult) -> String {
 }
 
 /// Format as JSON
-fn format_json(result: &SatdAnalysisResult, metrics: bool, evolution: bool) -> String {
+fn format_json(result: &SatdAnalysisResult, metrics: bool) -> String {
     let mut json_data = serde_json::json!({
         "total_files": result.total_files,
         "total_violations": result.violations.len(),
@@ -147,12 +164,6 @@ fn format_json(result: &SatdAnalysisResult, metrics: bool, evolution: bool) -> S
             "low_count": result.violations.iter()
                 .filter(|v| matches!(v.severity, crate::services::facades::satd_facade::SatdSeverity::Low))
                 .count(),
-        });
-    }
-
-    if evolution {
-        json_data["evolution"] = serde_json::json!({
-            "message": "Evolution tracking would show SATD trends over time"
         });
     }
 
@@ -221,7 +232,7 @@ fn format_sarif(result: &SatdAnalysisResult) -> String {
 }
 
 /// Format as Markdown
-fn format_markdown(result: &SatdAnalysisResult, evolution: bool, days: u32) -> String {
+fn format_markdown(result: &SatdAnalysisResult) -> String {
     let mut output = String::new();
     output.push_str("# SATD Analysis Report\n\n");
     output.push_str(&format!("**Summary:** {}\n\n", result.summary));
@@ -258,11 +269,6 @@ fn format_markdown(result: &SatdAnalysisResult, evolution: bool, days: u32) -> S
 
     output.push_str(&format!("| Critical Violations | {critical_count} |\n"));
     output.push_str(&format!("| High Violations | {high_count} |\n\n"));
-
-    if evolution {
-        output.push_str(&format!("## Evolution (Last {days} Days)\n\n"));
-        output.push_str("*Evolution tracking would show SATD trends over time*\n\n");
-    }
 
     if !result.violations.is_empty() {
         output.push_str("## Violations\n\n");
@@ -324,14 +330,17 @@ fn print_metrics(result: &SatdAnalysisResult) {
         })
         .count();
 
+    // Same unconditional-const defect as the severity block above.
     eprintln!(
         "  {}Critical violations:{} {}",
-        c::BOLD_RED, c::RESET,
+        c::seq(c::BOLD_RED),
+        c::seq(c::RESET),
         c::number(&critical_count.to_string())
     );
     eprintln!(
         "  {}High violations:{} {}",
-        c::BOLD_RED, c::RESET,
+        c::seq(c::BOLD_RED),
+        c::seq(c::RESET),
         c::number(&high_count.to_string())
     );
 

--- a/src/cli/handlers/satd_handler_tests.rs
+++ b/src/cli/handlers/satd_handler_tests.rs
@@ -69,8 +69,6 @@ mod tests {
             &result_with_all_severities(),
             SatdOutputFormat::Summary,
             false,
-            0,
-            false,
         );
         let s = strip_ansi(&r);
         assert!(s.contains("SATD Analysis Summary"));
@@ -82,8 +80,6 @@ mod tests {
             &result_with_all_severities(),
             SatdOutputFormat::Json,
             false,
-            0,
-            false,
         );
         assert!(r.contains("\"total_violations\": 4"));
     }
@@ -93,8 +89,6 @@ mod tests {
         let r = format_output(
             &result_with_all_severities(),
             SatdOutputFormat::Sarif,
-            false,
-            0,
             false,
         );
         assert!(r.contains("\"version\":\"2.1.0\""));
@@ -106,8 +100,6 @@ mod tests {
         let r = format_output(
             &result_with_all_severities(),
             SatdOutputFormat::Markdown,
-            false,
-            0,
             false,
         );
         assert!(r.contains("# SATD Analysis Report"));
@@ -122,6 +114,30 @@ mod tests {
         assert!(r.contains("High:"));
         assert!(r.contains("Medium:"));
         assert!(r.contains("Low:"));
+        assert!(r.contains("Top Violations"));
+    }
+
+    /// `--color never` (and NO_COLOR, and a redirected stdout) must leave no
+    /// escape sequence in the summary. The Severity Distribution and Top
+    /// Violations blocks interpolated the raw `c::BOLD` / `c::RED` / `c::RESET`
+    /// consts, which are unconditional, so five sequences survived
+    /// `analyze satd --color never` and landed in redirected files.
+    #[test]
+    fn test_format_summary_emits_no_ansi_when_colors_are_disabled() {
+        // Under `cargo test` stdout is captured, so colour resolves to off —
+        // unless the operator forced it on, in which case there is nothing to
+        // assert.
+        if crate::cli::colors::colors_enabled() {
+            return;
+        }
+
+        let r = format_summary(&result_with_all_severities());
+        assert!(
+            !r.contains('\x1b'),
+            "no ANSI escape may survive with colour disabled, got: {r:?}"
+        );
+        // And the content itself is untouched by the migration.
+        assert!(r.contains("Critical:"));
         assert!(r.contains("Top Violations"));
     }
 
@@ -146,11 +162,11 @@ mod tests {
         assert!(!r.contains("V11"));
     }
 
-    // ── format_json: metrics + evolution flag toggles ──
+    // ── format_json: metrics flag toggle ──
 
     #[test]
     fn test_format_json_metrics_flag_adds_metrics_block() {
-        let r = format_json(&result_with_all_severities(), true, false);
+        let r = format_json(&result_with_all_severities(), true);
         assert!(r.contains("\"metrics\""));
         assert!(r.contains("\"critical_count\": 1"));
         assert!(r.contains("\"high_count\": 1"));
@@ -158,15 +174,34 @@ mod tests {
 
     #[test]
     fn test_format_json_no_metrics_flag_omits_metrics() {
-        let r = format_json(&result_with_all_severities(), false, false);
+        let r = format_json(&result_with_all_severities(), false);
         assert!(!r.contains("\"metrics\""));
     }
 
+    /// This test used to assert the opposite: that `--evolution` added
+    /// `"evolution": {"message": "Evolution tracking would show SATD trends
+    /// over time"}` to the document. Nothing computed a trend, so that block
+    /// was a sentence shaped like a measurement. `--evolution` is now refused
+    /// by the handler and no such key can be emitted.
     #[test]
-    fn test_format_json_evolution_flag_adds_evolution_block() {
-        let r = format_json(&result_with_all_severities(), false, true);
-        assert!(r.contains("\"evolution\""));
-        assert!(r.contains("Evolution tracking"));
+    fn test_format_json_never_emits_an_evolution_placeholder() {
+        let r = format_json(&result_with_all_severities(), true);
+        assert!(!r.contains("\"evolution\""));
+        assert!(!r.contains("Evolution tracking"));
+    }
+
+    /// `analyze satd --evolution --days 90` produced output byte-identical to
+    /// `analyze satd` in the summary format and a placeholder sentence in the
+    /// others. A flag that measures nothing must be refused.
+    #[test]
+    fn test_evolution_flag_is_rejected() {
+        assert!(reject_unimplemented_evolution(false).is_ok());
+        let err = reject_unimplemented_evolution(true)
+            .expect_err("--evolution computes nothing and must be refused");
+        assert!(
+            err.to_string().contains("--evolution"),
+            "the error must name the flag: {err}"
+        );
     }
 
     // ── format_sarif: severity → level mapping ──
@@ -186,31 +221,31 @@ mod tests {
         assert!(r.contains("\"results\":[]"));
     }
 
-    // ── format_markdown: evolution + violations table gating ──
+    // ── format_markdown: violations table gating ──
 
+    /// This pair used to assert that `--evolution` emitted a
+    /// `## Evolution (Last 30 Days)` heading over "*Evolution tracking would
+    /// show SATD trends over time*" — a heading and a sentence, with no trend
+    /// behind either, and `--days` feeding only the heading. No evolution
+    /// section may be emitted at all now.
     #[test]
-    fn test_format_markdown_with_evolution_emits_section() {
-        let r = format_markdown(&result_with_all_severities(), true, 30);
-        assert!(r.contains("## Evolution (Last 30 Days)"));
-    }
-
-    #[test]
-    fn test_format_markdown_without_evolution_skips_section() {
-        let r = format_markdown(&result_with_all_severities(), false, 0);
+    fn test_format_markdown_never_emits_an_evolution_section() {
+        let r = format_markdown(&result_with_all_severities());
         assert!(!r.contains("## Evolution"));
+        assert!(!r.contains("Evolution tracking"));
     }
 
     #[test]
     fn test_format_markdown_violations_table_emitted_only_when_non_empty() {
-        let with = format_markdown(&result_with_all_severities(), false, 0);
+        let with = format_markdown(&result_with_all_severities());
         assert!(with.contains("## Violations"));
-        let without = format_markdown(&empty_result(), false, 0);
+        let without = format_markdown(&empty_result());
         assert!(!without.contains("## Violations"));
     }
 
     #[test]
     fn test_format_markdown_metrics_table_includes_critical_high_counts() {
-        let r = format_markdown(&result_with_all_severities(), false, 0);
+        let r = format_markdown(&result_with_all_severities());
         assert!(r.contains("Critical Violations | 1"));
         assert!(r.contains("High Violations | 1"));
     }

--- a/src/cli/handlers/score_handler.rs
+++ b/src/cli/handlers/score_handler.rs
@@ -77,10 +77,7 @@ pub async fn handle_score(
     persist_score(path, &score);
 
     // Format output
-    let output_text = match format {
-        RepoScoreOutputFormat::Json => serde_json::to_string_pretty(&score)?,
-        _ => format_text(&score),
-    };
+    let output_text = render_score(&score, format)?;
 
     if let Some(output_path) = output {
         std::fs::write(output_path, &output_text)?;
@@ -135,6 +132,60 @@ pub async fn handle_score(
     }
 
     Ok(())
+}
+
+/// Render a computed score in the requested output format.
+///
+/// Every non-JSON variant used to fall through to the ANSI text renderer, so
+/// `-f yaml` and `-f markdown` emitted byte-identical banner text despite --help
+/// promising "YAML format" and "Markdown format with tables". Each advertised
+/// format now has its own arm, and the match is exhaustive so a new variant
+/// cannot silently inherit the text renderer again.
+fn render_score(score: &CompositeScore, format: &RepoScoreOutputFormat) -> Result<String> {
+    Ok(match format {
+        RepoScoreOutputFormat::Json => serde_json::to_string_pretty(score)?,
+        RepoScoreOutputFormat::Yaml => serde_yaml_ng::to_string(score)?,
+        RepoScoreOutputFormat::Markdown => format_markdown(score),
+        RepoScoreOutputFormat::Text => format_text(score),
+    })
+}
+
+/// Render the composite score as Markdown tables (`-f markdown`).
+fn format_markdown(score: &CompositeScore) -> String {
+    use std::fmt::Write as _;
+    let mut out = String::new();
+    out.push_str("# PMAT Unified Score\n\n");
+    let _ = writeln!(out, "- **Composite**: {:.1}/100", score.composite);
+    let _ = writeln!(out, "- **Grade**: {}", score.grade);
+    let _ = writeln!(out, "- **Commit**: {}", score.sha);
+    let _ = writeln!(out, "- **Timestamp**: {}\n", score.timestamp);
+
+    out.push_str("## Sub-Scores\n\n");
+    out.push_str("| Sub-Score | Value |\n|---|---:|\n");
+    let s = &score.sub_scores;
+    let _ = writeln!(out, "| RPS | {:.1} |", s.rps);
+    let _ = writeln!(
+        out,
+        "| Comply | {:.1} ({} errors, {} warnings) |",
+        s.comply, score.comply_errors, score.comply_warnings
+    );
+    let _ = writeln!(out, "| Coverage | {:.1} |", s.coverage);
+    let _ = writeln!(out, "| Muda (inv) | {:.1} |", s.muda_inv);
+    let _ = writeln!(out, "| EvoScore | {:.1} |", s.evoscore);
+    let _ = writeln!(out, "| DBC | {:.1} |", s.dbc);
+    let _ = writeln!(out, "| File Health | {:.1} |", s.file_health);
+    let _ = writeln!(out, "| PV Lint | {:.1} |", s.pv_lint);
+
+    if !score.rps_categories.is_empty() {
+        out.push_str("\n## RPS Categories\n\n");
+        out.push_str("| Category | Percent |\n|---|---:|\n");
+        let mut cats: Vec<_> = score.rps_categories.iter().collect();
+        cats.sort_by(|a, b| a.0.cmp(b.0));
+        for (name, pct) in cats {
+            let _ = writeln!(out, "| {name} | {pct:.1} |");
+        }
+    }
+    out
 }
 
 /// Compute the geometric composite from all sub-scores.
@@ -759,5 +810,36 @@ mod tests {
         let _ = check_pv_lint_gates(tmp.path());
         // No assertion on return — the behavior depends on host. We only need to
         // hit the function for coverage.
+    }
+
+    // --- render_score: each advertised format must be its own format ---
+
+    #[test]
+    fn test_render_score_yaml_and_markdown_are_not_the_text_banner() {
+        let score = dummy_score(zero_subs(), 58.3, 2);
+
+        let text = render_score(&score, &RepoScoreOutputFormat::Text).unwrap();
+        let yaml = render_score(&score, &RepoScoreOutputFormat::Yaml).unwrap();
+        let markdown = render_score(&score, &RepoScoreOutputFormat::Markdown).unwrap();
+
+        assert_ne!(
+            yaml, text,
+            "-f yaml must not fall through to the text renderer"
+        );
+        assert_ne!(
+            markdown, text,
+            "-f markdown must not fall through to the text renderer"
+        );
+
+        // YAML must actually parse as YAML and carry the composite.
+        let parsed: serde_yaml_ng::Value = serde_yaml_ng::from_str(&yaml).expect("valid YAML");
+        assert!(parsed.get("composite").is_some(), "yaml: {yaml}");
+
+        // Markdown must carry a table, as --help promises.
+        assert!(
+            markdown.starts_with("# PMAT Unified Score"),
+            "md: {markdown}"
+        );
+        assert!(markdown.contains("| RPS |"), "md: {markdown}");
     }
 }

--- a/src/cli/handlers/spec_handlers/spec_handlers_commands.rs
+++ b/src/cli/handlers/spec_handlers/spec_handlers_commands.rs
@@ -32,8 +32,10 @@ pub async fn handle_spec_score(
         use crate::cli::colors as c;
         println!(
             "\n{}",
+            // `spec comply` cannot fix anything - it only lists the gaps - so
+            // do not point users at it as a fix command.
             c::warn(&format!(
-                "Spec score {:.1} is below 95 threshold. Run `pmat spec comply` to fix.",
+                "Spec score {:.1} is below 95 threshold. Run `pmat spec comply --dry-run` to list what is missing.",
                 score
             ))
         );
@@ -111,12 +113,18 @@ pub async fn handle_spec_comply(
 
         if dry_run {
             println!("\n{}", c::dim("(Dry run - no changes made)"));
-        } else {
-            println!("\n{}", c::warn("Auto-fix not yet implemented. Please apply fixes manually."));
+            return Ok(());
         }
     }
 
-    Ok(())
+    // There is no write path here: auto-fix was never implemented. Returning
+    // Ok(()) made a scripted `spec score || spec comply` loop believe the spec
+    // had been fixed, and made --dry-run indistinguishable from a real run.
+    // Report the unimplemented feature as a failure instead.
+    anyhow::bail!(
+        "spec comply auto-fix is not implemented; apply the {} listed fix(es) manually (use --dry-run to list them without an error)",
+        fixes.len()
+    )
 }
 
 /// Handle spec create command
@@ -444,5 +452,40 @@ mod spec_handlers_commands_tests {
     fn test_print_spec_list_empty_results_markdown_no_panic() {
         let dir = std::path::Path::new("docs");
         print_spec_list(&[], dir, SpecOutputFormat::Markdown).unwrap();
+    }
+
+    // ── spec comply: the unimplemented auto-fix must not report success ──
+
+    fn write_deficient_spec(name: &str) -> PathBuf {
+        let path = std::env::temp_dir().join(name);
+        std::fs::write(&path, "# Deficient Spec\n\nSome prose, no criteria.\n").unwrap();
+        path
+    }
+
+    #[tokio::test]
+    async fn test_spec_comply_non_dry_run_errors_when_fixes_are_needed() {
+        // Regression: the non-dry-run branch printed "Auto-fix not yet
+        // implemented" and returned Ok(()), leaving the file untouched while a
+        // scripted `spec score || spec comply` loop believed the fix landed.
+        let path = write_deficient_spec("pmat_spec_comply_regression.md");
+        let before = std::fs::read_to_string(&path).unwrap();
+
+        let result = handle_spec_comply(&path, false, SpecOutputFormat::Text).await;
+        assert!(
+            result.is_err(),
+            "spec comply must not report success when it cannot fix anything"
+        );
+
+        // And it must not have pretended to write either.
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), before);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[tokio::test]
+    async fn test_spec_comply_dry_run_still_succeeds() {
+        let path = write_deficient_spec("pmat_spec_comply_dryrun.md");
+        let result = handle_spec_comply(&path, true, SpecOutputFormat::Text).await;
+        assert!(result.is_ok(), "--dry-run only lists gaps, it must succeed");
+        let _ = std::fs::remove_file(&path);
     }
 }

--- a/src/cli/handlers/spec_handlers/spec_handlers_scoring.rs
+++ b/src/cli/handlers/spec_handlers/spec_handlers_scoring.rs
@@ -10,6 +10,15 @@ fn count_citations(content: &str) -> usize {
     seen.len()
 }
 
+/// Spec **completeness** score: counts the artefacts a spec carries (issue refs,
+/// examples, criteria, claims, title, test requirements, citations).
+///
+/// This is not the same metric as `pmat qa-work spec`, which verifies each claim
+/// and scores claim **falsifiability**. Both used to advertise themselves as "the
+/// 100-point Popperian score" and print bare "Score: NN/100" lines with different
+/// pass bars (95 here, 60 there), so the same file scored 41.0 FAIL and 50.0 FAIL
+/// and readers had no way to tell the two numbers apart. The renderers below name
+/// the metric they compute.
 fn calculate_spec_score(spec: &ParsedSpec) -> f64 {
     // Scoring based on spec requirements (100 pts total)
     let mut score = 0.0;
@@ -46,14 +55,14 @@ fn calculate_spec_score(spec: &ParsedSpec) -> f64 {
 fn format_spec_score_text(spec: &ParsedSpec, score: f64, verbose: bool) -> String {
     let mut out = String::new();
 
-    out.push_str("📋 Specification Score\n");
+    out.push_str("📋 Specification Completeness Score\n");
     out.push_str("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n\n");
 
     if !spec.title.is_empty() {
         out.push_str(&format!("Title: {}\n", spec.title));
     }
 
-    out.push_str(&format!("Score: {:.1}/100\n", score));
+    out.push_str(&format!("Completeness score: {:.1}/100\n", score));
     out.push_str(&format!(
         "Status: {}\n",
         if score >= 95.0 {
@@ -62,6 +71,9 @@ fn format_spec_score_text(spec: &ParsedSpec, score: f64, verbose: bool) -> Strin
             "❌ FAIL (needs ≥95)"
         }
     ));
+    out.push_str(
+        "Note: counts artefacts present in the spec. For claim verification, run\n      `pmat qa-work spec <file>` (claim falsifiability score, separate bar).\n",
+    );
 
     if verbose {
         out.push_str(&format!("\nClaims: {}\n", spec.claims.len()));
@@ -79,6 +91,10 @@ fn format_spec_score_text(spec: &ParsedSpec, score: f64, verbose: bool) -> Strin
 fn format_spec_score_json(spec: &ParsedSpec, score: f64) -> anyhow::Result<String> {
     let result = serde_json::json!({
         "title": spec.title,
+        // Name the metric so consumers cannot conflate it with qa-work spec's
+        // claim-falsifiability score, which has its own (60) threshold.
+        "metric": "spec_completeness",
+        "threshold": 95.0,
         "score": score,
         "passing": score >= 95.0,
         "claims": spec.claims.len(),
@@ -92,7 +108,7 @@ fn format_spec_score_json(spec: &ParsedSpec, score: f64) -> anyhow::Result<Strin
 fn format_spec_score_markdown(spec: &ParsedSpec, score: f64) -> String {
     let mut out = String::new();
 
-    out.push_str("# Specification Score Report\n\n");
+    out.push_str("# Specification Completeness Score Report\n\n");
 
     if !spec.title.is_empty() {
         out.push_str(&format!("**Title:** {}\n\n", spec.title));
@@ -100,7 +116,7 @@ fn format_spec_score_markdown(spec: &ParsedSpec, score: f64) -> String {
 
     out.push_str("| Metric | Value |\n");
     out.push_str("|--------|-------|\n");
-    out.push_str(&format!("| Score | {:.1}/100 |\n", score));
+    out.push_str(&format!("| Completeness score | {:.1}/100 |\n", score));
     out.push_str(&format!(
         "| Status | {} |\n",
         if score >= 95.0 {

--- a/src/cli/handlers/spec_handlers/spec_handlers_sync.rs
+++ b/src/cli/handlers/spec_handlers/spec_handlers_sync.rs
@@ -160,17 +160,38 @@ pub async fn handle_spec_drift(
     use regex::Regex;
     use std::collections::HashSet;
 
+    // A wrong -s used to satisfy the drift gate: find_specs returns an empty
+    // vec for a missing directory and the empty orphan list renders as
+    // "No drift detected. All specs are properly linked." with exit 0.
+    if !spec_path.exists() {
+        anyhow::bail!("spec path does not exist: {}", spec_path.display());
+    }
+
     let parser = SpecParser::new();
     let specs = parser.find_specs(spec_path)?;
+    if specs.is_empty() {
+        anyhow::bail!(
+            "no specs found under {}: nothing was examined, so drift cannot be cleared",
+            spec_path.display()
+        );
+    }
     let roadmap_service = RoadmapService::new(roadmap_path);
 
+    // A missing roadmap used to be swallowed here, leaving linked_specs empty
+    // so every spec was reported "not in roadmap" — a read failure rendered as
+    // a negative measurement. Report that we could not read it instead.
+    if !roadmap_service.exists() {
+        anyhow::bail!(
+            "roadmap not found at {}. Run 'pmat work init' first.",
+            roadmap_path.display()
+        );
+    }
+
     let mut linked_specs: HashSet<std::path::PathBuf> = HashSet::new();
-    if roadmap_service.exists() {
-        let roadmap = roadmap_service.load()?;
-        for item in &roadmap.roadmap {
-            if let Some(ref spec) = item.spec {
-                linked_specs.insert(spec.clone());
-            }
+    let roadmap = roadmap_service.load()?;
+    for item in &roadmap.roadmap {
+        if let Some(ref spec) = item.spec {
+            linked_specs.insert(spec.clone());
         }
     }
 
@@ -294,5 +315,52 @@ fn print_drift_text(orphans: &[DriftInfo]) {
             c::dim("Tip:"),
             c::label("pmat spec sync --dry-run")
         );
+    }
+}
+
+#[cfg(test)]
+mod drift_input_validation_tests {
+    //! Regression tests for the two ways `spec drift` used to pass without
+    //! measuring anything: a nonexistent -s printed the all-clear, and a
+    //! missing -r was swallowed so every spec was reported unlinked.
+    use super::*;
+    use crate::cli::commands::SpecOutputFormat;
+
+    fn write_spec(dir: &Path) -> std::path::PathBuf {
+        let spec = dir.join("example.md");
+        std::fs::write(&spec, "# Example\n\nTicket: PMAT-1\n").unwrap();
+        spec
+    }
+
+    #[tokio::test]
+    async fn test_drift_nonexistent_spec_path_is_an_error() {
+        let missing = Path::new("/does/not/exist/pmat-spec-drift");
+        let err = handle_spec_drift(missing, Path::new("roadmap.yaml"), SpecOutputFormat::Text)
+            .await
+            .expect_err("a wrong -s must not clear the drift gate");
+        assert!(
+            err.to_string().contains("spec path does not exist"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_drift_empty_spec_dir_does_not_report_all_clear() {
+        let dir = tempfile::tempdir().unwrap();
+        let err = handle_spec_drift(dir.path(), Path::new("roadmap.yaml"), SpecOutputFormat::Text)
+            .await
+            .expect_err("zero specs examined is not a clean drift report");
+        assert!(err.to_string().contains("no specs found"), "unexpected: {err}");
+    }
+
+    #[tokio::test]
+    async fn test_drift_missing_roadmap_is_an_error_not_a_measurement() {
+        let dir = tempfile::tempdir().unwrap();
+        write_spec(dir.path());
+        let roadmap = dir.path().join("no-such-roadmap.yaml");
+        let err = handle_spec_drift(dir.path(), &roadmap, SpecOutputFormat::Text)
+            .await
+            .expect_err("an unreadable roadmap must not be reported as 'not in roadmap'");
+        assert!(err.to_string().contains("roadmap not found"), "unexpected: {err}");
     }
 }

--- a/src/cli/handlers/spec_handlers/tests_part1.rs
+++ b/src/cli/handlers/spec_handlers/tests_part1.rs
@@ -350,9 +350,14 @@
         let spec = create_minimal_spec("My Spec");
         let output = format_spec_score_text(&spec, 75.0, false);
 
-        assert!(output.contains("Specification Score"));
+        // Used to assert the bare headings "Specification Score" and
+        // "Score: 75.0/100". Those were the defect: `pmat qa-work spec` prints an
+        // unrelated claim-falsifiability score with the same wording and a
+        // different pass bar (60 vs 95), so the two numbers were indistinguishable.
+        // The renderer now names the metric it computes.
+        assert!(output.contains("Specification Completeness Score"));
         assert!(output.contains("Title: My Spec"));
-        assert!(output.contains("Score: 75.0/100"));
+        assert!(output.contains("Completeness score: 75.0/100"));
         assert!(output.contains("FAIL"));
     }
 
@@ -469,9 +474,13 @@
         let spec = create_minimal_spec("Markdown Spec");
         let output = format_spec_score_markdown(&spec, 75.0);
 
-        assert!(output.contains("# Specification Score Report"));
+        // Used to assert "# Specification Score Report" and "| Score | 75.0/100 |";
+        // that ambiguous wording is what let this completeness score be mistaken for
+        // qa-work spec's claim-falsifiability score. The heading and the table row
+        // now say which metric this is.
+        assert!(output.contains("# Specification Completeness Score Report"));
         assert!(output.contains("**Title:** Markdown Spec"));
-        assert!(output.contains("| Score | 75.0/100 |"));
+        assert!(output.contains("| Completeness score | 75.0/100 |"));
     }
 
     #[test]

--- a/src/cli/handlers/stack_sync_handler.rs
+++ b/src/cli/handlers/stack_sync_handler.rs
@@ -295,6 +295,44 @@ pub fn is_batuta_crate(name: &str) -> bool {
 
 // ── Mismatch Detection ──────────────────────────────────────────────────
 
+/// Lowest version a manifest requirement admits, with omitted components
+/// filled in as 0 (`"2.17"` -> 2.17.0, `"^0.4.22"` -> 0.4.22).
+fn requirement_floor(req: &str) -> Option<semver::Version> {
+    let head = req.trim().split(',').next()?.trim();
+    let head = head.trim_start_matches(['^', '~', '=', '>', '<']).trim();
+
+    let mut parts = head.split('.');
+    let major = parts.next()?.parse::<u64>().ok()?;
+    let component = |p: Option<&str>| {
+        p.and_then(|p| p.split(['-', '+']).next())
+            .and_then(|p| p.parse::<u64>().ok())
+            .unwrap_or(0)
+    };
+    let minor = component(parts.next());
+    let patch = component(parts.next());
+
+    Some(semver::Version::new(major, minor, patch))
+}
+
+/// Is the manifest requirement `current` behind registry version `latest`?
+///
+/// This used to be a raw string inequality after stripping `^`/`~`, so
+/// `pmcp = "2.17"` — a requirement 2.17.0 satisfies exactly — was reported as
+/// `2.17 -> 2.17.0`, and the outdated count necessarily equalled the total dep
+/// count (23 of 23 in this repo). Compare versions as versions: a requirement
+/// whose floor already is the latest version is not outdated, whatever the two
+/// strings look like. Unparseable input falls back to the string compare so an
+/// unrecognised requirement is never silently reported as up to date.
+fn requirement_is_outdated(current: &str, latest: &str) -> bool {
+    match (requirement_floor(current), semver::Version::parse(latest)) {
+        (Some(floor), Ok(latest_version)) => floor < latest_version,
+        _ => {
+            let current_clean = current.trim_start_matches('^').trim_start_matches('~');
+            current_clean != latest
+        }
+    }
+}
+
 #[provable_contracts_macros::contract("pmat-core.yaml", equation = "check_compliance")]
 /// Detect mismatches.
 pub fn detect_mismatches(
@@ -314,8 +352,7 @@ pub fn detect_mismatches(
         }
         if let Some(current) = &dep.version {
             if let Some(latest) = latest_versions.get(&dep.name) {
-                let current_clean = current.trim_start_matches('^').trim_start_matches('~');
-                if current_clean != latest.as_str() {
+                if requirement_is_outdated(current, latest) {
                     mismatches.push(DepMismatch {
                         repo: repo_name.to_string(),
                         crate_name: dep.name.clone(),
@@ -543,8 +580,7 @@ fn print_status_table(
                 .map(|s| s.as_str())
                 .unwrap_or("?");
 
-            let current_clean = current.trim_start_matches('^').trim_start_matches('~');
-            let is_outdated = latest != "?" && current_clean != latest;
+            let is_outdated = latest != "?" && requirement_is_outdated(current, latest);
 
             if is_outdated {
                 println!(
@@ -948,6 +984,54 @@ proptest = "1.0"
         let mismatches = detect_mismatches("my-repo", &deps, &latest);
         // ^0.4.30 should match 0.4.30 (caret stripped)
         assert_eq!(mismatches.len(), 0);
+    }
+
+    /// `pmcp = "2.17"` is satisfied exactly by 2.17.0, but the freshness check
+    /// was a string inequality, so it printed `✗ pmcp 2.17 -> 2.17.0` and the
+    /// outdated count came back equal to the dep count (23 of 23).
+    #[test]
+    fn test_detect_mismatches_two_component_requirement_is_not_outdated() {
+        let deps = vec![DepInfo {
+            name: "pmcp".to_string(),
+            version: Some("2.17".to_string()),
+            source: DepSource::Registry,
+            section: "dependencies".to_string(),
+        }];
+
+        let mut latest = BTreeMap::new();
+        latest.insert("pmcp".to_string(), "2.17.0".to_string());
+
+        let mismatches = detect_mismatches("my-repo", &deps, &latest);
+        assert!(
+            mismatches.is_empty(),
+            "2.17 is 2.17.0, yet it was reported as {:?}",
+            mismatches
+                .iter()
+                .map(|m| format!("{} -> {}", m.current_version, m.latest_version))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_requirement_floor_pads_missing_components() {
+        assert_eq!(
+            requirement_floor("2.17"),
+            Some(semver::Version::new(2, 17, 0))
+        );
+        assert_eq!(requirement_floor("1"), Some(semver::Version::new(1, 0, 0)));
+        assert_eq!(
+            requirement_floor("^0.4.22"),
+            Some(semver::Version::new(0, 4, 22))
+        );
+        assert_eq!(requirement_floor("*"), None);
+    }
+
+    #[test]
+    fn test_requirement_is_outdated_still_flags_a_real_lag() {
+        // A genuinely older floor is still reported, so `stack sync` keeps working.
+        assert!(requirement_is_outdated("0.61", "0.63.0"));
+        assert!(requirement_is_outdated("^0.4.22", "0.4.30"));
+        assert!(!requirement_is_outdated("0.4.30", "0.4.30"));
     }
 
     #[test]

--- a/src/cli/handlers/stack_sync_handler.rs
+++ b/src/cli/handlers/stack_sync_handler.rs
@@ -502,7 +502,13 @@ pub async fn handle_stack_status(format: &OutputFormat) -> Result<()> {
         mismatches: all_mismatches,
     };
 
-    // Output
+    // Output.
+    //
+    // Six of the nine advertised `--format` values (markdown, csv, summary,
+    // text, plain, junit) used to fall through a `_ =>` catch-all to the
+    // coloured table, so `-f csv | column -s,` and `-f junit` handed a CI job
+    // ANSI-decorated prose. Every variant is now spelled out — a new one is a
+    // compile error here rather than another silent fall-through.
     match format {
         OutputFormat::Json => {
             println!("{}", serde_json::to_string_pretty(&status)?);
@@ -513,8 +519,16 @@ pub async fn handle_stack_status(format: &OutputFormat) -> Result<()> {
         OutputFormat::Table => {
             print_status_table(&repos, &all_deps, &latest_versions, &status);
         }
-        _ => {
-            print_status_table(&repos, &all_deps, &latest_versions, &status);
+        OutputFormat::Markdown
+        | OutputFormat::Csv
+        | OutputFormat::Summary
+        | OutputFormat::Text
+        | OutputFormat::Plain
+        | OutputFormat::Junit => {
+            print!(
+                "{}",
+                render_status_non_table(format, &repos, &all_deps, &latest_versions, &status)
+            );
         }
     }
 
@@ -598,6 +612,281 @@ fn print_status_table(
 
     println!("{}", c::rule());
     println!();
+}
+
+// ── Handler: stack status — non-table renderers ──────────────────────────
+
+/// Render `stack status` in one of the six formats that used to fall through to
+/// the coloured table. `Table`/`Json`/`Yaml` are handled by the caller.
+fn render_status_non_table(
+    format: &OutputFormat,
+    repos: &[RepoInfo],
+    all_deps: &BTreeMap<String, Vec<DepInfo>>,
+    latest_versions: &BTreeMap<String, String>,
+    status: &StackStatus,
+) -> String {
+    match format {
+        OutputFormat::Markdown => render_status_markdown(repos, all_deps, latest_versions, status),
+        OutputFormat::Csv => render_status_csv(repos, all_deps, latest_versions),
+        OutputFormat::Summary => format!("{}\n", render_status_summary(status)),
+        OutputFormat::Junit => render_status_junit(repos, all_deps, latest_versions, status),
+        // text/plain, plus the three the caller already handled — reaching here
+        // with those would be a caller bug, and plain text is the honest answer.
+        _ => render_status_text(repos, all_deps, latest_versions, status),
+    }
+}
+
+/// One line of the status report: either a batuta dependency of a repo, or the
+/// state of a repo that contributes no dependency row (missing / no deps).
+struct StatusRow {
+    repo: String,
+    crate_name: String,
+    current: String,
+    latest: String,
+    state: &'static str,
+}
+
+/// Flatten the discovered repos into report rows, in the order the table prints
+/// them, so every format describes the same run.
+fn status_rows(
+    repos: &[RepoInfo],
+    all_deps: &BTreeMap<String, Vec<DepInfo>>,
+    latest_versions: &BTreeMap<String, String>,
+) -> Vec<StatusRow> {
+    let mut rows = Vec::new();
+
+    for repo in repos {
+        if !repo.exists {
+            rows.push(StatusRow {
+                repo: repo.name.clone(),
+                crate_name: String::new(),
+                current: String::new(),
+                latest: String::new(),
+                state: "missing",
+            });
+            continue;
+        }
+
+        let Some(deps) = all_deps.get(&repo.name) else {
+            continue;
+        };
+
+        let batuta_deps: Vec<&DepInfo> = deps
+            .iter()
+            .filter(|d| is_batuta_crate(&d.name) && d.source == DepSource::Registry)
+            .collect();
+
+        if batuta_deps.is_empty() {
+            rows.push(StatusRow {
+                repo: repo.name.clone(),
+                crate_name: String::new(),
+                current: String::new(),
+                latest: String::new(),
+                state: "no-batuta-deps",
+            });
+            continue;
+        }
+
+        for dep in batuta_deps {
+            let current = dep.version.as_deref().unwrap_or("?").to_string();
+            let latest = latest_versions
+                .get(&dep.name)
+                .cloned()
+                .unwrap_or_else(|| "?".to_string());
+            // "?" is "crates.io was not reached / crate unpublished", which is
+            // not the same as up to date and must not be reported as either.
+            let state = if latest == "?" {
+                "unknown"
+            } else if requirement_is_outdated(&current, &latest) {
+                "outdated"
+            } else {
+                "current"
+            };
+
+            rows.push(StatusRow {
+                repo: repo.name.clone(),
+                crate_name: dep.name.clone(),
+                current,
+                latest,
+                state,
+            });
+        }
+    }
+
+    rows
+}
+
+fn render_status_summary(status: &StackStatus) -> String {
+    format!(
+        "repos_found={} repos_missing={} batuta_deps={} outdated={}",
+        status.repos_found, status.repos_missing, status.total_deps, status.outdated_deps
+    )
+}
+
+fn render_status_csv(
+    repos: &[RepoInfo],
+    all_deps: &BTreeMap<String, Vec<DepInfo>>,
+    latest_versions: &BTreeMap<String, String>,
+) -> String {
+    let mut out = String::from("repo,crate,current,latest,state\n");
+    for row in status_rows(repos, all_deps, latest_versions) {
+        out.push_str(&format!(
+            "{},{},{},{},{}\n",
+            csv_field(&row.repo),
+            csv_field(&row.crate_name),
+            csv_field(&row.current),
+            csv_field(&row.latest),
+            row.state
+        ));
+    }
+    out
+}
+
+/// Quote a CSV field that carries a separator, quote or newline (RFC 4180).
+fn csv_field(value: &str) -> String {
+    if value.contains([',', '"', '\n']) {
+        format!("\"{}\"", value.replace('"', "\"\""))
+    } else {
+        value.to_string()
+    }
+}
+
+fn render_status_markdown(
+    repos: &[RepoInfo],
+    all_deps: &BTreeMap<String, Vec<DepInfo>>,
+    latest_versions: &BTreeMap<String, String>,
+    status: &StackStatus,
+) -> String {
+    let mut out = String::from("# Stack Dependency Status\n\n");
+    out.push_str(&format!(
+        "- Repos found: {}\n- Repos missing: {}\n- Batuta deps: {}\n- Outdated: {}\n\n",
+        status.repos_found, status.repos_missing, status.total_deps, status.outdated_deps
+    ));
+    out.push_str("| Repo | Crate | Current | Latest | State |\n");
+    out.push_str("|------|-------|---------|--------|-------|\n");
+    for row in status_rows(repos, all_deps, latest_versions) {
+        out.push_str(&format!(
+            "| {} | {} | {} | {} | {} |\n",
+            row.repo,
+            if row.crate_name.is_empty() {
+                "-"
+            } else {
+                &row.crate_name
+            },
+            if row.current.is_empty() {
+                "-"
+            } else {
+                &row.current
+            },
+            if row.latest.is_empty() {
+                "-"
+            } else {
+                &row.latest
+            },
+            row.state
+        ));
+    }
+    out
+}
+
+/// `text`/`plain`: the table's content with no ANSI, for pipes and logs.
+fn render_status_text(
+    repos: &[RepoInfo],
+    all_deps: &BTreeMap<String, Vec<DepInfo>>,
+    latest_versions: &BTreeMap<String, String>,
+    status: &StackStatus,
+) -> String {
+    let mut out = String::from("Stack Dependency Status\n");
+    out.push_str(&format!(
+        "  Repos found: {}  Missing: {}\n  Batuta deps: {}  Outdated: {}\n",
+        status.repos_found, status.repos_missing, status.total_deps, status.outdated_deps
+    ));
+
+    let mut current_repo = String::new();
+    for row in status_rows(repos, all_deps, latest_versions) {
+        if row.repo != current_repo {
+            out.push_str(&format!("  {}\n", row.repo));
+            current_repo = row.repo.clone();
+        }
+        match row.state {
+            "missing" => out.push_str("    (not found)\n"),
+            "no-batuta-deps" => out.push_str("    (no batuta deps)\n"),
+            "outdated" => out.push_str(&format!(
+                "    {} {} -> {}\n",
+                row.crate_name, row.current, row.latest
+            )),
+            _ => out.push_str(&format!(
+                "    {} {} ({})\n",
+                row.crate_name, row.current, row.state
+            )),
+        }
+    }
+
+    out
+}
+
+fn render_status_junit(
+    repos: &[RepoInfo],
+    all_deps: &BTreeMap<String, Vec<DepInfo>>,
+    latest_versions: &BTreeMap<String, String>,
+    status: &StackStatus,
+) -> String {
+    let rows = status_rows(repos, all_deps, latest_versions);
+    let failures = rows
+        .iter()
+        .filter(|r| r.state == "outdated" || r.state == "missing")
+        .count();
+    let skipped = rows.iter().filter(|r| r.state == "unknown").count();
+
+    let mut out = String::from("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+    out.push_str(&format!(
+        "<testsuite name=\"pmat stack status\" tests=\"{}\" failures=\"{}\" errors=\"0\" skipped=\"{}\">\n",
+        rows.len(),
+        failures,
+        skipped
+    ));
+
+    for row in &rows {
+        let name = if row.crate_name.is_empty() {
+            row.repo.clone()
+        } else {
+            format!("{}::{}", row.repo, row.crate_name)
+        };
+        out.push_str(&format!(
+            "  <testcase classname=\"stack-status\" name=\"{}\"",
+            xml_escape(&name)
+        ));
+        match row.state {
+            "outdated" => out.push_str(&format!(
+                ">\n    <failure message=\"{} is {}, latest is {}\"/>\n  </testcase>\n",
+                xml_escape(&row.crate_name),
+                xml_escape(&row.current),
+                xml_escape(&row.latest)
+            )),
+            "missing" => {
+                out.push_str(">\n    <failure message=\"repo not found\"/>\n  </testcase>\n")
+            }
+            // Not measured is not a pass: crates.io was never reached for this
+            // crate, so the case is skipped rather than reported green.
+            "unknown" => out
+                .push_str(">\n    <skipped message=\"latest version unknown\"/>\n  </testcase>\n"),
+            _ => out.push_str("/>\n"),
+        }
+    }
+
+    out.push_str(&format!(
+        "</testsuite>\n<!-- outdated_deps={} -->\n",
+        status.outdated_deps
+    ));
+    out
+}
+
+fn xml_escape(value: &str) -> String {
+    value
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
 }
 
 // ── Handler: stack sync ──────────────────────────────────────────────────
@@ -1122,5 +1411,127 @@ serde = "1.0"
             DepSource::Path("/a".to_string()),
             DepSource::Git("https://x".to_string())
         );
+    }
+}
+
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg(test)]
+mod status_format_tests {
+    use super::*;
+
+    /// (repos, deps by repo, latest version by crate, overall status)
+    type StatusFixture = (
+        Vec<RepoInfo>,
+        BTreeMap<String, Vec<DepInfo>>,
+        BTreeMap<String, String>,
+        StackStatus,
+    );
+
+    fn fixture() -> StatusFixture {
+        let repos = vec![
+            RepoInfo {
+                name: "aprender".to_string(),
+                path: PathBuf::from("/tmp/aprender"),
+                exists: true,
+            },
+            RepoInfo {
+                name: "ghost".to_string(),
+                path: PathBuf::from("/tmp/ghost"),
+                exists: false,
+            },
+        ];
+
+        let mut all_deps = BTreeMap::new();
+        all_deps.insert(
+            "aprender".to_string(),
+            vec![DepInfo {
+                name: "trueno".to_string(),
+                version: Some("0.4.30".to_string()),
+                source: DepSource::Registry,
+                section: "dependencies".to_string(),
+            }],
+        );
+
+        let mut latest = BTreeMap::new();
+        latest.insert("trueno".to_string(), "0.5.0".to_string());
+
+        let status = StackStatus {
+            repos_found: 1,
+            repos_missing: 1,
+            total_deps: 1,
+            outdated_deps: 1,
+            mismatches: vec![],
+        };
+
+        (repos, all_deps, latest, status)
+    }
+
+    /// markdown/csv/summary/text/plain/junit used to fall through a `_ =>`
+    /// catch-all to the coloured table, so six of the nine advertised formats
+    /// emitted identical ANSI output.
+    #[test]
+    fn every_format_renders_its_own_shape() {
+        let (repos, all_deps, latest, status) = fixture();
+
+        let render = |format: OutputFormat| {
+            render_status_non_table(&format, &repos, &all_deps, &latest, &status)
+        };
+        let markdown = render(OutputFormat::Markdown);
+        let csv = render(OutputFormat::Csv);
+        let summary = render(OutputFormat::Summary);
+        let text = render(OutputFormat::Text);
+        let junit = render(OutputFormat::Junit);
+
+        assert_eq!(
+            text,
+            render(OutputFormat::Plain),
+            "text and plain are the same report"
+        );
+
+        let rendered = [&markdown, &csv, &summary, &text, &junit];
+        for (i, a) in rendered.iter().enumerate() {
+            for b in rendered.iter().skip(i + 1) {
+                assert_ne!(a, b, "two formats produced the same bytes");
+            }
+            assert!(
+                !a.contains('\u{1b}'),
+                "machine-readable format must not carry ANSI escapes: {a}"
+            );
+        }
+
+        assert!(markdown.starts_with("# Stack Dependency Status"));
+        assert!(markdown.contains("| aprender | trueno | 0.4.30 | 0.5.0 | outdated |"));
+
+        assert!(csv.starts_with("repo,crate,current,latest,state\n"));
+        assert!(csv.contains("aprender,trueno,0.4.30,0.5.0,outdated\n"));
+        assert!(csv.contains("ghost,,,,missing\n"));
+
+        assert_eq!(
+            summary,
+            "repos_found=1 repos_missing=1 batuta_deps=1 outdated=1\n"
+        );
+
+        assert!(text.contains("trueno 0.4.30 -> 0.5.0"));
+        assert!(text.contains("(not found)"));
+
+        assert!(junit.starts_with("<?xml version=\"1.0\""));
+        assert!(junit.contains("<testsuite name=\"pmat stack status\" tests=\"2\" failures=\"2\""));
+        assert!(junit.contains("name=\"aprender::trueno\""));
+        assert!(junit.contains("<failure message=\"repo not found\"/>"));
+    }
+
+    /// A crate whose latest version was never fetched is not "up to date"; the
+    /// JUnit case is skipped rather than reported as a pass.
+    #[test]
+    fn unknown_latest_is_not_a_pass() {
+        let (repos, all_deps, _latest, status) = fixture();
+        let empty = BTreeMap::new();
+
+        let junit = render_status_junit(&repos, &all_deps, &empty, &status);
+        assert!(junit.contains("<skipped message=\"latest version unknown\"/>"));
+        assert!(junit.contains("skipped=\"1\""));
+
+        let csv = render_status_csv(&repos, &all_deps, &empty);
+        assert!(csv.contains("aprender,trueno,0.4.30,?,unknown\n"));
     }
 }

--- a/src/cli/handlers/tdg_diagnostic_handler.rs
+++ b/src/cli/handlers/tdg_diagnostic_handler.rs
@@ -76,29 +76,89 @@ pub async fn handle_tdg_diagnostics(command: &TdgCommand, base_path: &PathBuf) -
     }
 }
 
+/// Whether the storage section should be rendered for this flag combination.
+///
+/// A bare `pmat tdg diagnostics` used to `return Ok(())` before printing
+/// anything — exit 0 with zero bytes on stdout and stderr, from a command whose
+/// help promises "TDG system diagnostics and health status". With no section
+/// selected the caller means "whatever you have", and storage is the only
+/// section that exists.
+fn should_show_storage(storage: bool, scheduler: bool, adaptive: bool, resources: bool) -> bool {
+    storage || !scheduler && !adaptive && !resources
+}
+
+/// Sections `tdg diagnostics` advertises but has no implementation for.
+///
+/// `--scheduler`, `--adaptive` and `--resources` were underscore-prefixed
+/// unused parameters: three documented flags that were compiled-in no-ops.
+/// Naming them as unavailable is the only honest answer while that is true.
+fn unavailable_sections(scheduler: bool, adaptive: bool, resources: bool) -> Vec<&'static str> {
+    let mut out = Vec::new();
+    if scheduler {
+        out.push("scheduler");
+    }
+    if adaptive {
+        out.push("adaptive-thresholds");
+    }
+    if resources {
+        out.push("resources");
+    }
+    out
+}
+
 /// Show TDG system diagnostics
 async fn show_diagnostics(
     base_path: &PathBuf,
     detailed: bool,
     show_storage: bool,
-    _show_scheduler: bool,
-    _show_adaptive: bool,
-    _show_resources: bool,
+    show_scheduler: bool,
+    show_adaptive: bool,
+    show_resources: bool,
     format: DiagnosticOutputFormat,
 ) -> Result<()> {
-    if !show_storage {
-        return Ok(());
+    let show_storage =
+        should_show_storage(show_storage, show_scheduler, show_adaptive, show_resources);
+    let unavailable = unavailable_sections(show_scheduler, show_adaptive, show_resources);
+
+    let structured = matches!(
+        format,
+        DiagnosticOutputFormat::Json | DiagnosticOutputFormat::Yaml
+    );
+
+    // Opening the tiered store creates .pmat/tdg-*.db, so only do it when the
+    // storage section is actually going to be reported.
+    if show_storage || structured {
+        let storage = TieredStorageFactory::create_at_path(base_path)?;
+        let stats = storage.get_statistics();
+
+        match format {
+            DiagnosticOutputFormat::Plain => show_plain_diagnostics(&stats, detailed),
+            DiagnosticOutputFormat::Human => show_human_diagnostics(&stats, detailed),
+            DiagnosticOutputFormat::Json => {
+                show_json_diagnostics(&stats, show_storage, &unavailable)?;
+            }
+            DiagnosticOutputFormat::Yaml => {
+                show_yaml_diagnostics(&stats, show_storage, &unavailable)?;
+            }
+            DiagnosticOutputFormat::Table => show_table_diagnostics(&stats),
+        }
     }
 
-    let storage = TieredStorageFactory::create_at_path(base_path)?;
-    let stats = storage.get_statistics();
-
-    match format {
-        DiagnosticOutputFormat::Plain => show_plain_diagnostics(&stats, detailed),
-        DiagnosticOutputFormat::Human => show_human_diagnostics(&stats, detailed),
-        DiagnosticOutputFormat::Json => show_json_diagnostics(&stats, show_storage)?,
-        DiagnosticOutputFormat::Yaml => show_yaml_diagnostics(&stats, show_storage)?,
-        DiagnosticOutputFormat::Table => show_table_diagnostics(&stats),
+    if !unavailable.is_empty()
+        && matches!(
+            format,
+            DiagnosticOutputFormat::Plain
+                | DiagnosticOutputFormat::Human
+                | DiagnosticOutputFormat::Table
+        )
+    {
+        println!(
+            "{}",
+            c::warn(&format!(
+                "Requested but not implemented: {}. These flags have no diagnostic behind them yet.",
+                unavailable.join(", ")
+            ))
+        );
     }
 
     Ok(())
@@ -133,9 +193,11 @@ fn show_human_diagnostics(stats: &crate::tdg::storage::StorageStatistics, detail
 fn show_json_diagnostics(
     stats: &crate::tdg::storage::StorageStatistics,
     show_storage: bool,
+    unavailable: &[&str],
 ) -> Result<()> {
     let json_output = json!({
         "storage": if show_storage { Some(stats) } else { None },
+        "unavailable_sections": unavailable,
         "note": "Full diagnostic infrastructure in development"
     });
     println!("{}", serde_json::to_string_pretty(&json_output)?);
@@ -145,9 +207,11 @@ fn show_json_diagnostics(
 fn show_yaml_diagnostics(
     stats: &crate::tdg::storage::StorageStatistics,
     show_storage: bool,
+    unavailable: &[&str],
 ) -> Result<()> {
     let yaml_output = json!({
         "storage": if show_storage { Some(stats) } else { None },
+        "unavailable_sections": unavailable,
         "note": "Full diagnostic infrastructure in development"
     });
     println!("{}", serde_yaml_ng::to_string(&yaml_output)?);
@@ -170,8 +234,8 @@ fn show_table_diagnostics(stats: &crate::tdg::storage::StorageStatistics) {
         stats.warm_backend, stats.cold_backend
     );
     println!(
-        "│ Compression │ {:>16.1}% │ Memory: {:>21} KB │",
-        stats.compression_ratio * 100.0,
+        "│ Compression │ {:>17} │ Memory: {:>21} KB │",
+        stats.compression_ratio_display(),
         stats.hot_memory_kb
     );
     println!("└─────────────┴─────────────────────┴─────────────────────────────────┘");
@@ -201,7 +265,7 @@ fn print_basic_storage_info(stats: &crate::tdg::storage::StorageStatistics) {
     println!(
         "{} {}, {} {} KB",
         c::label("Compression:"),
-        c::number(&format!("{:.1}%", stats.compression_ratio * 100.0)),
+        c::number(&stats.compression_ratio_display()),
         c::label("Memory:"),
         c::number(&format!("{}", stats.hot_memory_kb))
     );
@@ -270,10 +334,17 @@ fn handle_stats(storage: &TieredStore, detailed: bool) -> Result<()> {
         c::dim("Total"),
         c::number(&stats.total_entries.to_string())
     );
+    // `tdg storage stats` printed "Compression ratio: 33.0%" over a store with
+    // zero entries, byte-identically before and after a full `pmat tdg .` run.
+    // 0.0 means the ratio was never measured, and must not render as a number.
     println!(
         "   {}: {}",
         c::dim("Compression ratio"),
-        c::pct(f64::from(stats.compression_ratio) * 100.0, 50.0, 20.0)
+        if stats.compression_ratio > 0.0 {
+            c::pct(f64::from(stats.compression_ratio) * 100.0, 50.0, 20.0)
+        } else {
+            c::dim(&stats.compression_ratio_display())
+        }
     );
     println!();
 
@@ -534,14 +605,53 @@ mod tests {
     fn test_show_json_diagnostics_with_storage_includes_field() {
         // The function prints — we can't intercept, but it returns Ok and
         // the json! macro internally serializes. Just exercise both branches.
-        assert!(show_json_diagnostics(&populated_stats(), true).is_ok());
-        assert!(show_json_diagnostics(&populated_stats(), false).is_ok());
+        assert!(show_json_diagnostics(&populated_stats(), true, &[]).is_ok());
+        assert!(show_json_diagnostics(&populated_stats(), false, &["scheduler"]).is_ok());
     }
 
     #[test]
     fn test_show_yaml_diagnostics_no_panic_both_branches() {
-        assert!(show_yaml_diagnostics(&populated_stats(), true).is_ok());
-        assert!(show_yaml_diagnostics(&populated_stats(), false).is_ok());
+        assert!(show_yaml_diagnostics(&populated_stats(), true, &[]).is_ok());
+        assert!(show_yaml_diagnostics(&populated_stats(), false, &["resources"]).is_ok());
+    }
+
+    // ── silent-success diagnostics + fabricated compression ratio ───────────
+
+    /// `pmat tdg diagnostics` with no flags produced zero bytes and exit 0.
+    /// With nothing selected, storage — the only implemented section — must be
+    /// shown.
+    #[test]
+    fn test_bare_diagnostics_selects_storage_section() {
+        // Bare invocation: no flags at all must still render something.
+        assert!(should_show_storage(false, false, false, false));
+        assert!(should_show_storage(true, false, false, false));
+        // An explicit unrelated section does not silently pull storage in.
+        assert!(!should_show_storage(false, true, false, false));
+        assert!(!should_show_storage(false, false, true, true));
+    }
+
+    /// The three flags with no implementation must be named, not ignored.
+    #[test]
+    fn test_unavailable_sections_names_unimplemented_flags() {
+        assert!(unavailable_sections(false, false, false).is_empty());
+        assert_eq!(unavailable_sections(true, false, false), vec!["scheduler"]);
+        assert_eq!(
+            unavailable_sections(true, true, true),
+            vec!["scheduler", "adaptive-thresholds", "resources"]
+        );
+    }
+
+    /// A ratio cannot be derived from zero stored entries; it used to print
+    /// "Compression ratio: 33.0%" regardless.
+    #[test]
+    fn test_compression_ratio_not_reported_for_empty_store() {
+        let rendered = empty_stats().compression_ratio_display();
+        assert!(
+            rendered.contains("not measured"),
+            "empty store must not report a compression percentage, got {rendered}"
+        );
+        assert!(!rendered.contains('%'), "got {rendered}");
+        assert_eq!(populated_stats().compression_ratio_display(), "65.0%");
     }
 
     #[test]

--- a/src/cli/handlers/tdg_handlers/display.rs
+++ b/src/cli/handlers/tdg_handlers/display.rs
@@ -280,10 +280,16 @@ pub(in crate::cli::handlers::tdg_handlers) fn display_grade_distribution(
         Grade::D,
         Grade::F,
     ];
+    // Bar length used to be `min(count, 30)`, so every bucket with 30+ files
+    // drew the same 30 blocks: A+ (1423), A (767), A- (65) and B+ (41) were
+    // rendered identical, hiding a 35x difference in the one part of the report
+    // whose entire job is showing proportion. Scale to the largest bucket
+    // instead, so the widest bar is 30 and the rest are relative to it.
+    let max_count = grade_counts.values().copied().max().unwrap_or(0);
     for grade in grade_order {
         let count = grade_counts.get(&grade).unwrap_or(&0);
         if *count > 0 {
-            let bar = "█".repeat((*count).min(30));
+            let bar = "█".repeat(scaled_bar_width(*count, max_count));
             println!(
                 "   {}: {} {}",
                 c::grade(&format!("{:>3}", grade)),
@@ -295,6 +301,22 @@ pub(in crate::cli::handlers::tdg_handlers) fn display_grade_distribution(
 
     display_f_grade_warning(&f_grade_files);
 }
+
+/// Bar width for `count` when the biggest bucket in the histogram is `max`.
+///
+/// The widest bar is [`GRADE_HISTOGRAM_WIDTH`]; every other bar is that many
+/// blocks scaled by `count / max`, rounded up so a nonzero bucket is always
+/// at least one block wide.
+pub(in crate::cli::handlers::tdg_handlers) fn scaled_bar_width(count: usize, max: usize) -> usize {
+    if count == 0 || max == 0 {
+        return 0;
+    }
+    let scaled = (count * GRADE_HISTOGRAM_WIDTH).div_ceil(max);
+    scaled.clamp(1, GRADE_HISTOGRAM_WIDTH)
+}
+
+/// Blocks in the widest grade-distribution bar.
+const GRADE_HISTOGRAM_WIDTH: usize = 30;
 
 /// Display F-grade warning if any files have F grades
 fn display_f_grade_warning(f_grade_files: &[String]) {
@@ -354,4 +376,41 @@ pub(in crate::cli::handlers::tdg_handlers) fn display_baseline_table(
         );
     }
     println!();
+}
+
+#[cfg(test)]
+mod grade_histogram_tests {
+    use super::*;
+
+    /// The bars used to be `min(count, 30)`, so `pmat tdg baseline` on this
+    /// repo drew A+ (1423), A (767), A- (65) and B+ (41) as four identical
+    /// 30-block bars. A histogram in which a 35x difference is invisible is
+    /// not reporting the distribution it claims to.
+    #[test]
+    fn bars_are_proportional_not_saturated() {
+        let counts = [1423usize, 767, 65, 41, 25, 9];
+        let max = 1423;
+        let widths: Vec<usize> = counts.iter().map(|&c| scaled_bar_width(c, max)).collect();
+
+        assert_eq!(widths[0], 30, "the largest bucket fills the width");
+        assert!(
+            widths[0] > widths[1] && widths[1] > widths[2],
+            "1423/767/65 must draw three different widths, got {widths:?}"
+        );
+        assert!(
+            widths.iter().all(|&w| w >= 1),
+            "no nonzero bucket may vanish: {widths:?}"
+        );
+        assert!(
+            widths.iter().all(|&w| w <= 30),
+            "no bar may exceed the histogram width: {widths:?}"
+        );
+    }
+
+    #[test]
+    fn a_single_bucket_and_empty_input_are_well_defined() {
+        assert_eq!(scaled_bar_width(7, 7), 30, "one bucket fills the width");
+        assert_eq!(scaled_bar_width(0, 100), 0, "an empty bucket draws nothing");
+        assert_eq!(scaled_bar_width(5, 0), 0, "no max means no histogram");
+    }
 }

--- a/src/cli/handlers/tdg_handlers/formatting.rs
+++ b/src/cli/handlers/tdg_handlers/formatting.rs
@@ -9,6 +9,48 @@ use crate::cli::colors as c;
 use crate::cli::TdgOutputFormat;
 use anyhow::Result;
 
+/// What the project aggregate knows that a bare `TdgScore` cannot say.
+///
+/// Two facts travel with the score to every renderer, because without them the
+/// rendered output contradicts itself:
+///
+/// * the F-GRADE CAP. `ProjectScore::aggregate` caps the project grade at B
+///   whenever any file grades F, so this repo printed
+///   `Overall Score: 99.8/100 (B)` while a 96.7 sub-tree printed `(A+)` — a
+///   strictly higher score with a strictly worse grade, from the same command,
+///   with no explanation anywhere in the six-line box or in the JSON.
+/// * how many files were analysed. Zero means the breakdown is not a
+///   measurement and must not be printed as one.
+type ProjectContext<'a> = Option<&'a crate::tdg::ProjectScore>;
+
+/// The disclosure of the F-grade cap, when it fired.
+fn cap_note(project: ProjectContext<'_>) -> Option<String> {
+    project.filter(|p| p.grade_capped).map(|p| {
+        format!(
+            "capped from {} by {} F-grade file{}",
+            format_grade(p.uncapped_grade()),
+            p.f_grade_count,
+            if p.f_grade_count == 1 { "" } else { "s" }
+        )
+    })
+}
+
+/// Grade text for the headline, disclosing the cap when it fired. Used where
+/// the line has no width budget; the box renderer puts the note on its own row
+/// because `box_row` clips at 47 columns.
+fn grade_headline(score: &crate::tdg::TdgScore, project: ProjectContext<'_>) -> String {
+    let grade = format_grade(score.grade);
+    match cap_note(project) {
+        Some(note) => format!("{grade} — {note}"),
+        None => grade,
+    }
+}
+
+/// True when the run analysed no file at all, so there is no breakdown to show.
+fn nothing_was_measured(project: ProjectContext<'_>) -> bool {
+    project.is_some_and(|p| p.total_files == 0)
+}
+
 /// Format TDG output based on config (cognitive complexity ≤3)
 #[provable_contracts_macros::contract("pmat-core.yaml", equation = "check_compliance")]
 pub(crate) fn format_tdg_output(
@@ -16,14 +58,26 @@ pub(crate) fn format_tdg_output(
     git_context: Option<&crate::models::git_context::GitContext>,
     config: &TdgCommandConfig,
 ) -> Result<String> {
+    format_tdg_output_with_project(score, git_context, config, None)
+}
+
+/// As `format_tdg_output`, but carrying the project aggregate so the renderers
+/// can disclose the F-grade cap and an empty analysis.
+pub(crate) fn format_tdg_output_with_project(
+    score: &crate::tdg::TdgScore,
+    git_context: Option<&crate::models::git_context::GitContext>,
+    config: &TdgCommandConfig,
+    project: ProjectContext<'_>,
+) -> Result<String> {
     if config.quiet {
         Ok(format!("{:.1}", score.total))
     } else {
-        format_tdg_score(
+        format_tdg_score_with_project(
             score.clone(),
             git_context,
             config.format.clone(),
             config.include_components,
+            project,
         )
     }
 }
@@ -46,11 +100,25 @@ pub(crate) fn format_tdg_score(
     format: TdgOutputFormat,
     include_components: bool,
 ) -> Result<String> {
+    format_tdg_score_with_project(score, git_context, format, include_components, None)
+}
+
+pub(crate) fn format_tdg_score_with_project(
+    score: crate::tdg::TdgScore,
+    git_context: Option<&crate::models::git_context::GitContext>,
+    format: TdgOutputFormat,
+    include_components: bool,
+    project: ProjectContext<'_>,
+) -> Result<String> {
     match format {
-        TdgOutputFormat::Table => format_tdg_score_table(&score, git_context, include_components),
-        TdgOutputFormat::Json => format_tdg_score_json(&score, git_context, include_components),
+        TdgOutputFormat::Table => {
+            format_tdg_score_table(&score, git_context, include_components, project)
+        }
+        TdgOutputFormat::Json => {
+            format_tdg_score_json(&score, git_context, include_components, project)
+        }
         TdgOutputFormat::Markdown => {
-            format_tdg_score_markdown(&score, git_context, include_components)
+            format_tdg_score_markdown(&score, git_context, include_components, project)
         }
         // Issue #669: this arm used to `return format!("{:.1}", score.total)`,
         // so `tdg --format sarif` emitted exactly `84.0\n` — the same 5 bytes
@@ -77,7 +145,12 @@ pub(crate) fn format_tdg_analysis(
         // uploader rejects. A declared machine format must produce that format.
         return Ok(serde_json::to_string_pretty(&sarif_for(analysis))?);
     }
-    format_tdg_output(&analysis.score, git_context, config)
+    format_tdg_output_with_project(
+        &analysis.score,
+        git_context,
+        config,
+        analysis.project.as_ref(),
+    )
 }
 
 /// SARIF for the analysis: project document for a directory, file document for
@@ -100,6 +173,7 @@ fn format_tdg_score_table(
     score: &crate::tdg::TdgScore,
     git_context: Option<&crate::models::git_context::GitContext>,
     include_components: bool,
+    project: ProjectContext<'_>,
 ) -> Result<String> {
     use crate::tdg::formatters::boxdraw::{box_blank, box_bottom, box_row, box_separator, box_top};
     let mut output = String::new();
@@ -119,13 +193,19 @@ fn format_tdg_score_table(
     }
     line(box_separator());
 
-    // Overall score
+    // Overall score. The grade may be the F-grade-capped one, and if it is, the
+    // next row says so: an unexplained `99.8/100 (B)` next to a `96.7/100 (A+)`
+    // from the same command is not a report, it is a contradiction. The note
+    // gets its own row because `box_row` clips at the frame width.
     let grade_str = format_grade(score.grade);
     line(box_row(&format!(
         "Overall Score: {}/100 ({})",
         c::number(&format!("{:.1}", score.total)),
         c::grade(&grade_str)
     )));
+    if let Some(note) = cap_note(project) {
+        line(box_row(&format!("⚠ Grade {note}")));
+    }
     line(box_row(&format!(
         "Language: {:?} (confidence: {}%)",
         score.language,
@@ -144,7 +224,13 @@ fn format_tdg_score_table(
         line(box_row(&format!("└─ Author:  {}", &git.author_name)));
     }
 
-    if include_components {
+    if include_components && nothing_was_measured(project) {
+        // No file was analysed, so there is no breakdown. Printing the struct
+        // defaults here showed 25/20/20/15/10/10 — full marks, summing to 100 —
+        // under a total of 0.0.
+        line(box_blank());
+        line(box_row("📊 Breakdown: not measured (0 files analyzed)"));
+    } else if include_components {
         line(box_blank());
         line(box_row("📊 Breakdown:"));
         for (label, value, max) in [
@@ -173,15 +259,26 @@ fn format_tdg_score_json(
     score: &crate::tdg::TdgScore,
     git_context: Option<&crate::models::git_context::GitContext>,
     include_components: bool,
+    project: ProjectContext<'_>,
 ) -> Result<String> {
+    // A machine consumer saw `{"total": 99.83, "grade": "B"}` with nothing to
+    // explain why the grade disagreed with the number, and a full-marks
+    // breakdown under `"total": 0.0` when no file could be parsed. Both facts
+    // now travel with the score.
     let json_value = serde_json::json!({
         "file": score.file_path.as_ref().map(|p| p.to_string_lossy().to_string()),
         "language": format!("{:?}", score.language),
         "confidence": score.confidence,
+        "files_analyzed": project.map(|p| p.total_files),
+        "grade_capped": project.map(|p| p.grade_capped),
+        "grade_uncapped": project
+            .filter(|p| p.grade_capped)
+            .map(|p| format_grade(p.uncapped_grade())),
+        "f_grade_count": project.map(|p| p.f_grade_count),
         "score": {
             "total": score.total,
             "grade": format_grade(score.grade),
-            "breakdown": if include_components {
+            "breakdown": if include_components && !nothing_was_measured(project) {
                 Some(serde_json::json!({
                     "structural_complexity": score.structural_complexity,
                     "semantic_complexity": score.semantic_complexity,
@@ -215,6 +312,7 @@ fn format_tdg_score_markdown(
     score: &crate::tdg::TdgScore,
     _git_context: Option<&crate::models::git_context::GitContext>,
     include_components: bool,
+    project: ProjectContext<'_>,
 ) -> Result<String> {
     let mut output = String::new();
 
@@ -226,7 +324,7 @@ fn format_tdg_score_markdown(
     output.push_str(&format!(
         "**Overall Score**: {:.1}/100 ({})\n",
         score.total,
-        format_grade(score.grade)
+        grade_headline(score, project)
     ));
     output.push_str(&format!(
         "**Language**: {:?} (confidence: {:.0}%)\n\n",
@@ -234,7 +332,9 @@ fn format_tdg_score_markdown(
         score.confidence * 100.0
     ));
 
-    if include_components {
+    if include_components && nothing_was_measured(project) {
+        output.push_str("## Component Breakdown\n\nNot measured — 0 files analyzed.\n");
+    } else if include_components {
         output.push_str("## Component Breakdown\n\n");
         output.push_str("| Component | Score | Max |\n");
         output.push_str("|-----------|-------|-----|\n");
@@ -319,5 +419,113 @@ pub(crate) fn format_comparison(
             "winner": comparison.winner
         });
         Ok(serde_json::to_string_pretty(&json_value)?)
+    }
+}
+
+#[cfg(test)]
+mod cap_disclosure_tests {
+    use super::*;
+    use crate::tdg::{Grade, ProjectScore, TdgScore};
+
+    fn file_at(total: f32) -> TdgScore {
+        let mut score = TdgScore {
+            structural_complexity: total * 0.25,
+            semantic_complexity: total * 0.20,
+            duplication_ratio: total * 0.20,
+            coupling_score: total * 0.15,
+            doc_coverage: total * 0.10,
+            consistency_score: total * 0.10,
+            entropy_score: 0.0,
+            ..TdgScore::default()
+        };
+        score.calculate_total();
+        score
+    }
+
+    /// A project with one F-grade file: the printed score is A+ territory and
+    /// the printed grade is B, and the released binary said nothing about why.
+    fn capped_project() -> ProjectScore {
+        let mut files = vec![file_at(100.0); 19];
+        files.push(file_at(10.0));
+        let project = ProjectScore::aggregate(files);
+        assert!(project.grade_capped, "fixture must exercise the cap");
+        project
+    }
+
+    #[test]
+    fn table_names_the_cap_that_moved_the_grade() {
+        let project = capped_project();
+        let score = project.average();
+        let rendered = format_tdg_score_table(&score, None, false, Some(&project)).expect("render");
+        assert!(
+            rendered.contains("capped from A+"),
+            "the box must say the grade was capped, got:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("1 F-grade file"),
+            "the box must say how many files caused it, got:\n{rendered}"
+        );
+    }
+
+    #[test]
+    fn json_carries_grade_capped_and_the_uncapped_grade() {
+        let project = capped_project();
+        let score = project.average();
+        let rendered = format_tdg_score_json(&score, None, false, Some(&project)).expect("render");
+        let value: serde_json::Value = serde_json::from_str(&rendered).expect("valid json");
+
+        assert_eq!(value["score"]["grade"], "B");
+        assert_eq!(value["grade_capped"], true);
+        assert_eq!(value["grade_uncapped"], "A+");
+        assert_eq!(value["f_grade_count"], 1);
+    }
+
+    /// An uncapped run must not grow a cap note out of nowhere.
+    #[test]
+    fn uncapped_grade_is_printed_bare() {
+        let project = ProjectScore::aggregate(vec![file_at(100.0), file_at(100.0)]);
+        assert!(!project.grade_capped);
+        let score = project.average();
+        assert_eq!(score.grade, Grade::APlus);
+        let rendered = format_tdg_score_table(&score, None, false, Some(&project)).expect("render");
+        assert!(rendered.contains("(A+)"), "got:\n{rendered}");
+        assert!(!rendered.contains("capped"), "got:\n{rendered}");
+    }
+
+    /// `--include-components` over a directory where nothing could be analysed
+    /// printed the full-marks defaults (25/20/20/15/10/10 = 100) under a total
+    /// of 0.0, byte-identically to an empty directory.
+    #[test]
+    fn empty_analysis_emits_no_breakdown() {
+        let project = ProjectScore::aggregate(vec![]);
+        let score = project.average();
+
+        let json = format_tdg_score_json(&score, None, true, Some(&project)).expect("render");
+        let value: serde_json::Value = serde_json::from_str(&json).expect("valid json");
+        assert_eq!(value["score"]["total"], 0.0);
+        assert!(
+            value["score"]["breakdown"].is_null(),
+            "breakdown must be null when no file was analyzed, got {}",
+            value["score"]["breakdown"]
+        );
+        assert_eq!(value["files_analyzed"], 0);
+
+        let table = format_tdg_score_table(&score, None, true, Some(&project)).expect("render");
+        assert!(table.contains("not measured"), "got:\n{table}");
+        assert!(!table.contains("25.0"), "got:\n{table}");
+
+        let md = format_tdg_score_markdown(&score, None, true, Some(&project)).expect("render");
+        assert!(md.contains("Not measured"), "got:\n{md}");
+    }
+
+    /// A single-file run has no project aggregate; nothing may be suppressed or
+    /// annotated there.
+    #[test]
+    fn single_file_render_is_unchanged() {
+        let score = file_at(96.0);
+        let json = format_tdg_score_json(&score, None, true, None).expect("render");
+        let value: serde_json::Value = serde_json::from_str(&json).expect("valid json");
+        assert!(value["score"]["breakdown"].is_object());
+        assert!(value["grade_capped"].is_null());
     }
 }

--- a/src/cli/handlers/tdg_handlers/history.rs
+++ b/src/cli/handlers/tdg_handlers/history.rs
@@ -54,12 +54,32 @@ async fn query_history_records(
     repo_path: &Path,
 ) -> Result<Vec<crate::tdg::FullTdgRecord>> {
     if let Some(commit_ref) = commit {
-        let found: Vec<crate::tdg::FullTdgRecord> = storage.get_by_commit(&commit_ref).await?;
+        // `--commit` takes a ref, but the raw string used to go straight to
+        // storage, which only string-matches the SHAs and tags recorded at
+        // capture time. So `--commit HEAD`, a branch name, or a tag created
+        // after the capture matched nothing — and the error blamed a missing
+        // `--with-git-context` run that had just succeeded. Ask git what the
+        // ref means first, exactly as the --since/--range paths already do.
+        let resolved = resolve_commit_ref(&commit_ref, repo_path);
+        let lookup = resolved.as_deref().unwrap_or(commit_ref.as_str());
+        let mut found: Vec<crate::tdg::FullTdgRecord> = storage.get_by_commit(lookup).await?;
+        if found.is_empty() && lookup != commit_ref.as_str() {
+            // Records captured before the SHA existed may still be keyed by the
+            // literal the user typed (e.g. a tag name).
+            found = storage.get_by_commit(&commit_ref).await?;
+        }
         if found.is_empty() {
-            return Err(anyhow!(
-                "No TDG data found for commit '{}'. Ensure TDG was run with --with-git-context.",
-                commit_ref
-            ));
+            return Err(match resolved {
+                Some(sha) => anyhow!(
+                    "No TDG record for commit '{commit_ref}' (resolved to {sha}). \
+That commit was never captured — run `pmat tdg --with-git-context` there."
+                ),
+                None => anyhow!(
+                    "Could not resolve '{commit_ref}' to a commit in {}. \
+Pass a SHA, branch, tag or ref that exists in this repository.",
+                    repo_path.display()
+                ),
+            });
         }
         return Ok(found);
     }
@@ -71,6 +91,34 @@ async fn query_history_records(
         return filter_by_git_range(&range_ref, all_records, repo_path);
     }
     Ok(all_records)
+}
+
+/// Resolve a git ref (`HEAD`, a branch, a tag, a short SHA) to its full commit
+/// SHA in `repo_path`. Returns `None` when the ref does not name a commit here,
+/// which is what distinguishes "you typed a ref I cannot resolve" from "that
+/// commit exists but was never captured".
+fn resolve_commit_ref(commit_ref: &str, repo_path: &Path) -> Option<String> {
+    let output = Command::new("git")
+        .args([
+            "rev-parse",
+            "--verify",
+            "--quiet",
+            &format!("{commit_ref}^{{commit}}"),
+        ])
+        .current_dir(repo_path)
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let sha = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if sha.is_empty() {
+        None
+    } else {
+        Some(sha)
+    }
 }
 
 /// Filter records by git "since" reference
@@ -152,4 +200,156 @@ fn filter_by_git_range(
     });
 
     Ok(records)
+}
+
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg(test)]
+mod commit_ref_resolution_tests {
+    use super::*;
+    use crate::models::git_context::GitContext;
+    use crate::tdg::storage::{
+        AnalysisMetadata, ComponentScores, FileIdentity, FullTdgRecord, SemanticSignature,
+    };
+    use crate::tdg::TieredStore;
+    use chrono::Utc;
+    use std::time::SystemTime;
+
+    fn git(repo: &Path, args: &[&str]) {
+        let status = Command::new("git")
+            .args(args)
+            .current_dir(repo)
+            .output()
+            .expect("git runs");
+        assert!(
+            status.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&status.stderr)
+        );
+    }
+
+    fn one_commit_repo(repo: &Path) -> String {
+        git(repo, &["init", "-q", "-b", "main"]);
+        git(repo, &["config", "user.email", "t@example.com"]);
+        git(repo, &["config", "user.name", "T"]);
+        // The developer's globally configured hooks must not run in a fixture.
+        git(repo, &["config", "core.hooksPath", "/dev/null"]);
+        std::fs::write(repo.join("a.txt"), "hello").unwrap();
+        git(repo, &["add", "."]);
+        git(repo, &["commit", "-q", "--no-verify", "-m", "first"]);
+        let out = Command::new("git")
+            .args(["rev-parse", "HEAD"])
+            .current_dir(repo)
+            .output()
+            .unwrap();
+        String::from_utf8_lossy(&out.stdout).trim().to_string()
+    }
+
+    fn record_at(sha: &str) -> FullTdgRecord {
+        FullTdgRecord {
+            identity: FileIdentity {
+                path: std::path::PathBuf::from("a.rs"),
+                content_hash: blake3::hash(b"a"),
+                size_bytes: 1,
+                modified_time: SystemTime::now(),
+            },
+            score: Default::default(),
+            components: ComponentScores::default(),
+            semantic_sig: SemanticSignature {
+                ast_structure_hash: 1,
+                identifier_pattern: String::new(),
+                control_flow_pattern: String::new(),
+                import_dependencies: Vec::new(),
+            },
+            metadata: AnalysisMetadata {
+                analyzer_version: "test".to_string(),
+                analysis_duration_ms: 1,
+                language_confidence: 1.0,
+                analysis_timestamp: SystemTime::now(),
+                cache_hit: false,
+            },
+            git_context: Some(GitContext {
+                commit_sha: sha.to_string(),
+                commit_sha_short: sha[..7].to_string(),
+                branch: "main".to_string(),
+                author_name: "T".to_string(),
+                author_email: "t@example.com".to_string(),
+                commit_timestamp: Utc::now(),
+                commit_message: "first".to_string(),
+                tags: vec![],
+                parent_commits: vec![],
+                remote_url: None,
+                is_clean: true,
+                uncommitted_files: 0,
+            }),
+        }
+    }
+
+    /// `--commit HEAD` used to fail with "No TDG data found for commit 'HEAD'.
+    /// Ensure TDG was run with --with-git-context" even when the run that stored
+    /// the record had just succeeded, because the literal string was matched
+    /// against the stored SHA instead of being resolved by git.
+    #[tokio::test]
+    async fn commit_ref_head_resolves_to_the_stored_sha() {
+        let dir = tempfile::tempdir().unwrap();
+        let sha = one_commit_repo(dir.path());
+
+        let storage = TieredStore::in_memory();
+        storage.store(record_at(&sha)).await.unwrap();
+
+        let found =
+            query_history_records(&storage, Some("HEAD".to_string()), None, None, dir.path())
+                .await
+                .expect("HEAD must resolve to the captured commit");
+        assert_eq!(found.len(), 1);
+
+        // A branch name must work for the same reason.
+        let found =
+            query_history_records(&storage, Some("main".to_string()), None, None, dir.path())
+                .await
+                .expect("a branch name must resolve too");
+        assert_eq!(found.len(), 1);
+    }
+
+    /// A tag created after the capture names the same commit, so it must find
+    /// the same record — it used to fail because only tags recorded at capture
+    /// time were string-matched.
+    #[tokio::test]
+    async fn tag_created_after_capture_still_resolves() {
+        let dir = tempfile::tempdir().unwrap();
+        let sha = one_commit_repo(dir.path());
+
+        let storage = TieredStore::in_memory();
+        storage.store(record_at(&sha)).await.unwrap();
+
+        git(dir.path(), &["tag", "v2.0.0"]);
+
+        let found =
+            query_history_records(&storage, Some("v2.0.0".to_string()), None, None, dir.path())
+                .await
+                .expect("a tag added after capture points at a captured commit");
+        assert_eq!(found.len(), 1);
+    }
+
+    /// An unresolvable ref must say so, not blame a missing capture run.
+    #[tokio::test]
+    async fn unresolvable_ref_is_reported_as_such() {
+        let dir = tempfile::tempdir().unwrap();
+        one_commit_repo(dir.path());
+        let storage = TieredStore::in_memory();
+
+        let err = query_history_records(
+            &storage,
+            Some("no-such-ref".to_string()),
+            None,
+            None,
+            dir.path(),
+        )
+        .await
+        .unwrap_err()
+        .to_string();
+        assert!(
+            err.contains("Could not resolve"),
+            "expected a resolution error, got: {err}"
+        );
+    }
 }

--- a/src/cli/handlers/tdg_handlers/quality_gates.rs
+++ b/src/cli/handlers/tdg_handlers/quality_gates.rs
@@ -304,6 +304,21 @@ mod min_grade_flag_tests {
     }
 
     #[test]
+    fn min_grade_a_plus_counts_every_file_the_distribution_puts_below_a_plus() {
+        // The dogfood symptom ran the other way from `--min-grade F`: with
+        // `--min-grade A+` the printed grade distribution said 903 files were
+        // below A+ while the gate reported only 42 violations, because the
+        // built-in rust=B+ entry kept every A/A-/B+ .rs file out of the count.
+        let current = baseline_with("src/good.rs", 93.0, Grade::A);
+        let result = run_primary_gate(false, Some("A+"), None, &current).unwrap();
+        assert!(
+            !result.passed && result.violations.len() == 1,
+            "an A-grade .rs file is below A+ and must be counted, got: {:?}",
+            result.violations
+        );
+    }
+
+    #[test]
     fn without_min_grade_the_per_language_defaults_still_apply() {
         // Not passing --min-grade leaves the built-in rust=B+ table in place.
         let current = baseline_with("src/bad.rs", 83.0, Grade::B);

--- a/src/cli/handlers/tdg_handlers/quality_gates.rs
+++ b/src/cli/handlers/tdg_handlers/quality_gates.rs
@@ -170,7 +170,16 @@ fn run_primary_gate(
         let baseline = TdgBaseline::new(None);
         let mut config = GateConfig::default();
         if let Some(grade_str) = min_grade_str {
+            // `--min-grade` used to write only `default_min_grade`, which
+            // `MinimumGradeGate::get_min_grade_for_file` consults ONLY for
+            // extensions it does not recognise. Every .rs/.ts/.py/.js file was
+            // still judged against the built-in per-language table
+            // (rust=B+, typescript=B+, python=B, javascript=B), so
+            // `--min-grade F` — the loosest threshold that exists — still
+            // reported B/B-/C+/C files as "Below minimum grade" and exited 3.
+            // An explicitly requested threshold replaces that table outright.
             config.default_min_grade = parse_grade(grade_str)?;
+            config.min_grades.clear();
         }
         MinimumGradeGate::new(config).check(&baseline, current)
     }
@@ -236,4 +245,69 @@ pub(super) fn check_quality_json(
         "f_grade_gate": f_grade,
         "passed": primary.passed && f_grade.passed,
     }))?)
+}
+
+#[cfg(test)]
+mod min_grade_flag_tests {
+    //! `tdg check-quality --min-grade` must be the threshold every file is
+    //! judged against, including files whose language has a built-in default.
+    use super::*;
+    use crate::tdg::{BaselineEntry, ComponentScores, Grade, Language, TdgBaseline, TdgScore};
+
+    fn baseline_with(path: &str, total: f32, grade: Grade) -> TdgBaseline {
+        let mut baseline = TdgBaseline::new(None);
+        let path = PathBuf::from(path);
+        let entry = BaselineEntry {
+            content_hash: blake3::hash(b"min-grade-flag-test"),
+            score: TdgScore {
+                total,
+                grade,
+                structural_complexity: total,
+                semantic_complexity: total,
+                duplication_ratio: 0.0,
+                coupling_score: total,
+                doc_coverage: total,
+                consistency_score: total,
+                entropy_score: total,
+                confidence: 1.0,
+                language: Language::Rust,
+                file_path: Some(path.clone()),
+                penalties_applied: Vec::new(),
+                critical_defects_count: 0,
+                has_critical_defects: false,
+                has_contract_coverage: false,
+            },
+            components: ComponentScores::default(),
+            git_context: None,
+        };
+        baseline.add_entry(path, entry);
+        baseline
+    }
+
+    #[test]
+    fn min_grade_f_accepts_a_c_grade_rust_file() {
+        let current = baseline_with("src/bad.rs", 73.0, Grade::C);
+        let result = run_primary_gate(false, Some("F"), None, &current).unwrap();
+        assert!(
+            result.passed,
+            "--min-grade F is the loosest threshold there is; a C-grade .rs file must pass it, \
+             got violations: {:?}",
+            result.violations
+        );
+    }
+
+    #[test]
+    fn min_grade_a_still_rejects_a_c_grade_rust_file() {
+        let current = baseline_with("src/bad.rs", 73.0, Grade::C);
+        let result = run_primary_gate(false, Some("A"), None, &current).unwrap();
+        assert!(!result.passed, "--min-grade A must reject a C-grade file");
+    }
+
+    #[test]
+    fn without_min_grade_the_per_language_defaults_still_apply() {
+        // Not passing --min-grade leaves the built-in rust=B+ table in place.
+        let current = baseline_with("src/bad.rs", 83.0, Grade::B);
+        let result = run_primary_gate(false, None, None, &current).unwrap();
+        assert!(!result.passed, "rust defaults to B+, so a B file fails");
+    }
 }

--- a/src/cli/handlers/telemetry_handlers.rs
+++ b/src/cli/handlers/telemetry_handlers.rs
@@ -27,9 +27,16 @@ pub async fn handle_telemetry(
         return handle_reset_command().await;
     }
 
-    // Handle test event command
+    // Handle test event command.
+    //
+    // This must NOT return: the telemetry store lives in this process only, so
+    // an early return meant the recorded event was thrown away before anything
+    // could show it. `pmat telemetry --test-event` reported success and the very
+    // next `pmat telemetry --system` reported "Total Operations: 0", and even
+    // `--test-event --system` in one process printed nothing but the success
+    // line. Falling through is what makes the recorded event observable at all.
     if test_event {
-        return handle_test_event_command().await;
+        handle_test_event_command().await?;
     }
 
     // Handle display commands
@@ -61,9 +68,16 @@ async fn handle_reset_command() -> Result<()> {
 }
 
 /// Handle test event recording command
+///
+/// The success line has to say WHERE the event went. Telemetry is an in-memory,
+/// process-local store with no persistence, so "recorded successfully" read as a
+/// promise that a later `pmat telemetry --system` would count it — it never can.
 async fn handle_test_event_command() -> Result<()> {
     record_test_telemetry_event().await?;
-    println!("{}", c::pass("Test telemetry event recorded successfully"));
+    println!(
+        "{}",
+        c::pass("Test telemetry event recorded in this process (telemetry is in-memory and is not persisted between runs)")
+    );
     Ok(())
 }
 
@@ -300,9 +314,16 @@ async fn show_system_overview() -> Result<()> {
 
     if system_data.services.is_empty() {
         println!("{}", c::dim("No service telemetry data available yet"));
+        // The old hint — "Use --test-event to generate sample telemetry data" —
+        // pointed at something that cannot work across invocations: counters
+        // live in this process only, so a separate `--test-event` run always
+        // leaves this report at zero.
         println!(
             "{}",
-            c::dim("Use --test-event to generate sample telemetry data")
+            c::dim(
+                "Telemetry counts operations performed by THIS process and is not persisted; \
+                 use `pmat telemetry --test-event --system` to see a sample event in one run"
+            )
         );
     } else {
         println!(
@@ -390,6 +411,7 @@ mod tests {
     use super::*;
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn test_telemetry_command_system() {
         // Reset telemetry for clean test
         telemetry().reset();
@@ -403,6 +425,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn test_telemetry_command_service() {
         // Reset telemetry for clean test
         telemetry().reset();
@@ -420,6 +443,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn test_telemetry_reset() {
         // Add some data
         record_test_telemetry_event().await.unwrap();
@@ -432,6 +456,29 @@ mod tests {
         let _system_data = telemetry().get_system_telemetry().await.unwrap();
         // Note: Assertion disabled due to test flakiness in parallel test environment
         // assert_eq!(system_data.system_metrics.total_operations, 0);
+    }
+
+    /// `--test-event` used to return before the display path ran, so the event
+    /// it had just recorded was invisible even in the SAME process — and the
+    /// command execution that the display path records never happened either.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn test_test_event_falls_through_to_the_display_path() {
+        telemetry().reset();
+
+        handle_telemetry(true, None, false, true).await.unwrap();
+
+        let data = telemetry().get_system_telemetry().await.unwrap();
+        assert!(
+            data.services.contains_key("telemetry_test_service"),
+            "the test event itself must be recorded: {:?}",
+            data.services.keys().collect::<Vec<_>>()
+        );
+        assert!(
+            data.services.contains_key("cli_telemetry_handler"),
+            "--test-event returned before the display path ran: {:?}",
+            data.services.keys().collect::<Vec<_>>()
+        );
     }
 
     /// IGNORED: Flaky in parallel test environment - telemetry state races

--- a/src/cli/handlers/telemetry_handlers.rs
+++ b/src/cli/handlers/telemetry_handlers.rs
@@ -57,13 +57,12 @@ async fn handle_reset_command() -> Result<()> {
         Ok(())
     }
 
+    // `--reset` is advertised in `--help` on every published binary, but on a
+    // release build it printed a warning marker and exited 0 — a request that
+    // did nothing reported as success. It has to fail.
     #[cfg(not(test))]
     {
-        println!(
-            "{}",
-            c::warn("Telemetry reset is only available in test builds")
-        );
-        Ok(())
+        anyhow::bail!("Telemetry reset is only available in test builds; nothing was reset")
     }
 }
 
@@ -267,20 +266,17 @@ async fn show_service_telemetry(service_name: &str) -> Result<()> {
         println!();
         println!("{}", c::dim("Raw Data (JSON):"));
         println!("{}", serde_json::to_string_pretty(&service_data)?);
+        Ok(())
     } else {
-        println!(
-            "{}",
-            c::fail(&format!(
-                "No telemetry data found for service: {service_name}"
-            ))
-        );
-        println!(
-            "{}",
-            c::dim("Available services can be seen with: pmat telemetry --system")
-        );
+        // This printed a ✗ failure marker and then exited 0, so `--service`
+        // naming a service that does not exist was indistinguishable from a
+        // successful report to anything scripting pmat. A named service that
+        // cannot be found is an error.
+        Err(anyhow::anyhow!(
+            "No telemetry data found for service: {service_name}. \
+             Available services can be seen with: pmat telemetry --system"
+        ))
     }
-
-    Ok(())
 }
 
 /// Show system overview (default command)
@@ -437,9 +433,32 @@ mod tests {
         let result = show_service_telemetry("telemetry_test_service").await;
         assert!(result.is_ok());
 
-        // Test non-existent service
+        // Test non-existent service. This used to assert `is_ok()` — it was
+        // pinning the defect: the handler printed a ✗ marker and returned Ok,
+        // so `pmat telemetry --service nonexistent` exited 0.
         let result = show_service_telemetry("non_existent_service").await;
-        assert!(result.is_ok()); // Should handle gracefully
+        let err = result.expect_err("an unknown service must not report success");
+        assert!(
+            err.to_string().contains("non_existent_service"),
+            "the error must name the service asked for: {err}"
+        );
+    }
+
+    /// `--service <unknown>` and, on a release build, `--reset` both printed a
+    /// failure marker and then exited 0. A request that could not be carried
+    /// out has to surface as an error.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn unknown_service_makes_the_whole_command_fail() {
+        telemetry().reset();
+        record_test_telemetry_event().await.unwrap();
+
+        let result =
+            handle_telemetry(false, Some("no_such_service".to_string()), false, false).await;
+        assert!(
+            result.is_err(),
+            "pmat telemetry --service no_such_service must exit non-zero"
+        );
     }
 
     #[tokio::test]

--- a/src/cli/handlers/test_discovery_handlers_discovery.rs
+++ b/src/cli/handlers/test_discovery_handlers_discovery.rs
@@ -139,11 +139,18 @@ fn parse_test_output(stdout: &str, stderr: &str) -> Result<Vec<TestFailure>> {
     let mut failures = Vec::new();
     let combined = format!("{}\n{}", stdout, stderr);
 
+    // nextest re-emits each failing test's captured libtest output, which
+    // contains "test <name> ... FAILED" too. Parsing both arms turned three
+    // real failures into six entries (one prefixed "(3/4) tiny ", one bare)
+    // that the name-equality dedup could not collapse. When the runner is
+    // nextest, its own FAIL lines are the only authority.
+    let nextest = is_nextest_output(&combined);
+
     for line in combined.lines() {
         let trimmed = line.trim();
 
         // cargo test format: "test path::to::test ... FAILED"
-        if trimmed.starts_with("test ") && trimmed.ends_with("FAILED") {
+        if !nextest && trimmed.starts_with("test ") && trimmed.ends_with("FAILED") {
             let name = trimmed
                 .strip_prefix("test ")
                 .unwrap_or(trimmed)
@@ -163,35 +170,63 @@ fn parse_test_output(stdout: &str, stderr: &str) -> Result<Vec<TestFailure>> {
             continue;
         }
 
-        // nextest format: "    FAIL [   0.123s] crate::binary test_name"
-        // Also: "        (N/M) FAIL [   0.123s] crate::binary test_name" (with progress prefix)
-        let nextest_line = trimmed
-            .strip_prefix('(')
-            .and_then(|s| s.split(')').nth(1))
-            .map(str::trim)
-            .unwrap_or(trimmed);
-        if nextest_line.starts_with("FAIL") {
-            if let Some(after_bracket) = nextest_line.split(']').nth(1) {
-                let name = after_bracket.trim().to_string();
-                // Deduplicate: nextest may print FAIL lines in both stdout and stderr
-                if !failures.iter().any(|f| f.name == name) {
-                    failures.push(TestFailure {
-                        name,
-                        file: PathBuf::from("unknown"),
-                        line: None,
-                        reason: "FAILED".to_string(),
-                        category: FailureCategory::Unknown,
-                        duration_ms: None,
-                    });
-                }
+        if let Some(name) = nextest_fail_name(trimmed) {
+            // Deduplicate: nextest may print FAIL lines in both stdout and stderr
+            if !failures.iter().any(|f| f.name == name) {
+                failures.push(TestFailure {
+                    name,
+                    file: PathBuf::from("unknown"),
+                    line: None,
+                    reason: "FAILED".to_string(),
+                    category: FailureCategory::Unknown,
+                    duration_ms: None,
+                });
             }
         }
     }
 
     // Try to refine failure reasons from the "failures:" section at the bottom
     refine_failure_reasons(&combined, &mut failures);
+    // ...and from nextest's per-test captured output, which has no such section.
+    refine_nextest_reasons(&combined, &mut failures);
 
     Ok(failures)
+}
+
+/// True when the captured output came from `cargo nextest` rather than libtest.
+fn is_nextest_output(output: &str) -> bool {
+    output.lines().map(str::trim).any(|line| {
+        (line.starts_with("Summary") && line.contains("tests run"))
+            || (line.starts_with("Starting") && line.contains("tests across"))
+            || nextest_fail_name(line).is_some()
+    })
+}
+
+/// Extract the test name from a nextest FAIL line, if this is one.
+///
+/// nextest prints `FAIL [   0.123s] (1/4) tiny fail_mod::always_fails_assert`
+/// (and older builds put the `(n/m)` counter before `FAIL`). Everything after
+/// the `]` used to be taken verbatim as the name, so reports carried names
+/// like `(3/4) tiny fail_mod::always_panics` — a progress counter and a binary
+/// id that are not part of any test's name.
+fn nextest_fail_name(line: &str) -> Option<String> {
+    let line = line
+        .strip_prefix('(')
+        .and_then(|s| s.split(')').nth(1))
+        .map(str::trim)
+        .unwrap_or(line);
+    if !line.starts_with("FAIL") {
+        return None;
+    }
+    let after_bracket = line.split(']').nth(1)?.trim();
+    // Drop a leading "(n/m)" progress counter, then the binary id: what is
+    // left is the test path, the last whitespace-separated token.
+    let rest = after_bracket
+        .strip_prefix('(')
+        .and_then(|s| s.split_once(')'))
+        .map_or(after_bracket, |(_, tail)| tail.trim());
+    let name = rest.split_whitespace().next_back()?;
+    (!name.is_empty()).then(|| name.to_string())
 }
 
 /// Extract detailed failure reasons from the "failures:" block printed by cargo test
@@ -227,6 +262,64 @@ fn refine_failure_reasons(output: &str, failures: &mut [TestFailure]) {
     }
 }
 
+/// Extract failure reasons from nextest's per-test captured output.
+///
+/// `refine_failure_reasons` only understands libtest's `failures:` section
+/// with its `---- <name> stdout ----` headers, which nextest never prints — so
+/// every real nextest failure kept the placeholder reason "FAILED" and
+/// `categorize_failure` was never reached, leaving `pmat test-discovery
+/// categorize` with a single "Unknown / priority 4" bucket for a run whose
+/// failures were an assertion, a panic and a flake. nextest labels each
+/// captured block with the failing test's name (`--- STDERR: tiny my::test ---`
+/// in older builds, a `stderr ───` block under the FAIL line in newer ones),
+/// so evidence is attributed to the most recent test named above it.
+fn refine_nextest_reasons(output: &str, failures: &mut [TestFailure]) {
+    let lines: Vec<&str> = output.lines().map(str::trim).collect();
+    let mut current: Option<usize> = None;
+
+    for (i, line) in lines.iter().enumerate() {
+        if let Some(idx) = failures
+            .iter()
+            .position(|f| !f.name.is_empty() && line.contains(f.name.as_str()))
+        {
+            // Not `continue`: a panic line names its own test *and* is the
+            // evidence for it ("thread 'my::test' panicked at …").
+            current = Some(idx);
+        }
+        let Some(idx) = current else { continue };
+        if failures[idx].reason != "FAILED" || !is_failure_evidence(line) {
+            continue;
+        }
+        let mut reason = (*line).to_string();
+        // "panicked at src/lib.rs:12:9:" carries its message on the next line.
+        if reason.ends_with(':') {
+            if let Some(next) = lines.get(i + 1).filter(|l| !l.is_empty()) {
+                reason.push(' ');
+                reason.push_str(next);
+            }
+        }
+        failures[idx].category = categorize_failure(&reason);
+        failures[idx].reason = reason;
+    }
+}
+
+/// Lines that actually say why a test failed (as opposed to nextest framing).
+fn is_failure_evidence(line: &str) -> bool {
+    const MARKERS: &[&str] = &[
+        "panicked at",
+        "assertion",
+        "timed out",
+        "overflowed its stack",
+        "SIGSEGV",
+        "SIGABRT",
+        "SIGILL",
+        "No such file or directory",
+        "onnection refused",
+        "Address already in use",
+    ];
+    line.starts_with("error:") || MARKERS.iter().any(|m| line.contains(m))
+}
+
 fn flush_failure_reason(
     current_test: &Option<String>,
     current_reason: &str,
@@ -252,7 +345,16 @@ fn categorize_failure(reason: &str) -> FailureCategory {
         FailureCategory::Timeout
     } else if reason.contains("failed to compile") || reason.contains("unresolved import") {
         FailureCategory::CompileError
-    } else if reason.contains("panicked at") || reason.contains("thread panicked") {
+    } else if reason.contains("panicked at")
+        || reason.contains("thread panicked")
+        // A crashed test binary reports no panic message at all; leaving these
+        // in Unknown put real stack overflows and signals in the
+        // "needs triage" bucket alongside genuinely unparsed failures.
+        || reason.contains("overflowed its stack")
+        || reason.contains("SIGSEGV")
+        || reason.contains("SIGABRT")
+        || reason.contains("SIGILL")
+    {
         FailureCategory::RuntimeError
     } else if reason.contains("assert") || reason.contains("expected") {
         FailureCategory::AssertionFailure
@@ -264,7 +366,14 @@ fn categorize_failure(reason: &str) -> FailureCategory {
 /// Count total tests from human-readable output.
 /// Parses "test result: ok. N passed; M failed; I ignored" summary lines.
 fn count_total_tests(stdout: &str) -> Result<usize> {
-    let mut total = 0usize;
+    // nextest prints exactly ONE "Summary [..] N tests run" line for the whole
+    // run, but it also re-emits each failing test's captured libtest output —
+    // whose "test result:" lines were summed on top of the summary, reporting
+    // 7 tests for a 4-test crate. When a nextest summary is present it is the
+    // only count; libtest summaries are then just echoed fragments of it.
+    let mut nextest_total: Option<usize> = None;
+    let mut libtest_total = 0usize;
+
     for line in stdout.lines() {
         let trimmed = line.trim();
         // cargo test: "test result: ok. 123 passed; 0 failed; 5 ignored; 0 measured; 0 filtered out"
@@ -274,15 +383,14 @@ fn count_total_tests(stdout: &str) -> Result<usize> {
             let passed = extract_number_before(trimmed, " passed").unwrap_or(0);
             let failed = extract_number_before(trimmed, " failed").unwrap_or(0);
             let ignored = extract_number_before(trimmed, " ignored").unwrap_or(0);
-            total += passed + failed + ignored;
+            libtest_total += passed + failed + ignored;
         } else if trimmed.starts_with("Summary") && trimmed.contains("tests run") {
-            // nextest summary: "Summary [   1.234s] 123 tests run: 120 passed, 3 failed, 5 skipped"
             if let Some(count) = extract_number_before(trimmed, " tests run") {
-                total += count;
+                nextest_total = Some(nextest_total.map_or(count, |t: usize| t.max(count)));
             }
         }
     }
-    Ok(total)
+    Ok(nextest_total.unwrap_or(libtest_total))
 }
 
 /// Extract the number immediately before a suffix in a string.
@@ -344,6 +452,118 @@ mod runner_status_tests {
         assert!(has_test_summary_line(
             "Summary [   0.1s] 3 tests run: 3 passed, 0 failed, 0 skipped"
         ));
+    }
+}
+
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg(test)]
+mod nextest_parsing_tests {
+    //! Regression tests for the nextest output shape: a real run of a 4-test
+    //! crate with 3 failures used to report 7 tests and 6 failures, with
+    //! names carrying nextest's "(n/m) <binary>" progress prefix and every
+    //! reason stuck on the placeholder "FAILED".
+    use super::*;
+
+    /// Real `cargo nextest run --workspace --no-fail-fast` shape: nextest's
+    /// own FAIL lines plus the libtest output it re-emits per failing test.
+    const NEXTEST_OUTPUT: &str = r#"
+    Starting 4 tests across 1 binary (run ID: abc, nextest profile: default)
+        PASS [   0.002s] (1/4) tiny ok_mod::passes
+        FAIL [   0.004s] (2/4) tiny fail_mod::always_fails_assert
+
+--- STDOUT:              tiny fail_mod::always_fails_assert ---
+
+running 1 test
+test fail_mod::always_fails_assert ... FAILED
+
+failures:
+
+failures:
+    fail_mod::always_fails_assert
+
+test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+--- STDERR:              tiny fail_mod::always_fails_assert ---
+thread 'fail_mod::always_fails_assert' panicked at src/lib.rs:12:9:
+assertion `left == right` failed
+  left: 1
+ right: 2
+
+        FAIL [   0.005s] (3/4) tiny slow_mod::takes_forever
+
+--- STDERR:              tiny slow_mod::takes_forever ---
+error: test timed out after 60s
+
+        FAIL [   0.006s] (4/4) tiny deep_mod::recurses
+
+--- STDERR:              tiny deep_mod::recurses ---
+thread 'deep_mod::recurses' has overflowed its stack
+
+------------
+     Summary [   0.010s] 4 tests run: 1 passed, 3 failed, 0 skipped
+"#;
+
+    #[test]
+    fn nextest_failures_are_not_double_counted_and_names_have_no_progress_prefix() {
+        let failures = parse_test_output(NEXTEST_OUTPUT, "").expect("parse");
+        let names: Vec<&str> = failures.iter().map(|f| f.name.as_str()).collect();
+        assert_eq!(
+            names,
+            vec![
+                "fail_mod::always_fails_assert",
+                "slow_mod::takes_forever",
+                "deep_mod::recurses"
+            ],
+            "one entry per failing test, named as the test is named"
+        );
+    }
+
+    #[test]
+    fn nextest_total_is_the_summary_line_not_the_re_emitted_libtest_lines() {
+        assert_eq!(
+            count_total_tests(NEXTEST_OUTPUT).expect("count"),
+            4,
+            "a 4-test crate has 4 tests, however many libtest summaries nextest echoes"
+        );
+    }
+
+    #[test]
+    fn nextest_failures_are_categorized_from_their_captured_output() {
+        let failures = parse_test_output(NEXTEST_OUTPUT, "").expect("parse");
+        let by_name = |n: &str| {
+            failures
+                .iter()
+                .find(|f| f.name == n)
+                .unwrap_or_else(|| panic!("missing {n}"))
+        };
+        assert_ne!(
+            by_name("fail_mod::always_fails_assert").category,
+            FailureCategory::Unknown,
+            "a panicking assertion must not stay uncategorized: {:?}",
+            by_name("fail_mod::always_fails_assert").reason
+        );
+        assert!(by_name("fail_mod::always_fails_assert")
+            .reason
+            .contains("assertion"));
+        assert_eq!(
+            by_name("slow_mod::takes_forever").category,
+            FailureCategory::Timeout
+        );
+        assert_ne!(
+            by_name("deep_mod::recurses").category,
+            FailureCategory::Unknown
+        );
+    }
+
+    #[test]
+    fn plain_cargo_test_output_is_still_parsed() {
+        let out = "running 2 tests\ntest a::b ... FAILED\ntest c::d ... ok\n\n\
+                   failures:\n\n---- a::b stdout ----\nthread 'a::b' panicked at src/l.rs:1:1:\n\
+                   boom\n\ntest result: FAILED. 1 passed; 1 failed; 0 ignored\n";
+        let failures = parse_test_output(out, "").expect("parse");
+        assert_eq!(failures.len(), 1);
+        assert_eq!(failures[0].name, "a::b");
+        assert_eq!(count_total_tests(out).expect("count"), 2);
     }
 }
 

--- a/src/cli/handlers/test_discovery_handlers_discovery.rs
+++ b/src/cli/handlers/test_discovery_handlers_discovery.rs
@@ -54,6 +54,13 @@ async fn handle_discovery_run(
 
     // Create discovery report (check both stdout and stderr for summary lines)
     let combined_for_count = format!("{}\n{}", stdout, stderr);
+
+    // A runner that never started (missing `cargo nextest`, build failure) used
+    // to be indistinguishable from a clean run: `output.status` was discarded,
+    // the empty output parsed to zero tests, and the command printed
+    // "✅ Discovery complete: Total tests: 0" and exited 0. Zero tests executed
+    // is not a green run — it is a run that produced no evidence at all.
+    check_runner_actually_ran(&output.status, &combined_for_count, &stderr)?;
     let report = DiscoveryReport {
         total_tests: count_total_tests(&combined_for_count)?,
         failures: failures.len(),
@@ -77,6 +84,51 @@ async fn handle_discovery_run(
     print_category_summary(&failures);
 
     Ok(())
+}
+
+/// True when the captured output contains a runner summary line, i.e. proof
+/// that a test binary actually ran to completion.
+fn has_test_summary_line(output: &str) -> bool {
+    output.lines().map(str::trim).any(|line| {
+        line.starts_with("test result:")
+            || (line.starts_with("Summary") && line.contains("tests run"))
+    })
+}
+
+/// Distinguish "tests ran and some failed" from "the runner never ran".
+///
+/// A failing test suite exits non-zero *and* prints a summary line; a missing
+/// `cargo nextest` or a build failure exits non-zero with no summary at all.
+/// Only the second case is an error here — reporting it as a zero-test success
+/// is what let a broken runner masquerade as a green discovery.
+fn check_runner_actually_ran(
+    status: &std::process::ExitStatus,
+    combined_output: &str,
+    stderr: &str,
+) -> Result<()> {
+    if status.success() || has_test_summary_line(combined_output) {
+        return Ok(());
+    }
+
+    let detail = stderr.trim();
+    let detail = if detail.is_empty() {
+        "no output captured".to_string()
+    } else {
+        // Keep the tail: cargo puts the actual error last.
+        detail
+            .lines()
+            .rev()
+            .take(20)
+            .collect::<Vec<_>>()
+            .into_iter()
+            .rev()
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+
+    anyhow::bail!(
+        "test runner did not run any tests (exit status: {status}); no test summary line was produced.\n{detail}"
+    )
 }
 
 /// Parse test output to extract failures from human-readable cargo test / nextest output.
@@ -242,6 +294,57 @@ fn extract_number_before(s: &str, suffix: &str) -> Option<usize> {
     let num_str: String = before.chars().rev().take_while(|c| c.is_ascii_digit()).collect();
     let num_str: String = num_str.chars().rev().collect();
     num_str.parse().ok()
+}
+
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg(all(test, unix))]
+mod runner_status_tests {
+    use super::*;
+
+    fn status(code_is_zero: bool) -> std::process::ExitStatus {
+        let program = if code_is_zero { "true" } else { "false" };
+        std::process::Command::new(program)
+            .status()
+            .expect("spawn /bin/true or /bin/false")
+    }
+
+    #[test]
+    fn runner_that_never_started_is_an_error() {
+        // `cargo nextest` missing: non-zero exit, no summary line anywhere.
+        let stderr = "error: no such command: nextest\n";
+        let err = check_runner_actually_ran(&status(false), stderr, stderr)
+            .expect_err("a runner that produced no test summary must not be a success");
+        let msg = err.to_string();
+        assert!(msg.contains("did not run any tests"), "{msg}");
+        assert!(msg.contains("no such command: nextest"), "{msg}");
+    }
+
+    #[test]
+    fn failing_tests_with_a_cargo_summary_are_not_a_runner_error() {
+        let out = "test foo ... FAILED\ntest result: FAILED. 1 passed; 2 failed; 0 ignored\n";
+        assert!(check_runner_actually_ran(&status(false), out, "").is_ok());
+    }
+
+    #[test]
+    fn failing_tests_with_a_nextest_summary_are_not_a_runner_error() {
+        let out = "Summary [   1.234s] 3 tests run: 1 passed, 2 failed, 0 skipped\n";
+        assert!(check_runner_actually_ran(&status(false), out, "").is_ok());
+    }
+
+    #[test]
+    fn successful_run_is_never_an_error() {
+        assert!(check_runner_actually_ran(&status(true), "", "").is_ok());
+    }
+
+    #[test]
+    fn has_test_summary_line_needs_a_real_summary() {
+        assert!(!has_test_summary_line(""));
+        assert!(!has_test_summary_line("error: could not compile `foo`"));
+        assert!(has_test_summary_line("   test result: ok. 3 passed; 0 failed"));
+        assert!(has_test_summary_line(
+            "Summary [   0.1s] 3 tests run: 3 passed, 0 failed, 0 skipped"
+        ));
+    }
 }
 
 /// Print categorized summary

--- a/src/cli/handlers/utility_handlers/context_generation_annotations.rs
+++ b/src/cli/handlers/utility_handlers/context_generation_annotations.rs
@@ -7,7 +7,15 @@ fn get_simple_function_annotations(
     let mut annotations = String::new();
 
     add_complexity_annotation(&mut annotations, func_name, file, analyses);
-    add_provability_annotation(&mut annotations, analyses);
+    // No `[provability: N%]` annotation is emitted: it used to average
+    // `provability_score` over the WHOLE `provability_results` vector and stamp
+    // that one number onto every row — 22,925 functions on this repo all read
+    // "[provability: 71%]", and a three-language toy corpus all read 65%.
+    // `ProofSummary` carries no function or file identity, so there is no
+    // per-function record to look up; a project-wide mean printed on a function
+    // row is not that function's provability. Absent beats attributed-to-the-
+    // wrong-thing. See contracts/pmat-no-fabrication-v1.yaml, equation
+    // `measured_or_absent`.
     add_satd_annotation(&mut annotations, file, analyses);
     add_pagerank_annotation(&mut annotations, func_name, file, analyses);
     add_churn_annotation(&mut annotations, file, analyses);
@@ -30,7 +38,14 @@ fn add_complexity_annotation(
     file: &crate::services::context::FileContext,
     analyses: &crate::services::deep_context::AnalysisResults,
 ) {
-    let complexity_added = analyses
+    // When the lookup misses, nothing was measured for this function, so nothing
+    // is printed. This used to fall back to the literal
+    // " [complexity: 3] [cognitive: 2] [big-o: O(n)]", so a phantom `anonymous`
+    // row in a one-line TypeScript file was published carrying three invented
+    // metrics beside the real ones on the row above. The JSON path already emits
+    // no complexity keys in this case; the markdown path now matches it. See
+    // contracts/pmat-no-fabrication-v1.yaml, equation `measured_or_absent`.
+    let _measured = analyses
         .complexity_report
         .as_ref()
         .and_then(|report| {
@@ -64,26 +79,6 @@ fn add_complexity_annotation(
                 })
         })
         .is_some();
-
-    if !complexity_added {
-        annotations.push_str(" [complexity: 3] [cognitive: 2] [big-o: O(n)]");
-    }
-}
-
-fn add_provability_annotation(
-    annotations: &mut String,
-    analyses: &crate::services::deep_context::AnalysisResults,
-) {
-    let score = analyses
-        .provability_results
-        .as_ref()
-        .filter(|p| !p.is_empty())
-        .map(|provability| {
-            provability.iter().map(|p| p.provability_score).sum::<f64>() / provability.len() as f64
-        })
-        .unwrap_or(0.75);
-
-    annotations.push_str(&format!(" [provability: {:.0}%]", score * 100.0));
 }
 
 fn add_satd_annotation(
@@ -221,6 +216,130 @@ mod function_annotation_tests {
             let annotations =
                 super::get_simple_function_annotations(func, &file_ctx(path), &analyses);
             assert!(!annotations.contains("tdg"), "{path}: {annotations}");
+        }
+    }
+
+    /// A function the complexity report says nothing about used to be published
+    /// as `[complexity: 3] [cognitive: 2] [big-o: O(n)]` — a hardcoded string,
+    /// not a measurement. It is what made the phantom `anonymous` row in a
+    /// one-line TypeScript file look measured.
+    #[test]
+    fn unmeasured_function_gets_no_invented_complexity() {
+        let analyses = AnalysisResults::default();
+        let file = file_ctx("app.ts");
+
+        let annotations = super::get_simple_function_annotations("anonymous", &file, &analyses);
+
+        assert!(
+            !annotations.contains("[complexity:"),
+            "no complexity was measured, so none may be printed: {annotations}"
+        );
+        assert!(
+            !annotations.contains("[cognitive:"),
+            "no cognitive complexity was measured: {annotations}"
+        );
+        assert!(
+            !annotations.contains("[big-o:"),
+            "big-o is derived from an unmeasured cyclomatic value: {annotations}"
+        );
+    }
+
+    /// Measured functions must still be annotated — the fix above removes the
+    /// fabricated fallback, not the real lookup.
+    #[test]
+    fn measured_function_still_gets_its_own_complexity() {
+        use crate::services::complexity::{
+            ComplexityMetrics, ComplexityReport, ComplexitySummary, FileComplexityMetrics,
+            FunctionComplexity,
+        };
+
+        let metrics = ComplexityMetrics {
+            cyclomatic: 6,
+            cognitive: 4,
+            nesting_max: 1,
+            lines: 10,
+            halstead: None,
+        };
+
+        let analyses = AnalysisResults {
+            complexity_report: Some(ComplexityReport {
+                summary: ComplexitySummary {
+                    total_files: 1,
+                    total_functions: 1,
+                    median_cyclomatic: 6.0,
+                    median_cognitive: 4.0,
+                    max_cyclomatic: 6,
+                    max_cognitive: 4,
+                    p90_cyclomatic: 6,
+                    p90_cognitive: 4,
+                    technical_debt_hours: 0.0,
+                },
+                violations: vec![],
+                hotspots: vec![],
+                files: vec![FileComplexityMetrics {
+                    path: "src/lib.rs".to_string(),
+                    total_complexity: metrics,
+                    functions: vec![FunctionComplexity {
+                        name: "complex".to_string(),
+                        line_start: 1,
+                        line_end: 10,
+                        metrics,
+                    }],
+                    classes: vec![],
+                }],
+            }),
+            ..Default::default()
+        };
+
+        let annotations =
+            super::get_simple_function_annotations("complex", &file_ctx("src/lib.rs"), &analyses);
+
+        assert!(annotations.contains("[complexity: 6]"), "{annotations}");
+        assert!(annotations.contains("[cognitive: 4]"), "{annotations}");
+    }
+
+    /// `[provability: N%]` was a project-wide mean (or the 0.75 default) stamped
+    /// onto every row: one distinct value across 22,925 functions, and 92% on a
+    /// toy crate whose functions include one that unwraps. `ProofSummary` has no
+    /// function identity, so no per-function provability exists to print.
+    #[test]
+    fn provability_annotation_is_never_a_project_wide_constant() {
+        use crate::services::lightweight_provability_analyzer::ProofSummary;
+
+        // No analysis at all: the old code still printed the 0.75 default.
+        let empty = AnalysisResults::default();
+        let annotations = super::get_simple_function_annotations("add", &file_ctx("l.rs"), &empty);
+        assert!(
+            !annotations.contains("provability"),
+            "provability is not measured per function: {annotations}"
+        );
+
+        // Analysis present: the old code averaged it and stamped the mean on
+        // every function, however different the functions were.
+        let with_results = AnalysisResults {
+            provability_results: Some(vec![
+                ProofSummary {
+                    provability_score: 0.9,
+                    verified_properties: vec![],
+                    analysis_time_us: 0,
+                    version: 1,
+                },
+                ProofSummary {
+                    provability_score: 0.1,
+                    verified_properties: vec![],
+                    analysis_time_us: 0,
+                    version: 1,
+                },
+            ]),
+            ..Default::default()
+        };
+        for func in ["add", "dangerous"] {
+            let annotations =
+                super::get_simple_function_annotations(func, &file_ctx("l.rs"), &with_results);
+            assert!(
+                !annotations.contains("provability"),
+                "{func}: {annotations}"
+            );
         }
     }
 }

--- a/src/cli/handlers/utility_handlers/context_generation_annotations.rs
+++ b/src/cli/handlers/utility_handlers/context_generation_annotations.rs
@@ -11,7 +11,15 @@ fn get_simple_function_annotations(
     add_satd_annotation(&mut annotations, file, analyses);
     add_pagerank_annotation(&mut annotations, func_name, file, analyses);
     add_churn_annotation(&mut annotations, file, analyses);
-    annotations.push_str(" [tdg: 2.5]");
+    // No `[tdg: ...]` annotation is emitted: this was the literal
+    // `annotations.push_str(" [tdg: 2.5]")`, so `pmat context` on this repo
+    // printed "22925 [tdg: 2.5]" — one distinct value across 4260 files — and a
+    // three-function toy crate printed the very same 2.5. Every other
+    // annotation on this line is read from `analyses`; `AnalysisResults` carries
+    // no TDG scores at all, so there is nothing to read. An absent annotation is
+    // honest; a constant sitting beside measured neighbours borrows their
+    // credibility. See contracts/pmat-no-fabrication-v1.yaml, equation
+    // `measured_or_absent`.
 
     annotations
 }
@@ -168,5 +176,51 @@ fn add_churn_annotation(
 
     if !churn_added {
         annotations.push_str(" [churn: low(1)]");
+    }
+}
+
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg(test)]
+mod function_annotation_tests {
+    use crate::services::context::FileContext;
+    use crate::services::deep_context::AnalysisResults;
+
+    fn file_ctx(path: &str) -> FileContext {
+        FileContext {
+            path: path.to_string(),
+            language: "rust".to_string(),
+            items: vec![],
+            complexity_metrics: None,
+        }
+    }
+
+    /// `pmat context` annotated EVERY function with the literal `[tdg: 2.5]` —
+    /// 22,925 occurrences of one value on this repo, and the same 2.5 on a
+    /// three-function crate. There is no TDG score in `AnalysisResults` to look
+    /// up, so the annotation must be absent rather than invented.
+    #[test]
+    fn function_annotations_never_carry_an_unmeasured_tdg_score() {
+        let analyses = AnalysisResults::default();
+        let file = file_ctx("src/lib.rs");
+
+        let annotations = super::get_simple_function_annotations("main", &file, &analyses);
+
+        assert!(
+            !annotations.contains("[tdg:"),
+            "no TDG score is measured here, so none may be printed: {annotations}"
+        );
+    }
+
+    /// Guard against the annotation coming back as a constant under a different
+    /// name: two different functions in two different files with no analysis
+    /// data must not be told apart by a TDG figure, and none may appear.
+    #[test]
+    fn tdg_annotation_absent_for_every_function() {
+        let analyses = AnalysisResults::default();
+        for (path, func) in [("src/a.rs", "alpha"), ("src/b/c.rs", "beta")] {
+            let annotations =
+                super::get_simple_function_annotations(func, &file_ctx(path), &analyses);
+            assert!(!annotations.contains("tdg"), "{path}: {annotations}");
+        }
     }
 }

--- a/src/cli/handlers/utility_handlers/context_generation_markdown.rs
+++ b/src/cli/handlers/utility_handlers/context_generation_markdown.rs
@@ -19,15 +19,21 @@ fn generate_markdown_context(
     builder.content.push_str("## Project Structure\n\n");
 
     // Add project-level metrics summary
+    //
+    // These counts must describe the document they head. They used to be read
+    // from `complexity_report` while the body below is rendered from
+    // `analyses.ast_contexts`, so one document carried three mutually different
+    // function totals (32420 in this header, 22925 `- **Function**` entries in
+    // the body, 33754 summed from the per-file lines). Count what is actually
+    // emitted instead.
+    let (total_files, total_functions) = count_emitted_body(context);
+    builder
+        .content
+        .push_str(&format!("- **Total Files**: {}\n", total_files));
+    builder
+        .content
+        .push_str(&format!("- **Total Functions**: {}\n", total_functions));
     if let Some(complexity_report) = &context.analyses.complexity_report {
-        builder.content.push_str(&format!(
-            "- **Total Files**: {}\n",
-            complexity_report.files.len()
-        ));
-        builder.content.push_str(&format!(
-            "- **Total Functions**: {}\n",
-            complexity_report.summary.total_functions
-        ));
         builder.content.push_str(&format!(
             "- **Median Cyclomatic**: {:.2}\n",
             complexity_report.summary.median_cyclomatic
@@ -37,9 +43,6 @@ fn generate_markdown_context(
             complexity_report.summary.median_cognitive
         ));
     } else {
-        // Basic fallback metrics
-        builder.content.push_str("- **Total Files**: 0\n");
-        builder.content.push_str("- **Total Functions**: 0\n");
         builder.content.push('\n');
     }
 
@@ -86,6 +89,28 @@ fn generate_markdown_context(
     Ok(builder.content)
 }
 
+/// Count the file sections and function entries `generate_markdown_context`
+/// will emit into the body, so the header can report them rather than a
+/// different analysis pass's numbers.
+fn count_emitted_body(context: &crate::services::deep_context::DeepContext) -> (usize, usize) {
+    let files = context.analyses.ast_contexts.len();
+    let functions = context
+        .analyses
+        .ast_contexts
+        .iter()
+        .map(|c| count_listed_functions(&c.base))
+        .sum();
+    (files, functions)
+}
+
+/// Number of `- **Function**` entries a file section will emit.
+fn count_listed_functions(file: &crate::services::context::FileContext) -> usize {
+    file.items
+        .iter()
+        .filter(|item| matches!(item, crate::services::context::AstItem::Function { .. }))
+        .count()
+}
+
 /// Add simple file section with annotated AST
 fn add_simple_file_section(
     builder: &mut MarkdownBuilder,
@@ -98,20 +123,20 @@ fn add_simple_file_section(
     // File-level metrics from analyses (BUG-007 FIX: shared path matching)
     let file_metrics = find_file_metrics(file, analyses);
 
+    // **Functions** counts the entries listed immediately below it, not the
+    // complexity report's own tally for the file: the two disagree (the report
+    // also counts methods and nested items this listing does not emit), and
+    // summing the old per-file line gave a third project-wide total that
+    // matched neither the header nor the body.
+    let function_count = count_listed_functions(file);
+
     if let Some(file_metrics) = file_metrics {
         builder.content.push_str(&format!(
             "**File Complexity**: {} | **Functions**: {}\n\n",
-            file_metrics.total_complexity.cyclomatic,
-            file_metrics.functions.len()
+            file_metrics.total_complexity.cyclomatic, function_count
         ));
     } else {
-        // BUG-007 FIX: Fallback - count functions from file.items if complexity report missing
-        let function_count = file
-            .items
-            .iter()
-            .filter(|item| matches!(item, crate::services::context::AstItem::Function { .. }))
-            .count();
-
+        // BUG-007 FIX: Fallback - complexity report missing for this file
         if function_count > 0 || !file.items.is_empty() {
             builder.content.push_str(&format!(
                 "**File Complexity**: N/A | **Functions**: {}\n\n",
@@ -155,5 +180,87 @@ fn format_ast_item_line(
             }
         }
         _ => String::new(),
+    }
+}
+
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg(test)]
+mod header_body_agreement_tests {
+    use super::*;
+    use crate::services::complexity::{ComplexityReport, ComplexitySummary};
+    use crate::services::context::{AstItem, FileContext};
+    use crate::services::deep_context::{DeepContext, DefectAnnotations, EnhancedFileContext};
+
+    fn file_with_functions(path: &str, names: &[&str]) -> EnhancedFileContext {
+        EnhancedFileContext {
+            base: FileContext {
+                path: path.to_string(),
+                language: "rust".to_string(),
+                items: names
+                    .iter()
+                    .map(|n| AstItem::Function {
+                        name: (*n).to_string(),
+                        visibility: "pub".to_string(),
+                        is_async: false,
+                        line: 1,
+                    })
+                    .collect(),
+                complexity_metrics: None,
+            },
+            complexity_metrics: None,
+            churn_metrics: None,
+            defects: DefectAnnotations {
+                dead_code: None,
+                technical_debt: vec![],
+                complexity_violations: vec![],
+                tdg_score: None,
+            },
+            symbol_id: path.to_string(),
+        }
+    }
+
+    /// The `Total Files` / `Total Functions` header must count what the document
+    /// below it actually contains. It used to be read from the complexity report
+    /// while the body was rendered from `ast_contexts`, so one document carried
+    /// three mutually different function totals.
+    #[test]
+    fn header_totals_match_the_body_they_head() {
+        let mut context = DeepContext::default();
+        context.analyses.ast_contexts = vec![
+            file_with_functions("src/a.rs", &["one", "two"]),
+            file_with_functions("src/b.rs", &["three"]),
+        ];
+        // A complexity report that disagrees with the body, as the real one does.
+        context.analyses.complexity_report = Some(ComplexityReport {
+            summary: ComplexitySummary {
+                total_files: 7,
+                total_functions: 999,
+                ..ComplexitySummary::default()
+            },
+            violations: vec![],
+            hotspots: vec![],
+            files: vec![],
+        });
+
+        let md =
+            generate_markdown_context("rust", std::path::Path::new("/repo"), &context).unwrap();
+
+        assert!(
+            md.contains("- **Total Files**: 2\n"),
+            "header must count the emitted file sections:\n{md}"
+        );
+        assert!(
+            md.contains("- **Total Functions**: 3\n"),
+            "header must count the emitted function entries:\n{md}"
+        );
+        assert!(
+            !md.contains("999"),
+            "header must not report a count from a different analysis pass:\n{md}"
+        );
+
+        let sections = md.matches("\n### ").count();
+        let functions = md.matches("- **Function**").count();
+        assert_eq!(sections, 2);
+        assert_eq!(functions, 3);
     }
 }

--- a/src/cli/handlers/utility_handlers/utility_handlers_tests_part4.rs
+++ b/src/cli/handlers/utility_handlers/utility_handlers_tests_part4.rs
@@ -258,21 +258,10 @@ mod comprehensive_coverage_tests {
 
         add_complexity_annotation(&mut annotations, "test_function", &file, &analyses);
 
-        // Should add fallback annotations
-        assert!(annotations.contains("[complexity: 3]"));
-        assert!(annotations.contains("[cognitive: 2]"));
-        assert!(annotations.contains("[big-o: O(n)]"));
-    }
-
-    #[test]
-    fn test_add_provability_annotation_without_data() {
-        let analyses = create_test_analysis_results();
-        let mut annotations = String::new();
-
-        add_provability_annotation(&mut annotations, &analyses);
-
-        // Should use default 0.75
-        assert!(annotations.contains("[provability: 75%]"));
+        // This test used to assert the fabricated fallback
+        // "[complexity: 3] [cognitive: 2] [big-o: O(n)]". With nothing measured
+        // for the function, nothing may be printed.
+        assert!(annotations.is_empty(), "unmeasured: {annotations}");
     }
 
     #[test]

--- a/src/cli/handlers/wasm_handlers_assemblyscript.rs
+++ b/src/cli/handlers/wasm_handlers_assemblyscript.rs
@@ -4,7 +4,11 @@
 pub async fn handle_analyze_assemblyscript(
     project_path: PathBuf,
     format: ComplexityOutputFormat,
-    wasm_complexity: bool,
+    // --wasm-complexity used to decide whether a parsed file appeared in the
+    // report at all, which is why the default run reported files_analyzed 0.
+    // Complexity is now measured for every parsed file and the flag has nothing
+    // left to gate; it is kept so existing invocations keep working.
+    _wasm_complexity: bool,
     _memory_analysis: bool,
     security: bool,
     output: Option<PathBuf>,
@@ -19,7 +23,7 @@ pub async fn handle_analyze_assemblyscript(
     eprintln!("🔍 Analyzing AssemblyScript code...");
     let start = std::time::Instant::now();
 
-    let results = process_assemblyscript_files(&project_path, wasm_complexity, security).await?;
+    let results = process_assemblyscript_files(&project_path, security).await?;
     let elapsed = start.elapsed();
 
     eprintln!("📊 Analysis complete in {:.2}s", elapsed.as_secs_f64());
@@ -32,7 +36,6 @@ pub async fn handle_analyze_assemblyscript(
 
 async fn process_assemblyscript_files(
     project_path: &Path,
-    wasm_complexity: bool,
     security: bool,
 ) -> Result<Vec<(PathBuf, WasmComplexity)>> {
     let detector = WasmLanguageDetector::new();
@@ -43,14 +46,8 @@ async fn process_assemblyscript_files(
     eprintln!("📁 Found {} AssemblyScript files", as_files.len());
 
     for file_path in as_files {
-        if let Some(analysis_result) = analyze_single_file(
-            &file_path,
-            &detector,
-            &mut parser,
-            wasm_complexity,
-            security,
-        )
-        .await?
+        if let Some(analysis_result) =
+            analyze_single_file(&file_path, &detector, &mut parser, security).await?
         {
             results.push(analysis_result);
         }
@@ -63,7 +60,6 @@ async fn analyze_single_file(
     file_path: &Path,
     detector: &WasmLanguageDetector,
     parser: &mut AssemblyScriptParser,
-    wasm_complexity: bool,
     security: bool,
 ) -> Result<Option<(PathBuf, WasmComplexity)>> {
     let content = match tokio::fs::read_to_string(file_path).await {
@@ -85,35 +81,72 @@ async fn analyze_single_file(
 
     eprintln!("✅ Parsed: {}", file_path.display());
 
-    let result = process_parsed_ast(&ast, file_path, wasm_complexity, security)?;
+    let result = process_parsed_ast(&ast, file_path, security)?;
     Ok(result)
 }
 
+/// Build the report row for one parsed file.
+///
+/// This used to return `None` unless `--wasm-complexity` was passed, and
+/// `files_analyzed` is `results.len()`, so the DEFAULT run printed
+/// "📁 Found 2 AssemblyScript files" and two "✅ Parsed:" lines and then
+/// reported `files_analyzed: 0, results: []` — a report contradicting its own
+/// progress output. Every file we successfully parsed gets a row; the
+/// complexity is measured from that same AST rather than left out or defaulted.
 fn process_parsed_ast(
     ast: &AstDag,
     file_path: &Path,
-    wasm_complexity: bool,
     security: bool,
 ) -> Result<Option<(PathBuf, WasmComplexity)>> {
-    let mut result = None;
-
-    if wasm_complexity {
-        let complexity_analyzer = WasmComplexityAnalyzer::new();
-        let complexity = complexity_analyzer.analyze_ast(ast)?;
-        result = Some((file_path.to_path_buf(), complexity));
-    }
+    let complexity_analyzer = WasmComplexityAnalyzer::new();
+    let complexity = complexity_analyzer.analyze_ast(ast)?;
 
     if security {
         validate_ast_security(ast, file_path);
     }
 
-    Ok(result)
+    Ok(Some((file_path.to_path_buf(), complexity)))
 }
 
 fn validate_ast_security(ast: &AstDag, file_path: &Path) {
     let security_validator = WasmSecurityValidator::new();
     if let Err(e) = security_validator.validate_ast(ast) {
         eprintln!("⚠️  Security issue in {}: {}", file_path.display(), e);
+    }
+}
+
+#[cfg(test)]
+mod assemblyscript_default_run_tests {
+    //! The default run must report the files it says it parsed.
+    use super::*;
+
+    const FIXTURE: &str = "export function add(a: i32, b: i32): i32 {\n  return a + b;\n}\n";
+
+    /// Without `--wasm-complexity`, every parsed file was dropped, so
+    /// `files_analyzed` (= results.len()) was 0 while stderr had just printed
+    /// "Found 2 AssemblyScript files" and two "✅ Parsed:" lines.
+    #[tokio::test]
+    async fn test_default_run_yields_one_result_per_parsed_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir_all(dir.path().join("assembly")).expect("mkdir assembly");
+        std::fs::write(dir.path().join("assembly/index.ts"), FIXTURE).expect("write index.ts");
+        std::fs::write(dir.path().join("top.ts"), FIXTURE).expect("write top.ts");
+
+        let found = collect_assemblyscript_files(dir.path()).expect("collect");
+        assert_eq!(found.len(), 2, "fixture should present 2 AssemblyScript files");
+
+        // security=false, and no --wasm-complexity anywhere in the call.
+        let results = process_assemblyscript_files(dir.path(), false)
+            .await
+            .expect("analysis");
+
+        assert_eq!(
+            results.len(),
+            found.len(),
+            "reported {} results for {} parsed files",
+            results.len(),
+            found.len()
+        );
     }
 }
 

--- a/src/cli/handlers/wasm_handlers_execution.rs
+++ b/src/cli/handlers/wasm_handlers_execution.rs
@@ -79,7 +79,19 @@ async fn analyze_single_wasm_file(
         Some("wasm") if include_binary => analyze_wasm_binary(file_path).await,
         Some("wat") if include_text => {
             analyze_wat_text(file_path, security, complexity).await;
-            None // WAT analysis doesn't return WasmMetrics currently
+            // A parsed .wat contributes no row, so a .wat-only directory
+            // reported "Found 1 WebAssembly files" on stderr and then
+            // "**Files analyzed**: 0" with no Results section and exit 0 — the
+            // file was silently dropped. It still is (the WAT front end
+            // produces no `WasmMetrics`; emitting a zero-filled row would
+            // report measurements nothing took), but say so instead of
+            // leaving the gap to be read as "nothing found".
+            eprintln!(
+                "⚠️  Not reported: {} — .wat text format is parsed for security/complexity \
+                 checks only; metrics come from binary .wasm files",
+                file_path.display()
+            );
+            None
         }
         _ => None,
     }

--- a/src/cli/handlers/work_handlers/core_handlers/handlers.rs
+++ b/src/cli/handlers/work_handlers/core_handlers/handlers.rs
@@ -1268,8 +1268,20 @@ pub async fn handle_work_ledger_verify(
     path: Option<PathBuf>,
 ) -> Result<()> {
     let project_path = path.unwrap_or_else(|| PathBuf::from("."));
+    // This is the tamper-detection command, so "nothing was verified" must never render
+    // as the strongest green attestation. A mistyped -p used to walk a nonexistent
+    // directory, find zero receipts and print "Ledger intact: all hashes verify" with
+    // exit 0 — a CI step with a typo received a clean integrity report.
+    if !project_path.exists() {
+        anyhow::bail!(
+            "ledger verify: path does not exist: {}",
+            project_path.display()
+        );
+    }
+    let ledger_dir = project_path.join(".pmat-work");
     let ledger = FalsificationLedger::new(&project_path);
     let verification = ledger.verify_all()?;
+    let nothing_to_verify = verification.total_receipts == 0;
 
     if matches!(format, crate::cli::commands::QaOutputFormat::Json) {
         println!(
@@ -1302,12 +1314,27 @@ pub async fn handle_work_ledger_verify(
                 println!("  {n:>4}  {k}");
             }
         }
-        if verification.ok() {
+        if nothing_to_verify {
+            println!(
+                "{}",
+                c::warn(&format!(
+                    "No ledger to verify: no receipts under {}",
+                    ledger_dir.display()
+                ))
+            );
+        } else if verification.ok() {
             println!(
                 "{}",
                 c::pass("Ledger intact: all hashes verify, R1 order holds")
             );
         }
+    }
+
+    if nothing_to_verify {
+        anyhow::bail!(
+            "ledger verify: no receipts found under {} — nothing verified",
+            ledger_dir.display()
+        )
     }
 
     if verification.ok() {
@@ -1319,5 +1346,40 @@ pub async fn handle_work_ledger_verify(
             verification.unreadable.len(),
             verification.r1_violations.len()
         )
+    }
+}
+
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg(test)]
+mod ledger_verify_tests {
+    use super::*;
+    use crate::cli::commands::QaOutputFormat;
+
+    /// `work ledger verify` is the tamper-detection command: a path that does not
+    /// exist must be an error, never the "Ledger intact" attestation over 0/0.
+    #[tokio::test]
+    async fn test_ledger_verify_errors_on_missing_path() {
+        let result = handle_work_ledger_verify(
+            false,
+            QaOutputFormat::Text,
+            Some(PathBuf::from("/does/not/exist/pmat-ledger-test")),
+        )
+        .await;
+        assert!(result.is_err(), "missing path must not verify clean");
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("does not exist"), "got: {msg}");
+    }
+
+    /// An existing directory with no `.pmat-work` receipts is "nothing verified",
+    /// which must not render as a passing integrity check either.
+    #[tokio::test]
+    async fn test_ledger_verify_errors_on_empty_ledger() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let result =
+            handle_work_ledger_verify(false, QaOutputFormat::Text, Some(tmp.path().to_path_buf()))
+                .await;
+        assert!(result.is_err(), "0 receipts must not verify clean");
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("no receipts"), "got: {msg}");
     }
 }

--- a/src/cli/handlers/work_handlers/ticket_crud.rs
+++ b/src/cli/handlers/work_handlers/ticket_crud.rs
@@ -76,6 +76,22 @@ pub async fn handle_work_add(
     Ok(())
 }
 
+/// Resolve `--status` into the one status it names.
+///
+/// The whole alias vocabulary lives in `ItemStatus::from_string`, which is also
+/// what `work list-statuses` prints; going through it is what keeps the filter
+/// and the advertised aliases from drifting apart. An unparseable value is an
+/// error — returning "no items" for a status nobody can spell is the failure
+/// mode this replaced.
+fn parse_status_filter(status: Option<&str>) -> Result<Option<crate::models::roadmap::ItemStatus>> {
+    match status {
+        Some(s) => crate::models::roadmap::ItemStatus::from_string(s)
+            .map(Some)
+            .map_err(|e| anyhow::anyhow!("{e}")),
+        None => Ok(None),
+    }
+}
+
 /// Handle work list command (CRUD: Read - simple list)
 ///
 /// Lists all work tickets with optional filtering.
@@ -100,15 +116,24 @@ pub async fn handle_work_list(
 
     let roadmap = service.load()?;
 
+    // `--status` used to be matched with `format!("{:?}", item.status)
+    // .to_lowercase().contains(&s.to_lowercase())` — a Debug-string substring
+    // test. Every alias `work list-statuses` advertises (done/finished/closed,
+    // in-progress/wip, todo/open/pending) therefore matched nothing and
+    // returned an empty list, indistinguishable from "no work in that state".
+    // `ItemStatus::from_string` already implements the whole advertised alias
+    // vocabulary; parse once, compare exactly, and reject an unknown value
+    // instead of silently returning zero rows.
+    let status_filter = parse_status_filter(status.as_deref())?;
+
     // Filter items
     let items: Vec<_> = roadmap
         .roadmap
         .iter()
         .filter(|item| {
             // Filter by status if specified
-            if let Some(ref s) = status {
-                let item_status = format!("{:?}", item.status).to_lowercase();
-                if !item_status.contains(&s.to_lowercase()) {
+            if let Some(ref wanted) = status_filter {
+                if item.status != *wanted {
                     return false;
                 }
             }
@@ -279,4 +304,68 @@ pub async fn handle_work_delete(id: String, force: bool, path: Option<PathBuf>) 
     println!("🗑️  Deleted ticket: {} - {}", c::path(&item.id), item.title);
 
     Ok(())
+}
+
+#[cfg(test)]
+mod status_filter_tests {
+    use super::parse_status_filter;
+    use crate::models::roadmap::ItemStatus;
+
+    /// `work list --status done` returned 0 items while `--status completed`
+    /// returned 169: the filter was a Debug-string substring test, so none of
+    /// the aliases `work list-statuses` documents ever matched.
+    #[test]
+    fn every_documented_alias_resolves_to_its_canonical_status() {
+        let cases = [
+            ("completed", ItemStatus::Completed),
+            ("done", ItemStatus::Completed),
+            ("finished", ItemStatus::Completed),
+            ("closed", ItemStatus::Completed),
+            ("inprogress", ItemStatus::InProgress),
+            ("In-Progress", ItemStatus::InProgress),
+            ("in_progress", ItemStatus::InProgress),
+            ("InProgress", ItemStatus::InProgress),
+            ("wip", ItemStatus::InProgress),
+            ("planned", ItemStatus::Planned),
+            ("todo", ItemStatus::Planned),
+            ("open", ItemStatus::Planned),
+            ("pending", ItemStatus::Planned),
+        ];
+
+        for (input, expected) in cases {
+            assert_eq!(
+                parse_status_filter(Some(input)).expect("documented alias must parse"),
+                Some(expected),
+                "--status {input} must select {expected:?}"
+            );
+        }
+    }
+
+    /// The alias table itself is the contract; walk it rather than a copy.
+    #[test]
+    fn the_whole_status_table_is_filterable() {
+        for &(canonical, aliases, _) in ItemStatus::STATUS_TABLE {
+            let expected = ItemStatus::from_string(canonical).expect("canonical parses");
+            for alias in aliases.split(',').map(str::trim).filter(|a| !a.is_empty()) {
+                assert_eq!(
+                    parse_status_filter(Some(alias)).expect("table alias must parse"),
+                    Some(expected),
+                    "--status {alias} must select {canonical}"
+                );
+            }
+        }
+    }
+
+    /// A status nobody can spell must say so, not quietly return zero rows.
+    #[test]
+    fn an_unknown_status_is_an_error() {
+        let err = parse_status_filter(Some("definitely-not-a-status"))
+            .expect_err("an unknown --status must be rejected");
+        assert!(err.to_string().contains("unknown status"), "{err}");
+    }
+
+    #[test]
+    fn no_status_means_no_filter() {
+        assert_eq!(parse_status_filter(None).expect("no filter"), None);
+    }
 }

--- a/src/cli/handlers/work_handlers/ticket_score.rs
+++ b/src/cli/handlers/work_handlers/ticket_score.rs
@@ -32,15 +32,34 @@ pub async fn handle_work_score(
         let contract_path = format!(".pmat-work/{}/contract.json", id);
         let sarif = wc::lint_report_to_sarif(&lint_report, &contract_path);
         println!("{}", serde_json::to_string_pretty(&sarif)?);
-        return Ok(());
+        return fail_if_gate_failed(&id, &lint_report, effective_min);
     }
 
     if format == "json" {
-        return print_score_json(&id, &score, &drift, &lint_report, &trend, &lint_config);
+        print_score_json(&id, &score, &drift, &lint_report, &trend, &lint_config)?;
+        return fail_if_gate_failed(&id, &lint_report, effective_min);
     }
 
     print_score_text(&id, &contract, &score, &drift, &lint_report, &trend, &lint_config);
-    Ok(())
+    fail_if_gate_failed(&id, &lint_report, effective_min)
+}
+
+/// A printed FAIL must also be a nonzero exit.
+///
+/// `pmat work score <ID> --min-score 0.99` printed
+/// "✗ Result: FAIL (1 error(s), 15 warning(s))" and then returned `Ok(())`
+/// unconditionally, so a CI step written as `pmat work score $ID --min-score 0.9`
+/// passed no matter what the score was. The sibling gates in this binary
+/// (`spec score`, `work ledger verify`) do exit nonzero.
+fn fail_if_gate_failed(id: &str, lint_report: &wc::LintReport, min_score: f64) -> Result<()> {
+    if lint_report.passed {
+        return Ok(());
+    }
+    anyhow::bail!(
+        "contract score gate failed for '{id}': {} error(s), {} warning(s) against min-score {min_score:.2}",
+        lint_report.error_count,
+        lint_report.warning_count
+    )
 }
 
 fn print_score_json(
@@ -189,7 +208,21 @@ fn print_trend_text(trend: &wc::QualityTrend) {
 #[provable_contracts_macros::contract("pmat-core.yaml", equation = "path_exists")]
 pub async fn handle_work_codebase_score(path: Option<PathBuf>, format: String) -> Result<()> {
     let project_path = path.unwrap_or_else(|| PathBuf::from("."));
+
+    // `-p /does/not/exist` used to render a full report ending in
+    // "COMPOSITE: 0.00  Grade: F", exit 0 — a dashboard showed an F for a
+    // typo'd path. The `path_exists` contract annotation on this function had
+    // no runtime check behind it.
+    crate::cli::ensure_analysis_path_exists(&project_path)?;
+
     let score = wc::compute_codebase_score(&project_path);
+
+    // An F is a measurement over contracts that scored badly. With no contracts
+    // at all there is nothing to grade, so the grade is reported as
+    // not-measured (JSON null) rather than as the worst possible result.
+    if score.contract_count == 0 {
+        return report_ungraded_codebase(&project_path, &format);
+    }
 
     if format == "json" {
         println!("{}", serde_json::to_string_pretty(&score)?);
@@ -209,11 +242,83 @@ pub async fn handle_work_codebase_score(path: Option<PathBuf>, format: String) -
     println!("  ----------------------");
     println!("  COMPOSITE:         {:.2}  Grade: {}", score.composite, score.grade);
 
-    if score.contract_count == 0 {
-        println!();
-        println!("  No active work contracts found.");
-        println!("  Start a work item: pmat work start <ID>");
+    Ok(())
+}
+
+/// Report a codebase with no work contracts without inventing a grade.
+fn report_ungraded_codebase(project_path: &Path, format: &str) -> Result<()> {
+    if format == "json" {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "path": project_path.display().to_string(),
+                "contract_count": 0,
+                "measured": false,
+                "composite": serde_json::Value::Null,
+                "grade": serde_json::Value::Null,
+                "reason": "no active work contracts found, so there is nothing to score",
+            }))?
+        );
+        return Ok(());
     }
 
+    println!("Codebase Quality Score");
+    println!("======================");
+    println!();
+    println!("  Contracts:         0");
+    println!("  COMPOSITE:         not measured");
+    println!("  Grade:             not measured");
+    println!();
+    println!("  No active work contracts found, so there is nothing to score.");
+    println!("  Start a work item: pmat work start <ID>");
+
     Ok(())
+}
+
+#[cfg(test)]
+mod score_gate_tests {
+    //! Regression tests for two gates in this file that could never fail:
+    //! `work score --min-score` printed FAIL and exited 0, and
+    //! `work codebase-score -p /does/not/exist` graded a nonexistent path F.
+    use super::{fail_if_gate_failed, handle_work_codebase_score, wc};
+    use std::path::PathBuf;
+
+    fn report(passed: bool) -> wc::LintReport {
+        wc::LintReport {
+            findings: Vec::new(),
+            passed,
+            error_count: if passed { 0 } else { 1 },
+            warning_count: 15,
+            info_count: 0,
+        }
+    }
+
+    #[test]
+    fn test_failed_lint_report_is_an_error() {
+        let err = fail_if_gate_failed("MACS-002", &report(false), 0.99)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("MACS-002"),
+            "the failure must name the work item, got {err}"
+        );
+    }
+
+    #[test]
+    fn test_passing_lint_report_is_ok() {
+        assert!(fail_if_gate_failed("MACS-002", &report(true), 0.5).is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_codebase_score_rejects_a_nonexistent_path() {
+        let missing = PathBuf::from("/pmat-does-not-exist-codebase-score");
+        let err = handle_work_codebase_score(Some(missing), "json".to_string())
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("not found"),
+            "a nonexistent path must be an error, not a Grade F report; got {err}"
+        );
+    }
 }

--- a/src/cli/proof_annotation_helpers_format.rs
+++ b/src/cli/proof_annotation_helpers_format.rs
@@ -269,13 +269,80 @@ fn format_summary_top_files(
     let mut sorted_files: Vec<_> = file_counts.into_iter().collect();
     sorted_files.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(b.0)));
 
+    // Print the whole path, not `file_name()`: a repo has many `build.rs` and
+    // `mod.rs` files, so a basename-only list rendered ten *distinct* files as
+    // two basenames repeated five times each, with no way to tell them apart.
     for (i, (file_path, count)) in sorted_files.iter().take(10).enumerate() {
-        let filename = file_path
-            .file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or(file_path.to_str().unwrap_or("unknown"));
-        writeln!(output, "{}. `{}` - {} annotations", i + 1, filename, count)?;
+        writeln!(
+            output,
+            "{}. `{}` - {} annotations",
+            i + 1,
+            file_path.display(),
+            count
+        )?;
     }
 
     Ok(())
+}
+
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg(test)]
+mod top_files_path_tests {
+    use super::*;
+    use crate::models::unified_ast::{BytePos, EvidenceType, Span};
+    use chrono::Utc;
+    use std::path::PathBuf;
+    use uuid::Uuid;
+
+    fn entry(path: &str) -> (Location, ProofAnnotation) {
+        (
+            Location {
+                file_path: PathBuf::from(path),
+                span: Span {
+                    start: BytePos(0),
+                    end: BytePos(1),
+                },
+            },
+            ProofAnnotation {
+                annotation_id: Uuid::nil(),
+                property_proven: PropertyType::MemorySafety,
+                specification_id: None,
+                method: VerificationMethod::BorrowChecker,
+                tool_name: "test".to_string(),
+                tool_version: "1.0".to_string(),
+                confidence_level: ConfidenceLevel::High,
+                assumptions: vec![],
+                evidence_type: EvidenceType::ImplicitTypeSystemGuarantee,
+                evidence_location: None,
+                date_verified: Utc::now(),
+            },
+        )
+    }
+
+    /// Distinct files that share a basename must render as distinct lines. The
+    /// list used to print `file_name()` only, so a repo's many `build.rs` files
+    /// collapsed into the same label repeated over and over.
+    #[test]
+    fn top_files_distinguishes_same_basename_in_different_directories() {
+        let annotations = vec![
+            entry("/repo/a/build.rs"),
+            entry("/repo/a/build.rs"),
+            entry("/repo/b/build.rs"),
+        ];
+
+        let mut out = String::new();
+        format_summary_top_files(&mut out, &annotations).unwrap();
+
+        assert!(
+            out.contains("/repo/a/build.rs"),
+            "expected full path in top-files list, got:\n{out}"
+        );
+        assert!(
+            out.contains("/repo/b/build.rs"),
+            "expected full path in top-files list, got:\n{out}"
+        );
+        let lines: Vec<&str> = out.lines().filter(|l| l.contains("build.rs")).collect();
+        assert_eq!(lines.len(), 2, "two distinct files, two distinct lines");
+        assert_ne!(lines[0], lines[1], "lines must not be identical labels");
+    }
 }

--- a/src/cli/proof_annotation_helpers_format.rs
+++ b/src/cli/proof_annotation_helpers_format.rs
@@ -43,10 +43,19 @@ pub fn format_as_json(
         })
         .collect();
 
+    // COMPLETENESS: files the collector could not read or parse contribute no
+    // annotations, and their failure used to stop at one `warn!` line on
+    // stderr. The document then reported a total with nothing to say it was
+    // computed over a subset — 31 unparsed files on this repo, invisible to
+    // anything consuming the JSON. Reported here so a consumer can tell a
+    // complete analysis from a partial one.
+    let files_not_analyzed = annotator.collection_errors();
+
     let json_data = serde_json::json!({
         "proof_annotations": annotations_json,
         "summary": {
             "total_annotations": annotations.len(),
+            "files_not_analyzed": files_not_analyzed,
             "cache_stats": {
                 "size": cache_stats.size,
                 "files_tracked": cache_stats.files_tracked
@@ -135,6 +144,22 @@ pub async fn collect_and_filter_annotations(
     });
 
     collected
+}
+
+/// The disclosure appended to every human-readable report when the collector
+/// skipped files.
+///
+/// `None` when nothing was skipped, so a complete run reads exactly as before.
+/// The JSON document carries the same fact as `summary.files_not_analyzed`.
+#[must_use]
+pub fn incomplete_analysis_note(files_not_analyzed: usize) -> Option<String> {
+    if files_not_analyzed == 0 {
+        return None;
+    }
+    Some(format!(
+        "\nINCOMPLETE: {files_not_analyzed} file(s) could not be read or parsed and \
+         contributed no annotations. The totals above are computed over the rest.\n"
+    ))
 }
 
 /// Format annotations as table output

--- a/src/cli/provability_helpers.rs
+++ b/src/cli/provability_helpers.rs
@@ -29,6 +29,44 @@ pub fn parse_function_spec(spec: &str, project_path: &Path) -> Result<FunctionId
     }
 }
 
+/// Functions among `discovered` that a `--functions` spec names.
+///
+/// `parse_function_spec` above manufactures a `FunctionId` out of whatever
+/// string it is handed — its "will search all files" comment described a search
+/// that was never performed. That is why `analyze provability -p <empty dir>
+/// --functions ghost` reported "✓ Analyzed 1 functions / Average provability
+/// score: 20.0%": a phantom id with an empty file path, scored at the lattice
+/// Top default because its source could never be read. Matching against the
+/// functions actually discovered in the tree is the only way an answer here can
+/// be about the code rather than about the argument.
+///
+/// A spec is either `function_name` or `path/to/file.rs:function_name`; the
+/// file part matches a discovered path exactly or as a trailing path suffix.
+#[must_use]
+pub fn match_function_spec(spec: &str, discovered: &[FunctionId]) -> Vec<FunctionId> {
+    let (file_part, func_part) = match spec.split_once(':') {
+        Some((file, func)) => (Some(file.trim_start_matches("./")), func),
+        None => (None, spec),
+    };
+
+    discovered
+        .iter()
+        .filter(|id| {
+            if id.function_name != func_part {
+                return false;
+            }
+            match file_part {
+                None => true,
+                Some(wanted) => {
+                    let have = id.file_path.trim_start_matches("./");
+                    have == wanted || have.ends_with(&format!("/{wanted}"))
+                }
+            }
+        })
+        .cloned()
+        .collect()
+}
+
 /// Extract function name from a line
 fn extract_function_name(line: &str) -> Option<String> {
     let line = line.trim();

--- a/src/cli/provability_helpers_detailed.rs
+++ b/src/cli/provability_helpers_detailed.rs
@@ -76,7 +76,11 @@ fn write_function_details(
     use crate::cli::colors as c;
     use crate::services::lightweight_provability_analyzer::PropertyType;
 
-    writeln!(output, "  {}Function:{} {}", c::BOLD, c::RESET, c::label(&func_id.function_name))?;
+    // `c::seq`, not the bare `pub const`s: the raw sequences are `const` and so
+    // cannot consult `colors_enabled()`, which is why `--color never` and a
+    // redirected stdout still received `^[[1mFunction:^[[0m` here long after
+    // the summary renderer was migrated (GH #684).
+    writeln!(output, "  {}Function:{} {}", c::seq(c::BOLD), c::seq(c::RESET), c::label(&func_id.function_name))?;
     writeln!(output, "    Line: {}", c::number(&func_id.line_number.to_string()))?;
     writeln!(
         output,
@@ -110,13 +114,111 @@ fn write_function_details(
         }
     }
     if !verified.is_empty() {
-        writeln!(output, "    {}Verified:{} {}{}{}", c::BOLD, c::RESET, c::GREEN, verified.join(", "), c::RESET)?;
+        writeln!(output, "    {}Verified:{} {}{}{}", c::seq(c::BOLD), c::seq(c::RESET), c::seq(c::GREEN), verified.join(", "), c::seq(c::RESET))?;
     }
     if !missing.is_empty() {
-        writeln!(output, "    {}Missing:{} {}{}{}", c::BOLD, c::RESET, c::RED, missing.join(", "), c::RESET)?;
+        writeln!(output, "    {}Missing:{} {}{}{}", c::seq(c::BOLD), c::seq(c::RESET), c::seq(c::RED), missing.join(", "), c::seq(c::RESET))?;
     }
 
     Ok(())
+}
+
+/// Format provability results as GitHub-flavoured Markdown.
+///
+/// `-f markdown` was an alias for `-f full`: the two produced byte-identical
+/// output, so the "markdown" format emitted the ANSI-decorated terminal
+/// rendering (`^[[1mFunction:^[[0m add`) with not one markdown construct in it.
+/// A format that names a syntax has to produce that syntax.
+pub fn format_provability_markdown(
+    function_ids: &[FunctionId],
+    summaries: &[ProofSummary],
+    include_evidence: bool,
+) -> Result<String> {
+    use crate::services::lightweight_provability_analyzer::PropertyType;
+
+    const ALL_PROPERTIES: [PropertyType; 6] = [
+        PropertyType::NullSafety,
+        PropertyType::BoundsCheck,
+        PropertyType::NoAliasing,
+        PropertyType::PureFunction,
+        PropertyType::MemorySafety,
+        PropertyType::ThreadSafety,
+    ];
+
+    let mut output = String::new();
+    writeln!(&mut output, "# Provability Analysis\n")?;
+    writeln!(
+        &mut output,
+        "Functions analyzed: {}\n",
+        function_ids.len()
+    )?;
+
+    for (file_path, functions) in group_functions_by_file(function_ids, summaries) {
+        writeln!(&mut output, "## `{file_path}`\n")?;
+        writeln!(
+            &mut output,
+            "| Function | Line | Provability | Verified | Missing |"
+        )?;
+        writeln!(&mut output, "| --- | ---: | ---: | --- | --- |")?;
+
+        for (func_id, summary) in &functions {
+            let verified_types: Vec<&PropertyType> = summary
+                .verified_properties
+                .iter()
+                .map(|p| &p.property_type)
+                .collect();
+            let (verified, missing): (Vec<String>, Vec<String>) = ALL_PROPERTIES
+                .iter()
+                .map(|pt| (format!("{pt:?}"), verified_types.contains(&pt)))
+                .fold((Vec::new(), Vec::new()), |(mut v, mut m), (name, ok)| {
+                    if ok {
+                        v.push(name);
+                    } else {
+                        m.push(name);
+                    }
+                    (v, m)
+                });
+            let or_dash = |items: Vec<String>| {
+                if items.is_empty() {
+                    "—".to_string()
+                } else {
+                    items.join(", ")
+                }
+            };
+
+            writeln!(
+                &mut output,
+                "| `{}` | {} | {:.1}% | {} | {} |",
+                func_id.function_name,
+                func_id.line_number,
+                summary.provability_score * 100.0,
+                or_dash(verified),
+                or_dash(missing),
+            )?;
+        }
+        writeln!(&mut output)?;
+
+        if include_evidence {
+            for (func_id, summary) in &functions {
+                if summary.verified_properties.is_empty() {
+                    continue;
+                }
+                writeln!(&mut output, "### `{}` — evidence\n", func_id.function_name)?;
+                for prop in &summary.verified_properties {
+                    writeln!(
+                        &mut output,
+                        "- **{:?}** ({:.1}% confidence): {}",
+                        prop.property_type,
+                        prop.confidence * 100.0,
+                        prop.evidence,
+                    )?;
+                }
+                writeln!(&mut output)?;
+            }
+        }
+    }
+
+    Ok(output)
 }
 
 fn write_verified_properties(
@@ -124,17 +226,118 @@ fn write_verified_properties(
     properties: &[crate::services::lightweight_provability_analyzer::VerifiedProperty],
 ) -> Result<()> {
     use crate::cli::colors as c;
-    writeln!(output, "\n    {}Verified Properties:{}", c::BOLD, c::RESET)?;
+    writeln!(output, "\n    {}Verified Properties:{}", c::seq(c::BOLD), c::seq(c::RESET))?;
 
     for prop in properties {
         writeln!(
             output,
             "      {}{:?}{} (confidence: {})",
-            c::GREEN, prop.property_type, c::RESET,
+            c::seq(c::GREEN), prop.property_type, c::seq(c::RESET),
             c::pct(prop.confidence * 100.0, 80.0, 50.0),
         )?;
-        writeln!(output, "        Evidence: {}{}{}", c::DIM, prop.evidence, c::RESET)?;
+        writeln!(output, "        Evidence: {}{}{}", c::seq(c::DIM), prop.evidence, c::seq(c::RESET))?;
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod markdown_and_plain_output_tests {
+    //! `-f markdown` was an alias for `-f full` (identical md5), and the
+    //! detailed renderer interpolated the raw `pub const` ANSI sequences, so a
+    //! redirected `-f markdown` file was ANSI-decorated terminal text.
+    use super::*;
+    use crate::services::lightweight_provability_analyzer::{
+        FunctionId, ProofSummary, PropertyType, VerifiedProperty,
+    };
+
+    fn fixture() -> (Vec<FunctionId>, Vec<ProofSummary>) {
+        let ids = vec![
+            FunctionId {
+                file_path: "src/lib.rs".to_string(),
+                function_name: "add".to_string(),
+                line_number: 2,
+            },
+            FunctionId {
+                file_path: "src/lib.rs".to_string(),
+                function_name: "complex".to_string(),
+                line_number: 4,
+            },
+        ];
+        let summaries = vec![
+            ProofSummary {
+                provability_score: 0.2,
+                analysis_time_us: 12,
+                verified_properties: vec![],
+                version: 1,
+            },
+            ProofSummary {
+                provability_score: 0.9,
+                analysis_time_us: 3,
+                verified_properties: vec![VerifiedProperty {
+                    property_type: PropertyType::PureFunction,
+                    confidence: 0.75,
+                    evidence: "no writes to globals".to_string(),
+                }],
+                version: 1,
+            },
+        ];
+        (ids, summaries)
+    }
+
+    #[test]
+    fn detailed_output_is_plain_text_when_colour_is_disabled() {
+        assert!(
+            !crate::cli::colors::colors_enabled(),
+            "cargo test captures stdout, so colour must resolve to off here"
+        );
+
+        let (ids, summaries) = fixture();
+        let rendered = format_provability_detailed(&ids, &summaries, true).expect("render");
+
+        assert!(
+            !rendered.contains('\u{1b}'),
+            "no ANSI escape may reach a redirected stdout: {:?}",
+            rendered
+                .lines()
+                .filter(|l| l.contains('\u{1b}'))
+                .collect::<Vec<_>>()
+        );
+        // The payload must survive the de-colouring.
+        assert!(rendered.contains("Detailed Provability Analysis"));
+        assert!(rendered.contains("Function:"));
+        assert!(rendered.contains("Missing:"));
+        assert!(rendered.contains("no writes to globals"));
+    }
+
+    #[test]
+    fn markdown_is_markdown_and_not_the_terminal_rendering() {
+        let (ids, summaries) = fixture();
+        let markdown = format_provability_markdown(&ids, &summaries, true).expect("render");
+        let detailed = format_provability_detailed(&ids, &summaries, true).expect("render");
+
+        assert_ne!(
+            markdown, detailed,
+            "`-f markdown` must not be an alias for `-f full`"
+        );
+        assert!(!markdown.contains('\u{1b}'), "markdown must be plain text");
+
+        assert!(markdown.starts_with("# Provability Analysis"));
+        assert!(markdown.contains("## `src/lib.rs`"));
+        assert!(markdown.contains("| Function | Line | Provability | Verified | Missing |"));
+        assert!(markdown.contains("| `add` | 2 | 20.0% |"));
+        assert!(markdown.contains("| `complex` | 4 | 90.0% | PureFunction |"));
+        // Evidence is a section, not a colour-coded block.
+        assert!(markdown.contains("### `complex` — evidence"));
+        assert!(markdown.contains("- **PureFunction** (75.0% confidence): no writes to globals"));
+    }
+
+    #[test]
+    fn markdown_omits_the_evidence_sections_when_not_requested() {
+        let (ids, summaries) = fixture();
+        let markdown = format_provability_markdown(&ids, &summaries, false).expect("render");
+        assert!(!markdown.contains("evidence"));
+        // The table itself is unaffected.
+        assert!(markdown.contains("| `complex` | 4 | 90.0% | PureFunction |"));
+    }
 }

--- a/src/cli/provability_helpers_summary.rs
+++ b/src/cli/provability_helpers_summary.rs
@@ -249,7 +249,14 @@ fn write_top_files_list(
     top_files: usize,
 ) -> Result<()> {
     use crate::cli::colors as c;
-    let files_to_show = if top_files == 0 { 10 } else { top_files };
+    // `--help` documents `--top-files <N>` as "0 = all", but 0 was remapped to
+    // the default 10 here, so asking for every file silently truncated the
+    // ranking at ten and the dropped files were never mentioned. 0 means all.
+    let files_to_show = if top_files == 0 {
+        file_avg_scores.len()
+    } else {
+        top_files
+    };
 
     for (i, (file_path, avg_score, function_count)) in
         file_avg_scores.iter().take(files_to_show).enumerate()
@@ -331,5 +338,40 @@ mod plain_output_tests {
         assert!(rendered.contains("Scoring Model"));
         assert!(rendered.contains("Score Distribution"));
         assert!(rendered.contains("Top Files by Provability"));
+    }
+
+    /// `--top-files` documents "0 = all", but 0 was remapped to the default 10,
+    /// so every file past the tenth vanished from the ranking with no notice.
+    #[test]
+    fn top_files_zero_lists_every_file_not_the_default_ten() {
+        let ids: Vec<FunctionId> = (0..12)
+            .map(|i| FunctionId {
+                file_path: format!("src/f{i:02}.rs"),
+                function_name: format!("f{i}"),
+                line_number: i + 1,
+            })
+            .collect();
+        let summaries: Vec<ProofSummary> = (0..12)
+            .map(|i| ProofSummary {
+                provability_score: f64::from(i) / 100.0,
+                analysis_time_us: 1,
+                verified_properties: vec![],
+                version: 1,
+            })
+            .collect();
+
+        let rendered = format_provability_summary(&ids, &summaries, 0).expect("render");
+        let listed = rendered
+            .lines()
+            .filter(|l| l.contains("avg score"))
+            .count();
+        assert_eq!(
+            listed, 12,
+            "--top-files 0 must list all 12 files, not truncate to the default: {rendered}"
+        );
+        assert!(
+            rendered.contains("f11.rs"),
+            "the eleventh-ranked file was dropped: {rendered}"
+        );
     }
 }

--- a/src/cli/provability_helpers_summary.rs
+++ b/src/cli/provability_helpers_summary.rs
@@ -71,12 +71,12 @@ fn write_summary_header(output: &mut String, total_functions: usize) -> Result<(
 fn write_scoring_model(output: &mut String) -> Result<()> {
     use crate::cli::colors as c;
     writeln!(output, "\n{}\n", c::subheader("Scoring Model (4 factors, equally weighted)"))?;
-    writeln!(output, "  {}{:<14}{} {:<14} {:<14} 0%", c::BOLD, "Factor", c::RESET, "100%", "50%")?;
+    writeln!(output, "  {}{:<14}{} {:<14} {:<14} 0%", c::seq(c::BOLD), "Factor", c::seq(c::RESET), "100%", "50%")?;
     writeln!(output, "  {}", c::separator())?;
-    writeln!(output, "  {:<14} {}NotNull{}       {}MaybeNull{}    {}Unknown/Null{}", "Nullability", c::GREEN, c::RESET, c::YELLOW, c::RESET, c::RED, c::RESET)?;
-    writeln!(output, "  {:<14} {}Both bounds{}   {}One bound{}    {}No bounds{}", "Bounds", c::GREEN, c::RESET, c::YELLOW, c::RESET, c::RED, c::RESET)?;
-    writeln!(output, "  {:<14} {}NoAlias{}       {:<14} {}MayAlias/Unknown{}", "Aliasing", c::GREEN, c::RESET, "-", c::RED, c::RESET)?;
-    writeln!(output, "  {:<14} {}Pure{}          {}ReadOnly(70){} {}WriteGlobal{}", "Purity", c::GREEN, c::RESET, c::YELLOW, c::RESET, c::RED, c::RESET)?;
+    writeln!(output, "  {:<14} {}NotNull{}       {}MaybeNull{}    {}Unknown/Null{}", "Nullability", c::seq(c::GREEN), c::seq(c::RESET), c::seq(c::YELLOW), c::seq(c::RESET), c::seq(c::RED), c::seq(c::RESET))?;
+    writeln!(output, "  {:<14} {}Both bounds{}   {}One bound{}    {}No bounds{}", "Bounds", c::seq(c::GREEN), c::seq(c::RESET), c::seq(c::YELLOW), c::seq(c::RESET), c::seq(c::RED), c::seq(c::RESET))?;
+    writeln!(output, "  {:<14} {}NoAlias{}       {:<14} {}MayAlias/Unknown{}", "Aliasing", c::seq(c::GREEN), c::seq(c::RESET), "-", c::seq(c::RED), c::seq(c::RESET))?;
+    writeln!(output, "  {:<14} {}Pure{}          {}ReadOnly(70){} {}WriteGlobal{}", "Purity", c::seq(c::GREEN), c::seq(c::RESET), c::seq(c::YELLOW), c::seq(c::RESET), c::seq(c::RED), c::seq(c::RESET))?;
     Ok(())
 }
 
@@ -113,7 +113,7 @@ fn write_property_coverage(output: &mut String, summaries: &[ProofSummary]) -> R
     for (name, count) in &counts {
         let pct_val = (*count as f64 / total as f64) * 100.0;
         writeln!(output, "  {}{}{}: {}/{} ({})",
-            c::BOLD, name, c::RESET,
+            c::seq(c::BOLD), name, c::seq(c::RESET),
             c::number(&count.to_string()),
             c::number(&total.to_string()),
             c::pct(pct_val, 80.0, 50.0),
@@ -152,7 +152,7 @@ fn write_lowest_scoring_functions(
             .map(|p| format!("{:?}({:.0}%)", p.property_type, p.confidence * 100.0))
             .collect();
         let props_str = if props.is_empty() {
-            format!("{}none verified{}", c::DIM, c::RESET)
+            format!("{}none verified{}", c::seq(c::DIM), c::seq(c::RESET))
         } else {
             props.join(", ")
         };
@@ -173,9 +173,9 @@ fn write_score_distribution(output: &mut String, summaries: &[ProofSummary]) -> 
     let (high_count, medium_count, low_count) = categorize_scores(summaries);
 
     writeln!(output, "\n{}", c::subheader("Score Distribution:"))?;
-    writeln!(output, "  {}High{} ({}\u{2265}80%{}): {} functions", c::GREEN, c::RESET, c::GREEN, c::RESET, c::number(&high_count.to_string()))?;
-    writeln!(output, "  {}Medium{} ({}50-79%{}): {} functions", c::YELLOW, c::RESET, c::YELLOW, c::RESET, c::number(&medium_count.to_string()))?;
-    writeln!(output, "  {}Low{} ({}<50%{}): {} functions", c::RED, c::RESET, c::RED, c::RESET, c::number(&low_count.to_string()))?;
+    writeln!(output, "  {}High{} ({}\u{2265}80%{}): {} functions", c::seq(c::GREEN), c::seq(c::RESET), c::seq(c::GREEN), c::seq(c::RESET), c::number(&high_count.to_string()))?;
+    writeln!(output, "  {}Medium{} ({}50-79%{}): {} functions", c::seq(c::YELLOW), c::seq(c::RESET), c::seq(c::YELLOW), c::seq(c::RESET), c::number(&medium_count.to_string()))?;
+    writeln!(output, "  {}Low{} ({}<50%{}): {} functions", c::seq(c::RED), c::seq(c::RESET), c::seq(c::RED), c::seq(c::RESET), c::number(&low_count.to_string()))?;
 
     Ok(())
 }
@@ -266,4 +266,70 @@ fn write_top_files_list(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod plain_output_tests {
+    //! `--color never`, `NO_COLOR=1` and a redirected stdout all left 17
+    //! escape-bearing lines in `analyze provability`'s summary: the renderer
+    //! interpolated the raw `pub const` sequences, which are `const` and so
+    //! cannot consult `colors_enabled()`. Only `--color always` differed —
+    //! i.e. the flag parsed and only its "always" branch did anything.
+    use super::*;
+    use crate::services::lightweight_provability_analyzer::{FunctionId, ProofSummary};
+
+    fn fixture() -> (Vec<FunctionId>, Vec<ProofSummary>) {
+        let ids = vec![
+            FunctionId {
+                file_path: "src/main.rs".to_string(),
+                function_name: "high".to_string(),
+                line_number: 10,
+            },
+            FunctionId {
+                file_path: "src/lib.rs".to_string(),
+                function_name: "low".to_string(),
+                line_number: 20,
+            },
+        ];
+        let summaries = vec![
+            ProofSummary {
+                provability_score: 0.9,
+                analysis_time_us: 1000,
+                verified_properties: vec![],
+                version: 1,
+            },
+            ProofSummary {
+                provability_score: 0.3,
+                analysis_time_us: 500,
+                verified_properties: vec![],
+                version: 1,
+            },
+        ];
+        (ids, summaries)
+    }
+
+    #[test]
+    fn summary_is_plain_text_when_colour_is_disabled() {
+        assert!(
+            !crate::cli::colors::colors_enabled(),
+            "cargo test captures stdout, so colour must resolve to off here"
+        );
+
+        let (ids, summaries) = fixture();
+        let rendered = format_provability_summary(&ids, &summaries, 5).expect("render");
+
+        assert!(
+            !rendered.contains('\u{1b}'),
+            "no ANSI escape may reach a redirected stdout: {:?}",
+            rendered
+                .lines()
+                .filter(|l| l.contains('\u{1b}'))
+                .collect::<Vec<_>>()
+        );
+        // The payload must survive the de-colouring.
+        assert!(rendered.contains("Provability Analysis Summary"));
+        assert!(rendered.contains("Scoring Model"));
+        assert!(rendered.contains("Score Distribution"));
+        assert!(rendered.contains("Top Files by Provability"));
+    }
 }

--- a/src/cli/verify.rs
+++ b/src/cli/verify.rs
@@ -270,14 +270,42 @@ fn stage_clippy(args: &VerifyArgs) -> (bool, Vec<Violation>, Option<String>) {
     let (ok, out) = run(&mut check);
     let violations = parse_clippy_violations(&out);
     let detail = if violations.is_empty() {
-        tail(&out, 10)
+        first_error(&out).or_else(|| tail(&out, 10))
     } else {
         None
     };
     (ok, violations, detail)
 }
 
+/// First error-shaped line of a failed command's output.
+///
+/// Used instead of `tail` when a stage fails with no structured violations. The
+/// tail of a cargo build is the *end* of the progress stream ("Compiling pmat
+/// v3.28.2 …", "warning: build failed, waiting for other jobs to finish") — never
+/// the cause (#640). Cargo's own failures ("error: no such command: `clippy`")
+/// arrive as plain text on stderr, which `run` concatenates onto stdout, so they
+/// are findable here; `--message-format=json` diagnostics start with `{` and are
+/// skipped by the prefix test.
+fn first_error(output: &str) -> Option<String> {
+    output
+        .lines()
+        .map(str::trim)
+        .find(|l| l.starts_with("error"))
+        .map(str::to_string)
+}
+
 /// Parse `cargo clippy --message-format=json` output into structured violations.
+///
+/// Keeps **rustc errors as well as clippy lints**. The filter used to drop every
+/// diagnostic whose code did not start with `clippy::`, so a plain compile error
+/// — `error[E0063]: missing field ...` — left `violations` empty and pushed
+/// `detail` onto its last-10-lines fallback, which for a cargo build is progress
+/// noise ("Compiling pmat v3.28.2 …"). The one gate agents are told to trust
+/// reported strictly less than it already knew (#640).
+///
+/// rustc *warnings* stay filtered out: the clippy stage runs with `-D warnings`,
+/// so anything that actually fails the build arrives at `level == "error"`, and
+/// keeping warnings would bury the cause again under lints CI does not enforce.
 fn parse_clippy_violations(json_stream: &str) -> Vec<Violation> {
     let mut out = Vec::new();
     for line in json_stream.lines() {
@@ -293,7 +321,19 @@ fn parse_clippy_violations(json_stream: &str) -> Vec<Violation> {
             .and_then(|c| c.get("code"))
             .and_then(serde_json::Value::as_str)
             .unwrap_or_default();
-        if !rule.starts_with("clippy::") {
+        let level = msg
+            .get("level")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_default();
+        let text = msg
+            .get("message")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_default();
+        // rustc closes a failed build with "aborting due to N previous errors",
+        // which carries no code and no span. It is a count, not a cause.
+        let is_abort_summary = text.starts_with("aborting due to");
+        let keep = rule.starts_with("clippy::") || (level == "error" && !is_abort_summary);
+        if !keep {
             continue;
         }
         let span = msg
@@ -324,12 +364,15 @@ fn parse_clippy_violations(json_stream: &str) -> Vec<Violation> {
         out.push(Violation {
             file,
             line,
-            rule: rule.to_string(),
-            message: msg
-                .get("message")
-                .and_then(serde_json::Value::as_str)
-                .unwrap_or_default()
-                .to_string(),
+            // A codeless rustc error ("could not compile `cc` (lib) due to 11
+            // previous errors") still needs a rule slug the JSON consumer can
+            // switch on; `rustc` says which tool spoke.
+            rule: if rule.is_empty() {
+                "rustc".to_string()
+            } else {
+                rule.to_string()
+            },
+            message: text.to_string(),
         });
     }
     out
@@ -396,9 +439,66 @@ mod tests {
         assert_eq!(v[0].line, 230);
     }
 
+    /// A rustc compile error must reach the report (#640).
+    ///
+    /// This is the exact shape that used to render as
+    /// `{"name":"clippy","ok":false,"detail":"{\"reason\":\"build-finished\"…"}`
+    /// — a red gate whose output did not contain the error.
+    #[test]
+    fn test_parse_clippy_violations_keeps_rustc_errors() {
+        let stream = r#"{"reason":"compiler-message","message":{"level":"error","code":{"code":"E0063"},"message":"missing field `tdg_measured` in initializer of `EvidenceSummary`","spans":[{"file_name":"src/services/evidence.rs","line_start":412,"is_primary":true}]}}
+{"reason":"compiler-message","message":{"level":"error","code":null,"message":"aborting due to 1 previous error","spans":[]}}
+{"reason":"compiler-message","message":{"level":"error","code":null,"message":"could not compile `cc` (lib) due to 11 previous errors","spans":[]}}
+{"reason":"build-finished","success":false}"#;
+        let v = parse_clippy_violations(stream);
+
+        assert_eq!(v.len(), 2, "got {v:?}");
+        assert_eq!(v[0].rule, "E0063");
+        assert_eq!(v[0].file, "src/services/evidence.rs");
+        assert_eq!(v[0].line, 412);
+        assert!(v[0].message.contains("tdg_measured"));
+        // Codeless rustc errors still carry a slug and their text.
+        assert_eq!(v[1].rule, "rustc");
+        assert!(v[1].message.contains("could not compile `cc`"));
+        // "aborting due to N previous errors" is a count, not a cause.
+        assert!(!v.iter().any(|x| x.message.starts_with("aborting due to")));
+    }
+
+    /// rustc *warnings* must stay out — `-D warnings` promotes the ones that
+    /// matter to errors, and keeping the rest re-buries the cause.
+    #[test]
+    fn test_parse_clippy_violations_drops_rustc_warnings() {
+        let stream = r#"{"reason":"compiler-message","message":{"level":"warning","code":{"code":"unused_imports"},"message":"unused import: `std::fmt`","spans":[{"file_name":"src/a.rs","line_start":3,"is_primary":true}]}}"#;
+        assert!(parse_clippy_violations(stream).is_empty());
+    }
+
     #[test]
     fn test_tail() {
         assert_eq!(tail("a\n\nb\nc", 2).as_deref(), Some("b\nc"));
         assert_eq!(tail("", 5), None);
+    }
+
+    /// The failure detail must be the first error, not the tail of the progress
+    /// stream (#640).
+    #[test]
+    fn test_first_error_prefers_the_cause_over_progress_noise() {
+        let out = "   Compiling pmat v3.29.1\n\
+                   error: no such command: `clippy`\n\
+                   \n\
+                   	Did you mean `check`?\n\
+                      Compiling serde v1.0.0\n\
+                   warning: build failed, waiting for other jobs to finish";
+        assert_eq!(
+            first_error(out).as_deref(),
+            Some("error: no such command: `clippy`")
+        );
+        // tail(10) would have returned the trailing progress lines instead.
+        assert!(tail(out, 10).unwrap().contains("waiting for other jobs"));
+    }
+
+    #[test]
+    fn test_first_error_none_when_output_has_no_error_line() {
+        assert_eq!(first_error("   Compiling pmat v3.29.1\n    Finished"), None);
+        assert_eq!(first_error(""), None);
     }
 }

--- a/src/cli/verify.rs
+++ b/src/cli/verify.rs
@@ -10,7 +10,7 @@
 
 use anyhow::Result;
 use serde::Serialize;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::Instant;
 
@@ -83,14 +83,7 @@ struct VerifyReport {
 /// Run the CI-faithful gate set fail-fast; exit non-zero on any failure.
 pub async fn handle_verify(args: VerifyArgs) -> Result<()> {
     let overall = Instant::now();
-    let selected: Vec<&str> = match args.stage.as_deref() {
-        Some(s) => vec![s],
-        None => STAGES
-            .iter()
-            .copied()
-            .filter(|s| !args.skip.iter().any(|k| k == s))
-            .collect(),
-    };
+    let selected = select_stages(args.stage.as_deref(), &args.skip)?;
 
     let mut stages = Vec::new();
     let mut failed = false;
@@ -131,6 +124,27 @@ pub async fn handle_verify(args: VerifyArgs) -> Result<()> {
     Ok(())
 }
 
+/// Resolve which stages to run, rejecting a `--stage` that is not a stage.
+///
+/// An unrecognised name used to be taken at face value, so it matched no stage:
+/// every stage recorded "not-selected", `failed` stayed false, and
+/// `pmat verify --stage nonexistent` printed `ok:true` and exited 0 on a tree
+/// whose format stage was red. A typo in the one gate agents are told to trust
+/// read as a green tree.
+fn select_stages(stage: Option<&str>, skip: &[String]) -> Result<Vec<&'static str>> {
+    match stage {
+        Some(s) => match STAGES.iter().find(|k| **k == s) {
+            Some(&known) => Ok(vec![known]),
+            None => anyhow::bail!("unknown stage `{s}`; valid stages: {}", STAGES.join(",")),
+        },
+        None => Ok(STAGES
+            .iter()
+            .copied()
+            .filter(|s| !skip.iter().any(|k| k == s))
+            .collect()),
+    }
+}
+
 fn skipped(name: &'static str, why: &'static str) -> StageReport {
     StageReport {
         name,
@@ -149,7 +163,14 @@ fn run_stage(name: &str, args: &VerifyArgs) -> (bool, Vec<Violation>, Option<Str
         "satd" => stage_satd(),
         "clippy" => stage_clippy(args),
         "tests" => stage_tests(),
-        _ => (true, Vec::new(), None),
+        // A name that is not a stage must never read as a pass. `select_stages`
+        // rejects unknown names up front, so getting here means this match and
+        // `STAGES` have drifted apart — report that, don't return green.
+        other => (
+            false,
+            Vec::new(),
+            Some(format!("no such verify stage: `{other}`")),
+        ),
     }
 }
 
@@ -189,7 +210,12 @@ fn stage_format(args: &VerifyArgs) -> (bool, Vec<Violation>, Option<String>) {
         return (true, Vec::new(), None);
     }
     let (ok, out) = run(cargo().args(["fmt", "--all", "--", "--check"]));
-    (ok, Vec::new(), tail(&out, 20))
+    // Same reason as the clippy stage: when `cargo fmt` fails to even start —
+    // run outside a crate, it exits with "error: could not find Cargo.toml"
+    // followed by its whole --help text — `tail` returns the help and buries the
+    // cause, so `verify` reported a "format FAILURE" that looked like a
+    // formatting violation (#640, same family).
+    (ok, Vec::new(), first_error(&out).or_else(|| tail(&out, 20)))
 }
 
 fn stage_complexity() -> (bool, Vec<Violation>, Option<String>) {
@@ -218,8 +244,57 @@ fn stage_complexity() -> (bool, Vec<Violation>, Option<String>) {
 }
 
 fn stage_satd() -> (bool, Vec<Violation>, Option<String>) {
-    let (ok, out) = run(pmat_self().args(["analyze", "satd", "--strict"]));
-    (ok, Vec::new(), tail(&out, 25))
+    // This stage used to shell out to `analyze satd --strict` with no
+    // `--fail-on-violation` and take the child's exit status as its verdict, so
+    // it was green on a tree whose `src/lib.rs` had just gained a FIXME and a
+    // HACK: the subcommand prints "Found 3 SATD violations" and still exits 0.
+    // Ask for the JSON report and read the count ourselves — the gate's verdict
+    // must come from the measurement, not from an exit code that never moves.
+    let (_, out) = run(pmat_self().args([
+        "analyze",
+        "satd",
+        "--strict",
+        "--format",
+        "json",
+        "--fail-on-violation",
+    ]));
+    let (ok, detail) = satd_verdict(&out);
+    (ok, Vec::new(), detail)
+}
+
+/// Decide the satd stage from `analyze satd --format json` output.
+///
+/// No parseable count means the subcommand produced no report; an unmeasured
+/// gate must not read as a pass.
+fn satd_verdict(output: &str) -> (bool, Option<String>) {
+    match parse_satd_violation_count(output) {
+        Some(0) => (true, None),
+        Some(n) => (
+            false,
+            Some(format!(
+                "{n} strict-mode SATD violation(s) (TODO/FIXME/HACK/BUG)\n{}",
+                tail(output, 25).unwrap_or_default()
+            )),
+        ),
+        None => (
+            false,
+            first_error(output)
+                .or_else(|| tail(output, 25))
+                .or_else(|| Some("analyze satd produced no violation count".to_string())),
+        ),
+    }
+}
+
+/// Violation count out of `analyze satd --format json` (`"total_violations": N`).
+fn parse_satd_violation_count(output: &str) -> Option<u64> {
+    const KEY: &str = "\"total_violations\"";
+    let after = output.lines().find_map(|l| l.split_once(KEY))?.1;
+    let digits: String = after
+        .chars()
+        .skip_while(|c| !c.is_ascii_digit())
+        .take_while(char::is_ascii_digit)
+        .collect();
+    digits.parse().ok()
 }
 
 fn stage_tests() -> (bool, Vec<Violation>, Option<String>) {
@@ -379,14 +454,36 @@ fn parse_clippy_violations(json_stream: &str) -> Vec<Violation> {
 }
 
 fn changed_rust_files() -> Vec<String> {
-    let (ok, out) = run(Command::new("git").args(["diff", "--name-only", "HEAD"]));
-    if !ok {
-        return Vec::new();
+    changed_rust_files_in(Path::new("."))
+}
+
+/// Rust files a commit here would introduce or change.
+///
+/// `git diff --name-only HEAD` lists tracked modifications *only*: a brand-new
+/// file is invisible to it until it is `git add`ed, so a freshly written module
+/// with a cyclomatic-46 function passed the complexity stage with `ok:true` and
+/// only went red after staging. Union the working-tree diff with the index and
+/// with untracked-but-not-ignored files, so the gate sees exactly what a commit
+/// would carry.
+fn changed_rust_files_in(dir: &Path) -> Vec<String> {
+    const SOURCES: [&[&str]; 3] = [
+        &["diff", "--name-only", "HEAD"],
+        &["diff", "--name-only", "--cached"],
+        &["ls-files", "--others", "--exclude-standard"],
+    ];
+    let mut files: Vec<String> = Vec::new();
+    for args in SOURCES {
+        let (ok, out) = run(Command::new("git").args(args).current_dir(dir));
+        if !ok {
+            continue;
+        }
+        for line in out.lines().filter(|l| l.ends_with(".rs")) {
+            if !files.iter().any(|f| f == line) {
+                files.push(line.to_string());
+            }
+        }
     }
-    out.lines()
-        .filter(|l| l.ends_with(".rs"))
-        .map(str::to_string)
-        .collect()
+    files
 }
 
 fn print_text(report: &VerifyReport) {
@@ -500,5 +597,117 @@ mod tests {
     fn test_first_error_none_when_output_has_no_error_line() {
         assert_eq!(first_error("   Compiling pmat v3.29.1\n    Finished"), None);
         assert_eq!(first_error(""), None);
+    }
+
+    /// `--stage nonexistent` used to select nothing and report ok:true/exit 0.
+    #[test]
+    fn test_select_stages_rejects_an_unknown_stage_name() {
+        let err = select_stages(Some("nonexistent"), &[])
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("nonexistent"), "{err}");
+        // The message has to say what a valid stage is.
+        for s in STAGES {
+            assert!(err.contains(s), "{err} is missing {s}");
+        }
+    }
+
+    #[test]
+    fn test_select_stages_known_name_and_skip_list() {
+        assert_eq!(select_stages(Some("satd"), &[]).unwrap(), vec!["satd"]);
+        let skip = vec!["format".to_string(), "tests".to_string()];
+        assert_eq!(
+            select_stages(None, &skip).unwrap(),
+            vec!["complexity", "satd", "clippy"]
+        );
+    }
+
+    /// A name that is not a stage must never come back as a pass.
+    #[test]
+    fn test_run_stage_unknown_name_is_not_a_pass() {
+        let args = VerifyArgs {
+            format: VerifyFormat::Json,
+            fix: false,
+            no_fail_fast: false,
+            skip: Vec::new(),
+            stage: None,
+        };
+        let (ok, _, detail) = run_stage("nonexistent", &args);
+        assert!(!ok);
+        assert!(detail.unwrap_or_default().contains("nonexistent"));
+    }
+
+    /// The satd stage must fail on debt the subcommand reports while exiting 0.
+    #[test]
+    fn test_satd_verdict_fails_on_reported_violations() {
+        let report = r#"{
+  "total_files": 1,
+  "total_violations": 3,
+  "summary": "Found 3 SATD violations in 1 files"
+}"#;
+        let (ok, detail) = satd_verdict(report);
+        assert!(!ok, "3 reported violations must fail the stage");
+        assert!(detail.unwrap_or_default().contains('3'));
+        assert_eq!(parse_satd_violation_count(report), Some(3));
+    }
+
+    #[test]
+    fn test_satd_verdict_passes_only_on_a_measured_zero() {
+        let (ok, _) = satd_verdict("{\n  \"total_violations\": 0\n}");
+        assert!(ok);
+        // No count in the output ⇒ nothing was measured ⇒ not a pass.
+        let (ok, detail) = satd_verdict("error: no such subcommand: `satd`");
+        assert!(!ok);
+        assert!(detail.unwrap_or_default().contains("no such subcommand"));
+        assert_eq!(parse_satd_violation_count(""), None);
+    }
+
+    /// A new, not-yet-staged .rs file must be visible to the complexity gate:
+    /// it used to be invisible until `git add`, so a cyclomatic-46 module
+    /// passed verify and only failed after staging.
+    #[test]
+    fn test_changed_rust_files_sees_untracked_files() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let p = dir.path();
+        let git = |args: &[&str]| {
+            let ok = Command::new("git")
+                .args(args)
+                .current_dir(p)
+                .output()
+                .map(|o| o.status.success())
+                .unwrap_or(false);
+            assert!(ok, "git {args:?} failed");
+        };
+        git(&["init", "-q"]);
+        git(&["config", "user.email", "t@example.com"]);
+        git(&["config", "user.name", "t"]);
+        std::fs::write(p.join("tracked.rs"), "pub fn a() {}\n").expect("write");
+        git(&["add", "tracked.rs"]);
+        git(&["commit", "-qm", "init"]);
+
+        // Brand-new file, never staged, plus an ignored one and a non-Rust one.
+        std::fs::write(p.join("untracked.rs"), "pub fn b() {}\n").expect("write");
+        std::fs::write(p.join("notes.md"), "hi\n").expect("write");
+        std::fs::write(p.join(".gitignore"), "ignored.rs\n").expect("write");
+        std::fs::write(p.join("ignored.rs"), "pub fn c() {}\n").expect("write");
+
+        let files = changed_rust_files_in(p);
+        assert!(
+            files.iter().any(|f| f == "untracked.rs"),
+            "untracked .rs must be gated: {files:?}"
+        );
+        assert!(!files.iter().any(|f| f == "ignored.rs"), "{files:?}");
+        assert!(!files.iter().any(|f| f.ends_with(".md")), "{files:?}");
+
+        // Staged and modified files stay in, exactly once each.
+        std::fs::write(p.join("tracked.rs"), "pub fn a() -> u8 { 1 }\n").expect("write");
+        git(&["add", "untracked.rs", "tracked.rs"]);
+        let files = changed_rust_files_in(p);
+        assert_eq!(
+            files.iter().filter(|f| *f == "untracked.rs").count(),
+            1,
+            "{files:?}"
+        );
+        assert!(files.iter().any(|f| f == "tracked.rs"), "{files:?}");
     }
 }

--- a/src/cli/verify.rs
+++ b/src/cli/verify.rs
@@ -182,13 +182,63 @@ fn pmat_self() -> Command {
     Command::new(std::env::current_exe().unwrap_or_else(|_| PathBuf::from("pmat")))
 }
 
+/// Strip ANSI CSI/OSC escape sequences from captured child output.
+///
+/// `cargo fmt --check` colours its diff, and `verify` captured that verbatim
+/// into `StageReport::detail`. So `pmat verify --format json` emitted raw
+/// `\x1b[…m` bytes inside a JSON string — unreadable for the autonomous agent
+/// the JSON format exists for — and `--color never` changed nothing, because
+/// the escapes came from the child, not from us.
+fn strip_ansi(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars();
+    while let Some(c) = chars.next() {
+        if c != '\x1b' {
+            out.push(c);
+            continue;
+        }
+        match chars.next() {
+            // CSI: `ESC [` … final byte in 0x40..=0x7E.
+            Some('[') => {
+                for f in chars.by_ref() {
+                    if ('\x40'..='\x7e').contains(&f) {
+                        break;
+                    }
+                }
+            }
+            // OSC: `ESC ]` … terminated by BEL or `ESC \`.
+            Some(']') => {
+                while let Some(f) = chars.next() {
+                    if f == '\x07' {
+                        break;
+                    }
+                    if f == '\x1b' {
+                        let _ = chars.next();
+                        break;
+                    }
+                }
+            }
+            // Any other two-byte escape: drop both bytes.
+            Some(_) | None => {}
+        }
+    }
+    out
+}
+
 /// Run a command capturing output; return (success, combined stdout+stderr).
+///
+/// Output is de-ANSI'd here rather than at each call site: every consumer of it
+/// is a machine-readable `detail` field or a line `print_text` re-colours
+/// itself, so a child's colours can only corrupt them.
 fn run(cmd: &mut Command) -> (bool, String) {
+    // Belt and braces with `strip_ansi`: ask cargo not to colour in the first
+    // place, so the common case needs no stripping at all.
+    cmd.env("CARGO_TERM_COLOR", "never");
     match cmd.output() {
         Ok(out) => {
             let mut s = String::from_utf8_lossy(&out.stdout).into_owned();
             s.push_str(&String::from_utf8_lossy(&out.stderr));
-            (out.status.success(), s)
+            (out.status.success(), strip_ansi(&s))
         }
         Err(e) => (false, format!("failed to spawn command: {e}")),
     }
@@ -493,34 +543,48 @@ fn changed_rust_files_in(dir: &Path) -> Vec<String> {
     files
 }
 
+/// Render the text report.
+///
+/// The escape sequences go through `colors::seq`, which is `""` when colour is
+/// off. They used to be interpolated as bare literals, so `pmat verify --color
+/// never > verify.txt` wrote `^[[32m✓ pass^[[0m` into the file exactly like
+/// `--color auto` did — the flag parsed and changed nothing (GH #684, same
+/// family).
 fn print_text(report: &VerifyReport) {
+    use crate::cli::colors as c;
+    let (green, red, dim, reset) = (
+        c::seq(c::GREEN),
+        c::seq(c::RED),
+        c::seq(c::DIM),
+        c::seq(c::RESET),
+    );
     for s in &report.stages {
         let status = match s.ok {
-            Some(true) => "\x1b[32m✓ pass\x1b[0m",
-            Some(false) => "\x1b[31m✗ FAIL\x1b[0m",
-            None => "\x1b[2m- skip\x1b[0m",
+            Some(true) => format!("{green}✓ pass{reset}"),
+            Some(false) => format!("{red}✗ FAIL{reset}"),
+            None => format!("{dim}- skip{reset}"),
         };
         println!("  {status}  {:<11} {}ms", s.name, s.duration_ms);
         for v in &s.violations {
             println!(
-                "       \x1b[31m{}\x1b[0m {}:{}  {}",
+                "       {red}{}{reset} {}:{}  {}",
                 v.rule, v.file, v.line, v.message
             );
         }
         if let Some(d) = &s.detail {
             for l in d.lines() {
-                println!("       \x1b[2m{l}\x1b[0m");
+                println!("       {dim}{l}{reset}");
             }
         }
     }
     if report.ok {
         println!(
-            "\n\x1b[32m✓ verify passed\x1b[0m ({}ms) — safe to commit",
+            "\n{green}✓ verify passed{reset} ({}ms) — safe to commit",
             report.duration_ms
         );
     } else {
         println!(
-            "\n\x1b[31m✗ verify failed\x1b[0m ({}ms) — fix before committing",
+            "\n{red}✗ verify failed{reset} ({}ms) — fix before committing",
             report.duration_ms
         );
     }
@@ -749,5 +813,42 @@ mod tests {
             "{files:?}"
         );
         assert!(files.iter().any(|f| f == "tracked.rs"), "{files:?}");
+    }
+}
+
+#[cfg(test)]
+mod ansi_tests {
+    use super::*;
+
+    /// `cargo fmt --check` colours its diff, and that colour used to land
+    /// verbatim inside `--format json` `detail` strings. A machine-readable
+    /// field must not carry terminal escapes.
+    #[test]
+    fn strip_ansi_removes_csi_sequences() {
+        let coloured = "Diff in \u{1b}[1msrc/lib.rs\u{1b}[0m at line \u{1b}[31m3\u{1b}[0m:";
+        let plain = strip_ansi(coloured);
+        assert!(!plain.contains('\u{1b}'), "got: {plain:?}");
+        assert_eq!(plain, "Diff in src/lib.rs at line 3:");
+    }
+
+    #[test]
+    fn strip_ansi_removes_osc_and_leaves_plain_text_alone() {
+        assert_eq!(strip_ansi("\u{1b}]0;title\u{7}body"), "body");
+        assert_eq!(strip_ansi("no escapes here"), "no escapes here");
+        // A lone ESC at the very end must not spin or panic.
+        assert_eq!(strip_ansi("tail\u{1b}"), "tail");
+    }
+
+    /// The detail helpers feed off `run`'s output, so once that is stripped the
+    /// tail/first-error extraction is escape-free too.
+    #[test]
+    fn detail_helpers_carry_no_escapes_once_stripped() {
+        let raw = "\u{1b}[1mDiff in a.rs\u{1b}[0m\n\u{1b}[31merror: something broke\u{1b}[0m\n";
+        let cleaned = strip_ansi(raw);
+        assert_eq!(
+            first_error(&cleaned).as_deref(),
+            Some("error: something broke")
+        );
+        assert!(!tail(&cleaned, 5).unwrap().contains('\u{1b}'));
     }
 }

--- a/src/cli/verify.rs
+++ b/src/cli/verify.rs
@@ -210,12 +210,19 @@ fn stage_format(args: &VerifyArgs) -> (bool, Vec<Violation>, Option<String>) {
         return (true, Vec::new(), None);
     }
     let (ok, out) = run(cargo().args(["fmt", "--all", "--", "--check"]));
-    // Same reason as the clippy stage: when `cargo fmt` fails to even start —
-    // run outside a crate, it exits with "error: could not find Cargo.toml"
-    // followed by its whole --help text — `tail` returns the help and buries the
-    // cause, so `verify` reported a "format FAILURE" that looked like a
-    // formatting violation (#640, same family).
-    (ok, Vec::new(), first_error(&out).or_else(|| tail(&out, 20)))
+    (ok, Vec::new(), format_detail(&out))
+}
+
+/// Failure detail for the format stage.
+///
+/// Same reason as the clippy stage: when `cargo fmt` fails to even start — run
+/// outside a crate, it exits with "error: could not find Cargo.toml" followed
+/// by its whole rustfmt usage screen — `tail` returned the usage screen and
+/// buried the one actionable line, so `verify --format json` told an agent the
+/// code was misformatted when the real problem was that the directory is not a
+/// cargo project (#640, same family).
+fn format_detail(output: &str) -> Option<String> {
+    first_error(output).or_else(|| tail(output, 20))
 }
 
 fn stage_complexity() -> (bool, Vec<Violation>, Option<String>) {
@@ -591,6 +598,39 @@ mod tests {
         );
         // tail(10) would have returned the trailing progress lines instead.
         assert!(tail(out, 10).unwrap().contains("waiting for other jobs"));
+    }
+
+    /// The format stage run outside a cargo project must report the cargo
+    /// error, not rustfmt's usage screen. This is the verbatim shape 3.29.0
+    /// emitted from a directory with no Cargo.toml.
+    #[test]
+    fn test_format_detail_keeps_the_cargo_error_over_the_usage_screen() {
+        let out = "error: could not find `Cargo.toml` in `/tmp/empty` or any parent directory\n\
+                   Usage: cargo fmt [OPTIONS] [-- <rustfmt_options>...]\n\
+                   Arguments:\n\
+                   \x20 [rustfmt_options]...  Options passed to rustfmt\n\
+                   Options:\n\
+                   \x20 -q, --quiet\n\
+                   \x20 -h, --help\n\
+                   \x20         Print help";
+        let detail = format_detail(out).expect("a failing format stage must say why");
+        assert!(
+            detail.contains("could not find `Cargo.toml`"),
+            "the cause was dropped: {detail}"
+        );
+        assert!(
+            !detail.contains("Print help"),
+            "the usage screen is not a failure detail: {detail}"
+        );
+    }
+
+    /// A genuine formatting diff has no `error:` line, so the tail is still the
+    /// right detail there.
+    #[test]
+    fn test_format_detail_falls_back_to_the_diff_tail() {
+        let out = "Diff in /x/src/lib.rs at line 3:\n-fn a(){}\n+fn a() {}\n";
+        let detail = format_detail(out).expect("detail");
+        assert!(detail.contains("Diff in /x/src/lib.rs"), "{detail}");
     }
 
     #[test]

--- a/src/entropy/pattern_extractor_core.rs
+++ b/src/entropy/pattern_extractor_core.rs
@@ -89,6 +89,14 @@ impl PatternExtractor {
             .add_custom_ignore_filename(".paimlignore")
             .build();
 
+        // Source files in a language this analyzer has no pattern set for. They
+        // were dropped in silence: `analyze entropy` on a TypeScript/Python tree
+        // printed "Files Analyzed: 0" — byte-identical to the output for an
+        // EMPTY directory — so "we cannot analyze this language" and "there is
+        // nothing here" were indistinguishable. Counted so the caller can say
+        // which one happened.
+        let mut skipped_unsupported = 0usize;
+
         for entry in walker.filter_map(std::result::Result::ok) {
             let path = entry.path();
 
@@ -103,11 +111,68 @@ impl PatternExtractor {
                         }
                         Err(_) => continue, // Skip files we can't read
                     }
+                } else if Self::is_unsupported_source_extension(extension)
+                    && self.should_process_file(path)
+                {
+                    skipped_unsupported += 1;
                 }
             }
         }
 
+        // Nothing analyzable, but there IS source here. Reporting a block of
+        // zeros would be a clean bill of health for code that was never read —
+        // and `quality-gate --checks entropy` would pass on it.
+        if files.is_empty() && skipped_unsupported > 0 {
+            anyhow::bail!(
+                "entropy analysis found no analyzable source under {}: it reads Rust and Ruchy \
+                 (.rs/.ruchy/.rh), and the {skipped_unsupported} source file(s) there are in \
+                 other languages. No entropy was measured.",
+                project_path.display()
+            );
+        }
+
         Ok(ProjectContext { files })
+    }
+
+    /// Extensions this analyzer recognises as source but has no pattern set for.
+    ///
+    /// Deliberately a fixed list rather than "anything that is not .rs": a
+    /// README or a lockfile is not source, and must not turn a Rust-only project
+    /// into an error.
+    fn is_unsupported_source_extension(extension: &std::ffi::OsStr) -> bool {
+        let Some(ext) = extension.to_str() else {
+            return false;
+        };
+        matches!(
+            ext,
+            "ts" | "tsx"
+                | "js"
+                | "jsx"
+                | "mjs"
+                | "cjs"
+                | "py"
+                | "pyi"
+                | "go"
+                | "java"
+                | "kt"
+                | "kts"
+                | "scala"
+                | "c"
+                | "h"
+                | "cc"
+                | "cpp"
+                | "cxx"
+                | "hpp"
+                | "cs"
+                | "rb"
+                | "php"
+                | "swift"
+                | "dart"
+                | "lua"
+                | "ex"
+                | "exs"
+                | "zig"
+        )
     }
 
     /// Check if file should be processed
@@ -214,5 +279,59 @@ mod discovery_scope_tests {
             "gitignored output is not source: {:?}",
             context.files.keys().collect::<Vec<_>>()
         );
+    }
+
+    /// Round-5 dogfood: `analyze entropy -p <ts+py dir>` printed
+    /// "Files Analyzed: 0 / Source Lines Analyzed: 0 / Pattern Diversity: not
+    /// measured" and exited 0 — byte-for-byte what an EMPTY directory produces.
+    /// The walk only reads .rs/.ruchy/.rh; every other source file was dropped
+    /// without a word, so a clean report was indistinguishable from "we never
+    /// looked at your code".
+    #[tokio::test]
+    async fn a_tree_of_unanalyzable_source_is_not_reported_as_a_clean_zero() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        std::fs::write(root.join("app.ts"), "export function a() { return 1; }\n").unwrap();
+        std::fs::write(root.join("main.py"), "def a():\n    return 1\n").unwrap();
+
+        let extractor = PatternExtractor::new(EntropyConfig::default());
+        let err = extractor
+            .extract_patterns(root)
+            .await
+            .expect_err("a directory of unreadable-to-us source is not a measured zero");
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains("no analyzable source"),
+            "the report must say why nothing was analyzed: {msg}"
+        );
+        assert!(msg.contains('2'), "and how much was skipped: {msg}");
+    }
+
+    /// An actually empty directory still reports zero, quietly: there is
+    /// nothing to explain.
+    #[tokio::test]
+    async fn an_empty_directory_still_analyzes_to_zero_files() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let extractor = PatternExtractor::new(EntropyConfig::default());
+        let collection = extractor
+            .extract_patterns(dir.path())
+            .await
+            .expect("an empty directory is not an error");
+        assert_eq!(collection.total_files, 0);
+    }
+
+    /// A Rust project with docs and configs alongside it is untouched.
+    #[tokio::test]
+    async fn non_source_companions_do_not_turn_a_rust_project_into_an_error() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        std::fs::write(root.join("lib.rs"), "pub fn a() {}\n").unwrap();
+        std::fs::write(root.join("README.md"), "# hi\n").unwrap();
+        std::fs::write(root.join("Cargo.toml"), "[package]\nname=\"x\"\n").unwrap();
+
+        let extractor = PatternExtractor::new(EntropyConfig::default());
+        let collection = extractor.extract_patterns(root).await.expect("scan");
+        assert_eq!(collection.total_files, 1);
     }
 }

--- a/src/entropy/pattern_extractor_core.rs
+++ b/src/entropy/pattern_extractor_core.rs
@@ -62,20 +62,34 @@ impl PatternExtractor {
     }
 
     /// Walk `project_path` and read every source file we know how to analyze.
+    ///
+    /// DISCOVERY POLICY: the walk used to be a raw `walkdir::WalkDir` filtered
+    /// only by this analyzer's glob exclude list, so it descended into hidden
+    /// and gitignored trees. On this repo that meant `.claude/worktrees`:
+    /// entropy reported "Files Analyzed: 128656" where `analyze complexity`
+    /// reported 4260, with 6639 of 6778 referenced paths living under
+    /// `/.claude/worktrees/`. The walk now applies the same policy as the shared
+    /// `ProjectFileDiscovery` — .gitignore/.ignore/.pmatignore honoured, hidden
+    /// directories skipped, build artifacts skipped. It is spelled out here
+    /// rather than delegated because `ProjectFileDiscovery`'s extension list has
+    /// no `.ruchy`/`.rh`, which entropy analyzes.
     async fn scan_source_files(&self, project_path: &Path) -> Result<ProjectContext> {
         use std::fs;
-        use walkdir::WalkDir;
 
-        // BTreeMap: WalkDir yields entries in readdir order, which is not stable
-        // across machines or runs; the map re-imposes path order.
+        // BTreeMap: the walker yields entries in readdir order, which is not
+        // stable across machines or runs; the map re-imposes path order.
         let mut files = BTreeMap::new();
 
-        // Walk directory and read Rust files
-        for entry in WalkDir::new(project_path)
+        let walker = ignore::WalkBuilder::new(project_path)
+            .standard_filters(true)
+            .hidden(true)
+            .parents(true)
             .follow_links(false)
-            .into_iter()
-            .filter_map(std::result::Result::ok)
-        {
+            .add_custom_ignore_filename(".pmatignore")
+            .add_custom_ignore_filename(".paimlignore")
+            .build();
+
+        for entry in walker.filter_map(std::result::Result::ok) {
             let path = entry.path();
 
             // Process Rust and Ruchy files
@@ -144,5 +158,61 @@ impl PatternExtractor {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod discovery_scope_tests {
+    //! The entropy walk must not descend into hidden tool caches or gitignored
+    //! trees: with a raw WalkDir it reported 128,656 files analyzed on a repo
+    //! where `analyze complexity` reported 4,260, almost all of the extra paths
+    //! coming from `.claude/worktrees`.
+    use super::*;
+
+    #[tokio::test]
+    async fn scan_skips_hidden_tool_directories() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::create_dir_all(root.join(".claude/worktrees/wt/src")).unwrap();
+        std::fs::write(root.join("src/lib.rs"), "pub fn a() {}\n").unwrap();
+        std::fs::write(
+            root.join(".claude/worktrees/wt/src/lib.rs"),
+            "pub fn b() {}\n",
+        )
+        .unwrap();
+
+        let extractor = PatternExtractor::new(EntropyConfig::default());
+        let context = extractor.scan_source_files(root).await.expect("scan");
+
+        assert_eq!(
+            context.files.len(),
+            1,
+            "only the project's own source counts: {:?}",
+            context.files.keys().collect::<Vec<_>>()
+        );
+    }
+
+    #[tokio::test]
+    async fn scan_skips_gitignored_trees() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::create_dir_all(root.join("generated")).unwrap();
+        // `.git` must exist for gitignore rules to apply, exactly as in a checkout.
+        std::fs::create_dir_all(root.join(".git")).unwrap();
+        std::fs::write(root.join(".gitignore"), "generated/\n").unwrap();
+        std::fs::write(root.join("src/lib.rs"), "pub fn a() {}\n").unwrap();
+        std::fs::write(root.join("generated/g.rs"), "pub fn g() {}\n").unwrap();
+
+        let extractor = PatternExtractor::new(EntropyConfig::default());
+        let context = extractor.scan_source_files(root).await.expect("scan");
+
+        assert_eq!(
+            context.files.len(),
+            1,
+            "gitignored output is not source: {:?}",
+            context.files.keys().collect::<Vec<_>>()
+        );
     }
 }

--- a/src/explain.rs
+++ b/src/explain.rs
@@ -254,10 +254,19 @@ pub static EXPLANATIONS: &[CheckExplanation] = &[
     },
 
     // ── TDG Grades ────────────────────────────────────────────────────
+    //
+    // ONE band per grade `pmat tdg` can print, and the bands are the ones in
+    // `crate::tdg::Grade`'s GRADE_BANDS. What used to sit here was a
+    // hand-written FIVE-grade table whose numbers contradicted the analyzer:
+    // it said A was "Score 85-94" where the analyzer grades 85-89 as A-, and it
+    // had no entry at all for A-, B+, B-, C+, C- or D — so `pmat explain TDG-A-`
+    // answered "No checks matching 'TDG-A-'" for a grade the tool prints
+    // routinely. `tdg_grade_bands_match_the_analyzer` below fails if the two
+    // ever drift again.
     CheckExplanation {
         id: "TDG-A+",
         name: "Grade A+ (Excellent)",
-        what: "Score 95-100. Minimal complexity, full test coverage, clean documentation.",
+        what: "Score [95, 100]. Minimal complexity, full test coverage, clean documentation.",
         why: "A+ functions have near-zero defect probability and serve as reference implementations.",
         fail_when: &[],
         how_to_fix: "Already excellent. Maintain quality.",
@@ -266,37 +275,161 @@ pub static EXPLANATIONS: &[CheckExplanation] = &[
     CheckExplanation {
         id: "TDG-A",
         name: "Grade A (Good)",
-        what: "Score 85-94. Low complexity, good test coverage, acceptable documentation.",
+        what: "Score [90, 95). Low complexity, good test coverage, acceptable documentation.",
         why: "Grade A is the minimum acceptable for production code in projects with min_tdg_grade: A.",
         fail_when: &[],
         how_to_fix: "Reduce cyclomatic complexity, add edge-case tests, improve naming.",
-        see_also: &["TDG-A+ (Excellent)", "TDG-B (Needs Improvement)", "CB-200 (TDG Grade Gate)"],
+        see_also: &["TDG-A+ (Excellent)", "TDG-A- (Next Band Down)", "CB-200 (TDG Grade Gate)"],
+    },
+    CheckExplanation {
+        id: "TDG-A-",
+        name: "Grade A- (Good, Bottom of the A Band)",
+        what: "Score [85, 90). Low complexity with a thin margin on coverage or documentation.",
+        why: "A- passes an `min_tdg_grade: A-` gate but fails an A gate — the most common near-miss.",
+        fail_when: &["CB-200 fails if min_tdg_grade is set to A or A+"],
+        how_to_fix: "Close the smallest component gap first (usually documentation or duplication).",
+        see_also: &["TDG-A (Next Target)", "CB-200 (TDG Grade Gate)"],
+    },
+    CheckExplanation {
+        id: "TDG-B+",
+        name: "Grade B+ (Acceptable)",
+        what: "Score [80, 85). Moderate complexity, or one weak component.",
+        why: "B+ code carries measurably more defects than A code but is not a priority rewrite.",
+        fail_when: &["CB-200 fails if min_tdg_grade is set to A- or higher"],
+        how_to_fix: "Extract helper functions and add the missing test paths for the weakest component.",
+        see_also: &["TDG-A- (Next Target)", "pmat-book Ch4: TDG"],
     },
     CheckExplanation {
         id: "TDG-B",
         name: "Grade B (Needs Improvement)",
-        what: "Score 70-84. Moderate complexity or coverage gaps.",
+        what: "Score [75, 80). Moderate complexity or coverage gaps.",
         why: "Grade B functions have elevated defect risk. Refactor to reduce complexity.",
-        fail_when: &["CB-200 fails if min_tdg_grade is set to A or higher"],
+        fail_when: &["CB-200 fails if min_tdg_grade is set to B+ or higher"],
         how_to_fix: "Extract helper functions, reduce nesting depth, add missing test paths.",
-        see_also: &["TDG-A (Target)", "pmat-book Ch4: TDG"],
+        see_also: &["TDG-B+ (Next Target)", "pmat-book Ch4: TDG"],
+    },
+    CheckExplanation {
+        id: "TDG-B-",
+        name: "Grade B- (Needs Improvement)",
+        what: "Score [70, 75). Several components below target.",
+        why: "This is also the grade a project is CAPPED at when any file grades F, regardless of average.",
+        fail_when: &["CB-200 fails if min_tdg_grade is set to B or higher"],
+        how_to_fix: "Fix the F-grade files first, then the weakest component of this one.",
+        see_also: &["TDG-F (Project Cap)", "pmat-book Ch4: TDG"],
+    },
+    CheckExplanation {
+        id: "TDG-C+",
+        name: "Grade C+ (Poor)",
+        what: "Score [65, 70). High complexity, significant coverage gaps.",
+        why: "Grade C code is a primary defect source and a priority refactoring target.",
+        fail_when: &["CB-200 fails if min_tdg_grade is set to B- or higher"],
+        how_to_fix: "Break into smaller functions and add comprehensive tests.",
+        see_also: &["TDG-B- (Next Target)", "pmat five-whys"],
     },
     CheckExplanation {
         id: "TDG-C",
         name: "Grade C (Poor)",
-        what: "Score 50-69. High complexity, significant coverage gaps.",
+        what: "Score [60, 65). High complexity, significant coverage gaps.",
         why: "Grade C functions are primary defect sources. Priority refactoring target.",
-        fail_when: &["CB-200 fails for any grade gate setting above F"],
+        fail_when: &["CB-200 fails for any grade gate setting above C"],
         how_to_fix: "Break into smaller functions, add comprehensive tests, reduce cyclomatic complexity below 20.",
-        see_also: &["TDG-B (Next Target)", "pmat five-whys"],
+        see_also: &["TDG-C+ (Next Target)", "pmat five-whys"],
+    },
+    CheckExplanation {
+        id: "TDG-C-",
+        name: "Grade C- (Poor)",
+        what: "Score [55, 60). High complexity with little or no test coverage.",
+        why: "At this level the cheapest fix is usually tests, not restructuring — measure first.",
+        fail_when: &["CB-200 fails for any grade gate setting above C-"],
+        how_to_fix: "Add characterization tests, then split the largest function.",
+        see_also: &["TDG-C (Next Target)", "pmat five-whys"],
+    },
+    CheckExplanation {
+        id: "TDG-D",
+        name: "Grade D (Very Poor)",
+        what: "Score [50, 55). Extreme complexity with almost no coverage.",
+        why: "D is one band above the F cap: a small regression here starts capping the project grade.",
+        fail_when: &["CB-200 fails for any grade gate setting above D"],
+        how_to_fix: "Treat as a rewrite candidate: extract testable units before changing behaviour.",
+        see_also: &["TDG-F (Critical)", "pmat five-whys"],
     },
     CheckExplanation {
         id: "TDG-F",
         name: "Grade F (Critical)",
-        what: "Score below 50. Extreme complexity, untested, high defect density.",
-        why: "Grade F functions cap the entire project score at B. Fix these first.",
-        fail_when: &["Any F-grade function causes project-level score cap"],
+        what: "Score [0, 50). Extreme complexity, untested, high defect density.",
+        why: "Grade F files cap the entire PROJECT grade at B — a 99.8/100 project still reports (B) if one file grades F. `pmat tdg` names the cap and the F-grade count when it applies.",
+        fail_when: &["Any F-grade file causes the project grade to be capped at B"],
         how_to_fix: "Rewrite the function. Extract logic into testable units. Add property-based tests.",
-        see_also: &["TDG-C (Intermediate Target)", "pmat five-whys"],
+        see_also: &["TDG-D (Intermediate Target)", "pmat five-whys"],
     },
 ];
+
+#[cfg(test)]
+mod tdg_grade_registry_tests {
+    use super::*;
+    use crate::tdg::Grade;
+
+    /// The band text an entry must open with, derived from the analyzer's own
+    /// table rather than restated here.
+    fn band_text(grade: Grade) -> String {
+        let (floor, ceiling) = grade.score_band();
+        if grade == Grade::APlus {
+            format!("Score [{floor}, {ceiling}]")
+        } else {
+            format!("Score [{floor}, {ceiling})")
+        }
+    }
+
+    /// Every grade `pmat tdg` can print must be explainable, with the bands the
+    /// analyzer actually uses. Before this, `explain` documented five grades
+    /// with a stale table (A = "Score 85-94" against the analyzer's 90..95) and
+    /// `explain TDG-A-` reported that no such check existed.
+    #[test]
+    fn tdg_grade_bands_match_the_analyzer() {
+        for grade in Grade::all() {
+            let id = format!("TDG-{grade}");
+            let entries: Vec<_> = EXPLANATIONS.iter().filter(|e| e.id == id).collect();
+            assert_eq!(
+                entries.len(),
+                1,
+                "{id}: expected exactly one explain entry, found {}",
+                entries.len()
+            );
+            let expected = band_text(grade);
+            assert!(
+                entries[0].what.starts_with(&expected),
+                "{id} documents {:?} but the analyzer's band is {expected}",
+                entries[0].what
+            );
+        }
+    }
+
+    /// `pmat explain TDG-A-` must answer, not report an unknown check.
+    #[test]
+    fn every_grade_id_is_looked_up_exactly() {
+        for grade in Grade::all() {
+            let id = format!("TDG-{grade}");
+            let found = lookup(&id);
+            assert_eq!(
+                found.len(),
+                1,
+                "lookup({id}) returned {} entries",
+                found.len()
+            );
+            assert_eq!(found[0].id, id);
+        }
+    }
+
+    /// ... and the registry must not document a grade the analyzer cannot emit.
+    #[test]
+    fn no_tdg_entry_without_a_grade() {
+        let known: Vec<String> = Grade::all().iter().map(|g| format!("TDG-{g}")).collect();
+        for entry in EXPLANATIONS.iter().filter(|e| e.id.starts_with("TDG-")) {
+            assert!(
+                known.iter().any(|k| k == entry.id),
+                "{} documents a grade no score maps to",
+                entry.id
+            );
+        }
+    }
+}

--- a/src/explain.rs
+++ b/src/explain.rs
@@ -48,6 +48,50 @@ pub fn lookup(pattern: &str) -> Vec<&'static CheckExplanation> {
         .collect()
 }
 
+/// Does `pattern` have the shape of an ID the scoring commands print
+/// (`CB-030`, `PV-04`, `RT-12`)?
+///
+/// Used to tell "you typed something that is not an ID" apart from "that IS an
+/// ID pmat prints, but nobody has written an explanation for it yet".
+#[must_use]
+pub fn looks_like_check_id(pattern: &str) -> bool {
+    let Some((prefix, number)) = pattern.split_once('-') else {
+        return false;
+    };
+    !prefix.is_empty()
+        && prefix.chars().all(|c| c.is_ascii_alphabetic())
+        && !number.is_empty()
+        && number.chars().all(|c| c.is_ascii_digit())
+}
+
+/// What to print when [`lookup`] finds nothing.
+///
+/// The old message was "No checks matching 'CB-030'. Run `pmat explain` to list
+/// all." — which reads as "no such check". `CB-030` is a real check
+/// (`CB-030: O(1) Hooks`); the registry below simply does not cover it. Only 11
+/// of the ~153 `CB-*` IDs `pmat comply check` emits have an entry, so the
+/// common case for a user pasting an ID out of a report was being told their
+/// ID was wrong. Say which of the two it is, and point at the check's own
+/// description as the fallback source of truth.
+#[must_use]
+pub fn miss_message(pattern: &str) -> String {
+    let registered = EXPLANATIONS.len();
+    if looks_like_check_id(pattern) {
+        format!(
+            "No explanation is registered for '{pattern}'.\n\
+             The explanation registry covers {registered} IDs; it is not a catalogue of every \
+             check pmat emits, so '{pattern}' may still be a real check.\n\
+             \x20 • `pmat explain` lists every ID that has an explanation\n\
+             \x20 • `pmat comply check --format json` reports each check's own name and message"
+        )
+    } else {
+        format!(
+            "No checks matching '{pattern}' among the {registered} registered explanations. \
+             Run `pmat explain` to list all."
+        )
+    }
+}
+
 /// List all available check IDs grouped by domain.
 #[provable_contracts_macros::contract("pmat-core.yaml", equation = "check_compliance")]
 pub fn list_all() -> Vec<(&'static str, Vec<&'static CheckExplanation>)> {
@@ -430,6 +474,48 @@ mod tdg_grade_registry_tests {
                 "{} documents a grade no score maps to",
                 entry.id
             );
+        }
+    }
+}
+
+#[cfg(test)]
+mod miss_message_tests {
+    use super::*;
+
+    /// `CB-030` is a real check (`CB-030: O(1) Hooks`) with no registry entry.
+    /// Telling the user "No checks matching 'CB-030'" reads as "you typed a
+    /// check that does not exist" — the registry's gap, reported as the user's
+    /// mistake.
+    #[test]
+    fn an_unregistered_but_real_check_id_is_not_called_nonexistent() {
+        let msg = miss_message("CB-030");
+        assert!(
+            !msg.contains("No checks matching"),
+            "must not claim the ID does not exist, got: {msg}"
+        );
+        assert!(
+            msg.contains("may still be a real check"),
+            "must say the registry, not the ID, is incomplete, got: {msg}"
+        );
+        assert!(
+            msg.contains("comply check"),
+            "must point at the check's own description, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn a_non_id_pattern_still_reads_as_no_match() {
+        let msg = miss_message("zzzz nonsense");
+        assert!(msg.contains("No checks matching"), "got: {msg}");
+    }
+
+    #[test]
+    fn id_shape_detection() {
+        for id in ["CB-030", "CB-1210", "PV-04", "RT-12", "cb-030"] {
+            assert!(looks_like_check_id(id), "{id} is ID-shaped");
+        }
+        for other in ["unwrap", "CB030", "CB-", "-030", "CB-12a", "complexity"] {
+            assert!(!looks_like_check_id(other), "{other} is not ID-shaped");
         }
     }
 }

--- a/src/mcp/tools/agent_context_tools_lookup_tools.rs
+++ b/src/mcp/tools/agent_context_tools_lookup_tools.rs
@@ -51,7 +51,12 @@ impl McpTool for GetFunctionTool {
             .as_str()
             .ok_or("Missing required parameter: function_id")?;
 
-        let _include_source = params["include_source"].as_bool().unwrap_or(true);
+        // The schema advertises `include_source`, and callers pass
+        // `include_source: false` to keep a large function body out of a
+        // context window. It was parsed into a discarded binding, so `source`
+        // came back either way and the flag was documentation for behaviour the
+        // tool did not have.
+        let include_source = params["include_source"].as_bool().unwrap_or(true);
 
         // Parse function_id: "file_path::function_name"
         let (file_path, function_name) = parse_function_id(function_id)?;
@@ -62,34 +67,53 @@ impl McpTool for GetFunctionTool {
             .get_function(&file_path, &function_name)
             .ok_or_else(|| format!("Function not found: {}", function_id))?;
 
-        let mut response = json!({
-            "id": function_id,
-            "name": result.function_name,
-            "signature": result.signature,
-            "file_path": result.file_path,
-            "start_line": result.start_line,
-            "end_line": result.end_line,
-            "language": result.language,
-            "quality": {
-                "grade": result.tdg_grade,
-                "complexity": result.complexity,
-                "tdg_score": result.tdg_score,
-                "loc": result.loc,
-                "big_o": result.big_o,
-                "satd_count": result.satd_count
-            }
-        });
+        Ok(build_get_function_response(
+            function_id,
+            &result,
+            include_source,
+        ))
+    }
+}
 
-        if let Some(doc) = &result.doc_comment {
-            response["doc_comment"] = json!(doc);
+/// Build the `pmat_get_function` response document.
+///
+/// Split out of `execute` so the `include_source` contract is testable without
+/// an index on disk: the flag used to be parsed into a discarded binding, so
+/// `include_source: false` still returned the full body.
+fn build_get_function_response(
+    function_id: &str,
+    result: &crate::services::agent_context::QueryResult,
+    include_source: bool,
+) -> Value {
+    let mut response = json!({
+        "id": function_id,
+        "name": result.function_name,
+        "signature": result.signature,
+        "file_path": result.file_path,
+        "start_line": result.start_line,
+        "end_line": result.end_line,
+        "language": result.language,
+        "quality": {
+            "grade": result.tdg_grade,
+            "complexity": result.complexity,
+            "tdg_score": result.tdg_score,
+            "loc": result.loc,
+            "big_o": result.big_o,
+            "satd_count": result.satd_count
         }
+    });
 
+    if let Some(doc) = &result.doc_comment {
+        response["doc_comment"] = json!(doc);
+    }
+
+    if include_source {
         if let Some(source) = &result.source {
             response["source"] = json!(source);
         }
-
-        Ok(response)
     }
+
+    response
 }
 
 // ============================================================================

--- a/src/mcp/tools/agent_context_tools_tests.rs
+++ b/src/mcp/tools/agent_context_tools_tests.rs
@@ -78,4 +78,58 @@ mod tests {
         let guard = manager.index.read().await;
         assert!(guard.is_none());
     }
+
+    /// A `QueryResult` carrying a source body, built through serde so the test
+    /// does not have to name every field of the struct.
+    fn query_result_with_source() -> crate::services::agent_context::QueryResult {
+        serde_json::from_value(json!({
+            "file_path": "src/workflow/recovery.rs",
+            "function_name": "handle_error",
+            "signature": "fn handle_error()",
+            "doc_comment": null,
+            "start_line": 1,
+            "end_line": 3,
+            "language": "rust",
+            "tdg_score": 1.0,
+            "tdg_grade": "A",
+            "complexity": 1,
+            "big_o": "O(1)",
+            "satd_count": 0,
+            "loc": 3,
+            "relevance_score": 1.0,
+            "source": "fn handle_error() {\n    todo!()\n}"
+        }))
+        .expect("QueryResult fixture must deserialize")
+    }
+
+    /// `include_source` was parsed into a discarded `_include_source`, so
+    /// `pmat_get_function` returned the whole body even when the caller asked
+    /// it not to — the flag was documentation for behaviour the tool lacked.
+    #[test]
+    fn test_get_function_response_omits_source_when_not_requested() {
+        let result = query_result_with_source();
+
+        let with = super::build_get_function_response(
+            "src/workflow/recovery.rs::handle_error",
+            &result,
+            true,
+        );
+        assert!(
+            with["source"].is_string(),
+            "include_source: true must return the body"
+        );
+
+        let without = super::build_get_function_response(
+            "src/workflow/recovery.rs::handle_error",
+            &result,
+            false,
+        );
+        assert!(
+            without.get("source").is_none(),
+            "include_source: false must not return the body, got: {without}"
+        );
+        // Everything else is unaffected by the flag.
+        assert_eq!(without["name"], "handle_error");
+        assert_eq!(without["quality"]["grade"], "A");
+    }
 }

--- a/src/mcp_pmcp/context_handlers_context.rs
+++ b/src/mcp_pmcp/context_handlers_context.rs
@@ -15,6 +15,22 @@ struct ContextGenerateArgs {
     include_dependencies: bool,
 }
 
+/// Accept only the formats `generate_context` can actually produce.
+///
+/// `format: "markdown"` and `format: "xml"` used to come back as the JSON
+/// context plus the literal string "Context in markdown format (not
+/// implemented)", with status completed and isError=false — a client could not
+/// tell the stub from a rendered document, and the inputSchema advertised both.
+/// This tool emits JSON; anything else is now a validation error.
+fn validate_context_format(format: Option<&str>) -> Result<()> {
+    match format {
+        None | Some("json") => Ok(()),
+        Some(other) => Err(Error::validation(format!(
+            "Unsupported format: {other} (generate_context produces \"json\" only)"
+        ))),
+    }
+}
+
 impl ContextGenerateTool {
     #[must_use]
     #[provable_contracts_macros::contract("pmat-core.yaml", equation = "check_compliance")]
@@ -38,6 +54,10 @@ impl ToolHandler for ContextGenerateTool {
         let params: ContextGenerateArgs = serde_json::from_value(args)
             .map_err(|e| Error::validation(format!("Invalid arguments: {e}")))?;
 
+        // Checked before any analysis runs: an unsupported format is an
+        // argument error, not something to discover after the work is done.
+        validate_context_format(params.format.as_deref())?;
+
         let paths = crate::mcp_pmcp::tool_schemas::resolve_existing_paths(params.paths)?;
 
         let context =
@@ -45,24 +65,12 @@ impl ToolHandler for ContextGenerateTool {
                 .await
                 .map_err(|e| Error::internal(format!("Context generation failed: {e}")))?;
 
-        // Format the output based on requested format
-        match params.format.as_deref() {
-            Some("markdown") => Ok(json!({
-                "context": context,
-                "markdown": "Context in markdown format (not implemented)"
-            })),
-            Some("xml") => Ok(json!({
-                "context": context,
-                "xml": "Context in XML format (not implemented)"
-            })),
-            Some("json") | None => Ok(context),
-            Some(format) => Err(Error::validation(format!("Unsupported format: {format}"))),
-        }
+        Ok(context)
     }
 
     fn metadata(&self) -> Option<ToolInfo> {
         let extra = json!({
-            "format":               { "type": "string", "enum": ["json", "markdown", "xml"], "description": "Output format" },
+            "format":               { "type": "string", "enum": ["json"], "description": "Output format" },
             "max_depth":            { "type": "integer", "description": "Max directory-tree depth to include" },
             "include_dependencies": { "type": "boolean", "description": "Include dependency graph" }
         });
@@ -170,5 +178,41 @@ impl ToolHandler for ContextSummaryTool {
             "Produce a high-level project summary scaffold for the given paths.",
             paths_object_schema(extra, vec!["paths"]),
         ))
+    }
+}
+
+#[cfg(test)]
+mod context_format_tests {
+    //! `generate_context` must not advertise, nor silently stub, a format it
+    //! cannot render.
+    use super::*;
+
+    #[test]
+    fn only_json_is_accepted() {
+        assert!(validate_context_format(None).is_ok());
+        assert!(validate_context_format(Some("json")).is_ok());
+        for stubbed in ["markdown", "xml"] {
+            let err = validate_context_format(Some(stubbed))
+                .expect_err("a format the tool cannot render must be an error, not a stub string");
+            assert!(
+                err.to_string().contains("Unsupported format"),
+                "got: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn input_schema_advertises_only_renderable_formats() {
+        use pmcp::ToolHandler;
+
+        let info = ContextGenerateTool::new()
+            .metadata()
+            .expect("generate_context advertises metadata");
+        let formats = info.input_schema["properties"]["format"]["enum"].clone();
+        assert_eq!(
+            formats,
+            json!(["json"]),
+            "the schema must not offer formats the handler rejects"
+        );
     }
 }

--- a/src/mcp_pmcp/context_handlers_tests.rs
+++ b/src/mcp_pmcp/context_handlers_tests.rs
@@ -198,8 +198,13 @@ mod coverage_tests {
         assert!(result.is_ok());
     }
 
+    /// These two used to assert the STUB: `format: "markdown"` returned the
+    /// literal "Context in markdown format (not implemented)" as a string with
+    /// isError=false, and the assertion `value["markdown"].is_string()` was
+    /// satisfied by exactly that. A format the tool cannot render is now
+    /// rejected instead of faked.
     #[tokio::test]
-    async fn test_context_generate_tool_markdown_format() {
+    async fn test_context_generate_tool_markdown_format_is_rejected() {
         let tool = ContextGenerateTool::new();
         let fixture = fixture_dir();
         let fixture_dir_path = fixture.path().display().to_string();
@@ -207,14 +212,15 @@ mod coverage_tests {
             "paths": [fixture_dir_path.as_str()],
             "format": "markdown"
         });
-        let result = tool.handle(args, test_extra()).await;
-        assert!(result.is_ok());
-        let value = result.unwrap();
-        assert!(value["markdown"].is_string());
+        let err = tool
+            .handle(args, test_extra())
+            .await
+            .expect_err("markdown is not rendered, so it must not report success");
+        assert!(err.to_string().contains("Unsupported format"), "{err}");
     }
 
     #[tokio::test]
-    async fn test_context_generate_tool_xml_format() {
+    async fn test_context_generate_tool_xml_format_is_rejected() {
         let tool = ContextGenerateTool::new();
         let fixture = fixture_dir();
         let fixture_dir_path = fixture.path().display().to_string();
@@ -222,10 +228,11 @@ mod coverage_tests {
             "paths": [fixture_dir_path.as_str()],
             "format": "xml"
         });
-        let result = tool.handle(args, test_extra()).await;
-        assert!(result.is_ok());
-        let value = result.unwrap();
-        assert!(value["xml"].is_string());
+        let err = tool
+            .handle(args, test_extra())
+            .await
+            .expect_err("xml is not rendered, so it must not report success");
+        assert!(err.to_string().contains("Unsupported format"), "{err}");
     }
 
     #[tokio::test]

--- a/src/mcp_pmcp/handlers.rs
+++ b/src/mcp_pmcp/handlers.rs
@@ -16,8 +16,39 @@ use tracing::debug;
 /// MCP args for refactor.start: target file paths and optional refactoring configuration.
 #[derive(Debug, Deserialize)]
 struct RefactorStartArgs {
+    #[serde(deserialize_with = "deserialize_existing_targets")]
     targets: Vec<String>,
     config: Option<RefactorConfig>,
+}
+
+/// Reject `refactor.start` targets that do not exist on disk.
+///
+/// `RefactorStateMachine::new` stores its targets verbatim — it never stats
+/// them — so `refactor.start` on `/does/not/exist/at/all.rs` opened a session,
+/// walked Scan → Analyze → Plan → Complete and reported
+/// `files_processed: 0` with `isError: false`, i.e. a successful refactor of a
+/// file nothing ever opened. Validating here (the same guard
+/// `resolve_existing_paths` gives the path-taking tools) turns that into a
+/// JSON-RPC validation error naming the missing paths.
+fn deserialize_existing_targets<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Vec<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let targets = Vec::<String>::deserialize(deserializer)?;
+    let missing: Vec<&str> = targets
+        .iter()
+        .map(String::as_str)
+        .filter(|t| !std::path::Path::new(t).exists())
+        .collect();
+    if !missing.is_empty() {
+        return Err(serde::de::Error::custom(format!(
+            "refactor.start target(s) do not exist: {}",
+            missing.join(", ")
+        )));
+    }
+    Ok(targets)
 }
 
 #[derive(Debug, Serialize)]
@@ -77,6 +108,37 @@ impl RefactorStopTool {
     /// Create a new instance.
     pub fn new(state_manager: Arc<Mutex<StateManager>>) -> Self {
         Self { state_manager }
+    }
+}
+
+#[cfg(test)]
+mod refactor_start_target_tests {
+    //! `refactor.start` must not open a session on a path it never opened.
+    use super::RefactorStartArgs;
+
+    #[test]
+    fn nonexistent_targets_are_rejected() {
+        let err = serde_json::from_value::<RefactorStartArgs>(serde_json::json!({
+            "targets": ["/does/not/exist/at/all.rs"],
+            "config": null
+        }))
+        .expect_err("a target that is not on disk must not start a session");
+        let msg = err.to_string();
+        assert!(msg.contains("do not exist"), "{msg}");
+        assert!(msg.contains("/does/not/exist/at/all.rs"), "{msg}");
+    }
+
+    #[test]
+    fn existing_targets_are_accepted() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let file = dir.path().join("lib.rs");
+        std::fs::write(&file, "pub fn f() {}\n").expect("write fixture");
+        let args = serde_json::from_value::<RefactorStartArgs>(serde_json::json!({
+            "targets": [file.to_string_lossy()],
+            "config": null
+        }))
+        .expect("an existing target is accepted");
+        assert_eq!(args.targets.len(), 1);
     }
 }
 

--- a/src/mcp_pmcp/handlers_tests.rs
+++ b/src/mcp_pmcp/handlers_tests.rs
@@ -13,8 +13,11 @@ mod tests {
 
     #[test]
     fn test_refactor_start_args_deserialize() {
+        // Real paths: `refactor.start` now refuses targets that are not on
+        // disk (it used to open a session on `/does/not/exist` and report a
+        // successful Complete), and `src/main.rs` does not exist in this crate.
         let json = json!({
-            "targets": ["src/main.rs", "src/lib.rs"],
+            "targets": ["src/lib.rs", "Cargo.toml"],
             "config": null
         });
 
@@ -26,7 +29,7 @@ mod tests {
     #[test]
     fn test_refactor_start_args_with_config() {
         let json = json!({
-            "targets": ["src/main.rs"],
+            "targets": ["src/lib.rs"],
             "config": {
                 "target_complexity": 10,
                 "remove_satd": true,

--- a/src/mcp_pmcp/stdio_frames.rs
+++ b/src/mcp_pmcp/stdio_frames.rs
@@ -102,6 +102,17 @@ fn is_known_method(method: &str) -> bool {
     PMCP_CLIENT_METHODS.contains(&method) || PMCP_SERVER_METHODS.contains(&method)
 }
 
+/// The only value JSON-RPC 2.0 §4 permits for the `jsonrpc` member.
+///
+/// Nothing in pmcp looks at this member: `parse_message` deserializes by shape
+/// (`method`/`id`/`result`), so `{"jsonrpc":"1.0",…}` and a frame with no
+/// `jsonrpc` at all were both handled as if they said `"2.0"` — the 1.0 frame
+/// was *served a full `tools/list` result*, and the version-less one was
+/// rejected downstream and reported `-32602 Invalid params`, blaming the
+/// params for a defect in the envelope. §4 makes a frame whose `jsonrpc` is
+/// not exactly `"2.0"` an Invalid Request (`-32600`), whatever its params say.
+const JSONRPC_VERSION: &str = "2.0";
+
 /// Methods pmcp deserializes with **no** `params` field at all.
 ///
 /// Mirrors the special cases in `parse_client_request` / `parse_server_request`
@@ -299,6 +310,38 @@ pub(crate) fn classify_bad_frame(line: &[u8]) -> FrameVerdict {
     classify_object(obj, raw_id_text(line).as_deref())
 }
 
+/// What is wrong with this frame's `jsonrpc` member, if anything.
+///
+/// `None` means the member is exactly `"2.0"`; `Some(message)` describes the
+/// deviation using the value the client actually sent, so two different wrong
+/// versions never collapse to the same answer.
+fn jsonrpc_version_problem(obj: &Map<String, Value>) -> Option<String> {
+    match obj.get("jsonrpc") {
+        Some(Value::String(v)) if v == JSONRPC_VERSION => None,
+        Some(other) => Some(format!(
+            "Invalid Request: \"jsonrpc\" must be \"{JSONRPC_VERSION}\", not {other}"
+        )),
+        None => Some(format!(
+            "Invalid Request: \"jsonrpc\" member is missing; it must be \"{JSONRPC_VERSION}\""
+        )),
+    }
+}
+
+/// Is this line a JSON-RPC frame the server must refuse on its envelope alone?
+///
+/// pmcp never inspects `jsonrpc`, so a frame declaring a version we do not
+/// speak would otherwise be **served** — `{"jsonrpc":"1.0",…,"method":
+/// "tools/list"}` came back with the full tool listing, an answer in a protocol
+/// the client did not ask for. Frames that carry no id (notifications) and
+/// response frames still get [`FrameVerdict::Silent`]: §4.1 forbids replying to
+/// them, wrong version or not.
+fn wrong_version_verdict(line: &[u8]) -> Option<FrameVerdict> {
+    let value: Value = serde_json::from_slice(line).ok()?;
+    let obj = value.as_object()?;
+    jsonrpc_version_problem(obj)?;
+    Some(classify_object(obj, raw_id_text(line).as_deref()))
+}
+
 /// Classify a frame that parsed as a JSON object. Split out to keep
 /// [`classify_bad_frame`] under the cognitive-complexity ceiling.
 fn classify_object(obj: &Map<String, Value>, raw_id: Option<&str>) -> FrameVerdict {
@@ -318,6 +361,16 @@ fn classify_object(obj: &Map<String, Value>, raw_id: Option<&str>) -> FrameVerdi
         return FrameVerdict::Silent;
     }
     let id = echo_id(obj, raw_id);
+
+    // The envelope is checked before its contents: a frame that is not
+    // JSON-RPC 2.0 is an Invalid Request no matter how good its params are.
+    if let Some(message) = jsonrpc_version_problem(obj) {
+        return FrameVerdict::Error {
+            id,
+            code: ErrorCode::INVALID_REQUEST.as_i32(),
+            message,
+        };
+    }
 
     let Some(method) = method.and_then(Value::as_str) else {
         return FrameVerdict::Error {
@@ -424,6 +477,13 @@ where
     E: FnMut(&FrameVerdict),
 {
     while let Some(line) = read_frame_line(reader, partial).await? {
+        // The envelope is checked here rather than after `parse_message`,
+        // because pmcp *accepts* a frame whose `jsonrpc` is wrong or missing
+        // and would serve it (see [`wrong_version_verdict`]).
+        if let Some(verdict) = wrong_version_verdict(&line) {
+            emit(&verdict);
+            continue;
+        }
         match pmcp::shared::transport::parse_message(&line) {
             Ok(message) => return Ok(Some(message)),
             // The raw line is still in hand here — this is the whole point of
@@ -799,6 +859,31 @@ mod tests {
         assert_eq!(code, -32600);
     }
 
+    /// JSON-RPC 2.0 §4: the `jsonrpc` member must be exactly "2.0". A frame
+    /// missing it used to reach the method/params classifier and come back
+    /// `-32602 Invalid params for tools/list` — blaming params that were fine
+    /// for a broken envelope.
+    #[test]
+    fn a_frame_without_a_jsonrpc_member_is_invalid_request() {
+        let (id, code, message) = parts(r#"{"id":3,"method":"tools/list","params":{}}"#);
+        assert_eq!(id, serde_json::json!(3), "the client's id must be echoed");
+        assert_eq!(code, -32600, "a missing `jsonrpc` is -32600, not -32602");
+        assert!(
+            message.contains("jsonrpc"),
+            "the message must name the envelope member, got: {message}"
+        );
+    }
+
+    /// A version we do not speak is refused rather than served.
+    #[test]
+    fn a_frame_declaring_jsonrpc_1_0_is_invalid_request() {
+        let (id, code, message) =
+            parts(r#"{"jsonrpc":"1.0","id":4,"method":"tools/list","params":{}}"#);
+        assert_eq!(id, serde_json::json!(4));
+        assert_eq!(code, -32600);
+        assert!(message.contains("1.0"), "got: {message}");
+    }
+
     /// JSON-RPC 2.0 §4.1: a notification is never answered. Emitting a frame
     /// for one puts bytes on the wire the host never asked for.
     #[test]
@@ -1052,6 +1137,39 @@ mod tests {
         let frame = verdicts[0].to_frame().expect("an error frame");
         assert_eq!(frame["id"], serde_json::json!(8));
         assert_eq!(frame["error"]["code"], serde_json::json!(-32601));
+    }
+
+    /// The wire-level half of the `jsonrpc` defect: pmcp parses a 1.0 frame
+    /// happily, so without a check here the server answered
+    /// `{"jsonrpc":"1.0","id":4,"method":"tools/list"}` with the complete tool
+    /// listing — a reply in a protocol version the client never negotiated.
+    #[tokio::test]
+    async fn a_wrong_version_frame_is_refused_instead_of_served() {
+        let (messages, verdicts) = drain(concat!(
+            "{\"jsonrpc\":\"1.0\",\"id\":4,\"method\":\"tools/list\",\"params\":{}}\n",
+            "{\"jsonrpc\":\"2.0\",\"id\":5,\"method\":\"tools/list\",\"params\":{}}\n",
+        ))
+        .await;
+
+        assert_eq!(
+            messages.len(),
+            1,
+            "only the 2.0 frame may reach the server; got {} messages",
+            messages.len()
+        );
+        assert_eq!(verdicts.len(), 1);
+        let frame = verdicts[0].to_frame().expect("an error frame");
+        assert_eq!(frame["id"], serde_json::json!(4));
+        assert_eq!(frame["error"]["code"], serde_json::json!(-32600));
+    }
+
+    /// A notification is still never answered, wrong version or not.
+    #[tokio::test]
+    async fn a_wrong_version_notification_is_dropped_without_a_reply() {
+        let (messages, verdicts) =
+            drain("{\"jsonrpc\":\"1.0\",\"method\":\"notifications/initialized\"}\n").await;
+        assert!(messages.is_empty(), "a 1.0 notification is not served");
+        assert!(verdicts.iter().all(|v| v.to_frame().is_none()));
     }
 
     #[tokio::test]

--- a/src/mcp_pmcp/tool_functions/analysis_tools.rs
+++ b/src/mcp_pmcp/tool_functions/analysis_tools.rs
@@ -15,6 +15,11 @@ pub async fn analyze_complexity(
     top_files: Option<usize>,
     threshold: Option<u64>,
 ) -> Result<Value> {
+    // `analyze_file_complexity_uncached` used to run the heuristic counter
+    // while `pmat analyze complexity` ran the AST one, so this tool reported
+    // cyclomatic 10 / cognitive 18 (plus a threshold violation) for the same
+    // function the CLI scored 6 / 9 with no violation. Both surfaces now share
+    // the analyzer; keep them on one entry point.
     use crate::services::complexity::analyze_file_complexity_uncached;
 
     // Validate input

--- a/src/mcp_pmcp/tool_functions/analysis_tools.rs
+++ b/src/mcp_pmcp/tool_functions/analysis_tools.rs
@@ -474,12 +474,29 @@ pub async fn analyze_big_o(paths: &[PathBuf], top_files: Option<usize>) -> Resul
                 "file_path": f.file_path,
                 "function_name": f.function_name,
                 "line_number": f.line_number,
-                "time_complexity": f.time_complexity,
-                "space_complexity": f.space_complexity,
+                // `time_complexity` / `space_complexity` used to be the raw
+                // `#[repr(C)]` ComplexityBound, so the payload carried the
+                // struct's alignment padding and its packed flag byte
+                // (`{"class":"Quadratic","coefficient":1,"input_var":"N",
+                // "confidence":75,"flags":2,"_padding":[0,0]}`) to a reader
+                // that cannot tell layout from measurement. The CLI's JSON
+                // emits the notation and the confidence; emit the same.
+                "time_complexity": f.time_complexity.notation(),
+                "time_complexity_confidence": f.time_complexity.confidence,
+                "space_complexity": f.space_complexity.notation(),
+                "space_complexity_confidence": f.space_complexity.confidence,
                 "confidence": f.confidence,
             })
         })
         .collect();
+
+    // A LIST THAT IS SECRETLY A CAP: `top_files` truncated this silently, so
+    // a caller asking for 2 saw 2 and had no way to learn there were 8. The
+    // CLI names both numbers (`high_complexity_count` / `_found` /
+    // `_truncated`); keep the two surfaces telling the same story.
+    let listed = high_complexity.len();
+    let dist = &report.complexity_distribution;
+    let found = (dist.quadratic + dist.cubic + dist.exponential).max(report.high_complexity_functions.len());
 
     Ok(json!({
         "status": "completed",
@@ -488,6 +505,9 @@ pub async fn analyze_big_o(paths: &[PathBuf], top_files: Option<usize>) -> Resul
             "analyzed_functions": report.analyzed_functions,
             "complexity_distribution": report.complexity_distribution,
             "high_complexity_functions": high_complexity,
+            "high_complexity_count": listed,
+            "high_complexity_found": found,
+            "high_complexity_truncated": listed < found,
             "recommendations": report.recommendations,
         }
     }))
@@ -672,6 +692,89 @@ pub async fn analyze_coupling(paths: &[PathBuf], threshold: Option<f64>) -> Resu
             }
         }
     }))
+}
+
+#[cfg(test)]
+mod big_o_payload_tests {
+    //! The tool serialised the raw `#[repr(C)]` ComplexityBound and truncated
+    //! its function list without saying so.
+    use super::*;
+
+    /// Three functions with a doubly-nested loop each: enough for `top_files`
+    /// to bite.
+    fn quadratic_fixture() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut src = String::new();
+        for i in 0..3 {
+            src.push_str(&format!(
+                "pub fn pairs{i}(xs: &[usize]) -> usize {{\n    let mut acc = 0;\n    for a in xs {{\n        for b in xs {{\n            acc += a * b;\n        }}\n    }}\n    acc\n}}\n\n"
+            ));
+        }
+        std::fs::write(dir.path().join("lib.rs"), src).expect("write lib.rs");
+        dir
+    }
+
+    #[tokio::test]
+    async fn test_big_o_payload_has_no_struct_layout_fields() {
+        let dir = quadratic_fixture();
+        let value = analyze_big_o(&[dir.path().to_path_buf()], Some(1))
+            .await
+            .expect("analysis");
+        let payload = serde_json::to_string(&value).expect("serialise");
+
+        assert!(
+            !payload.contains("_padding"),
+            "alignment filler leaked into the MCP payload: {payload}"
+        );
+        let functions = value["results"]["high_complexity_functions"]
+            .as_array()
+            .expect("array");
+        assert!(
+            !functions.is_empty(),
+            "the fixture must produce a high-complexity function, or this asserts nothing"
+        );
+        for func in functions {
+            // A notation string ("O(n²)"), not the packed bound struct.
+            let time = func["time_complexity"].as_str().unwrap_or_else(|| {
+                panic!("time_complexity must be a notation string: {func}")
+            });
+            assert!(time.starts_with("O("), "unexpected notation {time:?}");
+            assert!(func["time_complexity_confidence"].is_number());
+            assert!(func["space_complexity"].is_string());
+        }
+    }
+
+    /// `top_files` capped the list silently: asking for 1 of 3 returned 1,
+    /// with nothing in the payload naming the other two.
+    #[tokio::test]
+    async fn test_big_o_payload_discloses_truncation() {
+        let dir = quadratic_fixture();
+        let results = analyze_big_o(&[dir.path().to_path_buf()], Some(1))
+            .await
+            .expect("analysis");
+        let results = &results["results"];
+
+        let listed = results["high_complexity_functions"]
+            .as_array()
+            .expect("array")
+            .len();
+        let count = results["high_complexity_count"].as_u64().expect("count");
+        let found = results["high_complexity_found"].as_u64().expect("found");
+
+        assert_eq!(count as usize, listed, "count must be the listed length");
+        // The fixture holds three quadratic functions and asks for one, so the
+        // cap must be visible rather than inferred.
+        assert_eq!(count, 1, "top_files=1 must list exactly one");
+        assert!(
+            found > count,
+            "found ({found}) must exceed the listed count ({count}) for this fixture"
+        );
+        assert_eq!(
+            results["high_complexity_truncated"],
+            serde_json::Value::Bool(count < found),
+            "the truncation flag must follow the two counts"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/src/mcp_pmcp/tool_functions/analysis_tools.rs
+++ b/src/mcp_pmcp/tool_functions/analysis_tools.rs
@@ -166,7 +166,7 @@ pub async fn analyze_satd(paths: &[PathBuf], _include_resolved: bool) -> Result<
 }
 
 #[provable_contracts_macros::contract("pmat-core.yaml", equation = "path_exists")]
-pub async fn analyze_dead_code(paths: &[PathBuf], _include_tests: bool) -> Result<Value> {
+pub async fn analyze_dead_code(paths: &[PathBuf], include_tests: bool) -> Result<Value> {
     use crate::services::dead_code_multi_language::analyze_dead_code_multi_language;
     use std::collections::HashMap;
 
@@ -189,12 +189,23 @@ pub async fn analyze_dead_code(paths: &[PathBuf], _include_tests: bool) -> Resul
         }
         match analyze_dead_code_multi_language(path) {
             Ok(result) => {
-                total_dead_code += result.dead_functions.len();
+                // `include_tests` used to be `_include_tests` — an inert
+                // parameter: passing include_tests:true returned a byte-identical
+                // response. The CLI's default (false) keeps test code out of the
+                // dead-code list, so honour the same default here instead of
+                // advertising a flag that does nothing.
+                let dead: Vec<_> = result
+                    .dead_functions
+                    .iter()
+                    .filter(|func| include_tests || !is_test_path(&func.file))
+                    .collect();
+
+                total_dead_code += dead.len();
                 total_functions += result.total_functions;
                 if !languages.contains(&result.language) {
                     languages.push(result.language.clone());
                 }
-                for func in &result.dead_functions {
+                for func in dead {
                     dead_by_file
                         .entry(func.file.clone())
                         .or_default()
@@ -227,8 +238,36 @@ pub async fn analyze_dead_code(paths: &[PathBuf], _include_tests: bool) -> Resul
             "total_functions": total_functions,
             "languages": languages,
             "files": file_results,
+            // This tool and `pmat analyze dead-code` disagreed (2 vs 0 dead
+            // functions on the same path) with nothing in either payload saying
+            // why: this is the language-agnostic reachability heuristic, which
+            // calls an un-called item dead, while the CLI runs cargo's own
+            // dead-code pass on Rust projects. Name the producer so a client can
+            // reconcile the two numbers instead of guessing which is wrong.
+            "analyzer": "multi-language-reachability",
+            "analyzer_note": "Un-called items are reported dead. `pmat analyze dead-code` \
+                              uses the cargo/AST analyzer on Rust projects and may report fewer.",
+            "include_tests": include_tests,
         }
     }))
+}
+
+/// Does this path look like test code? Used to honour `include_tests` for the
+/// reachability analyzer, which has no test-awareness of its own.
+fn is_test_path(file: &str) -> bool {
+    let path = std::path::Path::new(file);
+    let in_test_dir = path.components().any(|component| {
+        matches!(
+            component.as_os_str().to_str(),
+            Some("tests") | Some("test") | Some("testing")
+        )
+    });
+    let name = path
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .unwrap_or_default();
+
+    in_test_dir || name.starts_with("test_") || name.ends_with("_test") || name.ends_with("_tests")
 }
 
 #[provable_contracts_macros::contract("pmat-core.yaml", equation = "path_exists")]
@@ -633,4 +672,56 @@ pub async fn analyze_coupling(paths: &[PathBuf], threshold: Option<f64>) -> Resu
             }
         }
     }))
+}
+
+#[cfg(test)]
+mod dead_code_include_tests_tests {
+    //! `include_tests` used to be an unused parameter (`_include_tests`).
+    use super::*;
+
+    #[test]
+    fn test_is_test_path_recognises_the_usual_layouts() {
+        assert!(is_test_path("tests/integration.rs"));
+        assert!(is_test_path("crate/tests/helpers/mod.rs"));
+        assert!(is_test_path("src/foo_tests.rs"));
+        assert!(is_test_path("src/test_foo.py"));
+        assert!(!is_test_path("src/lib.rs"));
+        assert!(!is_test_path("src/latest.rs"));
+    }
+
+    /// Passing include_tests:true returned a byte-identical response, because
+    /// the tool signature was `analyze_dead_code(paths, _include_tests: bool)`.
+    #[tokio::test]
+    async fn test_include_tests_changes_the_result() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir_all(dir.path().join("src")).expect("mkdir src");
+        std::fs::create_dir_all(dir.path().join("tests")).expect("mkdir tests");
+        std::fs::write(
+            dir.path().join("src/lib.rs"),
+            "pub fn used() {}\npub fn never_called() {}\nfn main() { used(); }\n",
+        )
+        .expect("write lib.rs");
+        std::fs::write(
+            dir.path().join("tests/helper.rs"),
+            "fn only_in_tests() {}\n",
+        )
+        .expect("write tests/helper.rs");
+
+        let paths = vec![dir.path().to_path_buf()];
+        let without = analyze_dead_code(&paths, false).await.expect("analysis");
+        let with = analyze_dead_code(&paths, true).await.expect("analysis");
+
+        let count = |v: &Value| v["results"]["total_dead_code"].as_u64().unwrap_or(0);
+        assert!(
+            count(&with) > count(&without),
+            "include_tests made no difference: {} vs {}",
+            count(&without),
+            count(&with)
+        );
+        assert_eq!(
+            without["results"]["analyzer"].as_str(),
+            Some("multi-language-reachability"),
+            "the payload must name which analyzer produced these numbers"
+        );
+    }
 }

--- a/src/mcp_pmcp/tool_functions/context_tools.rs
+++ b/src/mcp_pmcp/tool_functions/context_tools.rs
@@ -1,8 +1,47 @@
+/// Is `file` within `max_depth` levels of one of the supplied roots?
+///
+/// Depth is counted the way the tool documents it: a file sitting directly in a
+/// supplied directory is depth 1. A file that is under none of the roots (a
+/// glob expansion, say) cannot be attributed a depth and is kept.
+fn within_max_depth(roots: &[PathBuf], file: &Path, max_depth: usize) -> bool {
+    let mut attributable = false;
+    for root in roots {
+        if root == file {
+            return true;
+        }
+        if let Ok(relative) = file.strip_prefix(root) {
+            attributable = true;
+            if relative.components().count() <= max_depth {
+                return true;
+            }
+        }
+    }
+    !attributable
+}
+
+/// Module paths this file imports, in source order and de-duplicated.
+fn collect_file_dependencies(items: &[crate::services::context::AstItem]) -> Vec<String> {
+    use crate::services::context::AstItem;
+
+    let mut out = Vec::new();
+    for item in items {
+        let dep = match item {
+            AstItem::Use { path, .. } => path.clone(),
+            AstItem::Import { module, .. } => module.clone(),
+            _ => continue,
+        };
+        if !dep.is_empty() && !out.contains(&dep) {
+            out.push(dep);
+        }
+    }
+    out
+}
+
 #[provable_contracts_macros::contract("pmat-core.yaml", equation = "path_exists")]
 pub async fn generate_context(
     paths: &[PathBuf],
-    _max_depth: Option<usize>,
-    _include_dependencies: bool,
+    max_depth: Option<usize>,
+    include_dependencies: bool,
 ) -> Result<Value> {
     use crate::services::deep_context::analyze_single_file;
 
@@ -12,14 +51,31 @@ pub async fn generate_context(
 
     // R17-2: Walk directories. Previously only `path.is_file()` was analyzed,
     // yielding instant empty responses for directory inputs (D82).
-    let files = expand_paths_to_source_files(paths);
+    let mut files = expand_paths_to_source_files(paths);
+
+    // `max_depth` and `include_dependencies` were declared as `_max_depth` /
+    // `_include_dependencies` and never read, so the two documented knobs did
+    // nothing at all: max_depth 1, 2 and 99 over a four-level tree returned
+    // byte-identical 1061-file responses, and `dependencies` was always [].
+    // A parameter the schema advertises must either act or not be advertised.
+    if let Some(depth) = max_depth {
+        files.retain(|file| within_max_depth(paths, file, depth));
+    }
+
     let mut all_files = Vec::new();
-    let all_dependencies: Vec<String> = Vec::new();
+    let mut all_dependencies: Vec<String> = Vec::new();
 
     for path in &files {
         // Analyze each file
         match analyze_single_file(path).await {
             Ok(file_context) => {
+                if include_dependencies {
+                    for dep in collect_file_dependencies(&file_context.items) {
+                        if !all_dependencies.contains(&dep) {
+                            all_dependencies.push(dep);
+                        }
+                    }
+                }
                 all_files.push(json!({
                     "path": file_context.path,
                     "language": file_context.language,
@@ -57,6 +113,89 @@ pub async fn generate_context(
             "total_files": all_files.len(),
         }
     }))
+}
+
+#[cfg(test)]
+mod generate_context_knob_tests {
+    use super::*;
+
+    #[test]
+    fn depth_one_keeps_only_the_top_level() {
+        let root = PathBuf::from("/p/src");
+        let roots = vec![root.clone()];
+
+        assert!(within_max_depth(&roots, Path::new("/p/src/lib.rs"), 1));
+        assert!(!within_max_depth(&roots, Path::new("/p/src/a/b.rs"), 1));
+        assert!(within_max_depth(&roots, Path::new("/p/src/a/b.rs"), 2));
+        assert!(!within_max_depth(&roots, Path::new("/p/src/a/b/c.rs"), 2));
+    }
+
+    #[test]
+    fn an_explicitly_named_file_is_always_within_depth() {
+        let file = PathBuf::from("/p/src/lib.rs");
+        assert!(within_max_depth(std::slice::from_ref(&file), &file, 1));
+    }
+
+    #[test]
+    fn a_file_under_no_supplied_root_is_kept() {
+        // Glob expansions are not attributable to a root; dropping them would
+        // silently lose results.
+        let roots = vec![PathBuf::from("/other")];
+        assert!(within_max_depth(&roots, Path::new("/p/src/lib.rs"), 1));
+    }
+
+    #[tokio::test]
+    async fn max_depth_actually_narrows_the_result_set() {
+        // The reported defect: max_depth 1, 2 and 99 returned byte-identical
+        // responses over a four-level tree.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path().to_path_buf();
+        std::fs::write(root.join("top.rs"), "pub fn top() {}\n").expect("write");
+        std::fs::create_dir_all(root.join("a/b")).expect("mkdir");
+        std::fs::write(root.join("a/mid.rs"), "pub fn mid() {}\n").expect("write");
+        std::fs::write(root.join("a/b/deep.rs"), "pub fn deep() {}\n").expect("write");
+
+        let paths = vec![root];
+        let count = |v: &Value| v["context"]["total_files"].as_u64().unwrap();
+
+        let d1 = generate_context(&paths, Some(1), false).await.expect("d1");
+        let d2 = generate_context(&paths, Some(2), false).await.expect("d2");
+        let d99 = generate_context(&paths, Some(99), false).await.expect("d99");
+
+        assert_eq!(count(&d1), 1, "depth 1 is the top level only");
+        assert_eq!(count(&d2), 2);
+        assert_eq!(count(&d99), 3);
+    }
+
+    #[tokio::test]
+    async fn include_dependencies_populates_the_dependencies_list() {
+        // `dependencies` was always [] whatever the flag said.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path().to_path_buf();
+        std::fs::write(
+            root.join("lib.rs"),
+            "use std::collections::HashMap;\npub fn f(_: HashMap<u8, u8>) {}\n",
+        )
+        .expect("write");
+
+        let paths = vec![root];
+        let with = generate_context(&paths, None, true).await.expect("with");
+        let without = generate_context(&paths, None, false)
+            .await
+            .expect("without");
+
+        assert!(
+            !with["context"]["dependencies"]
+                .as_array()
+                .expect("array")
+                .is_empty(),
+            "include_dependencies=true must report the file's imports"
+        );
+        assert!(without["context"]["dependencies"]
+            .as_array()
+            .expect("array")
+            .is_empty());
+    }
 }
 
 #[provable_contracts_macros::contract("pmat-core.yaml", equation = "path_exists")]

--- a/src/mcp_pmcp/tool_functions/context_tools.rs
+++ b/src/mcp_pmcp/tool_functions/context_tools.rs
@@ -316,8 +316,33 @@ pub async fn analyze_context(paths: &[PathBuf], analysis_types: &[String]) -> Re
     }))
 }
 
+/// Detail levels the `scaffold_project` schema advertises for `level`.
+const SUMMARY_LEVELS: [&str; 3] = ["brief", "normal", "detailed"];
+
+/// Resolve the advertised `level` enum, rejecting anything outside it.
+///
+/// `level` was bound to `_level` and never read, so `brief` and `detailed`
+/// returned byte-identical summaries and a value like `bogus-level-xyz` was
+/// accepted in silence. A schema `enum` the tool does not enforce is a
+/// documented contract the tool does not keep.
+fn resolve_summary_level(level: Option<&str>) -> Result<&'static str> {
+    let Some(requested) = level else {
+        return Ok("normal");
+    };
+    SUMMARY_LEVELS
+        .iter()
+        .find(|known| known.eq_ignore_ascii_case(requested))
+        .copied()
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "Unsupported level `{requested}`; expected one of: {}",
+                SUMMARY_LEVELS.join(", ")
+            )
+        })
+}
+
 #[provable_contracts_macros::contract("pmat-core.yaml", equation = "path_exists")]
-pub async fn context_summary(paths: &[PathBuf], _level: Option<&str>) -> Result<Value> {
+pub async fn context_summary(paths: &[PathBuf], level: Option<&str>) -> Result<Value> {
     use std::collections::HashSet;
     use std::fs;
 
@@ -325,12 +350,17 @@ pub async fn context_summary(paths: &[PathBuf], _level: Option<&str>) -> Result<
         return Err(anyhow::anyhow!("At least one path must be provided"));
     }
 
+    let level = resolve_summary_level(level)?;
+
     let project_path = &paths[0];
 
     // Count files and lines
     let mut total_files = 0;
     let mut total_lines = 0;
     let mut languages = HashSet::new();
+    // Per-language breakdown, only rendered above `brief`.
+    let mut per_language: std::collections::BTreeMap<String, (usize, usize)> =
+        std::collections::BTreeMap::new();
 
     fn detect_lang(ext: &str) -> Option<&'static str> {
         match ext {
@@ -360,6 +390,7 @@ pub async fn context_summary(paths: &[PathBuf], _level: Option<&str>) -> Result<
         total_files: &mut usize,
         total_lines: &mut usize,
         languages: &mut HashSet<String>,
+        per_language: &mut std::collections::BTreeMap<String, (usize, usize)>,
     ) -> Result<()> {
         if !dir.is_dir() {
             return Ok(());
@@ -370,7 +401,7 @@ pub async fn context_summary(paths: &[PathBuf], _level: Option<&str>) -> Result<
             if path.is_dir() {
                 let dominated = path.file_name().and_then(|n| n.to_str()).is_some_and(is_excluded_dir);
                 if !dominated {
-                    traverse_dir(&path, total_files, total_lines, languages)?;
+                    traverse_dir(&path, total_files, total_lines, languages, per_language)?;
                 }
                 continue;
             }
@@ -383,9 +414,14 @@ pub async fn context_summary(paths: &[PathBuf], _level: Option<&str>) -> Result<
 
             languages.insert(language.to_string());
             *total_files += 1;
+            let mut lines = 0;
             if let Ok(content) = fs::read_to_string(&path) {
-                *total_lines += content.lines().count();
+                lines = content.lines().count();
+                *total_lines += lines;
             }
+            let bucket = per_language.entry(language.to_string()).or_insert((0, 0));
+            bucket.0 += 1;
+            bucket.1 += lines;
         }
         Ok(())
     }
@@ -395,17 +431,93 @@ pub async fn context_summary(paths: &[PathBuf], _level: Option<&str>) -> Result<
         &mut total_files,
         &mut total_lines,
         &mut languages,
+        &mut per_language,
     )?;
 
-    let languages_vec: Vec<String> = languages.into_iter().collect();
+    let mut languages_vec: Vec<String> = languages.into_iter().collect();
+    languages_vec.sort();
+
+    // Levels are nested (brief ⊂ normal ⊂ detailed) so a consumer that asked for
+    // more never loses a key it already parsed.
+    let mut summary = serde_json::Map::new();
+    summary.insert("level".into(), json!(level));
+    summary.insert("total_files".into(), json!(total_files));
+    summary.insert("total_lines".into(), json!(total_lines));
+    summary.insert("languages".into(), json!(languages_vec));
+    if level != "brief" {
+        let by_files: serde_json::Map<String, Value> = per_language
+            .iter()
+            .map(|(lang, (files, _))| (lang.clone(), json!(files)))
+            .collect();
+        summary.insert("files_by_language".into(), Value::Object(by_files));
+    }
+    if level == "detailed" {
+        let by_lines: serde_json::Map<String, Value> = per_language
+            .iter()
+            .map(|(lang, (_, lines))| (lang.clone(), json!(lines)))
+            .collect();
+        summary.insert("lines_by_language".into(), Value::Object(by_lines));
+    }
 
     Ok(json!({
         "status": "completed",
         "message": "Context summary generated from file system analysis",
-        "summary": {
-            "total_files": total_files,
-            "total_lines": total_lines,
-            "languages": languages_vec,
-        }
+        "summary": summary,
     }))
+}
+
+#[cfg(test)]
+mod context_summary_level_tests {
+    use super::*;
+
+    #[test]
+    fn out_of_enum_levels_are_rejected() {
+        // The schema advertises an enum; accepting `bogus-level-xyz` in silence
+        // is the defect.
+        assert!(resolve_summary_level(Some("bogus-level-xyz")).is_err());
+        assert_eq!(resolve_summary_level(None).expect("default"), "normal");
+        for known in ["brief", "normal", "detailed", "DETAILED"] {
+            assert!(resolve_summary_level(Some(known)).is_ok(), "{known}");
+        }
+    }
+
+    #[tokio::test]
+    async fn level_changes_the_summary() {
+        // The reported defect: brief and detailed returned identical summaries.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path().to_path_buf();
+        std::fs::write(root.join("a.rs"), "fn a() {}\n").expect("write");
+        std::fs::write(root.join("b.py"), "def b():\n    pass\n").expect("write");
+        let paths = vec![root];
+
+        let brief = context_summary(&paths, Some("brief")).await.expect("brief");
+        let normal = context_summary(&paths, None).await.expect("normal");
+        let detailed = context_summary(&paths, Some("detailed"))
+            .await
+            .expect("detailed");
+
+        assert_ne!(brief["summary"], detailed["summary"]);
+        assert_eq!(brief["summary"]["level"], "brief");
+        assert!(brief["summary"]["files_by_language"].is_null());
+        assert!(normal["summary"]["files_by_language"].is_object());
+        assert!(normal["summary"]["lines_by_language"].is_null());
+        assert_eq!(detailed["summary"]["files_by_language"]["Rust"], 1);
+        assert!(detailed["summary"]["lines_by_language"]["Python"]
+            .as_u64()
+            .expect("line count")
+            >= 2);
+    }
+
+    #[tokio::test]
+    async fn an_unknown_level_is_an_error_not_a_default() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let paths = vec![dir.path().to_path_buf()];
+        let err = context_summary(&paths, Some("verbose"))
+            .await
+            .expect_err("out-of-enum level must be rejected");
+        assert!(
+            err.to_string().contains("Unsupported level"),
+            "got: {err}"
+        );
+    }
 }

--- a/src/mcp_pmcp/tool_functions/quality_tools.rs
+++ b/src/mcp_pmcp/tool_functions/quality_tools.rs
@@ -31,16 +31,17 @@ pub async fn check_quality_gates(paths: &[PathBuf], strict: bool) -> Result<Valu
 
     // Grade's derived Ord is inverted (better grades compare as smaller),
     // so use the semantic helper instead of a raw `>=` comparison.
-    let passed = project_score.average_score >= threshold_score
+    let tdg_passed = project_score.average_score >= threshold_score
         && project_score.average_grade.meets_threshold(threshold_grade);
 
     // Collect violations (files below threshold)
-    let violations: Vec<Value> = project_score
+    let mut violations: Vec<Value> = project_score
         .files
         .iter()
         .filter(|score| score.total < threshold_score)
         .map(|score| {
             json!({
+                "check_type": "tdg",
                 "file": score.file_path.as_ref().map(|p| p.display().to_string()).unwrap_or_else(|| "unknown".to_string()),
                 "score": score.total,
                 "grade": format!("{:?}", score.grade),
@@ -48,6 +49,45 @@ pub async fn check_quality_gates(paths: &[PathBuf], strict: bool) -> Result<Valu
             })
         })
         .collect();
+
+    // SATD comes from the same detector `pmat quality-gate` runs: this tool and
+    // the CLI gate carry one name and must not be two different checks. A
+    // TDG-only verdict let a `TODO:` the CLI fails on pass over MCP.
+    let satd: Vec<Value> = if project_path.is_file() {
+        satd_violations_for_file(project_path)
+    } else {
+        crate::cli::analysis_utilities::check_satd(project_path)
+            .await
+            .unwrap_or_default()
+            .iter()
+            .map(|v| {
+                json!({
+                    "check_type": v.check_type,
+                    "severity": v.severity,
+                    "file": v.file,
+                    "line": v.line,
+                    "message": v.message,
+                })
+            })
+            .collect()
+    };
+    let mut passed = tdg_passed && satd.is_empty();
+    violations.extend(satd);
+
+    // A path where nothing could be graded must SAY so. `analyze_project` skips
+    // files it cannot read or parse, so a directory whose only source file is
+    // `fn main( { let x = ;;;` came back with an empty score set — and before
+    // the analyzer refused to grade unparseable Rust, with 90.0/A. Zero graded
+    // files is not a measurement of quality.
+    if project_score.total_files == 0 {
+        passed = false;
+        violations.push(json!({
+            "check_type": "not_graded",
+            "severity": "error",
+            "file": project_path.display().to_string(),
+            "message": "no file under this path could be graded (unreadable, unparseable, or not source) — the score is not a measurement",
+        }));
+    }
 
     Ok(json!({
         "status": "completed",
@@ -62,6 +102,38 @@ pub async fn check_quality_gates(paths: &[PathBuf], strict: bool) -> Result<Valu
         "files_analyzed": project_score.total_files,
         "violations": violations
     }))
+}
+
+/// SATD violations for one file, from the detector `pmat quality-gate` uses.
+///
+/// Shape matches the CLI gate's `violations` entries (check_type/severity/
+/// file/line/message) so an agent reading either gate sees the same rows.
+fn satd_violations_for_file(file_path: &Path) -> Vec<Value> {
+    use crate::services::satd_detector::{SATDDetector, Severity};
+
+    let Ok(source) = std::fs::read_to_string(file_path) else {
+        return Vec::new();
+    };
+    let Ok(debts) = SATDDetector::new().extract_from_content(&source, file_path) else {
+        return Vec::new();
+    };
+
+    debts
+        .iter()
+        .map(|debt| {
+            json!({
+                "check_type": "satd",
+                "severity": match debt.severity {
+                    Severity::Critical | Severity::High => "error",
+                    Severity::Medium => "warning",
+                    Severity::Low => "info",
+                },
+                "file": debt.file.display().to_string(),
+                "line": debt.line,
+                "message": format!("{}: {}", debt.category, debt.text),
+            })
+        })
+        .collect()
 }
 
 #[provable_contracts_macros::contract("pmat-core.yaml", equation = "path_exists")]
@@ -91,11 +163,16 @@ pub async fn check_quality_gate_file(file_path: &Path, strict: bool) -> Result<V
 
     // Grade's derived Ord is inverted (better grades compare as smaller),
     // so use the semantic helper instead of a raw `>=` comparison.
-    let passed =
+    let tdg_passed =
         file_score.total >= threshold_score && file_score.grade.meets_threshold(threshold_grade);
 
-    // Collect violations (penalty details)
-    let violations: Vec<Value> = file_score
+    // TDG penalty attributions are NOT gate violations — they are the score's
+    // breakdown. They used to be reported as `violations`, which is why this
+    // tool and `pmat quality-gate --file` were two different checks under one
+    // name: the CLI failed tiny/src/lib.rs on a `TODO:` at line 4 while MCP
+    // returned {"passed":true,"grade":"A","violations":[]} for the same file in
+    // the same session that `analyze_satd` flagged that very TODO.
+    let tdg_penalties: Vec<Value> = file_score
         .penalties_applied
         .iter()
         .map(|p| {
@@ -106,6 +183,10 @@ pub async fn check_quality_gate_file(file_path: &Path, strict: bool) -> Result<V
             })
         })
         .collect();
+
+    // The gate's violations come from the same SATD detector the CLI gate runs.
+    let violations = satd_violations_for_file(file_path);
+    let passed = tdg_passed && violations.is_empty();
 
     Ok(json!({
         "status": "completed",
@@ -119,6 +200,7 @@ pub async fn check_quality_gate_file(file_path: &Path, strict: bool) -> Result<V
         "grade": format!("{:?}", file_score.grade),
         "threshold": threshold_score,
         "violations": violations,
+        "tdg_penalties": tdg_penalties,
         "metrics": {
             "structural_complexity": file_score.structural_complexity,
             "semantic_complexity": file_score.semantic_complexity,
@@ -355,4 +437,94 @@ pub async fn quality_gate_compare(baseline: &Path, paths: &[PathBuf]) -> Result<
             "total_changes": comparison.improved.len() + comparison.regressed.len() + comparison.added.len() + comparison.removed.len(),
         }
     }))
+}
+
+/// The MCP `quality_gate` tool and `pmat quality-gate` carry one name, so they
+/// must reach one verdict — and neither may grade a file that did not parse.
+#[cfg(test)]
+mod mcp_quality_gate_parity_tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn write(dir: &Path, name: &str, body: &str) -> PathBuf {
+        let p = dir.join(name);
+        std::fs::write(&p, body).expect("write fixture");
+        p
+    }
+
+    /// The CLI gate fails this file on SATD; MCP used to return
+    /// `{"passed":true,"grade":"A","violations":[]}` for it.
+    #[tokio::test]
+    async fn test_mcp_file_gate_fails_on_the_satd_the_cli_gate_fails_on() {
+        let tmp = TempDir::new().expect("tempdir");
+        let file = write(
+            tmp.path(),
+            "lib.rs",
+            "/// Adds.\npub fn add(a: i32, b: i32) -> i32 {\n    // TODO: handle overflow\n    a + b\n}\n",
+        );
+
+        let result = check_quality_gate_file(&file, false).await.expect("gate");
+
+        let violations = result["violations"].as_array().expect("violations array");
+        assert!(
+            violations.iter().any(|v| v["check_type"] == "satd"),
+            "the TODO must surface as a violation: {result}"
+        );
+        assert_eq!(
+            result["passed"], false,
+            "a file the CLI gate fails must not pass the MCP gate: {result}"
+        );
+        // The TDG breakdown is still reported, just not as gate violations.
+        assert!(result["tdg_penalties"].is_array(), "{result}");
+    }
+
+    /// A clean file must still pass — the gate is not fail-by-default.
+    #[tokio::test]
+    async fn test_mcp_file_gate_still_passes_a_clean_file() {
+        let tmp = TempDir::new().expect("tempdir");
+        let file = write(
+            tmp.path(),
+            "clean.rs",
+            "/// Adds two numbers.\npub fn add(a: i32, b: i32) -> i32 {\n    a + b\n}\n",
+        );
+
+        let result = check_quality_gate_file(&file, false).await.expect("gate");
+        assert_eq!(result["passed"], true, "{result}");
+        assert!(result["violations"].as_array().expect("array").is_empty());
+    }
+
+    /// `fn main( { let x = ;;;` scored 90.0/A with `violations: []` in strict
+    /// mode: the heuristic scorer never parsed, so a file rustc rejects earned
+    /// every untouched component cap.
+    #[tokio::test]
+    async fn test_unparseable_source_is_not_an_a_grade_pass() {
+        let tmp = TempDir::new().expect("tempdir");
+        std::fs::create_dir_all(tmp.path().join("src")).expect("mkdir");
+        write(&tmp.path().join("src"), "main.rs", "fn main( { let x = ;;;\n");
+
+        let result = check_quality_gates(&[tmp.path().to_path_buf()], true)
+            .await
+            .expect("gate");
+
+        assert_eq!(
+            result["passed"], false,
+            "a project whose only source file does not parse cannot pass: {result}"
+        );
+        let violations = result["violations"].as_array().expect("violations array");
+        assert!(
+            !violations.is_empty(),
+            "the payload must say why nothing was graded: {result}"
+        );
+    }
+
+    /// The single-file entry point must refuse outright rather than score.
+    #[tokio::test]
+    async fn test_unparseable_file_is_an_error_not_a_score() {
+        let tmp = TempDir::new().expect("tempdir");
+        let file = write(tmp.path(), "broken.rs", "fn main( { let x = ;;;\n");
+        let err = check_quality_gate_file(&file, false)
+            .await
+            .expect_err("a file that does not parse must not be graded");
+        assert!(err.to_string().contains("not parseable"), "{err}");
+    }
 }

--- a/src/mcp_pmcp/tool_functions/quality_tools.rs
+++ b/src/mcp_pmcp/tool_functions/quality_tools.rs
@@ -89,6 +89,21 @@ pub async fn check_quality_gates(paths: &[PathBuf], strict: bool) -> Result<Valu
         }));
     }
 
+    // With nothing graded there is no score to report. Reporting 0.0/"F" reads as
+    // "measured, and terrible"; `analyze_deep_context` already answers this case
+    // with nulls plus a `not_measured` list, and one server must not use two
+    // conventions for the same fact.
+    let graded = project_score.total_files > 0;
+    let (score, grade, not_measured) = if graded {
+        (
+            json!(project_score.average_score),
+            json!(format!("{:?}", project_score.average_grade)),
+            json!([]),
+        )
+    } else {
+        (Value::Null, Value::Null, json!(["score", "grade"]))
+    };
+
     Ok(json!({
         "status": "completed",
         "message": format!(
@@ -96,8 +111,9 @@ pub async fn check_quality_gates(paths: &[PathBuf], strict: bool) -> Result<Valu
             if strict { "strict" } else { "standard" }
         ),
         "passed": passed,
-        "score": project_score.average_score,
-        "grade": format!("{:?}", project_score.average_grade),
+        "score": score,
+        "grade": grade,
+        "not_measured": not_measured,
         "threshold": threshold_score,
         "files_analyzed": project_score.total_files,
         "violations": violations
@@ -515,6 +531,31 @@ mod mcp_quality_gate_parity_tests {
             !violations.is_empty(),
             "the payload must say why nothing was graded: {result}"
         );
+    }
+
+    /// Nothing graded ⇒ nothing to report. `analyze_deep_context` answers this
+    /// case with nulls + `not_measured`; the gate used to answer 0.0/"F", which
+    /// reads as a measured verdict.
+    #[tokio::test]
+    async fn test_ungraded_path_reports_not_measured_not_zero_f() {
+        let tmp = TempDir::new().expect("tempdir");
+        let result = check_quality_gates(&[tmp.path().to_path_buf()], false)
+            .await
+            .expect("empty dir is not an error");
+        assert_eq!(result["files_analyzed"], 0);
+        assert!(
+            result["score"].is_null(),
+            "score must be null when nothing was graded: {result}"
+        );
+        assert!(
+            result["grade"].is_null(),
+            "grade must be null when nothing was graded: {result}"
+        );
+        let not_measured = result["not_measured"]
+            .as_array()
+            .expect("not_measured array");
+        assert!(not_measured.iter().any(|v| v == "score"));
+        assert!(not_measured.iter().any(|v| v == "grade"));
     }
 
     /// The single-file entry point must refuse outright rather than score.

--- a/src/models/complexity_bound.rs
+++ b/src/models/complexity_bound.rs
@@ -67,6 +67,12 @@ pub struct ComplexityBound {
     /// Property flags (1 byte)
     pub flags: ComplexityFlags,
     /// Padding for alignment (2 bytes)
+    ///
+    /// `#[serde(skip)]`: this is `#[repr(C)]` alignment filler, not data. It
+    /// was reaching MCP clients as `"_padding":[0,0]` beside real measurements
+    /// — a field a reader has to guess the meaning of, whose only possible
+    /// value is zero.
+    #[serde(skip)]
     _padding: [u8; 2],
 }
 

--- a/src/models/complexity_bound_tests.rs
+++ b/src/models/complexity_bound_tests.rs
@@ -163,5 +163,21 @@ mod tests {
         assert_eq!(cache.miss_penalty, 1);
         assert_eq!(cache.working_set, BigOClass::Unknown);
     }
+
+    /// The MCP `analyze_big_o` payload carried this struct verbatim, so
+    /// clients received `"_padding":[0,0]` — `#[repr(C)]` alignment filler —
+    /// alongside the measurements. Padding is layout, never data.
+    #[test]
+    fn test_serialised_bound_carries_no_alignment_padding() {
+        let json = serde_json::to_string(&ComplexityBound::quadratic()).expect("serialise");
+        assert!(
+            !json.contains("_padding"),
+            "alignment filler must not be serialised: {json}"
+        );
+        // The measurements themselves still round-trip.
+        let back: ComplexityBound = serde_json::from_str(&json).expect("deserialise");
+        assert_eq!(back.class, BigOClass::Quadratic);
+        assert_eq!(back.confidence, ComplexityBound::quadratic().confidence);
+    }
 }
 

--- a/src/models/debug_analysis.rs
+++ b/src/models/debug_analysis.rs
@@ -173,6 +173,15 @@ pub enum Priority {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct EvidenceSummary {
     pub complexity_violations: usize,
+    /// Was any complexity evidence actually gathered?
+    ///
+    /// `complexity_violations` was structurally always 0 — the producer wrote
+    /// `{total_lines, deep_nesting, threshold}` while this consumer read a
+    /// `value` key nobody wrote — so a measured "no violations" and "the path
+    /// has no `src/` to measure" were the same 0. They are now distinguishable,
+    /// as `tdg_measured` already distinguishes an unmeasured TDG score.
+    #[serde(default)]
+    pub complexity_measured: bool,
     pub satd_markers: usize,
     pub tdg_score: f64,
     /// Was `tdg_score` actually populated by TDG evidence?
@@ -189,6 +198,13 @@ pub struct EvidenceSummary {
     /// CB-142 EvoScore trajectory: positive = improving, negative = regressing
     #[serde(default)]
     pub evoscore_trajectory: f64,
+    /// Was `evoscore_trajectory` actually populated?
+    ///
+    /// `gather_evoscore_evidence` returns None when the repo has fewer than
+    /// three `.pmat-metrics/commit-*-tests.json` files, which is the usual case,
+    /// so a genuine "no data" was reported as a flat 0.0 trajectory.
+    #[serde(default)]
+    pub evoscore_measured: bool,
     /// Coverage delta: positive = coverage increased, negative = decreased
     #[serde(default)]
     pub coverage_delta: f64,
@@ -196,6 +212,7 @@ pub struct EvidenceSummary {
 
 impl EvidenceSummary {
     fn process_complexity_evidence(&mut self, evidence: &Evidence) {
+        self.complexity_measured = true;
         let value = evidence
             .value
             .get("value")
@@ -247,6 +264,7 @@ impl EvidenceSummary {
                     .get("evoscore")
                     .and_then(|v| v.as_f64())
                     .unwrap_or(0.0);
+                self.evoscore_measured = true;
             }
             EvidenceSource::CoverageDelta => {
                 self.coverage_delta = evidence

--- a/src/models/debug_analysis_coverage_recommend.rs
+++ b/src/models/debug_analysis_coverage_recommend.rs
@@ -332,6 +332,9 @@
     fn test_evidence_summary_serialization_roundtrip() {
         let summary = EvidenceSummary {
             complexity_violations: 3,
+            // Same reason as `tdg_measured`: a count of 0 must be readable as
+            // "measured none" or "measured nothing at all".
+            complexity_measured: true,
             satd_markers: 7,
             tdg_score: 65.5,
             // A score is only meaningful alongside the flag saying it was
@@ -339,6 +342,7 @@
             tdg_measured: true,
             git_churn_high: true,
             evoscore_trajectory: 0.0,
+            evoscore_measured: false,
             coverage_delta: 0.0,
         };
 

--- a/src/models/debug_analysis_tests.rs
+++ b/src/models/debug_analysis_tests.rs
@@ -111,3 +111,60 @@
         assert_eq!(summary.evoscore_trajectory, 0.0);
         assert_eq!(summary.coverage_delta, 0.0);
     }
+
+/// The producer/consumer key mismatch that made `complexity_violations`
+/// structurally 0: `gather_complexity_evidence` wrote
+/// `{total_lines, deep_nesting, threshold}` while this consumer reads `value`,
+/// so the comparison was always `0.0 > 20.0`.
+#[test]
+fn complexity_evidence_is_read_under_the_key_the_producer_writes() {
+    let mut why = WhyIteration::new(1, "Why?".to_string(), "Hypothesis".to_string());
+    why.add_evidence(Evidence::new(
+        EvidenceSource::Complexity,
+        PathBuf::from("."),
+        "estimated_complexity".to_string(),
+        // Exactly what five_whys_analyzer::gather_complexity_evidence emits.
+        serde_json::json!({
+            "value": 37,
+            "threshold": 20,
+            "total_lines": 979_249,
+            "deep_nesting": 16_386,
+        }),
+        "979249 source lines, 16386 deeply-nested blocks".to_string(),
+    ));
+
+    let summary = EvidenceSummary::from_whys(&[why]);
+    assert_eq!(
+        summary.complexity_violations, 1,
+        "a density of 37 against a threshold of 20 is a violation"
+    );
+    assert!(summary.complexity_measured);
+}
+
+#[test]
+fn complexity_below_threshold_is_a_measured_zero_not_an_absent_one() {
+    let mut why = WhyIteration::new(1, "Why?".to_string(), "Hypothesis".to_string());
+    why.add_evidence(Evidence::new(
+        EvidenceSource::Complexity,
+        PathBuf::from("."),
+        "estimated_complexity".to_string(),
+        serde_json::json!({"value": 17, "threshold": 20}),
+        "est. complexity density: 17/1000 lines".to_string(),
+    ));
+
+    let summary = EvidenceSummary::from_whys(&[why]);
+    assert_eq!(summary.complexity_violations, 0);
+    assert!(
+        summary.complexity_measured,
+        "0 here means measured-and-under-threshold, not no-data"
+    );
+}
+
+#[test]
+fn absent_complexity_and_evoscore_evidence_is_flagged_unmeasured() {
+    let summary = EvidenceSummary::from_whys(&[]);
+    assert_eq!(summary.complexity_violations, 0);
+    assert!(!summary.complexity_measured);
+    assert_eq!(summary.evoscore_trajectory, 0.0);
+    assert!(!summary.evoscore_measured);
+}

--- a/src/models/pdmt.rs
+++ b/src/models/pdmt.rs
@@ -114,9 +114,14 @@ impl Default for ValidationCommands {
             unit_tests: "cargo test".to_string(),
             doctests: "cargo test --doc".to_string(),
             property_tests: "cargo test --features property-tests".to_string(),
+            // Both defaults have to be runnable as printed, and they have to
+            // agree with `ImplementationSpecs::default()`, which is what the
+            // same todo tells the user to create. `pmat quality-gate --file`
+            // shipped with a dangling flag and no value — clap rejects it — and
+            // `--example demo` named an example the default specs never list.
             examples: vec!["cargo run --example demo".to_string()],
             coverage_check: "cargo llvm-cov --fail-under-lines 80".to_string(),
-            quality_proxy: "pmat quality-gate --file".to_string(),
+            quality_proxy: "pmat quality-gate --file src/lib.rs".to_string(),
         }
     }
 }

--- a/src/models/refactor_impls.rs
+++ b/src/models/refactor_impls.rs
@@ -69,14 +69,11 @@ impl RefactorStateMachine {
             State::Scan { targets } => {
                 if targets.is_empty() {
                     State::Complete {
-                        summary: Summary::default(),
+                        summary: self.session_summary(),
                     }
                 } else {
                     State::Analyze {
-                        current: FileId {
-                            path: targets[0].clone(),
-                            hash: 0, // Will be computed during analysis
-                        },
+                        current: Self::file_id(&targets[0]),
                     }
                 }
             }
@@ -85,12 +82,9 @@ impl RefactorStateMachine {
             },
             State::Plan { violations } => {
                 if violations.is_empty() {
-                    self.next_target().map_or(
-                        State::Complete {
-                            summary: Summary::default(),
-                        },
-                        |t| State::Analyze { current: t },
-                    )
+                    let summary = self.session_summary();
+                    self.next_target()
+                        .map_or(State::Complete { summary }, |t| State::Analyze { current: t })
                 } else {
                     State::Refactor {
                         operation: violations[0].suggested_fix.clone().unwrap_or(
@@ -112,12 +106,11 @@ impl RefactorStateMachine {
             State::Emit { .. } => State::Checkpoint {
                 reason: "cycle_complete".to_string(),
             },
-            State::Checkpoint { .. } => self.next_target().map_or(
-                State::Complete {
-                    summary: Summary::default(),
-                },
-                |t| State::Analyze { current: t },
-            ),
+            State::Checkpoint { .. } => {
+                let summary = self.session_summary();
+                self.next_target()
+                    .map_or(State::Complete { summary }, |t| State::Analyze { current: t })
+            }
             State::Complete { .. } => {
                 return Ok(&self.current);
             }
@@ -182,12 +175,66 @@ impl RefactorStateMachine {
     fn next_target(&mut self) -> Option<FileId> {
         self.current_target_index += 1;
         if self.current_target_index < self.targets.len() {
-            Some(FileId {
-                path: self.targets[self.current_target_index].clone(),
-                hash: 0,
-            })
+            Some(Self::file_id(&self.targets[self.current_target_index]))
         } else {
             None
+        }
+    }
+
+    /// Identify a target by its *contents*.
+    ///
+    /// `FileId.hash` was the literal `0` with the comment "Will be computed
+    /// during analysis" — nothing ever computed it, so `refactor.nextIteration`
+    /// reported `{"path": "…", "hash": 0}` for every file, including files that
+    /// did not exist. An unreadable file keeps hash 0: that is "not measured",
+    /// not "empty".
+    fn file_id(path: &std::path::Path) -> FileId {
+        let hash = std::fs::read(path).map_or(0, |bytes| {
+            let digest = blake3::hash(&bytes);
+            let mut first8 = [0u8; 8];
+            first8.copy_from_slice(&digest.as_bytes()[..8]);
+            u64::from_le_bytes(first8)
+        });
+        FileId {
+            path: path.to_path_buf(),
+            hash,
+        }
+    }
+
+    /// Summarise the session from what actually happened.
+    ///
+    /// Every `State::Complete` used to carry `Summary::default()` — a struct
+    /// of hardcoded zeros — so a session that scanned and analysed a real file
+    /// still reported `files_processed: 0` and `total_time: 0s`. The counts
+    /// below are derived from the recorded transitions. `refactors_applied`,
+    /// `complexity_reduction` and `satd_removed` stay zero because this state
+    /// machine applies nothing (the tools disclose the simulated analysis
+    /// engine in their MCP descriptions); reporting anything else would be
+    /// inventing work that never happened.
+    fn session_summary(&self) -> Summary {
+        let files_processed = self
+            .history
+            .iter()
+            .filter(|t| matches!(t.to, State::Analyze { .. }))
+            .count() as u32;
+
+        let total_time = self
+            .history
+            .first()
+            .and_then(|first| {
+                SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .ok()
+                    .map(|now| Duration::from_secs(now.as_secs().saturating_sub(first.timestamp)))
+            })
+            .unwrap_or_default();
+
+        Summary {
+            files_processed,
+            refactors_applied: 0,
+            complexity_reduction: 0.0,
+            satd_removed: 0,
+            total_time,
         }
     }
 
@@ -207,6 +254,59 @@ impl RefactorStateMachine {
             estimated_improvement: 0.5,
             _padding: [0; 2],
         }
+    }
+}
+
+#[cfg(test)]
+mod session_summary_tests {
+    //! The Complete summary must describe the session that ran, not a
+    //! `Summary::default()` of hardcoded zeros.
+    use super::*;
+
+    #[test]
+    fn completing_a_one_file_session_reports_that_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let file = dir.path().join("lib.rs");
+        std::fs::write(&file, "pub fn f() -> i32 { 1 }\n").expect("write fixture");
+
+        let mut sm = RefactorStateMachine::new(vec![file.clone()], RefactorConfig::default());
+        // Scan -> Analyze
+        sm.advance().expect("scan");
+        let State::Analyze { current } = &sm.current else {
+            panic!("expected Analyze, got {:?}", sm.current)
+        };
+        assert_ne!(
+            current.hash, 0,
+            "the analysed file's id must be a real content hash"
+        );
+
+        sm.advance().expect("analyze"); // -> Plan (no violations)
+        sm.advance().expect("plan"); // -> Complete
+        let State::Complete { summary } = &sm.current else {
+            panic!("expected Complete, got {:?}", sm.current)
+        };
+        assert_eq!(
+            summary.files_processed, 1,
+            "one file was scanned and analysed"
+        );
+    }
+
+    #[test]
+    fn a_files_contents_decide_its_hash() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let a = dir.path().join("a.rs");
+        let b = dir.path().join("b.rs");
+        std::fs::write(&a, "pub fn a() {}\n").expect("write a");
+        std::fs::write(&b, "pub fn b() {}\n").expect("write b");
+        assert_ne!(
+            RefactorStateMachine::file_id(&a).hash,
+            RefactorStateMachine::file_id(&b).hash
+        );
+        // A path that cannot be read is "not measured", i.e. still 0.
+        assert_eq!(
+            RefactorStateMachine::file_id(&dir.path().join("missing.rs")).hash,
+            0
+        );
     }
 }
 

--- a/src/qdd/generator/quality_code_analysis.rs
+++ b/src/qdd/generator/quality_code_analysis.rs
@@ -26,10 +26,15 @@ impl QualityCodeGenerator {
     }
 
     /// Calculate quality score for generated code
+    ///
+    /// NOTE: `coverage` and `tdg` here are constants, not measurements — nothing
+    /// runs the generated tests and nothing computes a TDG for a body that is
+    /// `todo!()`. They exist only to feed `meets_thresholds`; the CLI reports them
+    /// as "not measured" rather than as the 100% they would otherwise claim.
     #[provable_contracts_macros::contract("pmat-core.yaml", equation = "score_range")]
     pub(crate) fn calculate_quality_score(&self, code: &str) -> Result<QualityScore> {
         let complexity = self.estimate_complexity(code);
-        let coverage = 100.0; // Generated code will have full coverage
+        let coverage = 100.0; // NOT a measurement — see the note above
         let tdg = if complexity <= 5 { 1 } else { complexity / 2 };
 
         Ok(QualityScore {
@@ -41,12 +46,15 @@ impl QualityCodeGenerator {
     }
 
     /// Calculate detailed metrics
+    ///
+    /// `coverage`/`tdg`/`dead_code_percentage` are constants feeding the threshold
+    /// check, not measurements; they must never be surfaced as a measured result.
     #[provable_contracts_macros::contract("pmat-core.yaml", equation = "score_range")]
     pub(crate) fn calculate_metrics(&self, code: &str, tests: &str) -> Result<QualityMetrics> {
         Ok(QualityMetrics {
             complexity: self.estimate_complexity(code),
             cognitive_complexity: self.estimate_complexity(code), // Same for now
-            coverage: 100, // Generated tests provide full coverage
+            coverage: 100, // NOT a measurement — no test run produced this
             tdg: 1,        // Generated code has minimal technical debt
             satd_count: code.matches("TODO").count() as u32,
             dead_code_percentage: 0, // Generated code has no dead code

--- a/src/qdd/generator_core.rs
+++ b/src/qdd/generator_core.rs
@@ -233,7 +233,9 @@ mod {} {{
             quality_score: QualityScore {
                 overall: metrics.calculate_score(),
                 complexity: metrics.complexity,
-                coverage: 100.0, // Tests provide coverage
+                // NOT a measurement: nothing runs the generated tests. The CLI
+                // reports coverage as not measured rather than as this literal.
+                coverage: 100.0,
                 tdg: 1,
             },
             metrics,
@@ -291,7 +293,7 @@ mod {} {{
         Ok(QualityMetrics {
             complexity: self.estimate_complexity(code),
             cognitive_complexity: self.estimate_complexity(code), // Same for now
-            coverage: 100, // Generated tests provide full coverage
+            coverage: 100, // NOT a measurement — no test run produced this
             tdg: 1,        // Generated code has minimal technical debt
             satd_count: code.matches("TODO").count() as u32,
             dead_code_percentage: 0, // Generated code has no dead code

--- a/src/qdd/mod.rs
+++ b/src/qdd/mod.rs
@@ -171,6 +171,12 @@ impl QddTool {
         let documentation = self.generator.generate_documentation(&enhanced_code)?;
 
         let metrics = QualityMetrics::default();
+        // NOT measurements: these four are constants that do not depend on
+        // `enhanced_code` at all — every enhancement, of every file, scored
+        // "complexity 5, coverage 90%, TDG 2". Nothing renders them today (no
+        // CLI subcommand or MCP tool reaches `enhance`), and `QualityScore` has
+        // no way to say "unmeasured", so any renderer added later must print
+        // them as not measured the way `display_refactor_results` does.
         let quality_score = QualityScore {
             overall: metrics.calculate_score(),
             complexity: 5,
@@ -214,6 +220,7 @@ impl QddTool {
         }
 
         let metrics = QualityMetrics::default();
+        // NOT measurements — same constants problem as `enhance_code` above.
         let quality_score = QualityScore {
             overall: metrics.calculate_score(),
             complexity: 8,

--- a/src/qdd/refactor_analyzer.rs
+++ b/src/qdd/refactor_analyzer.rs
@@ -31,6 +31,12 @@ impl CodeAnalyzer {
         1 + if_count + match_count + loop_count
     }
 
+    /// A stopping-condition heuristic, NOT a coverage measurement: it counts
+    /// `#[test]` attributes, multiplies by ten and divides by the line count.
+    /// No test is compiled or run here. It stays because the refactoring loop's
+    /// termination check (`meets_quality_standards`) is defined in terms of it,
+    /// but nothing may print it as a coverage figure — see
+    /// `display_refactor_results`, which reports coverage as not measured.
     fn estimate_coverage(&self, code: &str) -> f64 {
         let test_lines = code.matches("#[test]").count() * 10; // Rough estimate
         let total_lines = code.lines().count().max(1);

--- a/src/quality/gates_checks.rs
+++ b/src/quality/gates_checks.rs
@@ -273,26 +273,237 @@ fn parse_coverage_from_output(output: &str) -> f64 {
     0.0
 }
 
-/// Execute complexity gate (simplified version)
+/// What the complexity gate actually measured over a project tree.
+///
+/// `worst` is `(file, function, cyclomatic)` for the highest-scoring function
+/// found; `None` means nothing was measurable.
+#[derive(Debug, Default, PartialEq)]
+pub struct ComplexityScan {
+    /// Rust files discovered under the project directory.
+    pub files_seen: usize,
+    /// Rust files that parsed and were actually measured.
+    pub files_measured: usize,
+    /// Functions measured across those files.
+    pub functions_measured: usize,
+    /// Highest-complexity function seen: (file, function, cyclomatic).
+    pub worst: Option<(String, String, u32)>,
+}
+
+/// Per-function cyclomatic collector for the complexity gate.
+///
+/// Visits free functions and inherent/trait impl methods, the same two shapes
+/// `analyze complexity` counts, and delegates the count itself to
+/// `measure_block` so the gate cannot drift away from the analyzer.
+struct GateComplexityVisitor {
+    functions: Vec<(String, u32)>,
+}
+
+impl<'ast> syn::visit::Visit<'ast> for GateComplexityVisitor {
+    fn visit_item_fn(&mut self, node: &'ast syn::ItemFn) {
+        let name = node.sig.ident.to_string();
+        let measured =
+            crate::services::accurate_complexity_analyzer::measure_block(&name, &node.block);
+        self.functions.push((name, measured.cyclomatic));
+        syn::visit::visit_item_fn(self, node);
+    }
+
+    fn visit_impl_item_fn(&mut self, node: &'ast syn::ImplItemFn) {
+        let name = node.sig.ident.to_string();
+        let measured =
+            crate::services::accurate_complexity_analyzer::measure_block(&name, &node.block);
+        self.functions.push((name, measured.cyclomatic));
+        syn::visit::visit_impl_item_fn(self, node);
+    }
+}
+
+/// Measure every parsable Rust file under `project_dir`.
+///
+/// Discovery goes through `ProjectFileDiscovery` so .gitignore/.pmatignore are
+/// honoured and `target/` is not walked, matching `analyze complexity`.
+fn scan_rust_complexity(project_dir: &Path) -> ComplexityScan {
+    use crate::services::file_discovery::{FileDiscoveryConfig, ProjectFileDiscovery};
+    use syn::visit::Visit;
+
+    let discovery_config = FileDiscoveryConfig {
+        respect_gitignore: true,
+        filter_external_repos: true,
+        ..Default::default()
+    };
+    let discovery =
+        ProjectFileDiscovery::new(project_dir.to_path_buf()).with_config(discovery_config);
+    let files = discovery.discover_files().unwrap_or_default();
+
+    let mut scan = ComplexityScan::default();
+    for file in files {
+        if file.extension().and_then(|e| e.to_str()) != Some("rs") {
+            continue;
+        }
+        scan.files_seen += 1;
+
+        let Ok(content) = std::fs::read_to_string(&file) else {
+            continue;
+        };
+        let Ok(tree) = syn::parse_file(&content) else {
+            continue; // include!() fragments and non-standalone sources
+        };
+
+        let mut visitor = GateComplexityVisitor {
+            functions: Vec::new(),
+        };
+        visitor.visit_file(&tree);
+        scan.files_measured += 1;
+        scan.functions_measured += visitor.functions.len();
+
+        for (name, cyclomatic) in visitor.functions {
+            let worse = scan.worst.as_ref().is_none_or(|(_, _, w)| cyclomatic > *w);
+            if worse {
+                scan.worst = Some((file.display().to_string(), name, cyclomatic));
+            }
+        }
+    }
+    scan
+}
+
+/// Pure-compute decision builder for the complexity gate.
+///
+/// A scan that measured nothing must NOT report a pass — that was the whole
+/// defect below.
+fn build_complexity_decision(scan: &ComplexityScan, max_complexity: u32) -> (bool, String) {
+    let Some((file, function, worst)) = scan.worst.as_ref() else {
+        return (
+            false,
+            format!(
+                "✗ Complexity: not measured — 0 of {} Rust file(s) could be parsed",
+                scan.files_seen
+            ),
+        );
+    };
+
+    if *worst > max_complexity {
+        return (
+            false,
+            format!(
+                "✗ Complexity: {} in {} has cyclomatic {} (> {}); measured {} function(s) in {} of {} file(s)",
+                function, file, worst, max_complexity,
+                scan.functions_measured, scan.files_measured, scan.files_seen
+            ),
+        );
+    }
+
+    (
+        true,
+        format!(
+            "✓ Complexity: max cyclomatic {} (≤ {}); measured {} function(s) in {} of {} file(s)",
+            worst, max_complexity, scan.functions_measured, scan.files_measured, scan.files_seen
+        ),
+    )
+}
+
+/// Execute complexity gate
+///
+/// This gate used to ignore `project_dir` entirely: it set `let passed = true;`
+/// under the comment "Simplified: Assume complexity passes" and then printed
+/// the *configured* threshold back as if it had been measured. With
+/// `max_complexity = 0` pointed at a 4000-file tree it still reported
+/// `passed: true, "✓ Complexity: All functions <0"`. It now parses the tree and
+/// compares the real worst cyclomatic count, and refuses to pass when it could
+/// not measure anything.
 ///
 /// # Complexity
-/// - Time: O(1) - placeholder implementation
+/// - Time: O(codebase size)
 /// - Cyclomatic: 2
 #[provable_contracts_macros::contract("pmat-core.yaml", equation = "path_exists")]
-pub fn execute_complexity(config: &GateConfig, _project_dir: &Path) -> Result<GateResult> {
+pub fn execute_complexity(config: &GateConfig, project_dir: &Path) -> Result<GateResult> {
     use std::time::Instant;
 
     let start = Instant::now();
-
-    // Simplified: Assume complexity passes
-    // Full implementation would run pmat analyze and parse results
-    let passed = true;
+    let scan = scan_rust_complexity(project_dir);
     let duration = start.elapsed();
+
+    let (passed, message) = build_complexity_decision(&scan, config.max_complexity);
 
     Ok(GateResult {
         name: "complexity".to_string(),
         passed,
         duration,
-        message: format!("✓ Complexity: All functions <{}", config.max_complexity),
+        message,
     })
+}
+
+#[cfg(test)]
+mod complexity_gate_tests {
+    use super::*;
+
+    fn scan_with_worst(cyclomatic: u32) -> ComplexityScan {
+        ComplexityScan {
+            files_seen: 1,
+            files_measured: 1,
+            functions_measured: 1,
+            worst: Some(("src/lib.rs".to_string(), "complex".to_string(), cyclomatic)),
+        }
+    }
+
+    #[test]
+    fn test_complexity_gate_fails_when_worst_exceeds_threshold() {
+        // Regression: the gate used to hardcode `passed = true`, so a
+        // max_complexity of 0 passed over any tree.
+        let (passed, message) = build_complexity_decision(&scan_with_worst(6), 0);
+        assert!(!passed, "cyclomatic 6 must not pass a threshold of 0");
+        assert!(message.contains("complex"), "message names the offender: {message}");
+    }
+
+    #[test]
+    fn test_complexity_gate_passes_when_under_threshold() {
+        let (passed, message) = build_complexity_decision(&scan_with_worst(6), 10);
+        assert!(passed);
+        assert!(message.contains("max cyclomatic 6"), "{message}");
+    }
+
+    #[test]
+    fn test_complexity_gate_refuses_to_pass_when_nothing_measured() {
+        let scan = ComplexityScan {
+            files_seen: 3,
+            ..Default::default()
+        };
+        let (passed, message) = build_complexity_decision(&scan, 10);
+        assert!(!passed, "a gate that measured nothing has not passed");
+        assert!(message.contains("not measured"), "{message}");
+    }
+
+    #[test]
+    fn test_execute_complexity_measures_the_real_tree() {
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(
+            dir.path().join("lib.rs"),
+            "pub fn complex(n: u32) -> u32 {\n    let mut acc = 0;\n    for i in 0..n {\n        if i % 2 == 0 { acc += i; }\n        else if i % 3 == 0 { acc += i * 2; }\n        else if i % 5 == 0 { acc += i * 3; }\n        else if i % 7 == 0 { acc += i * 4; }\n        else { acc += 1; }\n    }\n    acc\n}\n",
+        )
+        .unwrap();
+
+        let config = GateConfig {
+            max_complexity: 0,
+            ..Default::default()
+        };
+        let result = execute_complexity(&config, dir.path()).unwrap();
+        assert!(
+            !result.passed,
+            "every function exceeds max_complexity 0: {}",
+            result.message
+        );
+        assert!(result.message.contains("complex"), "{}", result.message);
+
+        let lenient = GateConfig {
+            max_complexity: 100,
+            ..Default::default()
+        };
+        let result = execute_complexity(&lenient, dir.path()).unwrap();
+        assert!(result.passed, "{}", result.message);
+    }
+
+    #[test]
+    fn test_execute_complexity_does_not_pass_an_empty_tree() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let result = execute_complexity(&GateConfig::default(), dir.path()).unwrap();
+        assert!(!result.passed);
+        assert!(result.message.contains("not measured"), "{}", result.message);
+    }
 }

--- a/src/roadmap/commands/commands_status.rs
+++ b/src/roadmap/commands/commands_status.rs
@@ -18,36 +18,118 @@ async fn show_status(
     Ok(())
 }
 
+/// `--format junit` has no meaning here: a roadmap status is not a test run, and
+/// synthesising testcases from tasks would report a result nobody measured.
+/// Reject it by name rather than silently rendering the human table.
+fn reject_unsupported_status_format(format: OutputFormat) -> Result<()> {
+    if matches!(format, OutputFormat::Junit) {
+        anyhow::bail!(
+            "`roadmap status --format junit` is not supported: a roadmap status has no test \
+             cases to report. Use table, json, yaml, markdown, csv, summary, text or plain."
+        );
+    }
+    Ok(())
+}
+
 fn show_task_status(roadmap: &Roadmap, task_id: &str, format: OutputFormat) -> Result<()> {
     let task = roadmap
         .get_task(task_id)
         .context(format!("Task {task_id} not found"))?;
 
-    match format {
-        OutputFormat::Json => {
-            println!("{}", serde_json::to_string_pretty(task)?);
-        }
-        _ => {
-            display_task_details(task);
-        }
-    }
-
+    println!("{}", format_task_status(task, format)?);
     Ok(())
 }
 
-fn display_task_details(task: &Task) {
-    println!("Task {}: {}", task.id, task.status.to_emoji());
-    println!("  Description: {}", task.description);
-    println!("  Complexity: {:?}", task.complexity);
-    println!("  Priority: {:?}", task.priority);
+/// Render one task in the requested format.
+///
+/// Eight of the nine advertised `--format` values used to fall through a bare
+/// `_ =>` arm onto the human table, so `yaml`, `markdown`, `csv` and `summary`
+/// were byte-identical to `table` — a flag that parses but changes nothing.
+fn format_task_status(task: &Task, format: OutputFormat) -> Result<String> {
+    use std::fmt::Write as _;
+
+    reject_unsupported_status_format(format)?;
+
+    let mut out = String::new();
+    match format {
+        OutputFormat::Json => out.push_str(&serde_json::to_string_pretty(task)?),
+        OutputFormat::Yaml => out.push_str(&serde_yaml_ng::to_string(task)?),
+        OutputFormat::Csv => {
+            out.push_str(
+                "id,status,complexity,priority,assignee,started_at,completed_at,description\n",
+            );
+            let _ = writeln!(
+                out,
+                "{},{:?},{:?},{:?},{},{},{},{}",
+                task.id,
+                task.status,
+                task.complexity,
+                task.priority,
+                task.assignee.as_deref().unwrap_or(""),
+                task.started_at.map(|d| d.to_rfc3339()).unwrap_or_default(),
+                task.completed_at.map(|d| d.to_rfc3339()).unwrap_or_default(),
+                csv_field(&task.description),
+            );
+        }
+        OutputFormat::Markdown => {
+            let _ = writeln!(out, "# Task {}\n", task.id);
+            let _ = writeln!(out, "- **Status**: {:?}", task.status);
+            let _ = writeln!(out, "- **Description**: {}", task.description);
+            let _ = writeln!(out, "- **Complexity**: {:?}", task.complexity);
+            let _ = writeln!(out, "- **Priority**: {:?}", task.priority);
+            if let Some(assignee) = &task.assignee {
+                let _ = writeln!(out, "- **Assignee**: {assignee}");
+            }
+            if let Some(started) = task.started_at {
+                let _ = writeln!(out, "- **Started**: {}", started.format("%Y-%m-%d %H:%M"));
+            }
+            if let Some(completed) = task.completed_at {
+                let _ = writeln!(
+                    out,
+                    "- **Completed**: {}",
+                    completed.format("%Y-%m-%d %H:%M")
+                );
+            }
+        }
+        OutputFormat::Summary => {
+            let _ = write!(
+                out,
+                "{} [{:?}] {}",
+                task.id, task.status, task.description
+            );
+        }
+        _ => out.push_str(&render_task_details(task)),
+    }
+    Ok(out)
+}
+
+/// Escape a value for the CSV renderers: quote when it carries a delimiter.
+fn csv_field(value: &str) -> String {
+    if value.contains([',', '"', '\n']) {
+        format!("\"{}\"", value.replace('"', "\"\""))
+    } else {
+        value.to_string()
+    }
+}
+
+fn render_task_details(task: &Task) -> String {
+    use std::fmt::Write as _;
+
+    let mut out = String::new();
+    let _ = writeln!(out, "Task {}: {}", task.id, task.status.to_emoji());
+    let _ = writeln!(out, "  Description: {}", task.description);
+    let _ = writeln!(out, "  Complexity: {:?}", task.complexity);
+    let _ = write!(out, "  Priority: {:?}", task.priority);
 
     if let Some(started) = task.started_at {
-        println!("  Started: {}", started.format("%Y-%m-%d %H:%M"));
+        let _ = write!(out, "\n  Started: {}", started.format("%Y-%m-%d %H:%M"));
     }
 
     if let Some(completed) = task.completed_at {
-        println!("  Completed: {}", completed.format("%Y-%m-%d %H:%M"));
+        let _ = write!(out, "\n  Completed: {}", completed.format("%Y-%m-%d %H:%M"));
     }
+
+    out
 }
 
 async fn show_sprint_status(
@@ -63,30 +145,100 @@ async fn show_sprint_status(
         .get_sprint(sprint_id)
         .context(format!("Sprint {sprint_id} not found"))?;
 
-    match format {
-        OutputFormat::Json => {
-            println!("{}", serde_json::to_string_pretty(sprint)?);
-        }
-        _ => {
-            display_sprint_details(sprint);
-        }
-    }
-
+    println!("{}", format_sprint_status(sprint, format)?);
     Ok(())
 }
 
-fn display_sprint_details(sprint: &Sprint) {
+/// Render one sprint in the requested format. See [`format_task_status`] for the
+/// defect this replaced: every non-json value collapsed onto the human table.
+fn format_sprint_status(sprint: &Sprint, format: OutputFormat) -> Result<String> {
+    use std::fmt::Write as _;
+
+    reject_unsupported_status_format(format)?;
+
+    let (completed, in_progress, total) = calculate_sprint_progress(sprint);
+    let mut out = String::new();
+    match format {
+        OutputFormat::Json => out.push_str(&serde_json::to_string_pretty(sprint)?),
+        OutputFormat::Yaml => out.push_str(&serde_yaml_ng::to_string(sprint)?),
+        OutputFormat::Csv => {
+            out.push_str("sprint,task_id,status,complexity,priority,description\n");
+            for task in &sprint.tasks {
+                let _ = writeln!(
+                    out,
+                    "{},{},{:?},{:?},{:?},{}",
+                    sprint.version,
+                    task.id,
+                    task.status,
+                    task.complexity,
+                    task.priority,
+                    csv_field(&task.description),
+                );
+            }
+        }
+        OutputFormat::Markdown => {
+            let _ = writeln!(out, "# Sprint {}: {}\n", sprint.version, sprint.title);
+            let _ = writeln!(
+                out,
+                "- **Duration**: {} to {}",
+                sprint.start_date.format("%Y-%m-%d"),
+                sprint.end_date.format("%Y-%m-%d")
+            );
+            let _ = writeln!(
+                out,
+                "- **Progress**: {completed}/{total} completed, {in_progress} in progress\n"
+            );
+            out.push_str("| Task | Status | Description |\n| --- | --- | --- |\n");
+            for task in &sprint.tasks {
+                let _ = writeln!(
+                    out,
+                    "| {} | {:?} | {} |",
+                    task.id, task.status, task.description
+                );
+            }
+        }
+        OutputFormat::Summary => {
+            let _ = write!(
+                out,
+                "Sprint {}: {} — {completed}/{total} completed, {in_progress} in progress",
+                sprint.version, sprint.title
+            );
+        }
+        _ => out.push_str(&render_sprint_details(sprint)),
+    }
+    Ok(out)
+}
+
+fn render_sprint_details(sprint: &Sprint) -> String {
+    use std::fmt::Write as _;
+
     let (completed, in_progress, total) = calculate_sprint_progress(sprint);
 
-    println!("Sprint {}: {}", sprint.version, sprint.title);
-    println!(
+    let mut out = String::new();
+    let _ = writeln!(out, "Sprint {}: {}", sprint.version, sprint.title);
+    let _ = writeln!(
+        out,
         "  Duration: {} to {}",
         sprint.start_date.format("%Y-%m-%d"),
         sprint.end_date.format("%Y-%m-%d")
     );
-    println!("  Progress: {completed}/{total} completed, {in_progress} in progress");
+    let _ = writeln!(
+        out,
+        "  Progress: {completed}/{total} completed, {in_progress} in progress"
+    );
 
-    display_sprint_tasks(sprint);
+    out.push_str("\n  Tasks:");
+    for task in &sprint.tasks {
+        let _ = write!(
+            out,
+            "\n    {} {} - {}",
+            task.status.to_emoji(),
+            task.id,
+            task.description
+        );
+    }
+
+    out
 }
 
 fn calculate_sprint_progress(sprint: &Sprint) -> (usize, usize, usize) {
@@ -105,16 +257,4 @@ fn calculate_sprint_progress(sprint: &Sprint) -> (usize, usize, usize) {
     let total = sprint.tasks.len();
 
     (completed, in_progress, total)
-}
-
-fn display_sprint_tasks(sprint: &Sprint) {
-    println!("\n  Tasks:");
-    for task in &sprint.tasks {
-        println!(
-            "    {} {} - {}",
-            task.status.to_emoji(),
-            task.id,
-            task.description
-        );
-    }
 }

--- a/src/roadmap/commands/commands_status_tests.rs
+++ b/src/roadmap/commands/commands_status_tests.rs
@@ -1,0 +1,169 @@
+// Regression tests for `roadmap status --format`
+// Included from mod.rs - shares parent module scope
+
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg(test)]
+mod status_format_tests {
+    //! `roadmap status` advertises nine `--format` values but implemented one:
+    //! table, yaml, markdown, csv, summary, text, plain and junit all fell
+    //! through a bare `_ =>` arm onto the human table and were byte-identical
+    //! (8 of 9 shared a single md5). `stack status` already supported yaml, so
+    //! the two commands contradicted each other about what `--format yaml` did.
+    use super::*;
+    use crate::roadmap::{Complexity, Priority};
+    use chrono::TimeZone;
+
+    fn task(id: &str, status: TaskStatus) -> Task {
+        Task {
+            id: id.to_string(),
+            description: "Ship the thing".to_string(),
+            status,
+            complexity: Complexity::Medium,
+            priority: Priority::P0,
+            assignee: None,
+            started_at: None,
+            completed_at: None,
+        }
+    }
+
+    fn sprint() -> Sprint {
+        Sprint {
+            version: "1.2.0".to_string(),
+            title: "Hardening".to_string(),
+            start_date: Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap(),
+            end_date: Utc.with_ymd_and_hms(2026, 1, 14, 0, 0, 0).unwrap(),
+            priority: Priority::P0,
+            tasks: vec![
+                task("PMAT-1", TaskStatus::Completed),
+                task("PMAT-2", TaskStatus::InProgress),
+            ],
+            definition_of_done: vec![],
+            quality_gates: vec![],
+        }
+    }
+
+    const RENDERED: [OutputFormat; 7] = [
+        OutputFormat::Table,
+        OutputFormat::Json,
+        OutputFormat::Yaml,
+        OutputFormat::Markdown,
+        OutputFormat::Csv,
+        OutputFormat::Summary,
+        OutputFormat::Text,
+    ];
+
+    #[test]
+    fn sprint_formats_are_distinct_not_one_table_repeated() {
+        let rendered: Vec<String> = RENDERED
+            .iter()
+            .map(|f| format_sprint_status(&sprint(), *f).expect("format must render"))
+            .collect();
+        // table/text/plain are legitimately the same human rendering; every
+        // machine format must differ from it and from each other.
+        let table = &rendered[0];
+        for (fmt, out) in RENDERED.iter().zip(&rendered) {
+            if matches!(fmt, OutputFormat::Table | OutputFormat::Text) {
+                continue;
+            }
+            assert_ne!(
+                out, table,
+                "--format {fmt} must not be the human table verbatim"
+            );
+        }
+    }
+
+    #[test]
+    fn sprint_yaml_is_yaml() {
+        let out = format_sprint_status(&sprint(), OutputFormat::Yaml).unwrap();
+        assert!(out.contains("version: 1.2.0"), "{out}");
+        assert!(out.contains("title: Hardening"), "{out}");
+        let parsed: serde_yaml_ng::Value = serde_yaml_ng::from_str(&out).expect("valid YAML");
+        assert!(parsed.get("tasks").is_some(), "{out}");
+    }
+
+    #[test]
+    fn sprint_csv_has_a_header_and_a_row_per_task() {
+        let out = format_sprint_status(&sprint(), OutputFormat::Csv).unwrap();
+        let lines: Vec<&str> = out.lines().collect();
+        assert_eq!(
+            lines[0],
+            "sprint,task_id,status,complexity,priority,description"
+        );
+        assert_eq!(lines.len(), 3, "header + one row per task, got {out}");
+        assert!(lines[1].starts_with("1.2.0,PMAT-1,Completed"), "{out}");
+    }
+
+    #[test]
+    fn sprint_markdown_is_markdown() {
+        let out = format_sprint_status(&sprint(), OutputFormat::Markdown).unwrap();
+        assert!(out.starts_with("# Sprint 1.2.0: Hardening"), "{out}");
+        assert!(out.contains("| Task | Status | Description |"), "{out}");
+    }
+
+    #[test]
+    fn sprint_summary_is_one_line() {
+        let out = format_sprint_status(&sprint(), OutputFormat::Summary).unwrap();
+        assert_eq!(out.lines().count(), 1, "{out}");
+        assert!(out.contains("1/2 completed, 1 in progress"), "{out}");
+    }
+
+    #[test]
+    fn sprint_junit_is_rejected_rather_than_silently_ignored() {
+        let err = format_sprint_status(&sprint(), OutputFormat::Junit)
+            .expect_err("junit must not render a human table");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("junit"), "the error must name the format: {msg}");
+    }
+
+    #[test]
+    fn task_formats_are_distinct_not_one_table_repeated() {
+        let t = task("PMAT-9", TaskStatus::InProgress);
+        let table = format_task_status(&t, OutputFormat::Table).unwrap();
+        for fmt in [
+            OutputFormat::Json,
+            OutputFormat::Yaml,
+            OutputFormat::Markdown,
+            OutputFormat::Csv,
+            OutputFormat::Summary,
+        ] {
+            let out = format_task_status(&t, fmt).unwrap();
+            assert_ne!(
+                out, table,
+                "--format {fmt} must not be the human table verbatim"
+            );
+        }
+    }
+
+    #[test]
+    fn task_yaml_csv_and_summary_carry_the_task() {
+        let t = task("PMAT-9", TaskStatus::InProgress);
+        let yaml = format_task_status(&t, OutputFormat::Yaml).unwrap();
+        assert!(yaml.contains("id: PMAT-9"), "{yaml}");
+
+        let csv = format_task_status(&t, OutputFormat::Csv).unwrap();
+        let lines: Vec<&str> = csv.lines().collect();
+        assert_eq!(
+            lines[0],
+            "id,status,complexity,priority,assignee,started_at,completed_at,description"
+        );
+        assert!(lines[1].starts_with("PMAT-9,InProgress"), "{csv}");
+
+        let summary = format_task_status(&t, OutputFormat::Summary).unwrap();
+        assert_eq!(summary, "PMAT-9 [InProgress] Ship the thing");
+    }
+
+    #[test]
+    fn task_junit_is_rejected() {
+        assert!(
+            format_task_status(&task("PMAT-9", TaskStatus::Planned), OutputFormat::Junit).is_err()
+        );
+    }
+
+    #[test]
+    fn csv_fields_with_commas_are_quoted() {
+        let mut t = task("PMAT-9", TaskStatus::Planned);
+        t.description = "fix a, b and \"c\"".to_string();
+        let csv = format_task_status(&t, OutputFormat::Csv).unwrap();
+        assert!(csv.contains("\"fix a, b and \"\"c\"\"\""), "{csv}");
+    }
+}

--- a/src/roadmap/commands/commands_validation.rs
+++ b/src/roadmap/commands/commands_validation.rs
@@ -1,6 +1,45 @@
 // Validation and quality check commands
 // Included from mod.rs - shares parent module scope
 
+/// What `roadmap validate` could actually establish about a sprint.
+///
+/// The verdict used to be computed from `incomplete_tasks` alone, so a sprint
+/// with eight unchecked Definition-of-Done items — and a sprint with no tasks at
+/// all — both printed "ready for release!".
+#[derive(Debug, PartialEq, Eq)]
+enum SprintReadiness {
+    /// Every task complete and nothing left unevaluated.
+    Ready,
+    /// The sprint carries no tasks, so "all tasks completed" is vacuous.
+    NoTasks,
+    /// At least one task is not Completed.
+    IncompleteTasks(usize),
+    /// Tasks are done, but pmat holds no completion state for the sprint's
+    /// Definition-of-Done items / quality gates, so readiness is not certified.
+    Unverified { dod: usize, gates: usize },
+}
+
+fn assess_sprint_readiness(
+    total_tasks: usize,
+    incomplete_tasks: usize,
+    unevaluated_dod: usize,
+    unevaluated_gates: usize,
+) -> SprintReadiness {
+    if total_tasks == 0 {
+        return SprintReadiness::NoTasks;
+    }
+    if incomplete_tasks > 0 {
+        return SprintReadiness::IncompleteTasks(incomplete_tasks);
+    }
+    if unevaluated_dod > 0 || unevaluated_gates > 0 {
+        return SprintReadiness::Unverified {
+            dod: unevaluated_dod,
+            gates: unevaluated_gates,
+        };
+    }
+    SprintReadiness::Ready
+}
+
 async fn validate_sprint(
     roadmap_path: &Path,
     sprint_id: &str,
@@ -14,8 +53,6 @@ async fn validate_sprint(
         .get_sprint(sprint_id)
         .context(format!("Sprint {sprint_id} not found"))?;
 
-    let mut all_passed = true;
-
     // Check all tasks completed
     let incomplete_tasks: Vec<_> = sprint
         .tasks
@@ -23,52 +60,111 @@ async fn validate_sprint(
         .filter(|t| t.status != TaskStatus::Completed)
         .collect();
 
-    if incomplete_tasks.is_empty() {
+    if sprint.tasks.is_empty() {
+        println!("⚠️  Sprint has no tasks — there is nothing to validate");
+    } else if incomplete_tasks.is_empty() {
         println!("✅ All tasks completed");
     } else {
         println!("❌ Incomplete tasks:");
-        for task in incomplete_tasks {
+        for task in &incomplete_tasks {
             println!("    {} - {}", task.id, task.description);
         }
-        all_passed = false;
     }
 
-    // Check definition of done
-    println!("\n📋 Definition of Done:");
-    for item in &sprint.definition_of_done {
-        println!("  - [ ] {item}");
+    // Definition of Done: these were rendered as "- [ ]" — a literal unchecked
+    // box, printed whatever the real state was, and never folded into the
+    // verdict. A `Sprint` stores no completion state for them, so render them
+    // as what they are (a list pmat cannot check) rather than as a checkbox
+    // whose state is invented.
+    if !sprint.definition_of_done.is_empty() {
+        println!("\n📋 Definition of Done (pmat holds no completion state for these):");
+        for item in &sprint.definition_of_done {
+            println!("  • {item}");
+        }
     }
 
-    // Check quality gates
-    if config.enforce_quality_gates {
-        println!("\n🔍 Quality Gates:");
+    let evaluated_gates = config.enforce_quality_gates;
+    if evaluated_gates && !sprint.quality_gates.is_empty() {
+        // Same defect, same fix: the loop only printed the gate names.
+        println!("\n🔍 Quality Gates (declared, not evaluated here — run `pmat roadmap quality-check`):");
         for gate in &sprint.quality_gates {
-            println!("  - [ ] {gate}");
+            println!("  • {gate}");
         }
     }
 
-    if all_passed {
-        println!("\n✅ Sprint {sprint_id} is ready for release!");
+    let unevaluated_gates = if evaluated_gates {
+        sprint.quality_gates.len()
     } else {
-        println!("\n❌ Sprint {sprint_id} is NOT ready for release");
-        if strict {
-            anyhow::bail!("Sprint validation failed");
+        0
+    };
+
+    let readiness = assess_sprint_readiness(
+        sprint.tasks.len(),
+        incomplete_tasks.len(),
+        sprint.definition_of_done.len(),
+        unevaluated_gates,
+    );
+
+    match readiness {
+        SprintReadiness::Ready => {
+            println!("\n✅ Sprint {sprint_id} is ready for release!");
+            Ok(())
+        }
+        SprintReadiness::NoTasks => {
+            println!("\n❌ Sprint {sprint_id}: no tasks to validate — readiness not established");
+            anyhow::bail!("Sprint {sprint_id} has no tasks; readiness cannot be established")
+        }
+        SprintReadiness::IncompleteTasks(n) => {
+            println!("\n❌ Sprint {sprint_id} is NOT ready for release ({n} incomplete task(s))");
+            // `--strict` used to be the only way this exited nonzero. A
+            // validation command that exits 0 on a failed validation is a gate
+            // that always passes, so the failure is now reported either way and
+            // --strict only changes the wording.
+            if strict {
+                anyhow::bail!("Sprint validation failed (strict)");
+            }
+            anyhow::bail!("Sprint {sprint_id} is not ready for release: {n} incomplete task(s)")
+        }
+        SprintReadiness::Unverified { dod, gates } => {
+            println!(
+                "\n❌ Sprint {sprint_id}: readiness NOT certified — {dod} Definition-of-Done \
+                 item(s) and {gates} quality gate(s) are not evaluated by pmat"
+            );
+            anyhow::bail!(
+                "Sprint {sprint_id} readiness cannot be certified: {dod} definition-of-done item(s) \
+                 and {gates} quality gate(s) are unevaluated"
+            )
         }
     }
-
-    Ok(())
 }
 
 async fn quality_check(task_id: &str, config: &RoadmapConfig) -> Result<()> {
-    println!("🔍 Running quality checks for task {task_id}...");
+    // The id used to appear in nothing but the two println!s: `quality-check
+    // --task-id TOTALLY-MADE-UP` passed, and its output differed from a real
+    // id's by exactly those two lines. Resolve it against the roadmap first.
+    let roadmap = Roadmap::from_file(&config.path)?;
+    if roadmap.get_task(task_id).is_none() {
+        anyhow::bail!(
+            "unknown task '{task_id}' — not found in {}",
+            config.path.display()
+        );
+    }
 
-    // Run complexity check
+    // The checks below are repo-wide: a roadmap `Task` carries no file list, so
+    // there is nothing to scope them to. Say that rather than letting the
+    // heading imply the checks were about this task's code.
+    println!("🔍 Running repo-wide quality checks for task {task_id}...");
+
+    // Run complexity check. `--fail-on-violation` is what makes this a check:
+    // without it `pmat analyze complexity` prints its findings and exits 0, so
+    // the "Complexity check passed" line below was unconditional.
     let complexity_result = std::process::Command::new("pmat")
         .args([
             "analyze",
             "complexity",
             "--max-cyclomatic",
             &config.quality_gates.complexity_max.to_string(),
+            "--fail-on-violation",
         ])
         .output()?;
 
@@ -102,4 +198,76 @@ async fn quality_check(task_id: &str, config: &RoadmapConfig) -> Result<()> {
 
     println!("✅ All quality checks passed for task {task_id}");
     Ok(())
+}
+
+#[cfg(test)]
+mod validation_verdict_tests {
+    use super::{assess_sprint_readiness, quality_check, RoadmapConfig, SprintReadiness};
+
+    #[test]
+    fn a_sprint_with_no_tasks_is_not_ready() {
+        // `roadmap validate --sprint v2.18.0` printed "All tasks completed"
+        // and "ready for release!" for a sprint with no task rows at all.
+        assert_eq!(
+            assess_sprint_readiness(0, 0, 0, 0),
+            SprintReadiness::NoTasks
+        );
+    }
+
+    #[test]
+    fn unevaluated_definition_of_done_blocks_the_ready_verdict() {
+        // `--sprint v2.6.0`: every task complete, eight DoD items rendered as a
+        // literal "- [ ]", verdict "ready for release!".
+        assert_eq!(
+            assess_sprint_readiness(4, 0, 8, 0),
+            SprintReadiness::Unverified { dod: 8, gates: 0 }
+        );
+    }
+
+    #[test]
+    fn unevaluated_quality_gates_block_the_ready_verdict() {
+        assert_eq!(
+            assess_sprint_readiness(4, 0, 0, 3),
+            SprintReadiness::Unverified { dod: 0, gates: 3 }
+        );
+    }
+
+    #[test]
+    fn incomplete_tasks_still_dominate_the_verdict() {
+        assert_eq!(
+            assess_sprint_readiness(4, 2, 8, 3),
+            SprintReadiness::IncompleteTasks(2)
+        );
+    }
+
+    #[test]
+    fn ready_requires_tasks_done_and_nothing_left_unevaluated() {
+        assert_eq!(assess_sprint_readiness(4, 0, 0, 0), SprintReadiness::Ready);
+    }
+
+    #[tokio::test]
+    async fn quality_check_rejects_an_unknown_task_id() {
+        // `roadmap quality-check --task-id TOTALLY-MADE-UP` exited 0 with
+        // "All quality checks passed for task TOTALLY-MADE-UP".
+        let dir = tempfile::tempdir().unwrap();
+        let roadmap_path = dir.path().join("roadmap.md");
+        std::fs::write(
+            &roadmap_path,
+            "# Roadmap\n\n## Sprint v1.0.0: Test\n\n### Tasks\n\n- [ ] PMAT-0001: Real task\n",
+        )
+        .unwrap();
+
+        let config = RoadmapConfig {
+            path: roadmap_path,
+            ..Default::default()
+        };
+
+        let err = quality_check("TOTALLY-MADE-UP", &config)
+            .await
+            .expect_err("an unresolvable task id must fail the check");
+        assert!(
+            err.to_string().contains("unknown task"),
+            "unexpected error: {err}"
+        );
+    }
 }

--- a/src/roadmap/commands/mod.rs
+++ b/src/roadmap/commands/mod.rs
@@ -139,6 +139,9 @@ include!("commands_tasks.rs");
 include!("commands_status.rs");
 include!("commands_validation.rs");
 
+// Regression tests for `roadmap status --format`
+include!("commands_status_tests.rs");
+
 // TEMPORARILY DISABLED: File splitting broke syntax
 #[cfg(all(test, feature = "broken-tests"))]
 #[path = "tests.rs"]

--- a/src/scaffold/agent/templates_mcp_generation.rs
+++ b/src/scaffold/agent/templates_mcp_generation.rs
@@ -61,6 +61,15 @@ impl TemplateGenerator for MCPServerTemplate {
     }
 }
 
+/// The manifest declares only targets the scaffold actually writes.
+///
+/// It used to end with `[[bench]] name = "performance"` while no `benches/`
+/// directory was ever generated, so the scaffolded project was dead on arrival:
+/// `cargo check` failed at manifest PARSE time with "can't find `performance`
+/// bench at `benches/performance.rs`", before a single line of the generated
+/// code was compiled. A declared target with no file (and the criterion
+/// dev-dependency that only existed to serve it) is a promise the scaffold does
+/// not keep.
 fn generate_mcp_cargo_toml(ctx: &AgentContext) -> String {
     format!(
         r#"[package]
@@ -81,11 +90,6 @@ tracing-subscriber = {{ version = "0.3", features = ["env-filter"] }}
 [dev-dependencies]
 proptest = "1.5"
 tokio-test = "0.4"
-criterion = "0.5"
-
-[[bench]]
-name = "performance"
-harness = false
 "#,
         ctx.name
     )
@@ -136,6 +140,12 @@ pub mod transport;
     .to_string()
 }
 
+// None of the generated sources below carry a
+// `#[provable_contracts_macros::contract(...)]` attribute any more. pmat's own
+// sources do, and the attribute was copied into the templates — but
+// `provable_contracts_macros` is not among the `[dependencies]` the scaffold
+// writes, so every generated file that used it failed to resolve the macro
+// crate. Generated code may only use what the generated manifest declares.
 fn generate_mcp_server(ctx: &AgentContext) -> String {
     format!(
         r#"//! MCP server implementation for {}.
@@ -149,7 +159,6 @@ use super::tools::register_tools;
 use super::transport::create_transport;
 
 /// Run the MCP server.
-#[provable_contracts_macros::contract("pmat-core.yaml", equation = "check_compliance")]
 pub async fn run() -> Result<()> {{
     let transport = create_transport().await?;
     let agent = AgentCore::new();
@@ -181,7 +190,6 @@ use serde_json::Value;
 use crate::agent::core::AgentCore;
 
 /// Register all tools with the MCP server.
-#[provable_contracts_macros::contract("pmat-core.yaml", equation = "check_compliance")]
 pub fn register_tools(server: &Server, agent: AgentCore) -> Result<()> {
     // Register analyze tool
     server.register_tool(Tool {
@@ -218,7 +226,6 @@ use anyhow::Result;
 use pmcp::transport::{StdioTransport, Transport};
 
 /// Create the transport layer for the MCP server.
-#[provable_contracts_macros::contract("pmat-core.yaml", equation = "check_compliance")]
 pub async fn create_transport() -> Result<Box<dyn Transport>> {
     Ok(Box::new(StdioTransport::new()))
 }
@@ -265,7 +272,6 @@ impl AgentCore {{
     }}
 
     /// Analyze input data.
-    #[provable_contracts_macros::contract("pmat-core.yaml", equation = "check_compliance")]
     pub async fn analyze(&self, params: Value) -> Result<Value> {{
         // Implementation here
         Ok(serde_json::json!({{
@@ -286,7 +292,6 @@ use anyhow::Result;
 use serde_json::Value;
 
 /// Handle a request.
-#[provable_contracts_macros::contract("pmat-core.yaml", equation = "check_compliance")]
 pub async fn handle_request(request: Value) -> Result<Value> {
     // Implementation here
     Ok(serde_json::json!({
@@ -451,4 +456,108 @@ This agent follows {} quality standards.
             QualityLevel::Extreme => "Toyota Way extreme",
         }
     )
+}
+
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg(test)]
+mod mcp_scaffold_manifest_tests {
+    use super::*;
+
+    fn generate_mcp_project(quality: QualityLevel) -> GeneratedFiles {
+        MCPServerTemplate::default()
+            .generate(&AgentContext {
+                name: "ag".to_string(),
+                template_type: AgentTemplate::MCPToolServer,
+                features: Default::default(),
+                quality_level: quality,
+                deterministic_core: None,
+                probabilistic_wrapper: None,
+            })
+            .expect("mcp-server template must generate")
+    }
+
+    /// Collect `(target directory, target name)` for every `[[bench]]`,
+    /// `[[bin]]` and `[[example]]` section declared in a manifest.
+    fn declared_targets(manifest: &str) -> Vec<(&'static str, String)> {
+        let mut targets = Vec::new();
+        let mut section: Option<&'static str> = None;
+        for line in manifest.lines() {
+            let trimmed = line.trim();
+            match trimmed {
+                "[[bench]]" => section = Some("benches"),
+                "[[bin]]" => section = Some("src/bin"),
+                "[[example]]" => section = Some("examples"),
+                _ if trimmed.starts_with('[') => section = None,
+                _ => {
+                    if let (Some(dir), Some(rest)) = (section, trimmed.strip_prefix("name")) {
+                        let name = rest.trim_start_matches(['=', ' ']).trim_matches('"');
+                        targets.push((dir, name.to_string()));
+                    }
+                }
+            }
+        }
+        targets
+    }
+
+    /// The generated manifest declared `[[bench]] name = "performance"` while
+    /// the scaffold wrote no `benches/` directory, so `cargo check` in a freshly
+    /// scaffolded project died before compiling anything: "can't find
+    /// `performance` bench at `benches/performance.rs`". A manifest that cannot
+    /// be parsed is a project that was never generated.
+    #[test]
+    fn every_declared_target_has_a_generated_file() {
+        for quality in [
+            QualityLevel::Standard,
+            QualityLevel::Strict,
+            QualityLevel::Extreme,
+        ] {
+            let files = generate_mcp_project(quality);
+            let manifest = files
+                .files
+                .get(&PathBuf::from("Cargo.toml"))
+                .expect("Cargo.toml generated")
+                .as_str()
+                .expect("text manifest")
+                .to_string();
+
+            for (dir, name) in declared_targets(&manifest) {
+                let expected = PathBuf::from(format!("{dir}/{name}.rs"));
+                assert!(
+                    files.files.contains_key(&expected),
+                    "manifest declares {dir} target {name:?} but {} was never generated",
+                    expected.display()
+                );
+            }
+        }
+    }
+
+    /// `src/mcp/server.rs` (and four more generated files) carried
+    /// `#[provable_contracts_macros::contract(...)]`, copied from pmat's own
+    /// sources, while that crate appears nowhere in the generated
+    /// `[dependencies]`.
+    #[test]
+    fn generated_sources_use_only_declared_dependencies() {
+        let files = generate_mcp_project(QualityLevel::Extreme);
+        let manifest = files
+            .files
+            .get(&PathBuf::from("Cargo.toml"))
+            .expect("Cargo.toml generated")
+            .as_str()
+            .expect("text manifest")
+            .to_string();
+
+        for (path, content) in &files.files {
+            let Some(text) = content.as_str() else {
+                continue;
+            };
+            if !path.to_string_lossy().ends_with(".rs") {
+                continue;
+            }
+            assert!(
+                !text.contains("provable_contracts_macros"),
+                "{} uses provable_contracts_macros, which the manifest does not declare:\n{manifest}",
+                path.display()
+            );
+        }
+    }
 }

--- a/src/services/agent_context/function_index/build.rs
+++ b/src/services/agent_context/function_index/build.rs
@@ -22,6 +22,26 @@ fn has_coverage_off(content: &str) -> bool {
     })
 }
 
+/// One warning line per language whose files the chunker refused.
+///
+/// Files that fail to chunk used to vanish silently (`Err(_) => continue`): a
+/// tree holding `svc.go` and `util.py` indexed as `file_count: 1,
+/// languages: ["Python"]`, and `pmat_query_code language:"go"` answered
+/// `{"results":[],"total":0}` — indistinguishable from "your query matched
+/// nothing", when the real answer is that this build has no Go parser compiled
+/// in (`go-ast` is not in the default feature set). Naming the language, the
+/// count and the parser's own reason is what tells those two apart.
+fn format_skipped_summary(skipped: &HashMap<String, (usize, String)>) -> Vec<String> {
+    let mut by_language: Vec<(&String, &(usize, String))> = skipped.iter().collect();
+    by_language.sort_by(|a, b| a.0.cmp(b.0));
+    by_language
+        .into_iter()
+        .map(|(language, (count, reason))| {
+            format!("⚠️  Not indexed: {count} {language} file(s) could not be parsed ({reason})")
+        })
+        .collect()
+}
+
 /// Load cached coverage_off_files from SQLite metadata.
 fn load_coverage_off_files(conn: &rusqlite::Connection) -> HashSet<String> {
     let json: String = conn
@@ -53,6 +73,9 @@ impl AgentContextIndex {
         let mut languages_seen = HashMap::new();
         let mut file_checksums: HashMap<String, String> = HashMap::with_capacity(4_000);
         let mut coverage_off_files = HashSet::new();
+        // Language -> (how many files the chunker refused, the first reason it
+        // gave). Reported after the walk; see `format_skipped_summary`.
+        let mut skipped_by_language: HashMap<String, (usize, String)> = HashMap::new();
         // Reusable read buffer — avoids allocating a new String per file (~33 MB saved)
         let mut read_buf = String::with_capacity(32 * 1024);
 
@@ -104,10 +127,18 @@ impl AgentContextIndex {
                 coverage_off_files.insert(relative_path.clone());
             }
 
-            // Extract functions using AST chunker
+            // Extract functions using AST chunker. A refusal here is recorded,
+            // not swallowed — a language this build cannot parse must not look
+            // like a language that simply has no matches.
             let chunks = match chunk_code(content, language) {
                 Ok(c) => c,
-                Err(_) => continue, // Skip parse errors
+                Err(reason) => {
+                    let entry = skipped_by_language
+                        .entry(format!("{language:?}"))
+                        .or_insert((0, reason));
+                    entry.0 += 1;
+                    continue;
+                }
             };
 
             let lang_str = format!("{language:?}");
@@ -176,6 +207,9 @@ impl AgentContextIndex {
         }
         if file_count >= 500 {
             eprintln!("\r  Indexed {} files", file_count);
+        }
+        for line in format_skipped_summary(&skipped_by_language) {
+            eprintln!("{line}");
         }
 
         // Build indices and corpus
@@ -315,3 +349,59 @@ include!("build_persistence.rs");
 include!("build_incremental.rs");
 include!("build_accessors.rs");
 include!("build_helpers.rs");
+
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg(test)]
+mod skipped_file_reporting_tests {
+    use super::*;
+
+    /// The indexer used to drop every file its chunker refused with
+    /// `Err(_) => continue`, so a build without `go-ast` reported a Go+Python
+    /// tree as `file_count: 1, languages: ["Python"]` and said nothing at all
+    /// about the Go file it could not read.
+    #[test]
+    fn refused_files_are_counted_and_named_per_language() {
+        let mut skipped: HashMap<String, (usize, String)> = HashMap::new();
+        skipped.insert(
+            "Go".to_string(),
+            (2, "go-ast feature is disabled".to_string()),
+        );
+        skipped.insert("Lua".to_string(), (1, "parse error".to_string()));
+
+        let lines = format_skipped_summary(&skipped);
+
+        assert_eq!(lines.len(), 2, "{lines:?}");
+        // Deterministic order — the map's iteration order is not.
+        assert!(lines[0].contains("Go"), "{lines:?}");
+        assert!(lines[0].contains('2'), "{lines:?}");
+        assert!(
+            lines[0].contains("go-ast feature is disabled"),
+            "the parser's own reason must survive: {lines:?}"
+        );
+        assert!(lines[1].contains("Lua"), "{lines:?}");
+    }
+
+    #[test]
+    fn nothing_is_reported_when_every_file_parsed() {
+        assert!(format_skipped_summary(&HashMap::new()).is_empty());
+    }
+
+    /// The condition the report exists for: in a build without `go-ast`, Go
+    /// source really is refused, so `.go` files really are missing from the
+    /// index — which is exactly what must not happen silently.
+    #[cfg(not(feature = "go-ast"))]
+    #[test]
+    fn go_source_is_refused_by_this_build_and_therefore_reportable() {
+        let reason = crate::services::semantic::chunk_code(
+            "package main\n\nfunc main() {}\n",
+            crate::services::semantic::Language::Go,
+        )
+        .expect_err("a build without go-ast cannot chunk Go");
+
+        let mut skipped: HashMap<String, (usize, String)> = HashMap::new();
+        skipped.insert("Go".to_string(), (1, reason));
+        let lines = format_skipped_summary(&skipped);
+        assert_eq!(lines.len(), 1);
+        assert!(lines[0].contains("Go"), "{lines:?}");
+    }
+}

--- a/src/services/agent_context/query/engine.rs
+++ b/src/services/agent_context/query/engine.rs
@@ -69,3 +69,7 @@ include!("engine_scoring.rs");
 
 // --- impl AgentContextIndex: regex and literal search modes ---
 include!("engine_search.rs");
+
+#[cfg(test)]
+#[path = "path_pattern_glob_tests.rs"]
+mod path_pattern_glob_tests;

--- a/src/services/agent_context/query/engine_scoring.rs
+++ b/src/services/agent_context/query/engine_scoring.rs
@@ -200,9 +200,15 @@ impl AgentContextIndex {
             }
         }
 
-        // Path pattern filter
+        // Path pattern filter.
+        //
+        // The MCP schema calls this a "Path glob pattern filter", but the check
+        // was `file_path.contains(pattern)`: every glob metacharacter matched
+        // nothing, so `**/tdg/**` silently returned an empty set where the bare
+        // substring `src/tdg` returned five hits. `glob_matches` treats a
+        // pattern without `*` as a substring, so plain prefixes keep working.
         if let Some(pattern) = &options.path_pattern {
-            if !func.file_path.contains(pattern) {
+            if !glob_matches(pattern, &func.file_path) {
                 return false;
             }
         }

--- a/src/services/agent_context/query/path_pattern_glob_tests.rs
+++ b/src/services/agent_context/query/path_pattern_glob_tests.rs
@@ -1,0 +1,131 @@
+//! `path_pattern` glob-filter regression tests.
+//!
+//! In its own file, not at the end of `engine_scoring.rs`: that file is
+//! `include!`d into `engine.rs` ahead of `engine_search.rs`, so a test module
+//! at its end puts items after a test module in the expanded source
+//! (`clippy::items_after_test_module`, denied by `ci / lint`).
+
+//! `pmat_query_code`'s schema advertises `path_pattern` as a "Path glob
+//! pattern filter", but the filter was `file_path.contains(pattern)`: on the
+//! real index `src/tdg` returned five hits while `src/tdg/*`, `**/tdg/**`
+//! and `*tdg*` all returned zero — a silent empty set, not an error.
+use super::*;
+use crate::services::agent_context::function_index::DefinitionType;
+use crate::services::agent_context::{IndexManifest, QualityMetrics};
+use std::collections::HashMap;
+
+fn entry(file_path: &str) -> FunctionEntry {
+    FunctionEntry {
+        file_path: file_path.to_string(),
+        function_name: "f".to_string(),
+        signature: "fn f()".to_string(),
+        definition_type: DefinitionType::default(),
+        doc_comment: None,
+        source: "fn f() {}".to_string(),
+        start_line: 1,
+        end_line: 1,
+        language: "Rust".to_string(),
+        quality: QualityMetrics {
+            tdg_score: 1.0,
+            tdg_grade: "A".to_string(),
+            complexity: 1,
+            cognitive_complexity: 1,
+            big_o: "O(1)".to_string(),
+            satd_count: 0,
+            loc: 1,
+            commit_count: 0,
+            churn_score: 0.0,
+            contract_level: None,
+            contract_equation: None,
+        },
+        checksum: "chk".to_string(),
+        commit_count: 0,
+        churn_score: 0.0,
+        clone_count: 0,
+        pattern_diversity: 0.0,
+        fault_annotations: Vec::new(),
+        linked_definition: None,
+    }
+}
+
+/// `passes_filters` reads only `self.functions[idx]`, so the rest of the
+/// index can stay empty.
+fn index_of(paths: &[&str]) -> AgentContextIndex {
+    AgentContextIndex {
+        functions: paths.iter().map(|p| entry(p)).collect(),
+        name_index: HashMap::new(),
+        file_index: HashMap::new(),
+        corpus: Vec::new(),
+        corpus_lower: Vec::new(),
+        name_frequency: HashMap::new(),
+        calls: HashMap::new(),
+        called_by: HashMap::new(),
+        graph_metrics: Vec::new(),
+        project_root: std::path::PathBuf::from("/test"),
+        manifest: IndexManifest {
+            version: "1.2.0".to_string(),
+            built_at: "2025-01-01T00:00:00Z".to_string(),
+            project_root: "/test".to_string(),
+            function_count: paths.len(),
+            file_count: paths.len(),
+            languages: vec!["Rust".to_string()],
+            avg_tdg_score: 1.0,
+            file_checksums: HashMap::new(),
+            last_incremental_changes: 0,
+        },
+        db_path: None,
+        coverage_off_files: HashSet::new(),
+    }
+}
+
+fn kept(paths: &[&str], pattern: &str) -> Vec<String> {
+    let index = index_of(paths);
+    let options = QueryOptions {
+        path_pattern: Some(pattern.to_string()),
+        ..QueryOptions::default()
+    };
+    (0..paths.len())
+        .filter(|i| index.passes_filters(*i, &options))
+        .map(|i| paths[i].to_string())
+        .collect()
+}
+
+const PATHS: [&str; 3] = [
+    "src/tdg/scorers/consistency.rs",
+    "src/tdg/mod.rs",
+    "src/cli/handlers/score_handler.rs",
+];
+
+#[test]
+fn test_globstar_pattern_is_not_an_empty_set() {
+    // Under the substring filter this matched nothing at all.
+    assert_eq!(
+        kept(&PATHS, "**/tdg/**"),
+        vec![
+            "src/tdg/scorers/consistency.rs".to_string(),
+            "src/tdg/mod.rs".to_string()
+        ]
+    );
+}
+
+#[test]
+fn test_single_star_does_not_cross_a_path_separator() {
+    // Glob semantics: `src/tdg/*` is the files directly under src/tdg.
+    assert_eq!(
+        kept(&PATHS, "src/tdg/*"),
+        vec!["src/tdg/mod.rs".to_string()]
+    );
+}
+
+#[test]
+fn test_plain_prefix_still_behaves_as_a_substring() {
+    // A pattern with no metacharacter must keep matching the way callers
+    // relied on before the glob support went in.
+    assert_eq!(
+        kept(&PATHS, "src/tdg"),
+        vec![
+            "src/tdg/scorers/consistency.rs".to_string(),
+            "src/tdg/mod.rs".to_string()
+        ]
+    );
+}

--- a/src/services/agent_context/query/tests_query.rs
+++ b/src/services/agent_context/query/tests_query.rs
@@ -358,3 +358,47 @@ fn test_is_test_function() {
     entry.file_path = "src/handler_test.rs".to_string();
     assert!(is_test_function(&entry));
 }
+
+#[test]
+fn test_query_path_pattern_accepts_globs() {
+    // `path_pattern` is advertised in the MCP schema as a "Path glob pattern
+    // filter", but the filter was `file_path.contains(pattern)`: any glob
+    // metacharacter silently produced an empty result set instead of matching
+    // the files a bare substring matched.
+    let index = build_test_index();
+    let glob_hits = index
+        .query(
+            "handle",
+            QueryOptions {
+                limit: 10,
+                path_pattern: Some("src/*.rs".to_string()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+    assert!(
+        !glob_hits.is_empty(),
+        "a glob over src/ must match the same files the substring 'src/' matches"
+    );
+    for r in &glob_hits {
+        assert!(
+            r.file_path.starts_with("src/") && !r.file_path["src/".len()..].contains('/'),
+            "glob src/*.rs must not match {}",
+            r.file_path
+        );
+    }
+
+    // Substring patterns (no metacharacters) keep working unchanged.
+    let substring_hits = index
+        .query(
+            "handle",
+            QueryOptions {
+                limit: 10,
+                path_pattern: Some("src/".to_string()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    assert!(!substring_hits.is_empty());
+}

--- a/src/services/big_o_analyzer_analysis.rs
+++ b/src/services/big_o_analyzer_analysis.rs
@@ -42,52 +42,34 @@ impl BigOAnalyzer {
         Ok(report)
     }
 
+    /// Source extensions big-O analysis knows how to read.
+    const SOURCE_EXTENSIONS: [&str; 10] = [
+        "rs", "js", "ts", "jsx", "tsx", "py", "cpp", "c", "java", "go",
+    ];
+
     /// Discover source files based on patterns
+    ///
+    /// This used to be a bare `walkdir::WalkDir` with a six-entry exclude
+    /// list (target/node_modules/.git/build/dist/__pycache__). It therefore
+    /// descended into hidden and gitignored trees that `analyze complexity`
+    /// never sees — `.claude/worktrees` above all — and reported 2,650,897
+    /// functions on a repo where complexity reported 39,907, and 6 functions on
+    /// a fixture holding exactly one. File discovery is now the shared
+    /// `ProjectFileDiscovery` (gitignore-aware, hidden directories skipped), so
+    /// every analyzer is asked about the same corpus.
     async fn discover_source_files(&self, config: &BigOAnalysisConfig) -> Result<Vec<PathBuf>> {
-        use walkdir::WalkDir;
+        let discovery =
+            crate::services::file_discovery::ProjectFileDiscovery::new(config.project_path.clone());
 
-        let extensions = [
-            "rs", "js", "ts", "jsx", "tsx", "py", "cpp", "c", "java", "go",
-        ];
-        let exclude_dirs = [
-            "target",
-            "node_modules",
-            ".git",
-            "build",
-            "dist",
-            "__pycache__",
-        ];
-
-        let mut files = Vec::new();
-
-        for entry in WalkDir::new(&config.project_path)
-            .follow_links(false)
+        let mut files: Vec<PathBuf> = discovery
+            .discover_files()?
             .into_iter()
-            .filter_map(std::result::Result::ok)
-            .filter(|e| e.file_type().is_file())
-        {
-            let path = entry.path();
-
-            // Check exclusions
-            let should_exclude = path.components().any(|comp| {
-                if let Some(name) = comp.as_os_str().to_str() {
-                    exclude_dirs.contains(&name)
-                } else {
-                    false
-                }
-            });
-
-            if should_exclude {
-                continue;
-            }
-
-            // Check extensions
-            if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
-                if extensions.contains(&ext) {
-                    files.push(path.to_path_buf());
-                }
-            }
-        }
+            .filter(|path| {
+                path.extension()
+                    .and_then(|e| e.to_str())
+                    .is_some_and(|ext| Self::SOURCE_EXTENSIONS.contains(&ext))
+            })
+            .collect();
 
         files.sort_unstable();
         Ok(files)
@@ -266,5 +248,76 @@ impl BigOAnalyzer {
             confidence: (time_complexity.confidence + space_complexity.confidence) / 2,
             notes,
         }
+    }
+}
+
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg(test)]
+mod discovery_scope_tests {
+    //! Big-O discovery must see the same corpus as `analyze complexity`:
+    //! a raw WalkDir walked hidden tool caches such as `.claude/worktrees`
+    //! and reported 6 functions for a fixture holding exactly one.
+    use super::*;
+
+    fn config(root: &std::path::Path) -> BigOAnalysisConfig {
+        BigOAnalysisConfig {
+            project_path: root.to_path_buf(),
+            include_patterns: vec![],
+            exclude_patterns: vec![],
+            confidence_threshold: 0,
+            analyze_space_complexity: true,
+        }
+    }
+
+    #[tokio::test]
+    async fn discovery_skips_hidden_tool_directories() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::create_dir_all(root.join(".claude/junk")).unwrap();
+        std::fs::write(root.join("src/lib.rs"), "pub fn a() -> i32 { 1 }\n").unwrap();
+        for i in 0..5 {
+            std::fs::write(
+                root.join(format!(".claude/junk/h{i}.rs")),
+                format!("pub fn h{i}() -> i32 {{ {i} }}\n"),
+            )
+            .unwrap();
+        }
+
+        let analyzer = BigOAnalyzer::new();
+        let files = analyzer
+            .discover_source_files(&config(root))
+            .await
+            .expect("discovery");
+
+        assert_eq!(
+            files.len(),
+            1,
+            "only src/lib.rs is project source; got {files:?}"
+        );
+        assert!(files[0].ends_with("src/lib.rs"));
+
+        let report = analyzer.analyze(config(root)).await.expect("analysis");
+        assert_eq!(report.analyzed_functions, 1, "one file, one function");
+    }
+
+    #[tokio::test]
+    async fn discovery_skips_gitignored_files() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::create_dir_all(root.join("generated")).unwrap();
+        // `.git` must exist for gitignore rules to apply, exactly as in a checkout.
+        std::fs::create_dir_all(root.join(".git")).unwrap();
+        std::fs::write(root.join(".gitignore"), "generated/\n").unwrap();
+        std::fs::write(root.join("src/lib.rs"), "pub fn a() -> i32 { 1 }\n").unwrap();
+        std::fs::write(root.join("generated/g.rs"), "pub fn g() -> i32 { 2 }\n").unwrap();
+
+        let files = BigOAnalyzer::new()
+            .discover_source_files(&config(root))
+            .await
+            .expect("discovery");
+
+        assert_eq!(files.len(), 1, "gitignored trees are not project source: {files:?}");
     }
 }

--- a/src/services/big_o_analyzer_analysis.rs
+++ b/src/services/big_o_analyzer_analysis.rs
@@ -61,6 +61,12 @@ impl BigOAnalyzer {
         let discovery =
             crate::services::file_discovery::ProjectFileDiscovery::new(config.project_path.clone());
 
+        // `--include`/`--exclude` were carried in the config and never read, so
+        // `--exclude '**/*.rs'` on a Rust-only crate still analysed every function
+        // and `--include '**/*.py'` still returned the Rust ones. They are filters now.
+        let include_set = Self::build_pattern_set(&config.include_patterns)?;
+        let exclude_set = Self::build_pattern_set(&config.exclude_patterns)?;
+
         let mut files: Vec<PathBuf> = discovery
             .discover_files()?
             .into_iter()
@@ -69,10 +75,50 @@ impl BigOAnalyzer {
                     .and_then(|e| e.to_str())
                     .is_some_and(|ext| Self::SOURCE_EXTENSIONS.contains(&ext))
             })
+            .filter(|path| {
+                if let Some(ref set) = exclude_set {
+                    if Self::pattern_matches(set, path, &config.project_path) {
+                        return false;
+                    }
+                }
+                match include_set {
+                    Some(ref set) => Self::pattern_matches(set, path, &config.project_path),
+                    None => true,
+                }
+            })
             .collect();
 
         files.sort_unstable();
         Ok(files)
+    }
+
+    /// Compile user-supplied globs, or `None` when no pattern was given.
+    fn build_pattern_set(patterns: &[String]) -> Result<Option<globset::GlobSet>> {
+        if patterns.is_empty() {
+            return Ok(None);
+        }
+        let mut builder = globset::GlobSetBuilder::new();
+        for pattern in patterns {
+            builder.add(globset::Glob::new(pattern)?);
+        }
+        Ok(Some(builder.build()?))
+    }
+
+    /// Match a discovered file against a pattern set.
+    ///
+    /// Tested against the project-relative path, the full path and the bare file
+    /// name, so `src/**`, `**/*.rs` and `lib.rs` all mean what a user expects.
+    fn pattern_matches(
+        set: &globset::GlobSet,
+        path: &std::path::Path,
+        project_path: &std::path::Path,
+    ) -> bool {
+        let relative = path.strip_prefix(project_path).unwrap_or(path);
+        set.is_match(relative)
+            || set.is_match(path)
+            || path
+                .file_name()
+                .is_some_and(|name| set.is_match(std::path::Path::new(name)))
     }
 
     /// Analyze single file for complexity
@@ -319,5 +365,81 @@ mod discovery_scope_tests {
             .expect("discovery");
 
         assert_eq!(files.len(), 1, "gitignored trees are not project source: {files:?}");
+    }
+}
+
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg(test)]
+mod pattern_filter_tests {
+    //! `--include`/`--exclude` were stored in the config and never read, so
+    //! `--exclude '**/*.rs'` on a Rust-only crate still analysed every function.
+    use super::*;
+
+    fn fixture() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::write(root.join("src/lib.rs"), "pub fn a() -> i32 { 1 }\n").unwrap();
+        dir
+    }
+
+    fn config_with(
+        root: &std::path::Path,
+        include: Vec<&str>,
+        exclude: Vec<&str>,
+    ) -> BigOAnalysisConfig {
+        BigOAnalysisConfig {
+            project_path: root.to_path_buf(),
+            include_patterns: include.into_iter().map(String::from).collect(),
+            exclude_patterns: exclude.into_iter().map(String::from).collect(),
+            confidence_threshold: 0,
+            analyze_space_complexity: false,
+        }
+    }
+
+    async fn discovered(config: &BigOAnalysisConfig) -> usize {
+        BigOAnalyzer::new()
+            .discover_source_files(config)
+            .await
+            .expect("discovery")
+            .len()
+    }
+
+    #[tokio::test]
+    async fn exclude_patterns_remove_files() {
+        let dir = fixture();
+        let root = dir.path();
+
+        assert_eq!(discovered(&config_with(root, vec![], vec![])).await, 1);
+
+        for pattern in ["**/*.rs", "*.rs", "lib.rs", "src/**", "src/lib.rs"] {
+            assert_eq!(
+                discovered(&config_with(root, vec![], vec![pattern])).await,
+                0,
+                "--exclude '{pattern}' must drop the only Rust file"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn include_patterns_restrict_files() {
+        let dir = fixture();
+        let root = dir.path();
+
+        for pattern in ["**/*.py", "nothing_matches_zzz", "*.py"] {
+            assert_eq!(
+                discovered(&config_with(root, vec![pattern], vec![])).await,
+                0,
+                "--include '{pattern}' must match nothing in a Rust-only crate"
+            );
+        }
+
+        for pattern in ["**/*.rs", "lib.rs", "src/lib.rs"] {
+            assert_eq!(
+                discovered(&config_with(root, vec![pattern], vec![])).await,
+                1,
+                "--include '{pattern}' must keep the matching file"
+            );
+        }
     }
 }

--- a/src/services/cargo_dead_code_analyzer/analysis.rs
+++ b/src/services/cargo_dead_code_analyzer/analysis.rs
@@ -91,6 +91,15 @@ impl CargoDeadCodeAnalyzer {
                 continue;
             }
 
+            // Honour the include_tests/examples/benches flags. This layer used
+            // to walk EVERY .rs file regardless — only `run_cargo_check`
+            // consulted them — so `analyze dead-code` reported `tests/it.rs` by
+            // default on a crate never analysed before, and `--include-tests`
+            // could not add anything because nothing had been excluded.
+            if self.is_excluded_source(path) {
+                continue;
+            }
+
             // Read file content
             let content = match fs::read_to_string(path) {
                 Ok(c) => c,
@@ -115,6 +124,31 @@ impl CargoDeadCodeAnalyzer {
         );
 
         Ok(suppressed_items)
+    }
+
+    /// Is this source file outside the scope the analyzer was configured with?
+    ///
+    /// Mirrors what `--include-tests` / `--include-examples` /
+    /// `--include-benches` promise: with the flag absent, the corresponding
+    /// tree contributes nothing to the report.
+    fn is_excluded_source(&self, path: &Path) -> bool {
+        let relative = path.strip_prefix(&self.project_path).unwrap_or(path);
+        let under = |dir: &str| {
+            relative
+                .components()
+                .any(|c| c.as_os_str().to_string_lossy() == dir)
+        };
+
+        if self.exclude_tests && (under("tests") || is_test_file_name(relative)) {
+            return true;
+        }
+        if self.exclude_examples && under("examples") {
+            return true;
+        }
+        if self.exclude_benches && (under("benches") || under("benchmarks")) {
+            return true;
+        }
+        false
     }
 
     /// Scan a single file's lines for suppression attributes
@@ -221,6 +255,23 @@ impl CargoDeadCodeAnalyzer {
     }
 }
 
+/// Is this file name a test module by convention (`tests.rs`, `foo_test.rs`,
+/// `foo_tests.rs`, `test_foo.rs`)?
+///
+/// The repo's own `src/services/cargo_dead_code_analyzer/tests.rs` headed the
+/// dead-code list with `--include-tests` absent, which is what the flag exists
+/// to prevent.
+fn is_test_file_name(path: &std::path::Path) -> bool {
+    let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
+        return false;
+    };
+    stem == "tests"
+        || stem == "test"
+        || stem.ends_with("_test")
+        || stem.ends_with("_tests")
+        || stem.starts_with("test_")
+}
+
 /// Return `true` when the project at `project_path` has a library target.
 ///
 /// A library is present when *either* the conventional `src/lib.rs` file
@@ -301,5 +352,87 @@ mod project_has_library_tests {
         )
         .unwrap();
         assert!(project_has_library(tmp.path()));
+    }
+}
+
+/// `--include-tests` used to be inert: Layer 1 walked every `.rs` file in the
+/// project whatever the flag said, so a brand-new crate reported `tests/it.rs`
+/// with the flag absent and the flag could add nothing.
+#[cfg(test)]
+mod include_tests_flag_tests {
+    use super::*;
+
+    fn fixture() -> tempfile::TempDir {
+        // Non-hidden prefix: the walk skips hidden directories, and tempfile's
+        // default prefix is `.tmp`.
+        let tmp = tempfile::Builder::new()
+            .prefix("dcx")
+            .tempdir()
+            .expect("tempdir");
+        let root = tmp.path();
+        std::fs::create_dir_all(root.join("src")).expect("mkdir src");
+        std::fs::create_dir_all(root.join("tests")).expect("mkdir tests");
+        std::fs::create_dir_all(root.join("examples")).expect("mkdir examples");
+        std::fs::create_dir_all(root.join("benches")).expect("mkdir benches");
+        let body = |name: &str| format!("#[allow(dead_code)]\nfn {name}() {{}}\n");
+        std::fs::write(root.join("src/lib.rs"), body("in_lib")).expect("write lib");
+        std::fs::write(root.join("src/helpers_tests.rs"), body("in_src_tests")).expect("write");
+        std::fs::write(root.join("tests/it.rs"), body("in_it")).expect("write it");
+        std::fs::write(root.join("examples/demo.rs"), body("in_demo")).expect("write demo");
+        std::fs::write(root.join("benches/bench.rs"), body("in_bench")).expect("write bench");
+        tmp
+    }
+
+    fn names(items: &[(PathBuf, DeadItem)]) -> Vec<String> {
+        let mut v: Vec<String> = items.iter().map(|(_, i)| i.name.clone()).collect();
+        v.sort();
+        v
+    }
+
+    #[test]
+    fn test_suppression_scan_excludes_tests_by_default() {
+        let tmp = fixture();
+        let analyzer = CargoDeadCodeAnalyzer::new(tmp.path());
+        let found = names(&analyzer.scan_for_suppression_attributes().expect("scan"));
+        assert_eq!(
+            found,
+            vec!["in_lib".to_string()],
+            "only library code is in scope without --include-tests/examples/benches"
+        );
+    }
+
+    #[test]
+    fn test_include_tests_adds_the_test_trees() {
+        let tmp = fixture();
+        let analyzer = CargoDeadCodeAnalyzer::new(tmp.path()).include_tests();
+        let found = names(&analyzer.scan_for_suppression_attributes().expect("scan"));
+        assert!(found.contains(&"in_it".to_string()), "{found:?}");
+        assert!(found.contains(&"in_src_tests".to_string()), "{found:?}");
+        assert!(found.contains(&"in_lib".to_string()), "{found:?}");
+        // Examples and benches stay out — their own flags were not passed.
+        assert!(!found.contains(&"in_demo".to_string()), "{found:?}");
+        assert!(!found.contains(&"in_bench".to_string()), "{found:?}");
+    }
+
+    #[test]
+    fn test_include_examples_and_benches_add_their_trees() {
+        let tmp = fixture();
+        let analyzer = CargoDeadCodeAnalyzer::new(tmp.path())
+            .include_examples()
+            .include_benches();
+        let found = names(&analyzer.scan_for_suppression_attributes().expect("scan"));
+        assert!(found.contains(&"in_demo".to_string()), "{found:?}");
+        assert!(found.contains(&"in_bench".to_string()), "{found:?}");
+        assert!(!found.contains(&"in_it".to_string()), "{found:?}");
+    }
+
+    #[test]
+    fn test_is_test_file_name_conventions() {
+        for name in ["tests.rs", "foo_tests.rs", "foo_test.rs", "test_foo.rs"] {
+            assert!(is_test_file_name(Path::new(name)), "{name}");
+        }
+        for name in ["lib.rs", "attestation.rs", "contest.rs"] {
+            assert!(!is_test_file_name(Path::new(name)), "{name}");
+        }
     }
 }

--- a/src/services/cargo_dead_code_analyzer/cache_operations.rs
+++ b/src/services/cargo_dead_code_analyzer/cache_operations.rs
@@ -3,8 +3,32 @@
 
 impl CargoDeadCodeAnalyzer {
     /// Get the cache file path
+    ///
+    /// The key has to cover every input that changes the ANSWER, not just the
+    /// tree hash and the pmat version: two runs that differ only in
+    /// `--include-tests` (or the traversal depth) analyse different file sets,
+    /// and they used to share one entry, so the second run replayed the first
+    /// and the flag looked like a no-op even after the walk started honouring
+    /// it.
     fn cache_path(&self) -> PathBuf {
-        self.project_path.join(".pmat").join("dead-code-cache.json")
+        let included: String = [
+            (self.exclude_tests, 't'),
+            (self.exclude_examples, 'e'),
+            (self.exclude_benches, 'b'),
+        ]
+        .iter()
+        .filter(|(excluded, _)| !excluded)
+        .map(|(_, tag)| *tag)
+        .collect();
+        let scope = if included.is_empty() {
+            "default".to_string()
+        } else {
+            included
+        };
+        self.project_path.join(".pmat").join(format!(
+            "dead-code-cache-{scope}-d{}.json",
+            self.max_depth
+        ))
     }
 
     /// Get current git tree hash for cache invalidation
@@ -77,5 +101,39 @@ impl CargoDeadCodeAnalyzer {
             let _ = std::fs::write(self.cache_path(), content);
             tracing::debug!("Dead code cache saved");
         }
+    }
+}
+
+#[cfg(test)]
+mod cache_key_tests {
+    use super::*;
+
+    /// Toggling a flag that changes WHICH files are analysed must not hit the
+    /// entry written by the other configuration — with a shared key, the second
+    /// `analyze dead-code` run replayed the first and `--include-tests` looked
+    /// like a no-op even on a correct walk.
+    #[test]
+    fn test_cache_key_separates_include_tests_from_the_default() {
+        let root = std::path::Path::new("/p");
+        let default_path = CargoDeadCodeAnalyzer::new(root).cache_path();
+        let with_tests = CargoDeadCodeAnalyzer::new(root).include_tests().cache_path();
+        let with_examples = CargoDeadCodeAnalyzer::new(root)
+            .include_examples()
+            .cache_path();
+
+        assert_ne!(default_path, with_tests);
+        assert_ne!(default_path, with_examples);
+        assert_ne!(with_tests, with_examples);
+        assert!(default_path.starts_with("/p/.pmat"), "{default_path:?}");
+    }
+
+    /// Depth changes the walk, so it changes the answer too.
+    #[test]
+    fn test_cache_key_separates_traversal_depths() {
+        let root = std::path::Path::new("/p");
+        assert_ne!(
+            CargoDeadCodeAnalyzer::new(root).with_max_depth(2).cache_path(),
+            CargoDeadCodeAnalyzer::new(root).with_max_depth(8).cache_path()
+        );
     }
 }

--- a/src/services/cargo_dead_code_analyzer/tests.rs
+++ b/src/services/cargo_dead_code_analyzer/tests.rs
@@ -178,27 +178,68 @@ mod integration_tests {
             return;
         }
 
-        let analyzer = CargoDeadCodeAnalyzer::new(&project_path).without_cache();
-        let items = analyzer.scan_for_suppression_attributes().unwrap();
+        // This used to assert `items.len() >= 20` for the DEFAULT analyzer,
+        // which excludes tests. Of the ~47 item-matched suppression attributes
+        // in this repo, all but one live in `tests/` or in `*_tests.rs`, so the
+        // only way to reach 20 by default was for Layer 1 to ignore
+        // `exclude_tests` entirely — exactly the defect that made
+        // `--include-tests` inert. The dogfooding intent is kept, but the count
+        // is now asserted where the items actually are, and the default scan is
+        // checked for the property that matters: nothing from a test tree.
+        let default_items = CargoDeadCodeAnalyzer::new(&project_path)
+            .without_cache()
+            .scan_for_suppression_attributes()
+            .unwrap();
 
-        // The pmat codebase has many suppression attributes (#[allow(unused)] etc.)
+        for (path, item) in &default_items {
+            assert_eq!(item.kind, DeadCodeKind::Suppressed);
+            let relative = path.strip_prefix(&project_path).unwrap_or(path);
+            assert!(
+                !relative
+                    .components()
+                    .any(|c| c.as_os_str() == "tests" || c.as_os_str() == "examples"),
+                "{} is out of scope without --include-tests/--include-examples",
+                relative.display()
+            );
+            assert!(
+                !is_test_file_name(relative),
+                "{} is a test module and is out of scope without --include-tests",
+                relative.display()
+            );
+        }
+
+        // With the test trees in scope the pmat codebase has many suppression
+        // attributes (#[allow(unused)] etc.).
         // Note: Not all suppression attrs have items on the next line (some are on fields)
-        // Threshold lowered after bulk dead_code attribute cleanup
+        let with_tests = CargoDeadCodeAnalyzer::new(&project_path)
+            .without_cache()
+            .include_tests()
+            .scan_for_suppression_attributes()
+            .unwrap();
+
         assert!(
-            items.len() >= 20,
-            "Expected at least 20 suppressed items in pmat codebase, found {}. \
-             This suggests the suppression scan may not be working correctly.",
-            items.len()
+            with_tests.len() >= 20,
+            "Expected at least 20 suppressed items in the pmat codebase with \
+             --include-tests, found {}. This suggests the suppression scan may \
+             not be working correctly.",
+            with_tests.len()
+        );
+        assert!(
+            with_tests.len() > default_items.len(),
+            "--include-tests must widen the scan: {} with tests vs {} without",
+            with_tests.len(),
+            default_items.len()
         );
 
         // Verify items are marked as Suppressed
-        for (_, item) in &items {
+        for (_, item) in &with_tests {
             assert_eq!(item.kind, DeadCodeKind::Suppressed);
         }
 
         eprintln!(
-            "Layer 1 (suppression scan) detected {} suppressed items",
-            items.len()
+            "Layer 1 (suppression scan) detected {} suppressed items ({} with --include-tests)",
+            default_items.len(),
+            with_tests.len()
         );
     }
 }

--- a/src/services/clippy_fix/clippy_fix_tests.rs
+++ b/src/services/clippy_fix/clippy_fix_tests.rs
@@ -261,14 +261,35 @@ mod coverage_tests {
 
     #[test]
     fn test_from_json_missing_fields() {
-        // JSON with missing fields should use defaults
+        // A message with neither lint code nor span is not a fixable diagnostic.
+        // It used to parse into a placeholder (code "unknown", file "", line 0)
+        // that was then counted as a fix.
         let json = r#"{"message": {}}"#;
         let result = ClippyDiagnostic::from_json(json);
-        assert!(result.is_ok());
+        assert!(result.is_err(), "empty message must not parse as a fix");
+    }
 
-        let diag = result.unwrap();
-        assert_eq!(diag.code, "unknown");
-        assert_eq!(diag.level, DiagnosticLevel::Warning); // default for "warning"
+    #[test]
+    fn test_from_json_rejects_non_diagnostic_cargo_lines() {
+        // Regression: cargo's non-diagnostic JSON lines each became a "fix"
+        // with file:"" line:0 code:"unknown", inflating total_fixes.
+        let artifact = r#"{"reason":"compiler-artifact","package_id":"cx 0.1.0","target":{"name":"cx"}}"#;
+        assert!(ClippyDiagnostic::from_json(artifact).is_err());
+
+        let build_finished = r#"{"reason":"build-finished","success":true}"#;
+        assert!(ClippyDiagnostic::from_json(build_finished).is_err());
+
+        // The "generated N warnings" summary: a real compiler-message, but with
+        // no lint code and no spans.
+        let summary = r#"{"reason":"compiler-message","message":{"code":null,"level":"warning","message":"1 warning emitted","spans":[]}}"#;
+        assert!(ClippyDiagnostic::from_json(summary).is_err());
+
+        // The real diagnostic in the same stream still parses.
+        let real = r#"{"reason":"compiler-message","message":{"code":{"code":"clippy::clone_on_copy"},"level":"warning","message":"using `clone` on type `i32`","spans":[{"file_name":"src/lib.rs","line_start":17,"line_end":17,"column_start":5,"column_end":14}]}}"#;
+        let diag = ClippyDiagnostic::from_json(real).expect("real diagnostic must parse");
+        assert_eq!(diag.code, "clippy::clone_on_copy");
+        assert_eq!(diag.file, PathBuf::from("src/lib.rs"));
+        assert_eq!(diag.line_start, 17);
     }
 
     // ========================================================================

--- a/src/services/clippy_fix/mod.rs
+++ b/src/services/clippy_fix/mod.rs
@@ -34,11 +34,29 @@ impl ClippyDiagnostic {
     }
 
     /// Extract diagnostic from JSON value (complexity: 5)
+    ///
+    /// Cargo's `--message-format=json` stream interleaves compiler-artifact,
+    /// build-finished and "generated N warnings" summary lines with the real
+    /// diagnostics. This used to `unwrap_or` every field, so each of those
+    /// lines materialised as a fix with file:"" line:0 code:"unknown" and
+    /// inflated `total_fixes`. A line that carries neither a lint code nor a
+    /// source span is not a diagnostic we can fix, so reject it outright.
     fn parse_json_value(value: &serde_json::Value) -> Result<Self> {
+        if let Some(reason) = value.get("reason").and_then(serde_json::Value::as_str) {
+            if reason != "compiler-message" {
+                return Err(anyhow::anyhow!("not a compiler-message line: {reason}"));
+            }
+        }
+
         let message = &value["message"];
-        let code = message["code"]["code"].as_str().unwrap_or("unknown");
+        let code = message["code"]["code"]
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("diagnostic has no lint code"))?;
         let level = message["level"].as_str().unwrap_or("warning");
         let spans = &message["spans"][0];
+        if !spans["file_name"].is_string() {
+            return Err(anyhow::anyhow!("diagnostic has no primary source span"));
+        }
 
         Ok(Self {
             code: code.to_string(),

--- a/src/services/complexity/analysis.rs
+++ b/src/services/complexity/analysis.rs
@@ -225,18 +225,23 @@ fn calculate_max_values(all_cyclomatic: &[u16], all_cognitive: &[u16]) -> (u16, 
 }
 
 /// Calculate technical debt hours from violations
+///
+/// The fold is seeded at `+0.0` on purpose. `Iterator::sum::<f32>()` seeds with
+/// `-0.0` (the additive identity that preserves signed zeros through a sum), so
+/// summing an *empty* violation list yields `-0.0`, and every violation-free
+/// project reported `"technical_debt_hours": -0.0` — negative debt, which is not
+/// a quantity that exists (#719). Seeding at `+0.0` changes no non-empty sum.
 pub(super) fn calculate_technical_debt(violations: &[Violation]) -> f32 {
-    let debt_minutes: f32 = violations
-        .iter()
-        .map(|v| match v {
+    let debt_minutes = violations.iter().fold(0.0_f32, |acc, v| {
+        acc + match v {
             Violation::Error {
                 value, threshold, ..
             } => f32::from(value - threshold) * 30.0,
             Violation::Warning {
                 value, threshold, ..
             } => f32::from(value - threshold) * 15.0,
-        })
-        .sum();
+        }
+    });
     debt_minutes / 60.0
 }
 

--- a/src/services/complexity/tests.rs
+++ b/src/services/complexity/tests.rs
@@ -592,3 +592,53 @@ fn test_format_as_sarif_with_error() {
     assert!(sarif.contains("error"));
     assert!(sarif.contains("complex.rs"));
 }
+
+// ===================
+// technical_debt_hours sign (#719)
+// ===================
+
+/// A project with no complexity violations has *zero* debt, not negative debt.
+///
+/// `Iterator::sum::<f32>()` seeds with `-0.0`, so the previous implementation
+/// serialized `"technical_debt_hours": -0.0` for every clean project — including
+/// an empty directory. This asserts the sign, which is what the JSON consumer
+/// and the `{:.1} hours` renderer actually see.
+#[test]
+fn test_technical_debt_is_positive_zero_when_there_are_no_violations() {
+    let debt = analysis::calculate_technical_debt(&[]);
+
+    assert_eq!(debt, 0.0);
+    assert!(
+        !debt.is_sign_negative(),
+        "no violations must yield +0.0, got {debt:?} (renders as -0.0 in JSON)"
+    );
+    assert_eq!(format!("{:?}", f64::from(debt)), "0.0");
+}
+
+/// The seed change must not perturb a real, non-empty sum.
+#[test]
+fn test_technical_debt_still_sums_violations() {
+    let violations = vec![
+        Violation::Error {
+            rule: "cyclomatic-complexity".to_string(),
+            message: "too complex".to_string(),
+            value: 30,
+            threshold: 20,
+            file: "a.rs".to_string(),
+            line: 1,
+            function: None,
+        },
+        Violation::Warning {
+            rule: "cognitive-complexity".to_string(),
+            message: "getting complex".to_string(),
+            value: 14,
+            threshold: 10,
+            file: "b.rs".to_string(),
+            line: 2,
+            function: None,
+        },
+    ];
+
+    // (30-20)*30 + (14-10)*15 = 300 + 60 = 360 minutes = 6 hours
+    assert!((analysis::calculate_technical_debt(&violations) - 6.0).abs() < f32::EPSILON);
+}

--- a/src/services/complexity/uncached.rs
+++ b/src/services/complexity/uncached.rs
@@ -91,25 +91,86 @@ pub async fn analyze_file_complexity_uncached(
 ) -> anyhow::Result<FileComplexityMetrics> {
     use anyhow::Context;
 
-    // Read file content if not provided
-    let file_content;
-    let content_ref = if let Some(c) = content {
-        c
-    } else {
-        file_content = std::fs::read_to_string(path)
-            .with_context(|| format!("Failed to read file: {}", path.display()))?;
-        &file_content
-    };
+    // When the caller hands us the text to measure, measure THAT text: the
+    // AST path below reads the file from disk and would silently score
+    // something else (the Issue #67 extraction tests analyse content for paths
+    // that do not exist on disk at all).
+    if let Some(supplied) = content {
+        let language = crate::cli::language_analyzer::Language::from_path(path);
+        return crate::cli::language_analyzer::analyze_with_heuristics(path, supplied, language)
+            .with_context(|| format!("Failed to analyze file complexity: {}", path.display()));
+    }
 
-    // CRITICAL (Issue #67): Use heuristic analyzer for accurate line numbers
-    // The AST analyzer returns approximate line numbers (i * 50), which breaks
-    // extracted function scenarios. The heuristic analyzer provides EXACT line
-    // numbers by parsing the actual file content.
+    let file_content = std::fs::read_to_string(path)
+        .with_context(|| format!("Failed to read file: {}", path.display()))?;
+
+    // Route through the SAME entry point the project scan uses
+    // (`analysis_utilities::analyze_project_files` -> `analyze_file_complexity`),
+    // which prefers the AST analyzer and falls back to heuristics only when a
+    // file cannot be parsed.
     //
-    // This ensures:
-    // - Functions extracted from old_file.rs:500 to new_file.rs:148
-    // - Report line 148 (CURRENT location), not line 500 (OLD cached location)
-    let language = crate::cli::language_analyzer::Language::from_path(path);
-    crate::cli::language_analyzer::analyze_with_heuristics(path, content_ref, language)
+    // This function used to call `analyze_with_heuristics` directly, so the MCP
+    // `analyze_complexity` tool (its only production caller besides `--file`)
+    // reported different numbers from `pmat analyze complexity` for the same
+    // function: on a 10-line `complex()` the heuristic counter said cyclomatic
+    // 10 / cognitive 18 and raised a threshold violation, where the AST
+    // analyzer — and the CLI — said 6 / 9 with no violation.
+    //
+    // The Issue #67 concern that motivated the heuristic detour (AST line
+    // numbers invented as `i * 50`) no longer applies: extents now come from
+    // measured source spans, so line numbers still reflect the CURRENT file.
+    crate::cli::language_analyzer::analyze_file_complexity(path, &file_content)
+        .await
         .with_context(|| format!("Failed to analyze file complexity: {}", path.display()))
+}
+
+#[cfg(test)]
+mod uncached_agreement_tests {
+    use super::*;
+
+    /// The MCP `analyze_complexity` tool and `pmat analyze complexity` must
+    /// report the same numbers for the same function. They did not: the MCP
+    /// side came through here and got heuristic counts.
+    #[tokio::test]
+    async fn test_uncached_agrees_with_project_scan_analyzer() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let file = dir.path().join("lib.rs");
+        let source = "pub fn add(a: i32, b: i32) -> i32 { a + b }\n\
+                      \n\
+                      pub fn complex(n: u32) -> u32 {\n\
+                      \x20   let mut acc = 0;\n\
+                      \x20   for i in 0..n {\n\
+                      \x20       if i % 2 == 0 { acc += i; }\n\
+                      \x20       else if i % 3 == 0 { acc += i * 2; }\n\
+                      \x20       else if i % 5 == 0 { acc += i * 3; }\n\
+                      \x20       else if i % 7 == 0 { acc += i * 4; }\n\
+                      \x20       else { acc += 1; }\n\
+                      \x20   }\n\
+                      \x20   acc\n\
+                      }\n";
+        std::fs::write(&file, source).unwrap();
+
+        let uncached = analyze_file_complexity_uncached(&file, None).await.unwrap();
+        let project_scan = crate::cli::language_analyzer::analyze_file_complexity(&file, source)
+            .await
+            .unwrap();
+
+        let pick = |m: &FileComplexityMetrics| {
+            m.functions
+                .iter()
+                .find(|f| f.name == "complex")
+                .map(|f| (f.metrics.cyclomatic, f.metrics.cognitive))
+        };
+
+        assert_eq!(
+            pick(&uncached),
+            pick(&project_scan),
+            "uncached analysis must not diverge from the project scan"
+        );
+        assert!(
+            pick(&uncached).is_some(),
+            "`complex` must be found: {:?}",
+            uncached.functions
+        );
+    }
 }

--- a/src/services/configuration_impl.rs
+++ b/src/services/configuration_impl.rs
@@ -25,13 +25,45 @@ impl ConfigurationService {
                 .join("pmat.toml")
         });
 
-        let default_config = Self::default_config();
+        // Read the file here. `load()` is async and was only ever reached from
+        // `start()`, which nothing calls, so every reader saw the built-in
+        // defaults: `config --set quality.max_complexity=5` wrote pmat.toml,
+        // reported success, and the next `config` invocation still printed 30.
+        let config = Self::read_config_file(&default_path).unwrap_or_else(Self::default_config);
 
         Self {
-            config: Arc::new(RwLock::new(default_config)),
+            config: Arc::new(RwLock::new(config)),
             config_path: default_path,
             metrics: Arc::new(RwLock::new(ServiceMetrics::default())),
             watchers: Arc::new(RwLock::new(Vec::new())),
+        }
+    }
+
+    /// Read and parse a config file, returning None when there is nothing
+    /// usable on disk. A malformed file is reported on stderr rather than
+    /// silently replaced by defaults.
+    fn read_config_file(path: &std::path::Path) -> Option<PmatConfig> {
+        if !path.exists() {
+            return None;
+        }
+        match std::fs::read_to_string(path) {
+            Ok(content) => match toml::from_str::<PmatConfig>(&content) {
+                Ok(config) => Some(config),
+                Err(e) => {
+                    eprintln!(
+                        "warning: {} is not valid pmat configuration ({e}); using defaults",
+                        path.display()
+                    );
+                    None
+                }
+            },
+            Err(e) => {
+                eprintln!(
+                    "warning: could not read {} ({e}); using defaults",
+                    path.display()
+                );
+                None
+            }
         }
     }
 
@@ -304,6 +336,50 @@ impl ConfigurationService {
     pub async fn health_check(&self) -> Result<bool> {
         // Check if we can read the configuration
         self.get_config().map(|_| true)
+    }
+}
+
+#[cfg(test)]
+mod new_reads_disk_tests {
+    use super::ConfigurationService;
+
+    #[test]
+    fn test_new_reports_the_values_on_disk() {
+        // Regression: `config --set quality.max_complexity=5` wrote pmat.toml
+        // and said "Configuration updated successfully", but the readers only
+        // ever saw default_config() because load() was never called.
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("pmat.toml");
+
+        let mut on_disk = ConfigurationService::default_config();
+        on_disk.quality.max_complexity = 5;
+        on_disk.system.project_name = "written-by-set".to_string();
+        std::fs::write(&path, toml::to_string_pretty(&on_disk).unwrap()).unwrap();
+
+        let service = ConfigurationService::new(Some(path));
+        let config = service.get_config().unwrap();
+        assert_eq!(config.quality.max_complexity, 5);
+        assert_eq!(config.system.project_name, "written-by-set");
+    }
+
+    #[test]
+    fn test_new_falls_back_to_defaults_when_no_file() {
+        let temp = tempfile::tempdir().unwrap();
+        let service = ConfigurationService::new(Some(temp.path().join("absent.toml")));
+        let config = service.get_config().unwrap();
+        assert_eq!(
+            config.quality.max_complexity,
+            ConfigurationService::default_config().quality.max_complexity
+        );
+    }
+
+    #[test]
+    fn test_new_survives_a_malformed_file() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("pmat.toml");
+        std::fs::write(&path, "this is not toml {{{").unwrap();
+        let service = ConfigurationService::new(Some(path));
+        assert!(service.get_config().is_ok());
     }
 }
 

--- a/src/services/configuration_tests.rs
+++ b/src/services/configuration_tests.rs
@@ -227,58 +227,68 @@ mod getter_tests {
         assert_eq!(service.config_path, path);
     }
 
+    /// A service whose config file does not exist, so it reports the built-in
+    /// defaults. `ConfigurationService::new()` now reads the file it is pointed
+    /// at (it used to ignore it entirely), so a getter test that wants defaults
+    /// must not be pointed at the cwd's pmat.toml.
+    fn default_service() -> ConfigurationService {
+        ConfigurationService::new(Some(PathBuf::from(
+            "/nonexistent-pmat-config-dir/pmat.toml",
+        )))
+    }
+
     #[test]
     fn test_get_quality_config() {
-        let service = ConfigurationService::new(None);
+        let service = default_service();
         let quality = service.get_quality_config().unwrap();
         assert_eq!(quality.max_complexity, 30);
     }
 
     #[test]
     fn test_get_analysis_config() {
-        let service = ConfigurationService::new(None);
+        let service = default_service();
         let analysis = service.get_analysis_config().unwrap();
         assert_eq!(analysis.max_file_size, 1024 * 1024);
     }
 
     #[test]
     fn test_get_performance_config() {
-        let service = ConfigurationService::new(None);
+        let service = default_service();
         let perf = service.get_performance_config().unwrap();
         assert_eq!(perf.test_iterations, 10);
     }
 
     #[test]
     fn test_get_mcp_config() {
-        let service = ConfigurationService::new(None);
+        let service = default_service();
         let mcp = service.get_mcp_config().unwrap();
         assert_eq!(mcp.server_name, "pmat-mcp-server");
     }
 
     #[test]
     fn test_get_roadmap_config() {
-        let service = ConfigurationService::new(None);
+        let service = default_service();
         let roadmap = service.get_roadmap_config().unwrap();
         assert!(roadmap.auto_generate_todos);
     }
 
     #[test]
     fn test_get_telemetry_config() {
-        let service = ConfigurationService::new(None);
+        let service = default_service();
         let telemetry = service.get_telemetry_config().unwrap();
         assert!(telemetry.enabled);
     }
 
     #[test]
     fn test_get_semantic_config() {
-        let service = ConfigurationService::new(None);
+        let service = default_service();
         let semantic = service.get_semantic_config().unwrap();
         assert!(!semantic.enabled);
     }
 
     #[test]
     fn test_get_config_returns_full_config() {
-        let service = ConfigurationService::new(None);
+        let service = default_service();
         let config = service.get_config().unwrap();
         assert_eq!(config.system.project_name, "pmat");
         assert_eq!(config.quality.max_complexity, 30);

--- a/src/services/context_impl/build.rs
+++ b/src/services/context_impl/build.rs
@@ -17,6 +17,35 @@ fn build_gitignore(root_path: &Path) -> Result<ignore::gitignore::Gitignore, Tem
         .map_err(|e| TemplateError::InvalidUtf8(e.to_string()))
 }
 
+/// Whether `path` is excluded by the project's gitignore.
+///
+/// The context/dag walk used the non-recursive `gitignore.matched(path, false)`.
+/// A directory pattern like `.claude/worktrees/` never matches a file nested
+/// inside it, so every file under an ignored directory survived the filter:
+/// `analyze dag` on this repo scanned past 10000 files, hit the
+/// "Large project detected" cap, and rendered nodes rooted in
+/// `.claude/worktrees/...` — while `analyze defects` on the same tree saw 4260
+/// files. `matched_path_or_any_parents` consults the parent directories, which
+/// is what a `dir/` pattern actually means.
+///
+/// The path is made relative to the walk root first: `matched_path_or_any_parents`
+/// asserts its argument is under the matcher root, and a relative path can
+/// never trip that assert.
+fn is_gitignored(
+    gitignore: &ignore::gitignore::Gitignore,
+    root_path: &Path,
+    path: &Path,
+    is_dir: bool,
+) -> bool {
+    let relative = path.strip_prefix(root_path).unwrap_or(path);
+    if relative.as_os_str().is_empty() {
+        return false; // the walk root itself is never "ignored"
+    }
+    gitignore
+        .matched_path_or_any_parents(relative, is_dir)
+        .is_ignore()
+}
+
 /// Optimized file scanner for dead code - only scans Rust source files
 async fn scan_rust_files_only(
     root_path: &Path,
@@ -33,10 +62,20 @@ async fn scan_rust_files_only(
         .follow_links(false)
         .max_depth(MAX_DEPTH)
         .into_iter()
+        // Prune ignored directories instead of walking into them and
+        // discarding their files one by one.
+        .filter_entry(|entry| {
+            !is_gitignored(
+                gitignore,
+                root_path,
+                entry.path(),
+                entry.file_type().is_dir(),
+            )
+        })
         .filter_map(std::result::Result::ok)
         .filter(|entry| {
             let path = entry.path();
-            if path.is_dir() || gitignore.matched(path, false).is_ignore() {
+            if path.is_dir() {
                 return false;
             }
             // Only Rust files
@@ -111,11 +150,19 @@ async fn scan_and_analyze_files(
         .follow_links(false)
         .max_depth(MAX_DEPTH) // TDD Fix: Limit directory traversal depth
         .into_iter()
-        .filter_map(std::result::Result::ok)
-        .filter(|entry| {
-            let path = entry.path();
-            !path.is_dir() && !gitignore.matched(path, false).is_ignore()
+        // Prune ignored directories at the directory level: descending into
+        // them is what pushed this walk past the MAX_FILES cap on repos with a
+        // large gitignored tree (e.g. `.claude/worktrees/`).
+        .filter_entry(|entry| {
+            !is_gitignored(
+                gitignore,
+                root_path,
+                entry.path(),
+                entry.file_type().is_dir(),
+            )
         })
+        .filter_map(std::result::Result::ok)
+        .filter(|entry| !entry.path().is_dir())
         .take(MAX_FILES) // TDD Fix: Limit total files analyzed
         .map(|entry| {
             file_count += 1;

--- a/src/services/context_impl/tests.rs
+++ b/src/services/context_impl/tests.rs
@@ -458,4 +458,41 @@ mod context_tests {
         let cloned = ctx.clone();
         assert_eq!(cloned.project_type, ctx.project_type);
     }
+
+    // ========================================================================
+    // Gitignore directory-pattern regression (context/dag file discovery)
+    // ========================================================================
+
+    /// A file nested inside an ignored DIRECTORY was analyzed anyway: the walk
+    /// used the non-recursive `gitignore.matched()`, which a pattern like
+    /// `.claude/worktrees/` can never match against `.../worktrees/a/b.rs`.
+    /// That is how `analyze dag` on this repo blew the 10000-file cap and
+    /// emitted nodes rooted in `.claude/worktrees/`.
+    #[tokio::test]
+    async fn test_ignored_directory_contents_are_not_scanned() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let root = temp.path();
+
+        std::fs::write(root.join(".gitignore"), "ignored_dir/\n").unwrap();
+        std::fs::create_dir_all(root.join("ignored_dir/nested")).unwrap();
+        std::fs::write(root.join("ignored_dir/nested/hidden.rs"), "pub fn hidden() {}\n").unwrap();
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::write(root.join("src/visible.rs"), "pub fn visible() {}\n").unwrap();
+
+        let gitignore = build_gitignore(root).unwrap();
+
+        assert!(
+            is_gitignored(&gitignore, root, &root.join("ignored_dir/nested/hidden.rs"), false),
+            "a file under an ignored directory must be ignored"
+        );
+        assert!(!is_gitignored(&gitignore, root, &root.join("src/visible.rs"), false));
+
+        let files = scan_and_analyze_files(root, "rust", None, &gitignore).await;
+        let paths: Vec<&str> = files.iter().map(|f| f.path.as_str()).collect();
+        assert!(
+            !paths.iter().any(|p| p.contains("ignored_dir")),
+            "scan returned gitignored paths: {paths:?}"
+        );
+        assert!(paths.iter().any(|p| p.contains("visible.rs")), "{paths:?}");
+    }
 }

--- a/src/services/context_impl/visitor.rs
+++ b/src/services/context_impl/visitor.rs
@@ -1,21 +1,122 @@
 
 struct RustVisitor {
     items: Vec<AstItem>,
-    
+
     source: String,
+    /// Byte offsets of the start of every line in `source`.
+    line_starts: Vec<usize>,
+    /// How far into `source` declaration lookup has already consumed. Items are
+    /// visited in source order, so the scan never has to restart.
+    scan_offset: usize,
 }
 
 impl RustVisitor {
     fn new(source: String) -> Self {
+        let mut line_starts = vec![0usize];
+        line_starts.extend(
+            source
+                .char_indices()
+                .filter(|(_, c)| *c == '\n')
+                .map(|(i, _)| i + 1),
+        );
         Self {
             items: Vec::new(),
             source,
+            line_starts,
+            scan_offset: 0,
         }
     }
 
-    fn get_line<T: syn::spanned::Spanned>(&self, _span: T) -> usize {
-        // For simplicity, return 1. In production, use a proper source map
-        1
+    /// Line on which `keyword name` is declared, e.g. `("fn", "collect_nodes")`.
+    ///
+    /// This used to be `get_line(_span) -> 1` ("for simplicity, return 1"), so
+    /// every item in a project-AST `FileContext` — and therefore every node of
+    /// the DAG built from it — reported line 1 regardless of the file. syn's
+    /// spans carry no location unless proc-macro2's `span-locations` feature is
+    /// on (it is not, and turning it on taxes every build), so resolve the line
+    /// from the source text the visitor already holds. Items arrive in source
+    /// order, so a forward scan is both cheap and unambiguous. A declaration we
+    /// cannot locate reports 0 ("unknown") rather than a plausible 1.
+    fn line_of_decl(&mut self, keyword: &str, name: &str) -> usize {
+        match self.find_decl_offset(keyword, Some(name)) {
+            Some(offset) => {
+                self.scan_offset = offset + keyword.len();
+                self.line_at(offset)
+            }
+            None => 0,
+        }
+    }
+
+    /// Line of the next bare `keyword` token (used for `impl` / `use`, which
+    /// have no single declared identifier).
+    fn line_of_keyword(&mut self, keyword: &str) -> usize {
+        match self.find_decl_offset(keyword, None) {
+            Some(offset) => {
+                self.scan_offset = offset + keyword.len();
+                self.line_at(offset)
+            }
+            None => 0,
+        }
+    }
+
+    fn line_at(&self, offset: usize) -> usize {
+        match self.line_starts.binary_search(&offset) {
+            Ok(index) => index + 1,
+            Err(index) => index, // index of the following line start == 1-based line
+        }
+    }
+
+    /// Byte offset of the next `keyword` token (optionally followed by `name`)
+    /// at or after the scan cursor, skipping matches inside `//` comments.
+    fn find_decl_offset(&self, keyword: &str, name: Option<&str>) -> Option<usize> {
+        let bytes = self.source.as_bytes();
+        let is_ident = |b: u8| b == b'_' || b.is_ascii_alphanumeric();
+        let mut from = self.scan_offset.min(self.source.len());
+
+        while let Some(rel) = self.source.get(from..)?.find(keyword) {
+            let start = from + rel;
+            from = start + keyword.len();
+
+            // `keyword` must stand alone, not end a longer identifier.
+            if start > 0 && is_ident(bytes[start - 1]) {
+                continue;
+            }
+            let after_keyword = start + keyword.len();
+            if after_keyword < bytes.len() && is_ident(bytes[after_keyword]) {
+                continue;
+            }
+
+            if let Some(name) = name {
+                let mut cursor = after_keyword;
+                while cursor < bytes.len() && (bytes[cursor] as char).is_whitespace() {
+                    cursor += 1;
+                }
+                if !self.source[cursor..].starts_with(name) {
+                    continue;
+                }
+                let after_name = cursor + name.len();
+                if after_name < bytes.len() && is_ident(bytes[after_name]) {
+                    continue;
+                }
+            }
+
+            if self.is_line_commented(start) {
+                continue;
+            }
+
+            return Some(start);
+        }
+
+        None
+    }
+
+    /// Is `offset` preceded by `//` on its own line? Keeps doc comments and
+    /// commented-out code from being read as declarations.
+    fn is_line_commented(&self, offset: usize) -> bool {
+        let line_start = self.source[..offset]
+            .rfind('\n')
+            .map_or(0, |newline| newline + 1);
+        self.source[line_start..offset].contains("//")
     }
 
     fn get_visibility(&self, vis: &syn::Visibility) -> String {
@@ -42,11 +143,13 @@ impl RustVisitor {
 
 impl<'ast> Visit<'ast> for RustVisitor {
     fn visit_item_fn(&mut self, node: &'ast ItemFn) {
+        let name = node.sig.ident.to_string();
+        let line = self.line_of_decl("fn", &name);
         self.items.push(AstItem::Function {
-            name: node.sig.ident.to_string(),
+            name,
             visibility: self.get_visibility(&node.vis),
             is_async: node.sig.asyncness.is_some(),
-            line: self.get_line(node.sig.ident.span()),
+            line,
         });
     }
 
@@ -57,29 +160,35 @@ impl<'ast> Visit<'ast> for RustVisitor {
             syn::Fields::Unit => 0,
         };
 
+        let name = node.ident.to_string();
+        let line = self.line_of_decl("struct", &name);
         self.items.push(AstItem::Struct {
-            name: node.ident.to_string(),
+            name,
             visibility: self.get_visibility(&node.vis),
             fields_count,
             derives: Self::get_derives(&node.attrs),
-            line: self.get_line(node.ident.span()),
+            line,
         });
     }
 
     fn visit_item_enum(&mut self, node: &'ast ItemEnum) {
+        let name = node.ident.to_string();
+        let line = self.line_of_decl("enum", &name);
         self.items.push(AstItem::Enum {
-            name: node.ident.to_string(),
+            name,
             visibility: self.get_visibility(&node.vis),
             variants_count: node.variants.len(),
-            line: self.get_line(node.ident.span()),
+            line,
         });
     }
 
     fn visit_item_trait(&mut self, node: &'ast ItemTrait) {
+        let name = node.ident.to_string();
+        let line = self.line_of_decl("trait", &name);
         self.items.push(AstItem::Trait {
-            name: node.ident.to_string(),
+            name,
             visibility: self.get_visibility(&node.vis),
-            line: self.get_line(node.ident.span()),
+            line,
         });
     }
 
@@ -100,18 +209,21 @@ impl<'ast> Visit<'ast> for RustVisitor {
                 .map_or_else(|| "Unknown".to_string(), |s| s.ident.to_string())
         });
 
+        let line = self.line_of_keyword("impl");
         self.items.push(AstItem::Impl {
             type_name,
             trait_name,
-            line: 1, // Default line number
+            line,
         });
     }
 
     fn visit_item_mod(&mut self, node: &'ast ItemMod) {
+        let name = node.ident.to_string();
+        let line = self.line_of_decl("mod", &name);
         self.items.push(AstItem::Module {
-            name: node.ident.to_string(),
+            name,
             visibility: self.get_visibility(&node.vis),
-            line: self.get_line(node.ident.span()),
+            line,
         });
     }
 
@@ -124,10 +236,8 @@ impl<'ast> Visit<'ast> for RustVisitor {
         let mut path = String::new();
         collect_use_path(&node.tree, &mut path);
 
-        self.items.push(AstItem::Use {
-            path,
-            line: 1, // Default line number
-        });
+        let line = self.line_of_keyword("use");
+        self.items.push(AstItem::Use { path, line });
     }
 }
 
@@ -153,6 +263,77 @@ fn collect_use_path(tree: &syn::UseTree, out: &mut String) {
         syn::UseTree::Rename(r) => push(out, &r.ident.to_string()),
         syn::UseTree::Glob(_) => push(out, "*"),
         syn::UseTree::Group(_) => {}
+    }
+}
+
+#[cfg(test)]
+mod visitor_line_number_tests {
+    //! Every item used to report line 1, whatever the file.
+    use super::*;
+
+    const SOURCE: &str = r"// a comment that mentions fn beta and struct Alpha
+use std::io;
+
+pub struct Alpha {
+    x: u32,
+}
+
+fn beta() -> u32 {
+    1
+}
+
+pub mod inner {}
+";
+
+    fn items_of(source: &str) -> Vec<AstItem> {
+        let parsed = syn::parse_file(source).expect("fixture must parse");
+        let mut visitor = RustVisitor::new(source.to_string());
+        visitor.visit_file(&parsed);
+        visitor.items
+    }
+
+    #[test]
+    fn test_items_report_their_real_declaration_line() {
+        let items = items_of(SOURCE);
+
+        let mut seen = Vec::new();
+        for item in &items {
+            match item {
+                AstItem::Use { path, line } => seen.push((path.clone(), *line)),
+                AstItem::Struct { name, line, .. }
+                | AstItem::Function { name, line, .. }
+                | AstItem::Module { name, line, .. } => seen.push((name.clone(), *line)),
+                _ => {}
+            }
+        }
+
+        assert_eq!(
+            seen,
+            vec![
+                ("std::io".to_string(), 2),
+                ("Alpha".to_string(), 4),
+                ("beta".to_string(), 8),
+                ("inner".to_string(), 12),
+            ],
+            "declaration lines were {seen:?}"
+        );
+    }
+
+    #[test]
+    fn test_line_numbers_are_not_all_one() {
+        // The stub returned a literal 1 for every item; any file with more than
+        // one declaration must produce more than one distinct line.
+        let lines: std::collections::BTreeSet<usize> = items_of(SOURCE)
+            .iter()
+            .map(|item| match item {
+                AstItem::Use { line, .. }
+                | AstItem::Struct { line, .. }
+                | AstItem::Function { line, .. }
+                | AstItem::Module { line, .. } => *line,
+                _ => 0,
+            })
+            .collect();
+        assert!(lines.len() > 1, "all items landed on the same line: {lines:?}");
     }
 }
 

--- a/src/services/coverage_improvement/baseline_measurement.rs
+++ b/src/services/coverage_improvement/baseline_measurement.rs
@@ -1,6 +1,24 @@
 // Coverage baseline measurement and coverage gain tracking
 // Included into mod.rs via include!() -- no `use` imports or `#!` attributes allowed
 
+/// Why the improvement loop should stop after `report`, if it should.
+///
+/// "No progress" means the iteration generated no test AND coverage did not
+/// rise: the next iteration would run the same prioritisation over the same
+/// tree and produce the same report, so continuing only costs another full
+/// coverage build. Returns `None` while there is any reason to keep going.
+fn zero_progress_stop_reason(report: &IterationReport) -> Option<String> {
+    if report.tests_generated == 0 && report.coverage_gain <= 0.0 {
+        Some(format!(
+            "No progress in iteration {}: 0 tests generated and {:+.2}% coverage change; \
+             further iterations would repeat it",
+            report.iteration, report.coverage_gain
+        ))
+    } else {
+        None
+    }
+}
+
 impl CoverageImprovementService {
     /// Improve coverage to target percentage
     ///
@@ -47,7 +65,25 @@ impl CoverageImprovementService {
                     .map(|i: &IterationReport| i.coverage_gain)
                     .sum::<f64>()
                 + iteration_report.coverage_gain;
+            let stalled = zero_progress_stop_reason(&iteration_report);
             iterations.push(iteration_report);
+
+            // An iteration that generated no test and moved coverage nowhere is
+            // deterministic: repeating it produces byte-identical results. The
+            // loop had no stop condition other than the target, so
+            // `--max-iterations 10` on a project with no generatable targets
+            // printed ten identical zero-gain iterations (and re-ran the whole
+            // coverage build ten times) before stopping.
+            if let Some(stop_reason) = stalled {
+                return Ok(CoverageImprovementReport {
+                    baseline_coverage: baseline,
+                    target_coverage: self.config.target_coverage,
+                    final_coverage: current_coverage,
+                    iterations,
+                    success: current_coverage >= self.config.target_coverage,
+                    stop_reason,
+                });
+            }
         }
 
         // Max iterations reached

--- a/src/services/coverage_improvement/baseline_measurement_tests.rs
+++ b/src/services/coverage_improvement/baseline_measurement_tests.rs
@@ -1,0 +1,54 @@
+//! Regression tests for the improvement loop's stop conditions.
+//!
+//! `baseline_measurement.rs` is `include!`d into `mod.rs`, so its tests cannot
+//! live at the end of that file (the includes after it would become items after
+//! a test module).
+
+use super::{zero_progress_stop_reason, IterationReport};
+use std::path::PathBuf;
+
+fn report(iteration: usize, tests_generated: usize, coverage_gain: f64) -> IterationReport {
+    IterationReport {
+        iteration,
+        files_targeted: vec![PathBuf::from("src/lib.rs")],
+        tests_generated,
+        coverage_gain,
+        mutation_score: f64::NAN,
+    }
+}
+
+/// The reported defect: an iteration that generated nothing and gained nothing
+/// was repeated `--max-iterations` times with byte-identical results (and a
+/// full `make coverage` run each time).
+#[test]
+fn a_zero_progress_iteration_stops_the_loop() {
+    let reason = zero_progress_stop_reason(&report(1, 0, 0.0))
+        .expect("0 tests + 0.00% gain must stop the loop");
+    assert!(
+        reason.contains("No progress in iteration 1"),
+        "stop reason must name the stalled iteration: {reason}"
+    );
+    assert!(
+        reason.contains("0 tests generated"),
+        "stop reason must state what it observed: {reason}"
+    );
+}
+
+/// A coverage REGRESSION is also no progress — repeating it cannot help.
+#[test]
+fn a_negative_gain_iteration_stops_the_loop() {
+    assert!(zero_progress_stop_reason(&report(2, 0, -0.5)).is_some());
+}
+
+/// Anything that moved: keep going.
+#[test]
+fn progress_does_not_stop_the_loop() {
+    assert!(
+        zero_progress_stop_reason(&report(1, 0, 1.5)).is_none(),
+        "coverage rose, so the next iteration is not a repeat"
+    );
+    assert!(
+        zero_progress_stop_reason(&report(1, 3, 0.0)).is_none(),
+        "tests were written; the next coverage run has new input"
+    );
+}

--- a/src/services/coverage_improvement/generated_test_validity_tests.rs
+++ b/src/services/coverage_improvement/generated_test_validity_tests.rs
@@ -1,0 +1,86 @@
+//! Regression tests for generated proptest files.
+//!
+//! Lives in its own file rather than at the end of `test_generation.rs`:
+//! that file is `include!`d into `mod.rs` ahead of `mutation_testing.rs`, so a
+//! test module at its end put items after a test module in the expanded
+//! source (`clippy::items_after_test_module`, denied by `ci / lint`).
+
+use super::*;
+
+const MANIFEST_WITH_PROPTEST: &str = r#"
+[package]
+name = "tiny-crate"
+version = "0.1.0"
+
+[dev-dependencies]
+proptest = "1"
+"#;
+
+const MANIFEST_WITHOUT_PROPTEST: &str = r#"
+[package]
+name = "tiny-crate"
+version = "0.1.0"
+"#;
+
+#[test]
+fn test_read_generated_test_targets() {
+    let with = read_generated_test_targets(MANIFEST_WITH_PROPTEST).unwrap();
+    // cargo turns `-` into `_` for the crate identifier an integration
+    // test has to import.
+    assert_eq!(with.crate_ident, "tiny_crate");
+    assert!(with.has_proptest);
+
+    let without = read_generated_test_targets(MANIFEST_WITHOUT_PROPTEST).unwrap();
+    assert!(!without.has_proptest);
+
+    assert!(read_generated_test_targets("not a manifest {{{").is_none());
+}
+
+/// The generated file used to open with `use crate::<file_stem>::*;`, which
+/// in a `tests/` integration target resolves against the test crate and
+/// fails with E0432.
+#[test]
+fn test_generated_module_imports_the_crate_under_test() {
+    let service = CoverageImprovementService::new(CoverageImprovementConfig::default());
+    let syntax_tree = syn::parse_file("pub fn keep(x: i32) -> i32 { x }").unwrap();
+    let functions = service.extract_public_functions(&syntax_tree);
+
+    let module = service
+        .generate_proptest_module("tiny_crate", &PathBuf::from("src/lib.rs"), &functions)
+        .unwrap();
+
+    assert!(module.contains("use tiny_crate::*;"), "{module}");
+    assert!(!module.contains("use crate::"), "{module}");
+}
+
+/// Emitting `use proptest::prelude::*;` into a project that has no proptest
+/// dev-dependency broke `cargo test` there, and pmat still reported the
+/// tests as generated. Refusing is the honest outcome.
+#[tokio::test]
+async fn test_no_tests_written_without_a_proptest_dev_dependency() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let root = temp.path();
+    std::fs::write(root.join("Cargo.toml"), MANIFEST_WITHOUT_PROPTEST).unwrap();
+    std::fs::create_dir_all(root.join("src")).unwrap();
+    std::fs::write(
+        root.join("src/lib.rs"),
+        "pub fn keep(x: i32) -> i32 { x }\n",
+    )
+    .unwrap();
+
+    let service = CoverageImprovementService::new(CoverageImprovementConfig {
+        project_path: root.to_path_buf(),
+        ..CoverageImprovementConfig::default()
+    });
+
+    let generated = service
+        .generate_property_tests(&[PathBuf::from("src/lib.rs")])
+        .await
+        .unwrap();
+
+    assert_eq!(generated, 0, "tests were counted but cannot compile");
+    assert!(
+        !root.join("tests").join("proptest_lib.rs").exists(),
+        "a non-compiling test file was left in the target project"
+    );
+}

--- a/src/services/coverage_improvement/mod.rs
+++ b/src/services/coverage_improvement/mod.rs
@@ -100,6 +100,10 @@ include!("mutation_testing.rs");
 
 // Tests split for file health compliance (CB-040)
 // TEMPORARILY DISABLED: File splitting broke syntax
+#[cfg(test)]
+#[path = "generated_test_validity_tests.rs"]
+mod generated_test_validity_tests;
+
 #[cfg(all(test, feature = "broken-tests"))]
 #[path = "tests.rs"]
 mod tests;

--- a/src/services/coverage_improvement/mod.rs
+++ b/src/services/coverage_improvement/mod.rs
@@ -104,6 +104,10 @@ include!("mutation_testing.rs");
 #[path = "generated_test_validity_tests.rs"]
 mod generated_test_validity_tests;
 
+#[cfg(test)]
+#[path = "baseline_measurement_tests.rs"]
+mod baseline_measurement_tests;
+
 #[cfg(all(test, feature = "broken-tests"))]
 #[path = "tests.rs"]
 mod tests;

--- a/src/services/coverage_improvement/mutation_testing.rs
+++ b/src/services/coverage_improvement/mutation_testing.rs
@@ -1,6 +1,15 @@
 // Mutation testing and iteration orchestration
 // Included into mod.rs via include!() -- no `use` imports or `#!` attributes allowed
 
+/// The value `IterationReport::mutation_score` carries when mutation testing did
+/// not run at all. `serde_json` renders a non-finite float as `null`, which is
+/// what a consumer of `-f json` should see for a measurement that was skipped.
+/// (The field is a plain `f64` in `IterationReport`; turning it into an
+/// `Option<f64>` would be the tidier representation.)
+fn unmeasured_mutation_score() -> f64 {
+    f64::NAN
+}
+
 impl CoverageImprovementService {
     /// Run a single improvement iteration
     async fn run_iteration(
@@ -15,8 +24,17 @@ impl CoverageImprovementService {
         let tests_generated = self.generate_property_tests(&targets).await?;
 
         // Phase 4: Validate with mutation testing
+        //
+        // `--fast` deliberately does NOT run cargo-mutants, so there is no
+        // mutation score to report. This used to substitute `100.0`, i.e. a
+        // *perfect* score, on every iteration of a run where no mutant was ever
+        // generated — `analyze coverage-improve --fast -f json` printed
+        // "mutation_score": 100.0 ten times over with no mutants.out/ on disk.
+        // A measurement that was skipped is reported as not-a-number, which
+        // serialises to JSON `null` rather than to a number nobody measured.
         let mutation_score = if self.config.fast_mode {
-            100.0 // Skip mutation testing in fast mode
+            eprintln!("⏩ --fast: skipping mutation testing (mutation score not measured)");
+            unmeasured_mutation_score()
         } else {
             self.run_mutation_testing(&targets).await?
         };
@@ -118,5 +136,38 @@ impl CoverageImprovementService {
         let _ = tokio::fs::remove_file(json_path).await;
 
         Ok(mutation_score)
+    }
+}
+
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg(test)]
+mod fast_mode_mutation_score_tests {
+    use super::*;
+
+    /// `--fast` skips cargo-mutants entirely, yet every iteration used to report
+    /// `"mutation_score": 100.0` — a perfect score for a measurement that was
+    /// never taken. Whatever fast mode reports must not be a finite number, and
+    /// must serialise as JSON null.
+    #[test]
+    fn skipped_mutation_testing_is_not_reported_as_a_score() {
+        let score = unmeasured_mutation_score();
+        assert!(
+            !score.is_finite(),
+            "a skipped measurement must not be a number, got {score}"
+        );
+
+        let report = IterationReport {
+            iteration: 1,
+            files_targeted: vec![PathBuf::from("src/lib.rs")],
+            tests_generated: 0,
+            coverage_gain: 0.0,
+            mutation_score: score,
+        };
+        let json = serde_json::to_value(&report).expect("IterationReport serialises");
+        assert!(
+            json["mutation_score"].is_null(),
+            "expected null for an unmeasured score, got {}",
+            json["mutation_score"]
+        );
     }
 }

--- a/src/services/coverage_improvement/proptest_generation_tests.rs
+++ b/src/services/coverage_improvement/proptest_generation_tests.rs
@@ -12,10 +12,13 @@ mod proptest_generation_tests {
         let target = PathBuf::from("lib.rs");
 
         let module = service
-            .generate_proptest_module(&target, &functions)
+            .generate_proptest_module("tiny_crate", &target, &functions)
             .unwrap();
 
-        assert!(module.contains("use crate::lib::*;"));
+        // Integration tests live in their own crate: `use crate::lib::*;`
+        // (what this asserted before) can never resolve.
+        assert!(module.contains("use tiny_crate::*;"));
+        assert!(!module.contains("use crate::"));
     }
 
     #[test]
@@ -36,7 +39,7 @@ mod proptest_generation_tests {
         let target = PathBuf::from("multi.rs");
 
         let module = service
-            .generate_proptest_module(&target, &functions)
+            .generate_proptest_module("tiny_crate", &target, &functions)
             .unwrap();
 
         assert!(module.contains("fn proptest_func_a"));
@@ -55,10 +58,10 @@ mod proptest_generation_tests {
         let target = PathBuf::from("src/services/coverage.rs");
 
         let module = service
-            .generate_proptest_module(&target, &functions)
+            .generate_proptest_module("my_crate", &target, &functions)
             .unwrap();
 
-        // Should use just the file stem
-        assert!(module.contains("use crate::coverage::*;"));
+        // The import names the crate under test, never the target file stem.
+        assert!(module.contains("use my_crate::*;"));
     }
 }

--- a/src/services/coverage_improvement/test_generation.rs
+++ b/src/services/coverage_improvement/test_generation.rs
@@ -1,6 +1,44 @@
 // Property test generation from AST analysis
 // Included into mod.rs via include!() -- no `use` imports or `#!` attributes allowed
 
+/// What a generated `tests/` file may legally reference in the target project.
+pub(crate) struct GeneratedTestTargets {
+    /// The rust identifier of the crate under test (`-` replaced by `_`).
+    pub(crate) crate_ident: String,
+    /// Whether the project can compile `use proptest::prelude::*;` at all.
+    pub(crate) has_proptest: bool,
+}
+
+/// Read the target project's manifest for the facts a generated test depends on.
+///
+/// Generated files used to open with a fixed `use proptest::prelude::*;` and
+/// `use crate::<file_stem>::*;`. Both are wrong for a `tests/` integration
+/// target: `crate::` there is the *test* crate, not the crate under test, and
+/// proptest was never added as a dev-dependency. Writing that file turned a
+/// green `cargo test --no-run` in the user's project into E0433/E0432 — and
+/// pmat still counted the file as tests_generated. The manifest now decides
+/// what may be emitted, and a project without proptest gets nothing rather
+/// than a broken build.
+pub(crate) fn read_generated_test_targets(manifest: &str) -> Option<GeneratedTestTargets> {
+    let manifest: toml::Value = toml::from_str(manifest).ok()?;
+    let package_name = manifest.get("package")?.get("name")?.as_str()?;
+    let crate_ident = manifest
+        .get("lib")
+        .and_then(|lib| lib.get("name"))
+        .and_then(toml::Value::as_str)
+        .unwrap_or(package_name)
+        .replace('-', "_");
+    let has_proptest = manifest
+        .get("dev-dependencies")
+        .and_then(|deps| deps.get("proptest"))
+        .is_some();
+
+    Some(GeneratedTestTargets {
+        crate_ident,
+        has_proptest,
+    })
+}
+
 impl CoverageImprovementService {
     /// Generate property-based tests for target files
     ///
@@ -11,7 +49,33 @@ impl CoverageImprovementService {
     async fn generate_property_tests(&self, targets: &[PathBuf]) -> Result<usize> {
         eprintln!("🧪 Generating property-based tests...");
 
+        let manifest_path = self.config.project_path.join("Cargo.toml");
+        let manifest = tokio::fs::read_to_string(&manifest_path).await.ok();
+        let Some(test_targets) = manifest
+            .as_deref()
+            .and_then(read_generated_test_targets)
+        else {
+            eprintln!(
+                "⚠️  Not generating property tests: no readable [package] in {}",
+                manifest_path.display()
+            );
+            return Ok(0);
+        };
+
+        if !test_targets.has_proptest {
+            eprintln!(
+                "⚠️  Not generating property tests: {} has no `proptest` dev-dependency.",
+                manifest_path.display()
+            );
+            eprintln!(
+                "   Add `proptest = \"1\"` under [dev-dependencies] and re-run — emitting the\n\
+                 \x20  tests now would leave the project unable to compile its test targets."
+            );
+            return Ok(0);
+        }
+
         let mut tests_generated = 0;
+        let mut written: Vec<PathBuf> = Vec::new();
 
         for target in targets {
             // Only process .rs files
@@ -52,7 +116,8 @@ impl CoverageImprovementService {
             }
 
             // Generate proptest for each function
-            let test_content = self.generate_proptest_module(target, &functions)?;
+            let test_content =
+                self.generate_proptest_module(&test_targets.crate_ident, target, &functions)?;
 
             // Write to tests directory
             let test_filename = format!(
@@ -67,6 +132,7 @@ impl CoverageImprovementService {
             }
 
             tokio::fs::write(&test_path, test_content).await?;
+            written.push(test_path);
 
             tests_generated += functions.len();
             eprintln!(
@@ -77,9 +143,52 @@ impl CoverageImprovementService {
             );
         }
 
+        // Nothing previously compiled the files we just dropped into the user's
+        // tests/ directory, so a generated file that does not typecheck stayed
+        // there and broke `cargo test` for everything else — while still being
+        // reported as tests_generated. A file we cannot verify is rolled back.
+        if !written.is_empty() && !self.generated_tests_compile().await {
+            for path in &written {
+                let _ = tokio::fs::remove_file(path).await;
+            }
+            eprintln!(
+                "↩️  Reverted {} generated test file(s): they do not compile.",
+                written.len()
+            );
+            return Ok(0);
+        }
+
         eprintln!("✅ Generated {} property tests total", tests_generated);
 
         Ok(tests_generated)
+    }
+
+    /// Whether the target project's test targets still build.
+    ///
+    /// Returns false when cargo cannot be run at all: an unverifiable
+    /// generated file is treated exactly like a broken one.
+    async fn generated_tests_compile(&self) -> bool {
+        let output = Command::new("cargo")
+            .args(["test", "--no-run", "--tests"])
+            .current_dir(&self.config.project_path)
+            .output()
+            .await;
+
+        match output {
+            Ok(out) if out.status.success() => true,
+            Ok(out) => {
+                let stderr = String::from_utf8_lossy(&out.stderr);
+                eprintln!("⚠️  Generated tests do not compile:");
+                for line in stderr.lines().take(20) {
+                    eprintln!("   {line}");
+                }
+                false
+            }
+            Err(e) => {
+                eprintln!("⚠️  Could not verify generated tests compile: {e}");
+                false
+            }
+        }
     }
 
     /// Extract public functions from a syn::File
@@ -99,9 +208,14 @@ impl CoverageImprovementService {
     }
 
     /// Generate a proptest module for the given functions
+    ///
+    /// `crate_ident` is the crate under test as an integration test must name
+    /// it. This used to emit `use crate::<file_stem>::*;`, which in a `tests/`
+    /// target resolves against the test crate itself and never compiles.
     pub(crate) fn generate_proptest_module(
         &self,
-        target: &PathBuf,
+        crate_ident: &str,
+        _target: &PathBuf,
         functions: &[syn::ItemFn],
     ) -> Result<String> {
         let mut module = String::from(
@@ -113,12 +227,7 @@ use proptest::prelude::*;
 "#,
         );
 
-        // Add module import for the target file
-        let module_name = target
-            .file_stem()
-            .and_then(|s| s.to_str())
-            .unwrap_or("target");
-        module.push_str(&format!("use crate::{}::*;\n\n", module_name));
+        module.push_str(&format!("use {}::*;\n\n", crate_ident));
 
         for func in functions {
             let func_name = &func.sig.ident;

--- a/src/services/dag_builder_node_collection.rs
+++ b/src/services/dag_builder_node_collection.rs
@@ -114,17 +114,36 @@ impl DagBuilder {
         function_complexity: &FxHashMap<&str, u32>,
     ) {
         let id = format!("{}::{}", self.normalize_path(&file.path), name);
+
+        // The project-AST FileContexts the DAG is built from carry
+        // `complexity_metrics: None`, so this fell through to a literal
+        // `.unwrap_or(2)` and EVERY function node in a 6376-node graph came out
+        // with complexity 2 — a constant reported as a measurement, and one
+        // that contradicted `analyze_complexity` for the same function. The
+        // node still needs a weight, so it gets the neutral 1 the trait and
+        // module nodes use, and says so: consumers can tell "we measured 1"
+        // from "nobody measured this".
+        // (`enrich_node` overwrites metadata["complexity"] with the number, so
+        // the provenance lives under its own key.)
+        let measured = function_complexity.get(name).copied();
+        let mut metadata = FxHashMap::default();
+        metadata.insert(
+            "complexity_source".to_string(),
+            if measured.is_some() {
+                "measured".to_string()
+            } else {
+                "not-measured".to_string()
+            },
+        );
+
         let node = NodeInfo {
             id: id.clone(),
             label: name.to_string(),
             node_type: NodeType::Function,
             file_path: file.path.clone(),
             line_number: line,
-            complexity: function_complexity
-                .get(name)
-                .copied()
-                .unwrap_or(2), // Default function complexity
-            metadata: FxHashMap::default(),
+            complexity: measured.unwrap_or(1),
+            metadata,
         };
         self.add_node(self.enrich_node(node));
         self.function_map.insert(name.to_string(), id);
@@ -192,5 +211,68 @@ impl DagBuilder {
             metadata: FxHashMap::default(),
         };
         self.add_node(self.enrich_node(node));
+    }
+}
+
+#[cfg(test)]
+mod unmeasured_complexity_tests {
+    //! A constant is not a measurement.
+    use super::*;
+
+    fn project_with_one_function() -> ProjectContext {
+        let file = FileContext {
+            path: "src/lib.rs".to_string(),
+            language: "rust".to_string(),
+            items: vec![AstItem::Function {
+                name: "complex".to_string(),
+                visibility: "pub".to_string(),
+                is_async: false,
+                line: 5,
+            }],
+            // The project-AST path never populates this — that is the point.
+            complexity_metrics: None,
+        };
+
+        ProjectContext {
+            project_type: "rust".to_string(),
+            summary: crate::services::context::ProjectSummary {
+                total_files: 1,
+                total_functions: 1,
+                total_structs: 0,
+                total_enums: 0,
+                total_traits: 0,
+                total_impls: 0,
+                dependencies: vec![],
+            },
+            files: vec![file],
+            graph: None,
+        }
+    }
+
+    /// Every Function node used to come back with complexity 2 from
+    /// `.unwrap_or(2) // Default function complexity`, reported as if it had
+    /// been measured — and contradicting `analyze_complexity` on the same
+    /// function. When no metrics reached the builder the node must say so.
+    #[test]
+    fn test_function_node_without_metrics_is_labelled_not_measured() {
+        let graph = DagBuilder::build_from_project(&project_with_one_function());
+
+        let node = graph
+            .nodes
+            .values()
+            .find(|n| n.node_type == NodeType::Function)
+            .expect("the function node must exist");
+
+        assert_eq!(
+            node.metadata.get("complexity_source").map(String::as_str),
+            Some("not-measured"),
+            "node {} claims complexity {} with no provenance",
+            node.id,
+            node.complexity
+        );
+        assert_ne!(
+            node.complexity, 2,
+            "complexity 2 is the old fabricated default"
+        );
     }
 }

--- a/src/services/dead_code_multi_language.rs
+++ b/src/services/dead_code_multi_language.rs
@@ -115,6 +115,65 @@ mod tests {
         );
     }
 
+    /// A nonexistent path used to be reported as "not supported for language:
+    /// unknown" — a language verdict for a path that was never read.
+    #[test]
+    fn test_missing_path_is_a_path_error_not_a_language_verdict() {
+        let err = analyze_dead_code_multi_language(Path::new(
+            "/does/not/exist/pmat-dead-code-missing-path",
+        ))
+        .expect_err("a missing path must be an error");
+        let msg = err.to_string();
+        assert!(msg.contains("Path not found"), "{msg}");
+        assert!(
+            !msg.contains("unknown"),
+            "must not report a detected language for a path that does not exist: {msg}"
+        );
+    }
+
+    /// One unsupported dominant language used to abort the whole run, even when
+    /// every supported file under the path was analysable.
+    #[test]
+    fn test_unsupported_dominant_language_still_analyses_supported_files() {
+        let temp = TempDir::new().unwrap();
+        // Enough TypeScript to win language detection...
+        for i in 0..5 {
+            std::fs::write(
+                temp.path().join(format!("app{i}.ts")),
+                "export function f(): number { return 1; }\n",
+            )
+            .unwrap();
+        }
+        // ...plus one analysable Python file.
+        std::fs::write(
+            temp.path().join("main.py"),
+            "def main():\n    used()\n\ndef used():\n    pass\n\ndef dead_one():\n    pass\n",
+        )
+        .unwrap();
+
+        let result = analyze_dead_code_multi_language(temp.path())
+            .expect("supported files are present, so the run must not abort");
+        assert_eq!(result.language, "python");
+        assert!(
+            result.dead_functions.iter().any(|d| d.name == "dead_one"),
+            "the Python file must actually have been analysed: {result:?}"
+        );
+    }
+
+    /// ...but a tree with nothing analysable in it must still say so.
+    #[test]
+    fn test_no_supported_files_still_errors() {
+        let temp = TempDir::new().unwrap();
+        std::fs::write(
+            temp.path().join("app.ts"),
+            "export function f(): number { return 1; }\n",
+        )
+        .unwrap();
+        let err =
+            analyze_dead_code_multi_language(temp.path()).expect_err("nothing analysable here");
+        assert!(err.to_string().contains("no rust, c, cpp, python or lua"));
+    }
+
     fn create_test_c_project() -> TempDir {
         let temp = TempDir::new().unwrap();
         std::fs::write(

--- a/src/services/dead_code_multi_language_types.rs
+++ b/src/services/dead_code_multi_language_types.rs
@@ -33,10 +33,40 @@ pub trait DeadCodeStrategy {
     fn language(&self) -> &str;
 }
 
+/// Languages with a dead-code strategy, and the extensions that identify them.
+///
+/// Used to answer "is there anything here I *can* analyse?" when the project's
+/// dominant language has no strategy.
+const DEAD_CODE_SUPPORTED_LANGUAGES: &[(&str, &[&str])] = &[
+    ("rust", &["rs"]),
+    ("c", &["c", "h"]),
+    ("cpp", &["cpp", "cc", "cxx", "hpp", "hxx"]),
+    ("python", &["py"]),
+    ("lua", &["lua"]),
+];
+
+fn dead_code_strategy_for(language: &str) -> Option<Box<dyn DeadCodeStrategy>> {
+    match language {
+        "rust" => Some(Box::new(RustDeadCodeStrategy)),
+        "c" => Some(Box::new(CDeadCodeStrategy)),
+        "cpp" => Some(Box::new(CppDeadCodeStrategy)),
+        "python" => Some(Box::new(PythonDeadCodeStrategy)),
+        "lua" => Some(Box::new(LuaDeadCodeStrategy)),
+        _ => None,
+    }
+}
+
 /// Analyze dead code using appropriate strategy for the project language
 #[provable_contracts_macros::contract("pmat-core.yaml", equation = "path_exists")]
 pub fn analyze_dead_code_multi_language(path: &Path) -> Result<DeadCodeResult> {
     info!("Starting multi-language dead code analysis at: {:?}", path);
+
+    // A missing path used to fall through to language detection, which returned
+    // "unknown", so the user was told "not supported for language: unknown"
+    // instead of that the path does not exist.
+    if !path.exists() {
+        return Err(anyhow::anyhow!("Path not found: {}", path.display()));
+    }
 
     // Step 1: Detect language using enhanced detection from BUG-011
     let detection =
@@ -47,18 +77,34 @@ pub fn analyze_dead_code_multi_language(path: &Path) -> Result<DeadCodeResult> {
         detection.language, detection.confidence
     );
 
-    // Step 2: Select appropriate strategy
-    let strategy: Box<dyn DeadCodeStrategy> = match detection.language.as_str() {
-        "rust" => Box::new(RustDeadCodeStrategy),
-        "c" => Box::new(CDeadCodeStrategy),
-        "cpp" => Box::new(CppDeadCodeStrategy),
-        "python" => Box::new(PythonDeadCodeStrategy),
-        "lua" => Box::new(LuaDeadCodeStrategy),
-        _ => {
-            return Err(anyhow::anyhow!(
-                "Dead code analysis not supported for language: {}. Supported: rust, c, cpp, python, lua",
-                detection.language
-            ));
+    // Step 2: Select a strategy. Detection reports ONE dominant language, so a
+    // tree whose plurality language has no strategy (a TypeScript app with a
+    // handful of Python scripts) used to abort the whole run even though every
+    // supported file in it was analysable. Fall back to a language that is
+    // actually present rather than refusing outright.
+    let strategy: Box<dyn DeadCodeStrategy> = match dead_code_strategy_for(&detection.language) {
+        Some(s) => s,
+        None => {
+            let fallback = DEAD_CODE_SUPPORTED_LANGUAGES
+                .iter()
+                .find(|(_, exts)| !find_files_by_extension(path, exts).is_empty())
+                .and_then(|(lang, _)| {
+                    debug!(
+                        "No strategy for detected language {}; falling back to {lang}",
+                        detection.language
+                    );
+                    dead_code_strategy_for(lang)
+                });
+            match fallback {
+                Some(s) => s,
+                None => {
+                    return Err(anyhow::anyhow!(
+                        "Dead code analysis not supported for language: {}, and no rust, c, cpp, python or lua source files were found under {}",
+                        detection.language,
+                        path.display()
+                    ));
+                }
+            }
         }
     };
 

--- a/src/services/deep_context/analysis_functions/metrics_analyses.rs
+++ b/src/services/deep_context/analysis_functions/metrics_analyses.rs
@@ -339,7 +339,17 @@ pub async fn analyze_dag_with_context(
     };
 
     // Smart bounds: limit graph size to 200 nodes (was 400)
-    let graph = DagBuilder::build_from_project_with_limit(project_context, 200);
+    let mut graph = DagBuilder::build_from_project_with_limit(project_context, 200);
+
+    // #653 was only ever fixed on the CLI path. `DagBuilder` derives edges from
+    // `use`/`impl` items, so it emits no `EdgeType::Calls` edge at all and
+    // `filter_call_edges` below then deleted the entire graph: the MCP
+    // `analyze_dag` tool answered "DAG analysis completed (0 nodes, 0 edges)"
+    // for the very tree over which `pmat analyze dag --dag-type call-graph`
+    // drew 24 call edges. An empty graph reported as a completed analysis is a
+    // silent wrong answer, so the call-edge enrichment lives here, where both
+    // surfaces reach it.
+    crate::services::dag_call_edges::add_call_edges(&mut graph, path);
 
     // Apply filters based on DAG type
     let filtered_graph = match dag_type {
@@ -374,4 +384,40 @@ pub async fn analyze_big_o(
     };
 
     analyzer.analyze(config).await
+}
+
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg(test)]
+mod dag_service_tests {
+    use super::*;
+
+    /// The MCP `analyze_dag` tool goes through `analyze_dag_with_context`, not
+    /// through the CLI handler, and only the CLI handler added call edges — so
+    /// the tool reported "0 nodes, 0 edges" for a tree the CLI drew 24 edges
+    /// over. A call graph with no edges over real Rust sources is a wrong
+    /// answer, not an empty project.
+    #[tokio::test]
+    async fn call_graph_from_the_service_path_has_call_edges() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            dir.path().join("main.rs"),
+            "mod helper;\nfn main() { helper_one(); }\nfn helper_one() { helper_two(); }\nfn helper_two() {}\n",
+        )
+        .expect("write main.rs");
+
+        let graph = analyze_dag(dir.path(), DagType::CallGraph)
+            .await
+            .expect("call-graph analysis must succeed");
+
+        assert!(
+            !graph.edges.is_empty(),
+            "call graph over Rust sources must contain Calls edges, got {} nodes / {} edges",
+            graph.nodes.len(),
+            graph.edges.len()
+        );
+        assert!(
+            !graph.nodes.is_empty(),
+            "edges without nodes would be a filtered-away graph again"
+        );
+    }
 }

--- a/src/services/deep_context/analysis_helpers.rs
+++ b/src/services/deep_context/analysis_helpers.rs
@@ -136,54 +136,80 @@ async fn analyze_source_files_for_contexts(
     let mut enhanced_contexts = Vec::new();
     let mut file_count = 0;
     let analysis_start = std::time::Instant::now();
+    let discovered = source_files.len();
+    let mut failures: Vec<(PathBuf, String)> = Vec::new();
 
     for file_path in source_files {
-        if let Some(enhanced_context) =
-            analyze_single_file_for_context(&file_path, &mut file_count).await
-        {
-            enhanced_contexts.push(enhanced_context);
+        match analyze_single_file_for_context(&file_path, &mut file_count).await {
+            Ok(enhanced_context) => enhanced_contexts.push(enhanced_context),
+            Err(e) => failures.push((file_path, e.to_string())),
         }
     }
+
+    report_parse_failures(discovered, &failures);
 
     log_analysis_completion(analysis_start, file_count);
     Ok(enhanced_contexts)
 }
 
+/// Report files whose AST parse failed.
+///
+/// A crate whose every file fails to parse used to render exactly like an empty
+/// directory — "Total Files: 0", no warning, exit 0 — because the parse error was
+/// dropped by an `if let Ok(..)` with no else branch. Warnings go to stderr because
+/// the tracing subscriber is off in several of the modes that generate context.
+fn report_parse_failures(discovered: usize, failures: &[(PathBuf, String)]) {
+    if failures.is_empty() {
+        return;
+    }
+    const MAX_LISTED: usize = 10;
+    for (path, err) in failures.iter().take(MAX_LISTED) {
+        eprintln!("⚠️  failed to parse {}: {}", path.display(), err);
+    }
+    if failures.len() > MAX_LISTED {
+        eprintln!("⚠️  … and {} more", failures.len() - MAX_LISTED);
+    }
+    eprintln!(
+        "⚠️  {} of {} discovered source file(s) failed to parse and are absent from this context",
+        failures.len(),
+        discovered
+    );
+}
+
 /// Analyze single file and create enhanced context if successful
+/// Returns the parse error instead of swallowing it: the caller counts and reports
+/// unparseable files so they cannot vanish from the context without a word.
 async fn analyze_single_file_for_context(
     file_path: &Path,
     file_count: &mut usize,
-) -> Option<EnhancedFileContext> {
+) -> anyhow::Result<EnhancedFileContext> {
     let file_start = std::time::Instant::now();
 
-    if let Ok(file_context) = analysis_functions::analyze_single_file(file_path).await {
-        let ast_time = file_start.elapsed();
+    let file_context = analysis_functions::analyze_single_file(file_path).await?;
+    let ast_time = file_start.elapsed();
 
-        if (*file_count).is_multiple_of(10) {
-            info!(
-                "Progress: {} files processed. Last file - AST: {:?}",
-                file_count, ast_time
-            );
-        }
-
-        let enhanced_context = EnhancedFileContext {
-            base: file_context,
-            complexity_metrics: None,
-            churn_metrics: None,
-            defects: DefectAnnotations {
-                dead_code: None,
-                technical_debt: Vec::new(),
-                complexity_violations: Vec::new(),
-                tdg_score: None, // Skip TDG calculation for context generation
-            },
-            symbol_id: uuid::Uuid::new_v4().to_string(),
-        };
-
-        *file_count += 1;
-        Some(enhanced_context)
-    } else {
-        None
+    if (*file_count).is_multiple_of(10) {
+        info!(
+            "Progress: {} files processed. Last file - AST: {:?}",
+            file_count, ast_time
+        );
     }
+
+    let enhanced_context = EnhancedFileContext {
+        base: file_context,
+        complexity_metrics: None,
+        churn_metrics: None,
+        defects: DefectAnnotations {
+            dead_code: None,
+            technical_debt: Vec::new(),
+            complexity_violations: Vec::new(),
+            tdg_score: None, // Skip TDG calculation for context generation
+        },
+        symbol_id: uuid::Uuid::new_v4().to_string(),
+    };
+
+    *file_count += 1;
+    Ok(enhanced_context)
 }
 
 /// Log analysis completion statistics
@@ -197,3 +223,39 @@ fn log_analysis_completion(analysis_start: std::time::Instant, file_count: usize
     );
 }
 
+
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg(test)]
+mod analysis_helpers_tests {
+    use super::*;
+
+    /// An unparseable source file must surface its parse error, not be silently
+    /// dropped: a crate where every file fails to parse used to render exactly like
+    /// an empty directory.
+    #[tokio::test]
+    async fn test_analyze_single_file_for_context_reports_parse_error() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let broken = tmp.path().join("main.rs");
+        std::fs::write(&broken, "fn main( { let x = ;;;\n").unwrap();
+
+        let mut count = 0usize;
+        let result = analyze_single_file_for_context(&broken, &mut count).await;
+        assert!(
+            result.is_err(),
+            "unparseable file must yield an error, not a silent skip"
+        );
+        assert_eq!(count, 0, "a failed file must not be counted as analyzed");
+    }
+
+    #[tokio::test]
+    async fn test_analyze_single_file_for_context_ok_on_valid_rust() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let good = tmp.path().join("main.rs");
+        std::fs::write(&good, "fn main() {}\n").unwrap();
+
+        let mut count = 0usize;
+        let result = analyze_single_file_for_context(&good, &mut count).await;
+        assert!(result.is_ok(), "valid rust must parse: {result:?}");
+        assert_eq!(count, 1);
+    }
+}

--- a/src/services/deep_context/analyzer_core/quality.rs
+++ b/src/services/deep_context/analyzer_core/quality.rs
@@ -17,6 +17,21 @@ use crate::services::deep_context::{
 };
 use crate::services::quality_gates::{QAVerification, QAVerificationResult};
 
+/// Mean of the scorecard components that were actually measured.
+///
+/// `None` when nothing was measured — "we did not look" must not be reported as
+/// a score. Every measured component participates; leaving one out is how
+/// `overall_health` came to be a restatement of `complexity_score`.
+fn average_measured(components: &[Option<f64>]) -> Option<f64> {
+    let measured: Vec<f64> = components.iter().copied().flatten().collect();
+    if measured.is_empty() {
+        None
+    } else {
+        #[allow(clippy::cast_precision_loss)]
+        Some(measured.iter().sum::<f64>() / measured.len() as f64)
+    }
+}
+
 impl DeepContextAnalyzer {
     // New helper methods for phases that didn't exist before
     #[provable_contracts_macros::contract("pmat-core.yaml", equation = "score_range")]
@@ -73,15 +88,18 @@ impl DeepContextAnalyzer {
 
         // Averaging over only what was measured. Averaging in a constant is how
         // the old value became a function of one real input and two literals.
-        let measured: Vec<f64> = [complexity_score, maintainability_index, modularity_score]
-            .into_iter()
-            .flatten()
-            .collect();
-        let overall_health = if measured.is_empty() {
-            None
-        } else {
-            Some(measured.iter().sum::<f64>() / measured.len() as f64)
-        };
+        //
+        // `test_coverage` used to be left out of this list. Since the other two
+        // entries are permanently `None`, that made `overall_health` identically
+        // `complexity_score` — a four-component scorecard whose headline number
+        // reported one component and discarded the coverage it had just
+        // measured off disk.
+        let overall_health = average_measured(&[
+            complexity_score,
+            maintainability_index,
+            modularity_score,
+            test_coverage,
+        ]);
 
         Ok(QualityScorecard {
             overall_health,
@@ -528,5 +546,74 @@ impl DeepContextAnalyzer {
             build_info: context.build_info.clone(),
             project_overview: context.project_overview.clone(),
         })
+    }
+}
+
+#[cfg(test)]
+mod scorecard_tests {
+    //! `overall_health` averaged `[complexity_score, maintainability_index,
+    //! modularity_score]`. The last two are permanently `None` (no Halstead
+    //! volume is ever produced, and modularity has no implementation), so the
+    //! headline number was identically `complexity_score` — and the
+    //! `test_coverage` it had just read off disk was thrown away.
+    use super::*;
+    use crate::services::complexity::{
+        ComplexityMetrics, ComplexityReport, ComplexitySummary, FileComplexityMetrics,
+    };
+    use crate::services::deep_context::{DeepContextConfig, DefectSummary};
+
+    fn one_clean_file() -> ComplexityReport {
+        ComplexityReport {
+            summary: ComplexitySummary::default(),
+            violations: vec![],
+            hotspots: vec![],
+            files: vec![FileComplexityMetrics {
+                path: "src/lib.rs".to_string(),
+                total_complexity: ComplexityMetrics::default(),
+                functions: vec![],
+                classes: vec![],
+            }],
+        }
+    }
+
+    #[tokio::test]
+    async fn overall_health_averages_in_the_coverage_it_measured() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir_all(tmp.path().join("target/coverage")).expect("mkdir");
+        // Two instrumented lines, one hit => 50% line coverage.
+        std::fs::write(
+            tmp.path().join("target/coverage/lcov.info"),
+            "SF:src/lib.rs\nDA:1,1\nDA:2,0\nend_of_record\n",
+        )
+        .expect("write lcov");
+
+        let analyzer = DeepContextAnalyzer::new(DeepContextConfig::default());
+        let analyses = ParallelAnalysisResults {
+            complexity_report: Some(one_clean_file()),
+            ..Default::default()
+        };
+
+        let card = analyzer
+            .calculate_quality_scorecard(&analyses, &DefectSummary::default(), tmp.path())
+            .await
+            .expect("scorecard");
+
+        assert_eq!(card.complexity_score, Some(100.0));
+        assert_eq!(card.test_coverage, Some(50.0));
+        // mean(100, 50) — not 100, which is what dropping test_coverage gave.
+        let health = card.overall_health.expect("two components were measured");
+        assert!(
+            (health - 75.0).abs() < 1e-9,
+            "overall_health must average every measured component, got {health}"
+        );
+    }
+
+    #[test]
+    fn average_measured_reports_nothing_when_nothing_was_measured() {
+        assert_eq!(average_measured(&[None, None, None, None]), None);
+        assert_eq!(
+            average_measured(&[Some(40.0), None, None, Some(60.0)]),
+            Some(50.0)
+        );
     }
 }

--- a/src/services/defect_detector_rust.rs
+++ b/src/services/defect_detector_rust.rs
@@ -100,7 +100,13 @@ impl RustDefectDetector {
                     .to_string(),
                 evidence_description: "Cloudflare outage 2025-11-18 (3+ hour network outage)"
                     .to_string(),
-                evidence_url: Some("https://blog.cloudflare.com/2025-01-18-outage".to_string()),
+                // The slug used to say 2025-01-18 while the description said
+                // 2025-11-18: a citation for an outage that never happened, and
+                // the URL 404ed. The post about the November 18 outage — the one
+                // an `.unwrap()` on a bot-features file caused — is this one.
+                evidence_url: Some(
+                    "https://blog.cloudflare.com/18-november-2025-outage/".to_string(),
+                ),
                 instances: unwrap_instances,
             });
         }
@@ -353,6 +359,33 @@ mod colocated_test_module_regression_tests {
         assert!(
             defects.is_empty(),
             "test-module .unwrap() must stay excluded: {defects:?}"
+        );
+    }
+
+    /// The citation used to point at `/2025-01-18-outage` while claiming the
+    /// outage of 2025-11-18: two different dates in one piece of evidence, and
+    /// the URL 404ed. The date in the slug must match the date in the prose.
+    #[test]
+    fn unwrap_evidence_url_matches_its_own_description() {
+        let detector = RustDefectDetector::new();
+        let defects = detector.detect(PRODUCTION_THEN_TEST_MODULE, Path::new("src/lib.rs"));
+        let unwrap = defects
+            .iter()
+            .find(|d| d.id == "RUST-UNWRAP-001")
+            .expect("RUST-UNWRAP-001 must be reported");
+        let url = unwrap
+            .evidence_url
+            .as_deref()
+            .expect("RUST-UNWRAP-001 cites a URL");
+
+        assert!(
+            unwrap.evidence_description.contains("2025-11-18"),
+            "description names the November 2025 outage: {}",
+            unwrap.evidence_description
+        );
+        assert!(
+            url.contains("18-november-2025"),
+            "the cited URL must be the November 2025 outage post, not {url}"
         );
     }
 

--- a/src/services/defect_detector_rust.rs
+++ b/src/services/defect_detector_rust.rs
@@ -48,19 +48,14 @@ impl RustDefectDetector {
         false
     }
 
-    /// Check if content contains test-related markers
-    fn has_test_markers(&self, content: &str) -> bool {
-        // Check for test cfg attributes
-        let has_cfg_test = content.contains("#[cfg(test)]")
-            || content.contains("#[cfg(all(test,")
-            || content.contains("#[cfg(any(test,");
-
-        // Check for test function attributes
-        let has_test_attr = content.contains("#[test]")
-            || content.contains("#[tokio::test]")
-            || content.contains("#[async_test]");
-
-        has_cfg_test || has_test_attr
+    /// True if a single trimmed line is a test-function attribute (`#[test]`,
+    /// `#[tokio::test]`, …). The item it precedes is test code even when it is
+    /// not wrapped in a `#[cfg(test)]` module.
+    fn is_test_attr_line(trimmed: &str) -> bool {
+        trimmed.starts_with("#[test]")
+            || trimmed.starts_with("#[tokio::test")
+            || trimmed.starts_with("#[async_test")
+            || trimmed.starts_with("#[async_std::test")
     }
 
     /// Detect all defects in Rust source code
@@ -74,10 +69,21 @@ impl RustDefectDetector {
             return defects;
         }
 
-        // Exclude files with test markers
-        if self.has_test_markers(content) {
-            return defects;
-        }
+        // NOTE: there used to be a whole-file bail here —
+        // `if self.has_test_markers(content) { return defects; }` — where
+        // has_test_markers matched the bare substrings "#[cfg(test)]" / "#[test]"
+        // ANYWHERE in the file. Rust's idiomatic co-located unit-test module
+        // therefore blanked out every line of production code above it: a crate
+        // whose src/lib.rs was one `.unwrap()`-bearing function reported 1 defect,
+        // and reported 0 the moment an unrelated `#[cfg(test)] mod tests` was
+        // appended to the same file. Scanning this repo it left 44 defects in 5
+        // files against ~19,500 `.unwrap()` calls in ~1,300 files.
+        //
+        // Exclusion is now per-range, not per-file: detect_unwraps already skips
+        // the body of any `#[cfg(...)]` item by brace depth (which covers
+        // `#[cfg(test)] mod tests`), and additionally skips `#[test]`-attributed
+        // items, so test code is dropped while the production code around it is
+        // still reported.
 
         // Detect .unwrap() calls
         let unwrap_instances = self.detect_unwraps(content, file_path);
@@ -149,9 +155,13 @@ impl RustDefectDetector {
 
             // Detect #[cfg(...)] attributes — marks the next braced item as cfg-gated.
             // Also honor item-level (outer) #[allow(clippy::unwrap_used)] / clippy::restriction.
+            // `#[test]`-attributed items are skipped the same way, so a test
+            // function that is not inside a `#[cfg(test)]` module is still
+            // excluded without discarding the rest of the file.
             if trimmed.starts_with("#[cfg(")
                 || trimmed.starts_with("#[cfg_attr(")
                 || attr_line_allows_unwrap(trimmed)
+                || Self::is_test_attr_line(trimmed)
             {
                 pending_suppress = true;
             }
@@ -303,4 +313,63 @@ fn strip_string_literals(line: &str) -> String {
     }
 
     String::from_utf8(out).unwrap_or_else(|_| line.to_string())
+}
+
+/// Regression tests for the whole-file test-marker bail.
+///
+/// `detect` used to return an empty vec for any file containing the substring
+/// "#[cfg(test)]" or "#[test]", so a co-located unit-test module — the Rust
+/// idiom — hid every defect in the production code above it.
+#[cfg(test)]
+mod colocated_test_module_regression_tests {
+    use super::*;
+
+    const PRODUCTION_THEN_TEST_MODULE: &str = "pub fn dangerous(v: &[i32]) -> i32 {\n    \
+         *v.first().unwrap()\n}\n\n#[cfg(test)]\nmod tests {\n    #[test]\n    fn t() {\n        \
+         assert_eq!(1, 1);\n    }\n}\n";
+
+    #[test]
+    fn production_unwrap_survives_a_colocated_test_module() {
+        let detector = RustDefectDetector::new();
+        let defects = detector.detect(PRODUCTION_THEN_TEST_MODULE, Path::new("src/lib.rs"));
+
+        assert_eq!(
+            defects.len(),
+            1,
+            "the production .unwrap() was discarded because the file also contains a test module"
+        );
+        assert_eq!(defects[0].instances.len(), 1);
+        assert_eq!(defects[0].instances[0].line, 2);
+    }
+
+    #[test]
+    fn unwrap_inside_the_colocated_test_module_is_still_excluded() {
+        let detector = RustDefectDetector::new();
+        let code = "pub fn safe(v: &[i32]) -> i32 {\n    v.len() as i32\n}\n\n#[cfg(test)]\n\
+                    mod tests {\n    #[test]\n    fn t() {\n        \
+                    let _ = Some(1).unwrap();\n    }\n}\n";
+        let defects = detector.detect(code, Path::new("src/lib.rs"));
+
+        assert!(
+            defects.is_empty(),
+            "test-module .unwrap() must stay excluded: {defects:?}"
+        );
+    }
+
+    #[test]
+    fn bare_test_function_is_excluded_without_hiding_the_file() {
+        let detector = RustDefectDetector::new();
+        let code = "pub fn dangerous(v: &[i32]) -> i32 {\n    *v.first().unwrap()\n}\n\n\
+                    #[test]\nfn stray() {\n    let _ = Some(2).unwrap();\n}\n";
+        let defects = detector.detect(code, Path::new("src/lib.rs"));
+
+        assert_eq!(defects.len(), 1);
+        assert_eq!(
+            defects[0].instances.len(),
+            1,
+            "only the production .unwrap() should be reported: {:?}",
+            defects[0].instances
+        );
+        assert_eq!(defects[0].instances[0].line, 2);
+    }
 }

--- a/src/services/doc_validator_validation.rs
+++ b/src/services/doc_validator_validation.rs
@@ -315,23 +315,7 @@ impl DocValidator {
         let results = self.validate_links_concurrent(&all_links).await?;
 
         // Compute summary
-        let valid_count = results
-            .iter()
-            .filter(|r| r.status == ValidationStatus::Valid)
-            .count();
-        let broken_count = results
-            .iter()
-            .filter(|r| {
-                matches!(
-                    r.status,
-                    ValidationStatus::NotFound | ValidationStatus::HttpError(_)
-                )
-            })
-            .count();
-        let skipped_count = results
-            .iter()
-            .filter(|r| r.status == ValidationStatus::Skipped)
-            .count();
+        let (valid_count, broken_count, skipped_count) = bucket_statuses(&results);
 
         Ok(ValidationSummary {
             total_files: file_count,
@@ -361,5 +345,93 @@ impl DocValidator {
 impl Default for DocValidator {
     fn default() -> Self {
         Self::new(ValidatorConfig::default())
+    }
+}
+
+/// Split results into (valid, broken, skipped).
+///
+/// This used to be three inline filters, and the broken filter listed only
+/// `NotFound | HttpError(_)`. `NetworkError` and `InvalidLink` therefore landed
+/// in no bucket: running `validate-docs` with the network unreachable reported
+/// "Links found: 4 / Valid links: 0 / Broken links: 0 / Skipped links: 0",
+/// printed "All documentation links are valid!" and exited 0 even under
+/// `--fail-on-error`. A link that could not be reached is not a link that was
+/// validated, so it is broken. The `match` is exhaustive on purpose — adding a
+/// status now forces a bucket decision at compile time instead of silently
+/// dropping it from the totals.
+pub(crate) fn bucket_statuses(results: &[ValidationResult]) -> (usize, usize, usize) {
+    let mut valid = 0;
+    let mut broken = 0;
+    let mut skipped = 0;
+
+    for result in results {
+        match result.status {
+            ValidationStatus::Valid => valid += 1,
+            ValidationStatus::NotFound
+            | ValidationStatus::HttpError(_)
+            | ValidationStatus::NetworkError
+            | ValidationStatus::InvalidLink => broken += 1,
+            ValidationStatus::Skipped => skipped += 1,
+        }
+    }
+
+    (valid, broken, skipped)
+}
+
+#[cfg(test)]
+mod bucket_status_tests {
+    use super::*;
+
+    fn result_with(status: ValidationStatus) -> ValidationResult {
+        ValidationResult {
+            link: Link {
+                text: "a".to_string(),
+                target: "https://example.com".to_string(),
+                source_file: PathBuf::from("README.md"),
+                line_number: 1,
+                link_type: LinkType::ExternalHttp,
+            },
+            status,
+            error_message: None,
+            http_status_code: None,
+            response_time_ms: None,
+        }
+    }
+
+    #[test]
+    fn test_network_error_counts_as_broken() {
+        let results = vec![result_with(ValidationStatus::NetworkError)];
+        let (valid, broken, skipped) = bucket_statuses(&results);
+        assert_eq!(
+            (valid, broken, skipped),
+            (0, 1, 0),
+            "an unreachable link is not a validated link"
+        );
+    }
+
+    #[test]
+    fn test_invalid_link_counts_as_broken() {
+        let results = vec![result_with(ValidationStatus::InvalidLink)];
+        assert_eq!(bucket_statuses(&results), (0, 1, 0));
+    }
+
+    #[test]
+    fn test_every_status_lands_in_exactly_one_bucket() {
+        let results = vec![
+            result_with(ValidationStatus::Valid),
+            result_with(ValidationStatus::NotFound),
+            result_with(ValidationStatus::HttpError(500)),
+            result_with(ValidationStatus::NetworkError),
+            result_with(ValidationStatus::InvalidLink),
+            result_with(ValidationStatus::Skipped),
+        ];
+        let (valid, broken, skipped) = bucket_statuses(&results);
+        assert_eq!(
+            valid + broken + skipped,
+            results.len(),
+            "valid + broken + skipped must equal the total; a status in no bucket \
+             is what let an offline run report zero broken links"
+        );
+        assert_eq!((valid, broken, skipped), (1, 4, 1));
     }
 }

--- a/src/services/enhanced_language_detection.rs
+++ b/src/services/enhanced_language_detection.rs
@@ -105,10 +105,18 @@ pub fn detect_project_language_enhanced(path: &Path) -> LanguageDetection {
         }
     }
 
-    // Find highest score
+    // Find highest score.
+    //
+    // `scores` is a HashMap, so `max_by` on the score alone let RandomState
+    // iteration order pick the winner whenever two languages tied: eight
+    // consecutive `pmat context` runs over one unmodified polyglot tree
+    // (1 .go / 1 .ts / 1 .py, all 33.3) answered python/go/typescript. Ties
+    // now resolve alphabetically, the same tie-break `cli_language_detection`
+    // already carries (`max_by` keeps the LAST maximum, so the comparator is
+    // reversed on the name to keep the alphabetically first one).
     let (best_lang, best_score) = scores
         .iter()
-        .max_by(|a, b| a.1.total_cmp(b.1))
+        .max_by(|a, b| a.1.total_cmp(b.1).then_with(|| b.0.cmp(a.0)))
         .map(|(lang, score)| (lang.clone(), *score))
         .unwrap_or_else(|| ("unknown".to_string(), 0.0));
 
@@ -393,5 +401,28 @@ mod tests {
         let detection = detect_all_languages(temp.path());
         assert_eq!(detection.languages.len(), 2);
         assert_eq!(detection.primary, "rust");
+    }
+
+    #[test]
+    fn tied_polyglot_tree_detects_the_same_language_every_time() {
+        // A tie used to be resolved by HashMap iteration order, so `pmat
+        // context` reported a different language on every run for one
+        // unmodified tree. One file each of Go/TypeScript/Python ties at 33.3.
+        let temp = TempDir::new().expect("internal error");
+        std::fs::write(temp.path().join("main.go"), "package main\n").expect("internal error");
+        std::fs::write(temp.path().join("app.ts"), "export const a = 1;\n")
+            .expect("internal error");
+        std::fs::write(temp.path().join("main.py"), "print('hi')\n").expect("internal error");
+
+        let first = detect_project_language_enhanced(temp.path()).language;
+        for _ in 0..24 {
+            assert_eq!(
+                detect_project_language_enhanced(temp.path()).language,
+                first,
+                "a tied polyglot tree must detect the same language every run"
+            );
+        }
+        // Ties resolve alphabetically, so the answer is also predictable.
+        assert_eq!(first, "go");
     }
 }

--- a/src/services/facades/complexity_facade.rs
+++ b/src/services/facades/complexity_facade.rs
@@ -130,7 +130,7 @@ impl ComplexityFacade {
             .collect();
 
         let max_complexity = violations.iter().map(|v| v.complexity).max().unwrap_or(0);
-        let average_complexity = f64::from(report.summary.median_cyclomatic);
+        let average_complexity = mean_cyclomatic(&report.files);
 
         Ok(ComplexityAnalysisResult {
             total_files,
@@ -224,6 +224,37 @@ impl ComplexityFacade {
     }
 }
 
+/// Mean cyclomatic complexity over every analysed function, including class
+/// methods — the same population `summary.total_functions` counts.
+///
+/// `average_complexity` used to be assigned `summary.median_cyclomatic`, so a
+/// crate of nine trivial functions plus one function of cyclomatic 81 published
+/// an "average" of 1.0 where the mean is 9.0. A median published under the name
+/// `average` is a mislabelled number, not an approximation of one.
+fn mean_cyclomatic(files: &[crate::services::complexity::FileComplexityMetrics]) -> f64 {
+    let mut sum: u64 = 0;
+    let mut count: u64 = 0;
+
+    for file in files {
+        for func in &file.functions {
+            sum += u64::from(func.metrics.cyclomatic);
+            count += 1;
+        }
+        for class in &file.classes {
+            for method in &class.methods {
+                sum += u64::from(method.metrics.cyclomatic);
+                count += 1;
+            }
+        }
+    }
+
+    if count == 0 {
+        0.0
+    } else {
+        sum as f64 / count as f64
+    }
+}
+
 /// Complexity thresholds for different severity levels
 #[derive(Debug, Clone)]
 pub struct ComplexityThresholds {
@@ -282,5 +313,94 @@ mod tests {
         assert!(!validation.passed);
         assert_eq!(validation.errors, 1);
         assert!(validation.threshold_exceeded);
+    }
+
+    #[test]
+    fn test_mean_cyclomatic_is_the_mean_not_the_median() {
+        use crate::services::complexity::{
+            ComplexityMetrics, FileComplexityMetrics, FunctionComplexity,
+        };
+
+        fn metrics(cyclomatic: u16) -> ComplexityMetrics {
+            ComplexityMetrics {
+                cyclomatic,
+                cognitive: 0,
+                nesting_max: 0,
+                lines: 1,
+                halstead: None,
+            }
+        }
+
+        // The cx2 repro: nine trivial functions plus one of cyclomatic 81.
+        // Median 1.0, mean 9.0 — `average_complexity` published the median.
+        let mut functions: Vec<FunctionComplexity> = (0..9)
+            .map(|i| FunctionComplexity {
+                name: format!("triv{i}"),
+                line_start: i,
+                line_end: i,
+                metrics: metrics(1),
+            })
+            .collect();
+        functions.push(FunctionComplexity {
+            name: "nasty".to_string(),
+            line_start: 10,
+            line_end: 90,
+            metrics: metrics(81),
+        });
+
+        let file = FileComplexityMetrics {
+            path: "src/lib.rs".to_string(),
+            total_complexity: metrics(90),
+            functions,
+            classes: vec![],
+        };
+
+        let mean = mean_cyclomatic(std::slice::from_ref(&file));
+        assert!(
+            (mean - 9.0).abs() < f64::EPSILON,
+            "expected the mean 9.0, got {mean}"
+        );
+    }
+
+    #[test]
+    fn test_mean_cyclomatic_counts_class_methods_and_handles_empty() {
+        use crate::services::complexity::{
+            ClassComplexity, ComplexityMetrics, FileComplexityMetrics, FunctionComplexity,
+        };
+
+        let m = |c: u16| ComplexityMetrics {
+            cyclomatic: c,
+            cognitive: 0,
+            nesting_max: 0,
+            lines: 1,
+            halstead: None,
+        };
+
+        assert_eq!(mean_cyclomatic(&[]), 0.0);
+
+        let file = FileComplexityMetrics {
+            path: "src/lib.rs".to_string(),
+            total_complexity: m(9),
+            functions: vec![FunctionComplexity {
+                name: "free".to_string(),
+                line_start: 1,
+                line_end: 2,
+                metrics: m(3),
+            }],
+            classes: vec![ClassComplexity {
+                name: "C".to_string(),
+                line_start: 3,
+                line_end: 9,
+                metrics: m(6),
+                methods: vec![FunctionComplexity {
+                    name: "method".to_string(),
+                    line_start: 4,
+                    line_end: 5,
+                    metrics: m(7),
+                }],
+            }],
+        };
+
+        assert_eq!(mean_cyclomatic(std::slice::from_ref(&file)), 5.0);
     }
 }

--- a/src/services/facades/defect_prediction_facade.rs
+++ b/src/services/facades/defect_prediction_facade.rs
@@ -572,16 +572,23 @@ impl DefectPredictionFacade {
 
     /// Discover source files to analyze, in a deterministic order.
     async fn discover_files(&self, request: &DefectPredictionRequest) -> Result<Vec<PathBuf>> {
-        use walkdir::WalkDir;
+        use ignore::WalkBuilder;
 
+        // Bare `walkdir` saw everything on disk: this repo's `.gitignore` line
+        // `.claude/worktrees/` was invisible to it, so discovery reported
+        // 223673 files for a 4260-file project and ranked a file inside an
+        // ignored worktree copy as the single highest defect risk. `analyze
+        // complexity` honours the ignore files; discovery here must agree with
+        // it or the two commands are describing different projects.
         let mut files = Vec::new();
-        // sort_by_file_name: readdir order is filesystem-dependent, and the
-        // prediction list is derived from it — identical input must produce
-        // identical output.
-        for entry in WalkDir::new(&request.project_path)
+        for entry in WalkBuilder::new(&request.project_path)
             .follow_links(false)
-            .sort_by_file_name()
-            .into_iter()
+            .hidden(true)
+            .git_ignore(true)
+            .git_global(true)
+            .git_exclude(true)
+            .parents(true)
+            .build()
             .filter_map(std::result::Result::ok)
         {
             let path = entry.path();
@@ -590,6 +597,10 @@ impl DefectPredictionFacade {
             }
         }
 
+        // Directory read order is filesystem-dependent and the prediction list
+        // is derived from it — identical input must produce identical output.
+        // (`walkdir::sort_by_file_name` used to do this during the walk.)
+        files.sort();
         Ok(files)
     }
 
@@ -598,13 +609,19 @@ impl DefectPredictionFacade {
         let path_str = path.to_string_lossy();
 
         if let Some(ref excludes) = request.exclude {
-            if excludes.iter().any(|pattern| path_str.contains(pattern)) {
+            if excludes
+                .iter()
+                .any(|pattern| Self::matches_pattern(&path_str, pattern))
+            {
                 return false;
             }
         }
 
         if let Some(ref includes) = request.include {
-            if !includes.iter().any(|pattern| path_str.contains(pattern)) {
+            if !includes
+                .iter()
+                .any(|pattern| Self::matches_pattern(&path_str, pattern))
+            {
                 return false;
             }
         }
@@ -612,6 +629,31 @@ impl DefectPredictionFacade {
         path.extension()
             .and_then(|e| e.to_str())
             .is_some_and(|ext| matches!(ext, "rs" | "py" | "js" | "ts" | "cpp" | "c" | "java"))
+    }
+
+    /// Match one `--include`/`--exclude` pattern against a path.
+    ///
+    /// Both lists used to be `path_str.contains(pattern)`, so `--include
+    /// '**/*.rs'` — the example in the flag's own help text — matched nothing
+    /// and the command exited 0 with an empty analysis, while `--include
+    /// 'src/lib.rs'` matched because it happens to be a substring. Patterns
+    /// containing glob metacharacters are compiled as globs; plain strings keep
+    /// the substring behaviour people already rely on.
+    fn matches_pattern(path_str: &str, pattern: &str) -> bool {
+        if !pattern.contains(['*', '?', '[', '{']) {
+            return path_str.contains(pattern);
+        }
+
+        // Matched against the whole (usually absolute) path, so `*` has to be
+        // able to cross a separator — globset's default `literal_separator`
+        // off is what makes both `*.rs` and the documented `**/*.rs` match
+        // `/home/u/proj/src/lib.rs`.
+        match globset::Glob::new(pattern) {
+            Ok(glob) => glob.compile_matcher().is_match(path_str),
+            // An unparseable pattern falls back to the historical substring
+            // test rather than quietly selecting nothing.
+            Err(_) => path_str.contains(pattern),
+        }
     }
 
     /// Analyze a single file for defect probability
@@ -1414,5 +1456,96 @@ mod tests {
             count_imports(Path::new("a.rs"), "use a;\nuse b;\nfn f() {}\n"),
             Some(2)
         );
+    }
+
+    /// Discovery ignored `.gitignore` entirely: pmat's own ignored
+    /// `.claude/worktrees/` copies were discovered, analyzed and ranked as the
+    /// top defect risk, turning a 4260-file project into 223673 files.
+    #[tokio::test]
+    async fn test_discover_files_honours_gitignore() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        std::fs::write(root.join(".gitignore"), "ignored_dir/\n").unwrap();
+        write_sources(&root.join("src"), 2);
+        write_sources(&root.join("ignored_dir"), 3);
+        // Hidden directories are not project sources either.
+        write_sources(&root.join(".hidden"), 1);
+        init_repo(root);
+
+        let found = facade().discover_files(&request(root, 0)).await.unwrap();
+        let names: Vec<String> = found
+            .iter()
+            .map(|p| p.strip_prefix(root).unwrap().to_string_lossy().to_string())
+            .collect();
+
+        assert!(
+            names.iter().all(|n| !n.contains("ignored_dir")),
+            "gitignored files were discovered: {names:?}"
+        );
+        assert!(
+            names.iter().all(|n| !n.contains(".hidden")),
+            "hidden files were discovered: {names:?}"
+        );
+        assert_eq!(names.len(), 2, "{names:?}");
+        // Deterministic order survives the walker swap.
+        let mut sorted = names.clone();
+        sorted.sort();
+        assert_eq!(names, sorted);
+    }
+
+    /// `--include '**/*.rs'` — the example in the flag's own help — matched
+    /// nothing, because both lists were `path_str.contains(pattern)`.
+    #[test]
+    fn test_include_exclude_accept_globs() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        let file = root.join("src").join("lib.rs");
+
+        let mut req = request(root, 0);
+        req.include = Some(vec!["**/*.rs".to_string()]);
+        assert!(
+            DefectPredictionFacade::matches_filters(&file, &req),
+            "the documented glob example must match a .rs file"
+        );
+
+        req.include = None;
+        req.exclude = Some(vec!["**/*.rs".to_string()]);
+        assert!(
+            !DefectPredictionFacade::matches_filters(&file, &req),
+            "the same glob must exclude"
+        );
+
+        // Plain substrings keep working.
+        req.exclude = None;
+        req.include = Some(vec!["src/lib.rs".to_string()]);
+        assert!(DefectPredictionFacade::matches_filters(&file, &req));
+
+        // A glob that genuinely does not match still does not match.
+        req.include = Some(vec!["**/*.py".to_string()]);
+        assert!(!DefectPredictionFacade::matches_filters(&file, &req));
+    }
+
+    #[test]
+    fn test_matches_pattern_glob_vs_substring() {
+        assert!(DefectPredictionFacade::matches_pattern(
+            "/p/src/lib.rs",
+            "**/*.rs"
+        ));
+        assert!(DefectPredictionFacade::matches_pattern(
+            "/p/src/lib.rs",
+            "*"
+        ));
+        assert!(DefectPredictionFacade::matches_pattern(
+            "/p/src/lib.rs",
+            "**/lib.rs"
+        ));
+        assert!(DefectPredictionFacade::matches_pattern(
+            "/p/src/lib.rs",
+            "src/lib.rs"
+        ));
+        assert!(!DefectPredictionFacade::matches_pattern(
+            "/p/src/lib.rs",
+            "**/*.ts"
+        ));
     }
 }

--- a/src/services/facades/incremental_coverage_impl.rs
+++ b/src/services/facades/incremental_coverage_impl.rs
@@ -57,11 +57,19 @@ impl IncrementalCoverageFacade {
     /// — identical numbers whatever the project contained. Now it reads the same
     /// lcov/llvm-cov artifact `pmat context` reads, and reports "not measured"
     /// when there is none instead of a plausible default.
+    ///
+    /// Every changed file is looked up, not just the `--top-files` display
+    /// slice: the loop used to `break` at `top_files`, and the summary was then
+    /// derived from that truncated vector while `total_files` came from the
+    /// full changed-file list, so `files_not_measured` simply echoed
+    /// `--top-files` (3 -> 3, 10 -> 10, 50 -> 50) and 279 of 289 files were
+    /// unaccounted for. The lookup is a hash-map hit, so there is nothing to
+    /// save by stopping early.
     async fn analyze_coverage_changes(
         &self,
         project_path: &Path,
         changed_files: &[(PathBuf, String)],
-        request: &IncrementalCoverageRequest,
+        _request: &IncrementalCoverageRequest,
     ) -> Result<Vec<ChangedFileCoverage>> {
         let measured = Self::load_line_coverage(project_path);
         let mut coverage_data = Vec::new();
@@ -72,11 +80,6 @@ impl IncrementalCoverageFacade {
             }
 
             coverage_data.push(Self::file_coverage(path, measured.as_ref()));
-
-            // Only analyze top N files if requested
-            if coverage_data.len() >= request.top_files {
-                break;
-            }
         }
 
         Ok(coverage_data)
@@ -138,7 +141,10 @@ impl IncrementalCoverageFacade {
             .collect();
 
         let covered_files = measured.iter().filter(|pct| **pct > 0.0).count();
-        let files_not_measured = coverage_data.len() - measured.len();
+        // Counted against ALL changed files, so the summary reconciles:
+        // measured + not_measured == total_files. Deleted/renamed files, which
+        // get no coverage row at all, are unmeasured too.
+        let files_not_measured = total_files.saturating_sub(measured.len());
 
         // Absent, not zero: "no coverage artifact" is not "0% covered".
         #[allow(clippy::cast_precision_loss)]
@@ -172,6 +178,13 @@ impl IncrementalCoverageFacade {
             files_not_measured
         );
 
+        // --top-files is a display limit only; it must not change any count above.
+        let displayed = if request.top_files == 0 {
+            coverage_data
+        } else {
+            coverage_data.into_iter().take(request.top_files).collect()
+        };
+
         IncrementalCoverageResult {
             total_files,
             covered_files,
@@ -179,7 +192,7 @@ impl IncrementalCoverageFacade {
             files_above_threshold,
             files_below_threshold,
             files_not_measured,
-            changed_files: coverage_data,
+            changed_files: displayed,
             summary,
         }
     }
@@ -205,5 +218,60 @@ impl IncrementalCoverageFacade {
         };
 
         self.analyze_project(request).await
+    }
+}
+
+#[cfg(test)]
+mod top_files_accounting_tests {
+    //! `--top-files` is a display limit; it must not leak into the summary.
+    use super::*;
+    use crate::services::service_registry::ServiceRegistry;
+
+    fn request(top_files: usize) -> IncrementalCoverageRequest {
+        IncrementalCoverageRequest {
+            project_path: PathBuf::from("."),
+            base_branch: "master".to_string(),
+            target_branch: None,
+            coverage_threshold: 80.0,
+            changed_files_only: true,
+            detailed: false,
+            cache_dir: None,
+            force_refresh: false,
+            top_files,
+        }
+    }
+
+    /// `--top-files N` used to make `files_not_measured` come back as exactly N
+    /// (3 -> 3, 10 -> 10, 50 -> 50) against a constant total_files of 289,
+    /// because the summary was derived from the truncated display vector.
+    #[test]
+    fn test_top_files_truncates_the_display_list_not_the_counts() {
+        let facade = IncrementalCoverageFacade::new(Arc::new(ServiceRegistry::new()));
+
+        let changed: Vec<(PathBuf, String)> = (0..25)
+            .map(|i| (PathBuf::from(format!("src/f{i}.rs")), "M".to_string()))
+            .collect();
+        let coverage_data: Vec<ChangedFileCoverage> = changed
+            .iter()
+            .map(|(path, _)| IncrementalCoverageFacade::file_coverage(path, None))
+            .collect();
+
+        let result = facade.build_coverage_result(coverage_data, changed, &request(3));
+
+        assert_eq!(result.total_files, 25);
+        assert_eq!(
+            result.changed_files.len(),
+            3,
+            "--top-files 3 must cap the displayed list"
+        );
+        assert_eq!(
+            result.files_not_measured, 25,
+            "no coverage artifact ⇒ all 25 changed files are unmeasured, not --top-files of them"
+        );
+        assert_eq!(
+            result.files_above_threshold + result.files_below_threshold + result.files_not_measured,
+            result.total_files,
+            "the summary must reconcile with total_files"
+        );
     }
 }

--- a/src/services/facades/incremental_coverage_tests_async.rs
+++ b/src/services/facades/incremental_coverage_tests_async.rs
@@ -119,8 +119,26 @@ async fn test_analyze_coverage_changes_top_files_limit() {
         .await
         .expect("Failed to analyze coverage changes");
 
-    // Should only analyze top 2 files
-    assert_eq!(result.len(), 2);
+    // This used to assert `result.len() == 2`, i.e. that `--top-files 2` stopped
+    // the *analysis* after 2 files. That was the bug: the summary counts were
+    // then derived from the truncated vector while `total_files` came from the
+    // full changed-file list, so `files_not_measured` just echoed `--top-files`
+    // and the remaining changed files were unaccounted for. `--top-files` is a
+    // display limit, applied in `build_coverage_result`, so every changed file
+    // is analyzed here.
+    assert_eq!(result.len(), 4, "every changed file must be analyzed");
+
+    // ...and the display limit still caps what is rendered, without moving any count.
+    let summarized = facade.build_coverage_result(result, changed_files, &request);
+    assert_eq!(
+        summarized.changed_files.len(),
+        2,
+        "--top-files 2 caps the displayed list"
+    );
+    assert_eq!(
+        summarized.total_files, 4,
+        "--top-files must not shrink total_files"
+    );
 }
 
 #[tokio::test]
@@ -160,13 +178,21 @@ async fn test_get_changed_files_nonexistent_repo() {
     let facade = create_test_facade();
     let temp_dir = TempDir::new().expect("Failed to create temp dir");
 
-    // No git repo initialized, should return empty list (not error)
-    let result = facade
-        .get_changed_files(temp_dir.path(), "main", None)
-        .await
-        .expect("Should not fail on non-git directory");
+    // This used to assert that a non-git directory came back as an empty
+    // changelist ("should return empty list (not error)"). That was the bug:
+    // `git diff` failing was swallowed, so incremental-coverage rendered an
+    // all-zero "clean" gate report and exited 0 for a directory it could not
+    // diff at all. A coverage gate must never report a pass because the diff
+    // could not be taken.
+    let result = facade.get_changed_files(temp_dir.path(), "main", None).await;
 
-    assert!(result.is_empty());
+    let err = result
+        .expect_err("a non-git directory must surface as an error, not an empty changelist")
+        .to_string();
+    assert!(
+        err.contains("git diff"),
+        "the error must say the diff failed: {err}"
+    );
 }
 
 #[tokio::test]

--- a/src/services/facades/satd_facade.rs
+++ b/src/services/facades/satd_facade.rs
@@ -78,16 +78,45 @@ impl SatdFacade {
             SATDDetector::new()
         };
 
-        // Run analysis based on request parameters
+        // A single FILE is not a directory to walk. `analyze comprehensive
+        // --file src/lib.rs` handed that path straight to `analyze_directory`,
+        // whose walk over a file yields nothing: the report came back "Found 0
+        // SATD violations in 0 files" with quality_score 100.0 for a file whose
+        // TODO the same analysis reports under `-p`.
+        if request.path.is_file() {
+            let content = tokio::fs::read_to_string(&request.path).await?;
+            let satd_items = detector
+                .extract_from_content(&content, &request.path)
+                .map_err(|e| anyhow::anyhow!("SATD analysis of {:?} failed: {e}", request.path))?;
+            return Ok(Self::build_result(&satd_items));
+        }
+
+        // Run analysis based on request parameters.
+        //
+        // The second argument of `analyze_directory_with_tests` IS the
+        // include-tests switch. It used to be handed `request.strict_mode`
+        // (strict is already applied by the constructor above), so
+        // `analyze satd --include-tests` took the with-tests branch and then
+        // told the detector *not* to include tests: a `// TODO:` in `tests/`
+        // stayed invisible with the flag and without it alike.
         let satd_items = if request.include_tests {
             detector
-                .analyze_directory_with_tests(&request.path, request.strict_mode)
+                .analyze_directory_with_tests(&request.path, true)
                 .await?
         } else {
             detector.analyze_directory(&request.path).await?
         };
 
-        // Convert to facade types
+        Ok(Self::build_result(&satd_items))
+    }
+
+    /// Convert detector items into the facade's result shape.
+    ///
+    /// Shared by the directory walk and the single-file path so both report the
+    /// same counts for the same debt.
+    fn build_result(
+        satd_items: &[crate::services::satd_detector::TechnicalDebt],
+    ) -> SatdAnalysisResult {
         let violations: Vec<SatdViolation> = satd_items
             .iter()
             .map(|item| {
@@ -120,11 +149,11 @@ impl SatdFacade {
             total_files
         );
 
-        Ok(SatdAnalysisResult {
+        SatdAnalysisResult {
             total_files,
             violations,
             summary,
-        })
+        }
     }
 
     /// Analyze a single file for SATD
@@ -151,5 +180,98 @@ mod tests {
     async fn test_satd_facade_creation() {
         let registry = Arc::new(ServiceRegistry::new());
         let _facade = SatdFacade::new(registry);
+    }
+
+    fn facade() -> SatdFacade {
+        SatdFacade::new(Arc::new(ServiceRegistry::new()))
+    }
+
+    fn crate_with_test_debt() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir_all(dir.path().join("src")).expect("src");
+        std::fs::create_dir_all(dir.path().join("tests")).expect("tests");
+        std::fs::write(
+            dir.path().join("Cargo.toml"),
+            "[package]\nname = \"st\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+        )
+        .expect("manifest");
+        std::fs::write(
+            dir.path().join("src/lib.rs"),
+            "// TODO: prod debt\npub fn a() {}\n",
+        )
+        .expect("lib");
+        std::fs::write(
+            dir.path().join("tests/it.rs"),
+            "// TODO: fix this test\npub fn t() {}\n",
+        )
+        .expect("test file");
+        dir
+    }
+
+    fn request(path: std::path::PathBuf, include_tests: bool) -> SatdAnalysisRequest {
+        SatdAnalysisRequest {
+            path,
+            strict_mode: false,
+            include_tests,
+            extended: false,
+        }
+    }
+
+    /// `--include-tests` forwarded `strict_mode` as the include-tests argument,
+    /// so the flag whose only job is to add test-file debt added nothing.
+    #[tokio::test]
+    async fn test_include_tests_actually_includes_test_files() {
+        let dir = crate_with_test_debt();
+        let facade = facade();
+
+        let without = facade
+            .analyze_project(request(dir.path().to_path_buf(), false))
+            .await
+            .expect("analysis without tests");
+        let with = facade
+            .analyze_project(request(dir.path().to_path_buf(), true))
+            .await
+            .expect("analysis with tests");
+
+        assert_eq!(
+            without.violations.len(),
+            1,
+            "only src/lib.rs debt without the flag: {:?}",
+            without.violations
+        );
+        assert!(
+            with.violations.len() > without.violations.len(),
+            "--include-tests must add the TODO in tests/: {:?}",
+            with.violations
+        );
+        assert!(
+            with.violations
+                .iter()
+                .any(|v| v.file_path.contains("it.rs")),
+            "the test file's debt must be listed: {:?}",
+            with.violations
+        );
+    }
+
+    /// A single FILE path was walked as if it were a directory, so a file with
+    /// known debt reported zero violations.
+    #[tokio::test]
+    async fn test_a_single_file_path_is_analyzed_not_walked() {
+        let dir = crate_with_test_debt();
+        let file = dir.path().join("src/lib.rs");
+
+        let result = facade()
+            .analyze_project(request(file.clone(), false))
+            .await
+            .expect("single-file analysis");
+
+        assert_eq!(
+            result.violations.len(),
+            1,
+            "the file's own TODO must be reported: {:?}",
+            result.violations
+        );
+        assert_eq!(result.total_files, 1);
+        assert!(result.violations[0].file_path.contains("lib.rs"));
     }
 }

--- a/src/services/five_whys_analyzer.rs
+++ b/src/services/five_whys_analyzer.rs
@@ -139,8 +139,8 @@ impl FiveWhysAnalyzer {
             evidence.push(loc_ev);
         }
 
-        // Real SATD evidence: count TODO/FIXME/HACK/WORKAROUND in source
-        if let Some(satd_ev) = Self::gather_satd_evidence(path) {
+        // Real SATD evidence, from the SAME detector `pmat analyze satd` uses.
+        if let Some(satd_ev) = Self::gather_satd_evidence(path).await {
             evidence.push(satd_ev);
         }
 
@@ -167,11 +167,24 @@ impl FiveWhysAnalyzer {
         Ok(evidence)
     }
 
-    /// Count SATD markers (TODO, FIXME, HACK, WORKAROUND, XXX) in source files.
-    fn gather_satd_evidence(path: &Path) -> Option<Evidence> {
-        let src_dir = path.join("src");
-        let dir = if src_dir.is_dir() { &src_dir } else { path };
-        let count = Self::count_satd_markers(dir);
+    /// Count SATD markers using the detector `pmat analyze satd` uses.
+    ///
+    /// This used to be `count_satd_markers`, a raw recursive substring scan for
+    /// TODO/FIXME/HACK/WORKAROUND/XXX with no comment awareness and no
+    /// exclusions: it reported 808 markers for this repo while
+    /// `pmat analyze satd` reported 39 for the same path in the same session —
+    /// a 20x disagreement between two surfaces of one binary. It was counting
+    /// the detector's own pattern tables, test fixtures and doc prose, and then
+    /// presenting the total as measured technical-debt evidence for the
+    /// root-cause chain.
+    async fn gather_satd_evidence(path: &Path) -> Option<Evidence> {
+        use crate::services::satd_detector::SATDDetector;
+
+        let result = SATDDetector::new()
+            .analyze_project(path, false)
+            .await
+            .ok()?;
+        let count = result.summary.total_items;
         let description = if count == 0 {
             "No SATD markers found — codebase is clean of admitted technical debt".to_string()
         } else {
@@ -189,9 +202,9 @@ impl FiveWhysAnalyzer {
         ))
     }
 
+    /// Source extensions scanned when locating the reported issue.
     const SATD_EXTENSIONS: &'static [&'static str] =
         &["rs", "py", "ts", "js", "go", "lua", "c", "cpp", "java"];
-    const SATD_MARKERS: &'static [&'static str] = &["TODO", "FIXME", "HACK", "WORKAROUND", "XXX"];
 
     /// Words too common to identify anything, dropped from issue terms.
     const ISSUE_STOPWORDS: &'static [&'static str] = &[
@@ -343,34 +356,6 @@ impl FiveWhysAnalyzer {
         }
     }
 
-    fn count_satd_markers(dir: &Path) -> usize {
-        let entries = match std::fs::read_dir(dir) {
-            Ok(e) => e,
-            Err(_) => return 0,
-        };
-        entries
-            .flatten()
-            .map(|entry| entry.path())
-            .map(|p| {
-                if p.is_dir() {
-                    return Self::count_satd_markers(&p);
-                }
-                let is_source = p
-                    .extension()
-                    .and_then(|e| e.to_str())
-                    .is_some_and(|e| Self::SATD_EXTENSIONS.contains(&e));
-                if !is_source {
-                    return 0;
-                }
-                std::fs::read_to_string(&p)
-                    .unwrap_or_default()
-                    .lines()
-                    .filter(|line| Self::SATD_MARKERS.iter().any(|m| line.contains(m)))
-                    .count()
-            })
-            .sum()
-    }
-
     /// Count git commits in last 30 days.
     fn gather_git_churn_evidence(path: &Path) -> Option<Evidence> {
         let output = std::process::Command::new("git")
@@ -429,7 +414,19 @@ impl FiveWhysAnalyzer {
             EvidenceSource::Complexity,
             path.to_path_buf(),
             "estimated_complexity".to_string(),
-            json!({"total_lines": total_lines, "deep_nesting": deep_nesting_count, "threshold": 20}),
+            // `value` is the key `EvidenceSummary::process_complexity_evidence`
+            // reads. This payload used to carry only total_lines/deep_nesting/
+            // threshold, so the consumer's `value` lookup fell back to 0.0 and
+            // `0.0 > 20.0` could never fire: `complexity_violations` was
+            // structurally 0 for every path — an empty directory and this
+            // 979k-line repo reported the same 0 while the evidence text beside
+            // it quoted a density of 17/1000 lines.
+            json!({
+                "value": estimated_avg_complexity,
+                "threshold": 20,
+                "total_lines": total_lines,
+                "deep_nesting": deep_nesting_count,
+            }),
             description,
         ))
     }

--- a/src/services/five_whys_analyzer_tests.rs
+++ b/src/services/five_whys_analyzer_tests.rs
@@ -1869,4 +1869,92 @@ fn confidence_is_never_pinned_to_one() {
     );
 }
 
+
+/// five-whys reported 808 SATD markers for this repo while `pmat analyze satd`
+/// reported 39 for the same path in the same session — the old
+/// `count_satd_markers` was a raw substring scan with no comment awareness, so
+/// it counted pattern tables, fixtures and doc prose. Both surfaces now read the
+/// same detector.
+#[tokio::test]
+async fn satd_evidence_agrees_with_the_analyze_satd_detector() {
+    use crate::services::satd_detector::SATDDetector;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    // A named subdirectory: `tempfile` roots are dot-prefixed and source walks
+    // skip hidden entries.
+    let root = dir.path().join("proj");
+    std::fs::create_dir_all(root.join("src")).expect("mkdir");
+    std::fs::write(
+        root.join("src/lib.rs"),
+        // One genuine SATD comment, plus three lines that a bare substring
+        // scan counts and a detector does not: a string literal, a doc mention
+        // and an identifier.
+        "// TODO: implement retry\n\
+         pub const MARKERS: &[&str] = &[\"TODO\", \"FIXME\", \"HACK\"];\n\
+         /// Explains why the word FIXME appears in the pattern table above.\n\
+         pub fn xxx_helper() -> u32 { 1 }\n",
+    )
+    .expect("write");
+
+    let evidence = FiveWhysAnalyzer::gather_satd_evidence(&root)
+        .await
+        .expect("SATD evidence must be gathered");
+    let five_whys_count = evidence.value["count"].as_u64().expect("count key");
+
+    let detector_count = SATDDetector::new()
+        .analyze_project(&root, false)
+        .await
+        .expect("detector must run")
+        .summary
+        .total_items as u64;
+
+    assert_eq!(
+        five_whys_count, detector_count,
+        "five-whys must report the SATD number `analyze satd` reports"
+    );
+}
+
+
+/// `complexity_violations` was structurally always 0: this producer wrote
+/// `{total_lines, deep_nesting, threshold}` while
+/// `EvidenceSummary::process_complexity_evidence` reads a `value` key nobody
+/// wrote, so the comparison was always `0.0 > 20.0`. The producer and the
+/// consumer must agree on the key.
+#[test]
+fn complexity_evidence_carries_the_key_the_summary_reads() {
+    use crate::models::debug_analysis::{EvidenceSummary, WhyIteration};
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path().join("proj");
+    std::fs::create_dir_all(root.join("src")).expect("mkdir");
+    // Three of four lines sit deeper than the nesting threshold, so the
+    // estimated density is far above 20/1000 lines.
+    std::fs::write(root.join("src/deep.rs"), "{{{{{{\nfoo\nbar\n}}}}}}\n")
+        .expect("write");
+
+    let evidence = FiveWhysAnalyzer::gather_complexity_evidence(&root)
+        .expect("a src/ tree must yield complexity evidence");
+
+    let value = evidence
+        .value
+        .get("value")
+        .and_then(serde_json::Value::as_f64)
+        .expect("the payload must carry the `value` key the summary reads");
+    let threshold = evidence
+        .value
+        .get("threshold")
+        .and_then(serde_json::Value::as_f64)
+        .expect("threshold");
+    assert!(value > threshold, "{value} vs {threshold}");
+
+    let mut why = WhyIteration::new(1, "Why?".to_string(), "H".to_string());
+    why.add_evidence(evidence);
+    let summary = EvidenceSummary::from_whys(&[why]);
+    assert_eq!(
+        summary.complexity_violations, 1,
+        "the summary must see the violation the evidence describes"
+    );
+    assert!(summary.complexity_measured);
+}
+
 }

--- a/src/services/git_analysis.rs
+++ b/src/services/git_analysis.rs
@@ -312,10 +312,50 @@ impl GitAnalysisService {
         if parts.len() >= 3 {
             let additions = parts[0].parse::<usize>().ok()?;
             let deletions = parts[1].parse::<usize>().ok()?;
-            let file_path = parts[2..].join(" ");
+            let file_path = Self::resolve_rename_path(&parts[2..].join(" "));
             Some((additions, deletions, file_path))
         } else {
             None
+        }
+    }
+
+    /// The path a `--numstat` entry refers to today.
+    ///
+    /// `git log --numstat` does not print a plain path for a rename; it prints
+    /// either `old/path.rs => new/path.rs` or, when the two share a prefix
+    /// and/or a suffix, `shared/{old => new}/tail.rs`. Both were stored
+    /// verbatim as the file path, so `analyze churn` reported churn for
+    /// `{server/src => src}/tdg/analyzer.rs` — a path that exists nowhere on
+    /// disk — in `stable_files` and `hotspots`, and split one file's history
+    /// across the rename instead of accumulating it under the current name.
+    fn resolve_rename_path(raw: &str) -> String {
+        if !raw.contains("=>") {
+            return raw.to_string();
+        }
+
+        // Braced form: keep the shared prefix and suffix, take the new middle.
+        if let Some(open) = raw.find('{') {
+            if let Some(close) = raw[open..].find('}').map(|offset| offset + open) {
+                if let Some((_old, new)) = raw[open + 1..close].split_once("=>") {
+                    let rebuilt = format!("{}{}{}", &raw[..open], new.trim(), &raw[close + 1..]);
+                    // An empty side (`{ => modules}` / `{src => }`) leaves a
+                    // doubled or leading separator behind.
+                    let mut collapsed = rebuilt;
+                    while collapsed.contains("//") {
+                        collapsed = collapsed.replace("//", "/");
+                    }
+                    if !raw.starts_with('/') {
+                        collapsed = collapsed.trim_start_matches('/').to_string();
+                    }
+                    return collapsed;
+                }
+            }
+        }
+
+        // Plain form: `old => new`.
+        match raw.split_once("=>") {
+            Some((_old, new)) => new.trim().to_string(),
+            None => raw.to_string(),
         }
     }
 
@@ -446,6 +486,45 @@ mod tests {
         assert_eq!(additions, 5);
         assert_eq!(deletions, 15);
         assert_eq!(path, "path/to file.rs");
+    }
+
+    /// `git log --numstat` prints a rename as `old => new` or
+    /// `shared/{old => new}/tail.rs`. Both were stored verbatim, so churn
+    /// reported paths like `{server/src => src}/tdg/analyzer.rs`, which exist
+    /// nowhere on disk.
+    #[test]
+    fn test_parse_numstat_line_resolves_renames_to_the_current_path() {
+        let cases = [
+            (
+                "3\t1\t{server/src => src}/tdg/analyzer.rs",
+                "src/tdg/analyzer.rs",
+            ),
+            (
+                "1\t0\tserver/tests/{ => modules}/unit_mcp_semantic_tools.rs",
+                "server/tests/modules/unit_mcp_semantic_tools.rs",
+            ),
+            ("4\t4\t{src => }/main.rs", "main.rs"),
+            ("2\t2\told/path.rs => new/path.rs", "new/path.rs"),
+            ("7\t0\tsrc/{a.rs => b.rs}", "src/b.rs"),
+        ];
+
+        for (line, expected) in cases {
+            let (_, _, path) =
+                GitAnalysisService::parse_numstat_line(line).expect("numstat line must parse");
+            assert_eq!(path, expected, "line {line:?}");
+            assert!(
+                !path.contains("=>") && !path.contains('{'),
+                "rename syntax survived into the path: {path:?}"
+            );
+        }
+    }
+
+    /// A path that merely contains a brace is not a rename.
+    #[test]
+    fn test_parse_numstat_line_leaves_ordinary_paths_alone() {
+        let (_, _, path) = GitAnalysisService::parse_numstat_line("1\t1\tsrc/{weird}/f.rs")
+            .expect("numstat line must parse");
+        assert_eq!(path, "src/{weird}/f.rs");
     }
 
     #[test]

--- a/src/services/infra_score/models.rs
+++ b/src/services/infra_score/models.rs
@@ -12,6 +12,15 @@ use std::path::PathBuf;
 /// Maximum possible raw points for Infra Score (no bonuses — strict 100)
 pub const INFRA_SCORE_MAX_POINTS: f64 = 100.0;
 
+/// Maximum bonus points from the Provable Contracts category.
+///
+/// This MUST equal the sum of the PV-01..PV-05 check weights (3+3+2+2+2), which
+/// is what `ProvableContractsScorer` actually awards. Three places used to carry
+/// their own copy of this number — the scorer said 12, the model default said 10
+/// and the text renderer hardcoded a "/110.0" denominator — so a perfect run
+/// printed a bonus larger than the maximum the same output advertised.
+pub const INFRA_SCORE_BONUS_MAX_POINTS: f64 = 12.0;
+
 /// Overall infrastructure score result
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct InfraScore {
@@ -44,7 +53,7 @@ pub struct InfraCategoryScores {
     pub quality_pipeline: InfraCategoryScore,      // 20 points
     pub deployment_release: InfraCategoryScore,    // 15 points
     pub supply_chain: InfraCategoryScore,          // 15 points
-    pub provable_contracts: InfraCategoryScore,    // 10 points (bonus)
+    pub provable_contracts: InfraCategoryScore,    // 12 points (bonus)
 }
 
 /// Individual category score (mirrors repo_score CategoryScore)
@@ -229,7 +238,8 @@ impl InfraCategoryScores {
             + self.supply_chain.score
     }
 
-    /// Total including provable contracts bonus (110 max)
+    /// Total including provable contracts bonus
+    /// (`INFRA_SCORE_MAX_POINTS` + `INFRA_SCORE_BONUS_MAX_POINTS` max)
     #[provable_contracts_macros::contract("pmat-core.yaml", equation = "check_compliance")]
     pub fn total_with_bonus(&self) -> f64 {
         self.total() + self.provable_contracts.score
@@ -244,7 +254,7 @@ impl Default for InfraCategoryScores {
             quality_pipeline: InfraCategoryScore::empty(20.0),
             deployment_release: InfraCategoryScore::empty(15.0),
             supply_chain: InfraCategoryScore::empty(15.0),
-            provable_contracts: InfraCategoryScore::empty(10.0),
+            provable_contracts: InfraCategoryScore::empty(INFRA_SCORE_BONUS_MAX_POINTS),
         }
     }
 }

--- a/src/services/infra_score/scorers/build_reliability.rs
+++ b/src/services/infra_score/scorers/build_reliability.rs
@@ -50,6 +50,22 @@ impl InfraScorer for BuildReliabilityScorer {
 
         let uses_sovereign_ci = all_content.contains("sovereign-ci");
 
+        // No workflow files means no evidence, and the content scans below are
+        // then run against an EMPTY string, where "no continue-on-error", "all
+        // actions pinned" and "no `|| true`" are all trivially true. A repo
+        // without `.github/workflows` scored 15/25 on checks it never made.
+        let no_workflows = workflows.is_empty();
+        let unmeasured = |id: &str, name: &str, max: f64| {
+            InfraCheck::fail(
+                id,
+                name,
+                max,
+                vec![format!(
+                    "{name} NOT MEASURED — no .github/workflows files to scan"
+                )],
+            )
+        };
+
         let mut checks = Vec::new();
         let mut findings = Vec::new();
 
@@ -78,6 +94,8 @@ impl InfraScorer for BuildReliabilityScorer {
                 5.0,
                 vec!["Implied by sovereign-ci.yml".to_string()],
             )
+        } else if no_workflows {
+            unmeasured("BR-02", "No continue-on-error", 5.0)
         } else {
             check_no_continue_on_error(&all_content)
         };
@@ -146,6 +164,8 @@ impl InfraScorer for BuildReliabilityScorer {
                 3.0,
                 vec!["Implied by sovereign-ci.yml (SHA-pinned)".to_string()],
             )
+        } else if no_workflows {
+            unmeasured("BR-05", "Pinned action versions", 3.0)
         } else {
             check_pinned_actions(&workflows)
         };
@@ -162,7 +182,11 @@ impl InfraScorer for BuildReliabilityScorer {
         checks.push(br05);
 
         // BR-06 (2pts): No || true escape hatches
-        let br06 = check_no_or_true(&all_content);
+        let br06 = if no_workflows {
+            unmeasured("BR-06", "No || true escape hatches", 2.0)
+        } else {
+            check_no_or_true(&all_content)
+        };
         if !br06.passed {
             findings.push(InfraFinding {
                 severity: InfraSeverity::Warning,
@@ -264,12 +288,20 @@ async fn check_ci_success_rate(repo_path: &Path) -> InfraCheck {
             }
         }
         _ => {
-            // gh CLI not available or not in a GitHub repo — skip gracefully
-            InfraCheck::pass(
+            // gh CLI not available, or this is not a GitHub repo. There is no
+            // evidence either way, and an unmeasured check must not score.
+            // This arm used to return pass(5.0) with "assumed pass", so a
+            // project with NO CI at all outscored a real CI whose last ten runs
+            // were under 90% green (that one drops to `partial`).
+            InfraCheck::fail(
                 "BR-01",
                 "CI success rate",
                 5.0,
-                vec!["gh CLI not available — check skipped (assumed pass)".to_string()],
+                vec![
+                    "CI success rate NOT MEASURED — gh CLI unavailable or not a GitHub repo \
+                     (check skipped; an unmeasured check cannot pass)"
+                        .to_string(),
+                ],
             )
         }
     }
@@ -495,14 +527,41 @@ mod tests {
         tmp
     }
 
+    /// A directory with no `.github` at all must earn nothing here. It used to
+    /// score 15/25 — BR-01 "assumed pass" plus BR-02/05/06 scanning an empty
+    /// string and finding no violation — so having no CI outscored a real CI
+    /// with a mediocre run history.
     #[tokio::test]
-    async fn test_empty_repo() {
+    async fn test_empty_repo_scores_nothing_it_did_not_measure() {
         let tmp = TempDir::new().unwrap();
         let scorer = BuildReliabilityScorer::new();
         let result = scorer.score(tmp.path()).await.unwrap();
-        // BR-01 passes (gh skipped), BR-02 passes (no continue-on-error), BR-05 passes (no actions)
-        // BR-06 passes, all others fail
+
         assert_eq!(result.checks.len(), 7);
+        for check in &result.checks {
+            assert!(
+                !check.passed && check.score == 0.0,
+                "{} passed with no evidence: {:?}",
+                check.id,
+                check.evidence
+            );
+        }
+        assert_eq!(result.score, 0.0, "no evidence, no points");
+    }
+
+    /// The BR-01 arm that fires when `gh` cannot answer.
+    #[tokio::test]
+    async fn test_br01_unmeasurable_ci_is_not_a_pass() {
+        // A bare temp dir is not a GitHub repo, so `gh run list` cannot answer.
+        let tmp = TempDir::new().unwrap();
+        let check = check_ci_success_rate(tmp.path()).await;
+        assert!(!check.passed, "{:?}", check.evidence);
+        assert_eq!(check.score, 0.0);
+        assert!(
+            check.evidence.iter().any(|e| e.contains("NOT MEASURED")),
+            "the payload must say the check was not measured: {:?}",
+            check.evidence
+        );
     }
 
     #[test]
@@ -642,7 +701,21 @@ jobs:
         let tmp = setup_repo_with_workflow(content);
         let scorer = BuildReliabilityScorer::new();
         let result = scorer.score(tmp.path()).await.unwrap();
-        // BR-01 skipped (passes), BR-02 pass, BR-03 pass, BR-04 pass, BR-05 pass, BR-06 pass, BR-07 pass
-        assert!((result.score - 25.0).abs() < f64::EPSILON);
+        // BR-02..BR-07 all pass on this workflow: 20 of the 25 points. BR-01
+        // (5pts) cannot be measured in a temp dir — `gh run list` has no repo
+        // to ask about — and an unmeasured check no longer scores.
+        assert!(
+            (result.score - 20.0).abs() < f64::EPSILON,
+            "score={} checks={:?}",
+            result.score,
+            result
+                .checks
+                .iter()
+                .map(|c| (c.id.as_str(), c.score))
+                .collect::<Vec<_>>()
+        );
+        for check in result.checks.iter().filter(|c| c.id != "BR-01") {
+            assert!(check.passed, "{} failed: {:?}", check.id, check.evidence);
+        }
     }
 }

--- a/src/services/infra_score/scorers/mod.rs
+++ b/src/services/infra_score/scorers/mod.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(coverage_nightly, coverage(off))]
-//! Infra-score scorers — 5 base dimensions (100 pts) + 1 bonus (10 pts).
+//! Infra-score scorers — 5 base dimensions (100 pts) + 1 bonus (12 pts).
 //!
 //! Each scorer implements `InfraScorer` and evaluates one dimension
 //! of CI/CD infrastructure quality.

--- a/src/services/infra_score/scorers/provable_contracts.rs
+++ b/src/services/infra_score/scorers/provable_contracts.rs
@@ -35,7 +35,9 @@ impl InfraScorer for ProvableContractsScorer {
     }
 
     fn max_score(&self) -> f64 {
-        12.0
+        // Single source of truth — the renderer and the --help text used to carry
+        // their own (smaller) copy of this number.
+        crate::services::infra_score::models::INFRA_SCORE_BONUS_MAX_POINTS
     }
 
     async fn score(&self, repo_path: &Path) -> anyhow::Result<InfraCategoryScore> {

--- a/src/services/local_semantic.rs
+++ b/src/services/local_semantic.rs
@@ -59,7 +59,6 @@ use aprender::text::vectorize::TfidfVectorizer;
 use aprender::traits::UnsupervisedEstimator;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use walkdir::WalkDir;
 
 /// Local semantic analysis engine using aprender
 pub struct LocalSemanticEngine {

--- a/src/services/local_semantic_engine.rs
+++ b/src/services/local_semantic_engine.rs
@@ -36,12 +36,22 @@ impl LocalSemanticEngine {
     ) -> Result<usize, String> {
         self.documents.clear();
 
-        for entry in WalkDir::new(path)
-            .max_depth(10)
-            .into_iter()
-            .filter_map(Result::ok)
-        {
-            if !entry.file_type().is_file() {
+        // A bare `WalkDir` ignored .gitignore and hidden directories, so
+        // `analyze cluster` on this repository indexed 223,683 documents —
+        // 209k of them .rs files under the git-ignored .claude/worktrees tree —
+        // against the 4,260 `analyze complexity` sees for the same path, and
+        // the clusters were dominated by files that are not part of the
+        // project. Same walker configuration as the function index
+        // (`agent_context/function_index/build.rs`).
+        let walker = ignore::WalkBuilder::new(path)
+            .max_depth(Some(10))
+            .hidden(true)
+            .git_ignore(true)
+            .git_global(true)
+            .build();
+
+        for entry in walker.filter_map(Result::ok) {
+            if !entry.file_type().is_some_and(|ft| ft.is_file()) {
                 continue;
             }
 
@@ -105,10 +115,18 @@ impl LocalSemanticEngine {
         // Prepare document texts
         let texts: Vec<&str> = self.documents.iter().map(|d| d.content.as_str()).collect();
 
+        // A single document can never contain a term with df >= 2, so a
+        // one-file crate produced an empty vocabulary and aprender's internal
+        // precondition — "Vocabulary is empty. Call fit() first" — was surfaced
+        // verbatim as the user-facing error for `analyze cluster`/`topics`.
+        // With one document, every term is kept and the caller then gets an
+        // actionable message from the clustering stage instead.
+        let min_df = if texts.len() < 2 { 1 } else { 2 };
+
         // Create TF-IDF vectorizer with code-friendly settings
         let mut vectorizer = TfidfVectorizer::new()
             .with_tokenizer(Box::new(WhitespaceTokenizer::new()))
-            .with_min_df(2) // Minimum document frequency
+            .with_min_df(min_df) // Minimum document frequency
             .with_max_df(0.95) // Maximum document frequency (exclude very common terms)
             .with_max_features(1000); // Limit vocabulary size (usize, not Option)
 
@@ -333,5 +351,72 @@ impl LocalSemanticEngine {
             method: method.to_string(),
             num_documents: self.documents.len(),
         })
+    }
+}
+
+#[cfg(test)]
+mod corpus_scope_tests {
+    //! Regression tests for two defects in the semantic corpus: the walk
+    //! ignored .gitignore and hidden directories (223,683 documents for a tree
+    //! `analyze complexity` reads as 4,260 files), and a single-document corpus
+    //! could not be vectorized at all — `with_min_df(2)` surfaced aprender's
+    //! internal "Vocabulary is empty. Call fit() first" as the user-facing
+    //! error for any one-file crate.
+    use super::LocalSemanticEngine;
+
+    const SAMPLE: &str =
+        "pub fn add(a: i32, b: i32) -> i32 { a + b }\npub fn sub(a: i32, b: i32) -> i32 { a - b }\n";
+
+    #[test]
+    fn test_single_document_corpus_indexes() {
+        let temp = tempfile::TempDir::new().unwrap();
+        std::fs::write(temp.path().join("lib.rs"), SAMPLE).unwrap();
+
+        let mut engine = LocalSemanticEngine::new();
+        let indexed = engine
+            .index_directory(temp.path(), None)
+            .expect("a one-file crate must index, not report an aprender precondition");
+        assert_eq!(indexed, 1);
+    }
+
+    #[test]
+    fn test_single_document_clustering_reports_an_actionable_error() {
+        let temp = tempfile::TempDir::new().unwrap();
+        std::fs::write(temp.path().join("lib.rs"), SAMPLE).unwrap();
+
+        let mut engine = LocalSemanticEngine::new();
+        engine.index_directory(temp.path(), None).unwrap();
+
+        let err = engine.cluster("kmeans", Some(2)).unwrap_err();
+        assert!(
+            err.contains("1 documents"),
+            "the message must say how many documents there are, got {err}"
+        );
+        assert!(
+            !err.contains("Call fit() first"),
+            "aprender's internal precondition must never be the user-facing error"
+        );
+    }
+
+    #[test]
+    fn test_hidden_and_gitignored_files_are_not_indexed() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let root = temp.path();
+        // `ignore` only honours .gitignore inside a repository.
+        std::fs::create_dir_all(root.join(".git")).unwrap();
+        std::fs::write(root.join(".gitignore"), "vendored/\n").unwrap();
+
+        std::fs::write(root.join("lib.rs"), SAMPLE).unwrap();
+        std::fs::create_dir_all(root.join("vendored")).unwrap();
+        std::fs::write(root.join("vendored/dep.rs"), SAMPLE).unwrap();
+        std::fs::create_dir_all(root.join(".worktrees/copy")).unwrap();
+        std::fs::write(root.join(".worktrees/copy/dup.rs"), SAMPLE).unwrap();
+
+        let mut engine = LocalSemanticEngine::new();
+        let indexed = engine.index_directory(root, None).unwrap();
+        assert_eq!(
+            indexed, 1,
+            "only the project's own source file may be indexed, not the ignored or hidden trees"
+        );
     }
 }

--- a/src/services/makefile_linter/parser.rs
+++ b/src/services/makefile_linter/parser.rs
@@ -43,3 +43,6 @@ include!("parser_cursor.rs");
 
 // Unit tests and property tests
 include!("parser_tests.rs");
+
+// Regression tests for `::=` / `:::=` scanning
+include!("parser_scanner_tests.rs");

--- a/src/services/makefile_linter/parser_nodes.rs
+++ b/src/services/makefile_linter/parser_nodes.rs
@@ -87,13 +87,21 @@ impl<'src> MakefileParser<'src> {
             ));
         }
 
-        // Skip past operator
+        // Skip past operator. `Immediate` covers `:=`, `::=` (POSIX) and
+        // `:::=` (GNU Make 4.4) — the enum does not record which, so the width
+        // is measured from the source; a fixed 2 left the extra ':' and '=' in
+        // the value.
         let op_len = match op {
             AssignmentOp::Deferred => 1,
-            AssignmentOp::Immediate
-            | AssignmentOp::Conditional
-            | AssignmentOp::Append
-            | AssignmentOp::Shell => 2,
+            AssignmentOp::Immediate => {
+                let bytes = self.input.as_bytes();
+                let mut colons = 0;
+                while op_pos + colons < bytes.len() && bytes[op_pos + colons] == b':' {
+                    colons += 1;
+                }
+                colons + 1
+            }
+            AssignmentOp::Conditional | AssignmentOp::Append | AssignmentOp::Shell => 2,
         };
         self.cursor = (op_pos + op_len).min(self.input.len());
 

--- a/src/services/makefile_linter/parser_scanner.rs
+++ b/src/services/makefile_linter/parser_scanner.rs
@@ -75,15 +75,19 @@ impl<'src> MakefileParser<'src> {
     }
 
     fn check_colon_operator(&self, bytes: &[u8], pos: usize) -> Option<LineType> {
-        if pos + 1 < bytes.len() {
-            match bytes[pos + 1] {
-                b'=' => Some(LineType::Assignment(pos, AssignmentOp::Immediate)),
-                b':' => Some(LineType::Rule(pos, true)),
-                _ => Some(LineType::Rule(pos, false)),
-            }
-        } else {
-            Some(LineType::Rule(pos, false))
+        // A run of colons terminated by '=' is an assignment, not a rule.
+        // POSIX 2012 added `::=` and GNU Make 4.4 added `:::=`; both used to
+        // match the bare `b':'` arm and be reported as a double-colon rule, so
+        // `X ::= hello` yielded a target named `X` and a bogus "should probably
+        // be declared .PHONY" violation for a variable definition.
+        let mut colons = 0;
+        while pos + colons < bytes.len() && bytes[pos + colons] == b':' {
+            colons += 1;
         }
+        if bytes.get(pos + colons) == Some(&b'=') {
+            return Some(LineType::Assignment(pos, AssignmentOp::Immediate));
+        }
+        Some(LineType::Rule(pos, colons >= 2))
     }
 
     fn check_two_char_operator(

--- a/src/services/makefile_linter/parser_scanner_tests.rs
+++ b/src/services/makefile_linter/parser_scanner_tests.rs
@@ -1,0 +1,81 @@
+// Tests for the line-type scanner's colon handling
+// Included by parser.rs - shares parent module scope (no `use` imports here)
+
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg(test)]
+mod colon_operator_tests {
+    //! `X ::= hello` (POSIX immediate assignment) was scanned as a
+    //! double-colon *rule*, so `pmat analyze makefile` reported a target named
+    //! `X` and emitted "Target 'X' should probably be declared .PHONY" for what
+    //! is a variable definition.
+    use super::*;
+
+    fn variables(src: &str) -> Vec<(String, AssignmentOp, String)> {
+        let mut parser = MakefileParser::new(src);
+        let ast = parser.parse().expect("parse must succeed");
+        ast.get_variables()
+            .into_iter()
+            .map(|(n, op, v)| (n.clone(), *op, v.clone()))
+            .collect()
+    }
+
+    fn targets(src: &str) -> Vec<String> {
+        let mut parser = MakefileParser::new(src);
+        let ast = parser.parse().expect("parse must succeed");
+        ast.nodes
+            .iter()
+            .filter_map(|n| match &n.data {
+                NodeData::Rule { targets, .. } => Some(targets.clone()),
+                _ => None,
+            })
+            .flatten()
+            .collect()
+    }
+
+    #[test]
+    fn posix_immediate_assignment_is_a_variable_not_a_rule() {
+        assert_eq!(
+            variables("X ::= hello\n"),
+            vec![(
+                "X".to_string(),
+                AssignmentOp::Immediate,
+                "hello".to_string()
+            )]
+        );
+        assert!(
+            targets("X ::= hello\n").is_empty(),
+            "`::=` must not produce a rule target"
+        );
+    }
+
+    #[test]
+    fn gnu_44_immediate_with_expansion_is_a_variable_not_a_rule() {
+        assert_eq!(
+            variables("X :::= hello\n"),
+            vec![(
+                "X".to_string(),
+                AssignmentOp::Immediate,
+                "hello".to_string()
+            )]
+        );
+        assert!(targets("X :::= hello\n").is_empty());
+    }
+
+    #[test]
+    fn plain_immediate_assignment_still_parses() {
+        assert_eq!(
+            variables("X := hello\n"),
+            vec![(
+                "X".to_string(),
+                AssignmentOp::Immediate,
+                "hello".to_string()
+            )]
+        );
+    }
+
+    #[test]
+    fn a_real_double_colon_rule_is_still_a_rule() {
+        assert_eq!(targets("build:: dep\n\techo hi\n"), vec!["build".to_string()]);
+        assert!(variables("build:: dep\n\techo hi\n").is_empty());
+    }
+}

--- a/src/services/mermaid_generator/types.rs
+++ b/src/services/mermaid_generator/types.rs
@@ -12,6 +12,10 @@ pub struct MermaidGenerator {
 /// Configuration options for Mermaid diagram generation
 #[derive(Default)]
 pub struct MermaidOptions {
+    /// Advisory only: the renderer draws the graph it is handed and never
+    /// consults this. Depth is a property of the traversal, so callers must
+    /// prune the graph before rendering (`analyze dag` does, in
+    /// `limit_graph_depth`) — setting it here alone changes nothing.
     pub max_depth: Option<usize>,
     pub filter_external: bool,
     pub group_by_module: bool,

--- a/src/services/pdmt_service_generation.rs
+++ b/src/services/pdmt_service_generation.rs
@@ -141,6 +141,19 @@ impl PdmtService {
                 .or_default()
                 .push(base_id.clone());
 
+            // The doc todo used to hardcode `examples/demo.rs` and `cargo run
+            // --example demo` while the base todo for the SAME requirement named
+            // `examples/add_a_demo.rs`: two todos disagreeing about the file, and
+            // a command naming an example neither of them creates. Take the
+            // example from the requirement's own specs.
+            let doc_specs = self.generate_implementation_specs(requirement);
+            let doc_examples: Vec<String> = doc_specs
+                .example_files
+                .iter()
+                .filter_map(|file| example_target_name(file))
+                .map(|name| format!("cargo run --example {name}"))
+                .collect();
+
             let doc_todo = PdmtTodo {
                 id: doc_id,
                 content: format!("Document and create examples for: {requirement}"),
@@ -153,7 +166,7 @@ impl PdmtService {
                     unit_tests: String::new(),
                     doctests: "cargo test --doc".to_string(),
                     property_tests: String::new(),
-                    examples: vec!["cargo run --example demo".to_string()],
+                    examples: doc_examples,
                     coverage_check: String::new(),
                     quality_proxy: "pmat quality-gate --file README.md".to_string(),
                 },
@@ -165,8 +178,8 @@ impl PdmtService {
                 implementation_specs: ImplementationSpecs {
                     primary_files: vec![],
                     test_files: vec![],
-                    doc_files: vec!["README.md".to_string()],
-                    example_files: vec!["examples/demo.rs".to_string()],
+                    doc_files: doc_specs.doc_files,
+                    example_files: doc_specs.example_files,
                 },
             };
             todos.push(doc_todo);
@@ -258,8 +271,18 @@ impl PdmtService {
             } else {
                 String::new()
             },
+            // The example command must name the example this same todo tells the
+            // user to write. It was the literal `cargo run --example demo` while
+            // `implementation_specs.example_files` said `examples/add_a_demo.rs`,
+            // so the command in the response could not run in the project the
+            // response describes.
             examples: if config.require_examples {
-                vec!["cargo run --example demo".to_string()]
+                specs
+                    .example_files
+                    .iter()
+                    .filter_map(|file| example_target_name(file))
+                    .map(|name| format!("cargo run --example {name}"))
+                    .collect()
             } else {
                 vec![]
             },
@@ -328,6 +351,17 @@ impl PdmtService {
             }
         }
     }
+}
+
+/// `examples/add_a_demo.rs` -> `add_a_demo`, the name `cargo run --example`
+/// actually takes. Returns `None` for a path with no usable stem so a bad spec
+/// drops the command rather than emitting an unrunnable one.
+fn example_target_name(example_file: &str) -> Option<String> {
+    std::path::Path::new(example_file)
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .filter(|stem| !stem.is_empty())
+        .map(str::to_string)
 }
 
 #[cfg(test)]
@@ -421,5 +455,47 @@ mod validation_command_config_tests {
                 todo.id
             );
         }
+
+        // The Default impl is the other place the dangling flag shipped from.
+        assert_eq!(
+            ValidationCommands::default().quality_proxy,
+            "pmat quality-gate --file src/lib.rs"
+        );
+    }
+
+    /// `cargo run --example demo` was a literal, while the same todo's
+    /// `implementation_specs.example_files` said `examples/add_a_demo.rs` — the
+    /// command named an example the response never asks anyone to create.
+    #[test]
+    fn example_commands_name_the_example_the_todo_creates() {
+        let service = PdmtService::new();
+        let list = service
+            .generate_todos(
+                vec!["Add a caching layer".to_string()],
+                Some("demo".to_string()),
+                "high",
+                PdmtQualityConfig::default(),
+            )
+            .expect("generation succeeds");
+
+        let mut checked = 0;
+        for todo in &list.todos {
+            for command in &todo.validation_commands.examples {
+                checked += 1;
+                let target = command
+                    .strip_prefix("cargo run --example ")
+                    .unwrap_or_else(|| panic!("unexpected example command {command}"));
+                assert!(
+                    todo.implementation_specs
+                        .example_files
+                        .iter()
+                        .any(|file| file == &format!("examples/{target}.rs")),
+                    "todo {} runs example '{target}' but creates {:?}",
+                    todo.id,
+                    todo.implementation_specs.example_files
+                );
+            }
+        }
+        assert!(checked > 0, "no example command was generated to check");
     }
 }

--- a/src/services/pdmt_service_generation.rs
+++ b/src/services/pdmt_service_generation.rs
@@ -71,7 +71,7 @@ impl PdmtService {
                 complexity_limit: quality_config.max_complexity,
                 satd_tolerance: false, // Always zero tolerance
             },
-            validation_commands: self.generate_validation_commands(requirement),
+            validation_commands: self.generate_validation_commands(requirement, quality_config),
             success_criteria: self.generate_success_criteria(quality_config),
             implementation_specs: self.generate_implementation_specs(requirement),
         };
@@ -96,14 +96,24 @@ impl PdmtService {
                 quality_gates: base_todo.quality_gates.clone(),
                 validation_commands: ValidationCommands {
                     unit_tests: "cargo test".to_string(),
-                    doctests: "cargo test --doc".to_string(),
-                    property_tests: "cargo test --features property-tests".to_string(),
+                    doctests: if quality_config.require_doctests {
+                        "cargo test --doc".to_string()
+                    } else {
+                        String::new()
+                    },
+                    property_tests: if quality_config.require_property_tests {
+                        "cargo test --features property-tests".to_string()
+                    } else {
+                        String::new()
+                    },
                     examples: vec![],
                     coverage_check: format!(
                         "cargo llvm-cov --fail-under-lines {}",
                         quality_config.coverage_threshold
                     ),
-                    quality_proxy: "pmat quality-gate --file".to_string(),
+                    // `pmat quality-gate --file` with no argument is not a runnable
+                    // command; point it at the file this todo actually produces.
+                    quality_proxy: format!("pmat quality-gate --file tests/{base_id}_test.rs"),
                 },
                 success_criteria: vec![
                     format!(
@@ -145,7 +155,7 @@ impl PdmtService {
                     property_tests: String::new(),
                     examples: vec!["cargo run --example demo".to_string()],
                     coverage_check: String::new(),
-                    quality_proxy: "pmat quality-gate --file".to_string(),
+                    quality_proxy: "pmat quality-gate --file README.md".to_string(),
                 },
                 success_criteria: vec![
                     "Documentation is comprehensive".to_string(),
@@ -213,14 +223,51 @@ impl PdmtService {
     }
 
     /// Generate validation commands for a todo
-    fn generate_validation_commands(&self, _requirement: &str) -> ValidationCommands {
+    ///
+    /// This used to ignore the caller's `PdmtQualityConfig` entirely: it took only
+    /// the requirement text and returned a struct literal with a hardcoded
+    /// `--fail-under-lines 80`, plus doctest/property/example commands even when
+    /// the request had `require_doctests`/`require_property_tests`/`require_examples`
+    /// set to false. A single response therefore contained both the requested
+    /// threshold (in `quality_gates` and `success_criteria`) and the constant 80
+    /// in the command the user was told to run. The commands now come from the
+    /// same config as the gates they are supposed to enforce.
+    fn generate_validation_commands(
+        &self,
+        requirement: &str,
+        config: &PdmtQualityConfig,
+    ) -> ValidationCommands {
+        let specs = self.generate_implementation_specs(requirement);
+        let quality_proxy = specs
+            .primary_files
+            .first()
+            .map_or_else(
+                || "pmat quality-gate".to_string(),
+                |file| format!("pmat quality-gate --file {file}"),
+            );
+
         ValidationCommands {
             unit_tests: "cargo test".to_string(),
-            doctests: "cargo test --doc".to_string(),
-            property_tests: "cargo test --features property-tests".to_string(),
-            examples: vec!["cargo run --example demo".to_string()],
-            coverage_check: "cargo llvm-cov --fail-under-lines 80".to_string(),
-            quality_proxy: "pmat quality-gate --file".to_string(),
+            doctests: if config.require_doctests {
+                "cargo test --doc".to_string()
+            } else {
+                String::new()
+            },
+            property_tests: if config.require_property_tests {
+                "cargo test --features property-tests".to_string()
+            } else {
+                String::new()
+            },
+            examples: if config.require_examples {
+                vec!["cargo run --example demo".to_string()]
+            } else {
+                vec![]
+            },
+            coverage_check: format!(
+                "cargo llvm-cov --fail-under-lines {}",
+                config.coverage_threshold
+            ),
+            quality_proxy,
         }
     }
 
@@ -279,6 +326,100 @@ impl PdmtService {
             if let Some(deps) = dependency_map.get(&todo.id) {
                 todo.dependencies = deps.clone();
             }
+        }
+    }
+}
+
+#[cfg(test)]
+mod validation_command_config_tests {
+    use super::*;
+
+    fn strict_config(coverage: f32) -> PdmtQualityConfig {
+        PdmtQualityConfig {
+            coverage_threshold: coverage,
+            require_doctests: false,
+            require_property_tests: false,
+            require_examples: false,
+            ..PdmtQualityConfig::default()
+        }
+    }
+
+    /// The coverage command a todo tells you to run must enforce the coverage
+    /// threshold that todo's own quality gate demands — it used to be the
+    /// constant 80 regardless of the request.
+    #[test]
+    fn coverage_check_uses_requested_threshold() {
+        let service = PdmtService::new();
+        let list = service
+            .generate_todos(
+                vec!["Add a caching layer".to_string()],
+                Some("demo".to_string()),
+                "medium",
+                strict_config(99.0),
+            )
+            .expect("generation succeeds");
+
+        for todo in &list.todos {
+            if todo.validation_commands.coverage_check.is_empty() {
+                continue;
+            }
+            assert!(
+                todo.validation_commands
+                    .coverage_check
+                    .contains("--fail-under-lines 99"),
+                "todo {} reported coverage_check {:?} for a 99% requirement",
+                todo.id,
+                todo.validation_commands.coverage_check
+            );
+            assert!(
+                !todo.validation_commands.coverage_check.contains("80"),
+                "todo {} still carries the hardcoded 80 threshold",
+                todo.id
+            );
+        }
+    }
+
+    /// Doctest/property/example commands must not be emitted when the caller
+    /// explicitly said they are not required.
+    #[test]
+    fn optional_commands_omitted_when_not_required() {
+        let service = PdmtService::new();
+        let list = service
+            .generate_todos(
+                vec!["Add a caching layer".to_string()],
+                Some("demo".to_string()),
+                "medium",
+                strict_config(99.0),
+            )
+            .expect("generation succeeds");
+
+        let base = &list.todos[0];
+        assert_eq!(base.validation_commands.doctests, "");
+        assert_eq!(base.validation_commands.property_tests, "");
+        assert!(base.validation_commands.examples.is_empty());
+    }
+
+    /// `pmat quality-gate --file` with no argument is not a runnable command.
+    #[test]
+    fn quality_proxy_names_a_file() {
+        let service = PdmtService::new();
+        let list = service
+            .generate_todos(
+                vec!["Add a caching layer".to_string()],
+                Some("demo".to_string()),
+                "high",
+                PdmtQualityConfig::default(),
+            )
+            .expect("generation succeeds");
+
+        for todo in &list.todos {
+            let proxy = &todo.validation_commands.quality_proxy;
+            assert_ne!(
+                proxy.trim(),
+                "pmat quality-gate --file",
+                "todo {} emits an argument-less quality-gate command",
+                todo.id
+            );
         }
     }
 }

--- a/src/services/perfection_score/calculator.rs
+++ b/src/services/perfection_score/calculator.rs
@@ -111,19 +111,26 @@ impl PerfectionScoreCalculator {
         ));
 
         // 6. Mutation Score (20 pts) - Skip in fast mode
-        let mutation_score = if self.fast_mode {
-            50.0 // Default credit in fast mode
+        //
+        // `--fast` cannot run mutation testing, but this used to hand the category
+        // a flat 50.0 ("default credit in fast mode") while its own details string
+        // admitted "Skipped (fast mode)". That put 10 unearned points inside a
+        // total presented as a grade, identically for a real repo, an empty
+        // directory and a path that does not exist. A measurement that never ran
+        // earns nothing and is removed from the denominator instead.
+        if self.fast_mode {
+            let mut skipped = CategoryScore::new("Mutation Testing", 0.0, 0)
+                .with_details("Not measured — --fast skips mutation testing (excluded from total)");
+            skipped.grade = "N/A".to_string();
+            categories.push(skipped);
         } else {
-            self.get_mutation_score(project_path).await
-        };
-        categories.push(
-            CategoryScore::new("Mutation Testing", mutation_score, self.weights.mutation)
-                .with_details(if self.fast_mode {
-                    "Skipped (fast mode)"
-                } else {
-                    ""
-                }),
-        );
+            let mutation_score = self.get_mutation_score(project_path).await;
+            categories.push(CategoryScore::new(
+                "Mutation Testing",
+                mutation_score,
+                self.weights.mutation,
+            ));
+        }
 
         // 7. Documentation (15 pts)
         let doc_score = self.get_documentation_score(project_path).await;
@@ -141,7 +148,22 @@ impl PerfectionScoreCalculator {
             self.weights.performance,
         ));
 
-        Ok(PerfectionScoreResult::new(categories))
+        let mut result = PerfectionScoreResult::new(categories);
+
+        // The denominator must match the categories that were actually measured,
+        // otherwise a skipped category silently costs the project its own weight
+        // (or, as before, lends it half of it for free).
+        let measured_max: u16 = result.categories.iter().map(|c| c.max_points).sum();
+        if measured_max > 0 && measured_max != result.max_score {
+            result.max_score = measured_max;
+            // calculate_overall_grade normalises against the full 200-point scale,
+            // so rescale the total to that scale before grading it.
+            let scaled = result.total_score * f64::from(super::types::MAX_PERFECTION_SCORE)
+                / f64::from(measured_max);
+            result.grade = PerfectionScoreResult::calculate_overall_grade(scaled);
+        }
+
+        Ok(result)
     }
 
     pub(super) async fn get_tdg_score(&self, project_path: &Path) -> f64 {

--- a/src/services/perfection_score/calculator_tests.rs
+++ b/src/services/perfection_score/calculator_tests.rs
@@ -197,12 +197,16 @@ edition = "2021"
     // Calculator Fast Mode Integration Test
     // ============================================================================
 
+    /// Fast mode cannot run mutation testing, so it must not award points for it.
+    /// This test previously asserted the opposite — that the category came back
+    /// with a flat raw_score of 50.0 ("default credit") — which is exactly how ten
+    /// unearned points ended up inside a total presented as a grade, identically
+    /// for a real repo and for a path that does not exist.
     #[tokio::test]
-    async fn test_calculator_fast_mode_mutation_default_inline() {
+    async fn test_calculator_fast_mode_mutation_earns_nothing() {
         let temp_dir = TempDir::new().unwrap();
         let calc = PerfectionScoreCalculator::new().fast_mode(true);
 
-        // In fast mode, mutation score should be 50.0 (default credit)
         let result = calc.calculate(temp_dir.path()).await.unwrap();
 
         let mutation_cat = result
@@ -210,11 +214,23 @@ edition = "2021"
             .iter()
             .find(|c| c.name == "Mutation Testing")
             .unwrap();
-        assert_eq!(mutation_cat.raw_score, 50.0);
+        assert_eq!(
+            mutation_cat.earned_points, 0.0,
+            "an unmeasured category must not contribute points"
+        );
+        assert_eq!(
+            mutation_cat.max_points, 0,
+            "an unmeasured category must not sit in the denominator"
+        );
         assert!(mutation_cat
             .details
             .as_ref()
-            .is_some_and(|d| d.contains("fast mode")));
+            .is_some_and(|d| d.contains("Not measured")));
+
+        // The reported denominator must equal what was actually measured.
+        assert_eq!(result.max_score, 180);
+        let summed: u16 = result.categories.iter().map(|c| c.max_points).sum();
+        assert_eq!(summed, result.max_score);
     }
 
     #[test]

--- a/src/services/perfection_score/property_tests.rs
+++ b/src/services/perfection_score/property_tests.rs
@@ -269,7 +269,16 @@ mod property_tests {
         let temp_dir = TempDir::new().unwrap();
         let calc = PerfectionScoreCalculator::new().fast_mode(true);
 
-        // In fast mode, mutation score should be 50.0 (default credit)
+        // In fast mode mutation testing is not run at all, so the category is
+        // reported as not measured and excluded from the denominator.
+        //
+        // This used to assert `raw_score == 50.0` with the comment "default
+        // credit in fast mode" — a flat half-credit handed to a measurement
+        // that never ran (and identical for a real repo, an empty directory and
+        // a nonexistent path), while the category's own details string admitted
+        // "Skipped (fast mode)". Unearned points inside a number presented as a
+        // grade are exactly the defect; the category now scores nothing and
+        // costs nothing.
         let result = calc.calculate(temp_dir.path()).await.unwrap();
 
         let mutation_cat = result
@@ -277,11 +286,24 @@ mod property_tests {
             .iter()
             .find(|c| c.name == "Mutation Testing")
             .unwrap();
-        assert_eq!(mutation_cat.raw_score, 50.0);
-        assert!(mutation_cat
+        assert_eq!(mutation_cat.raw_score, 0.0);
+        assert_eq!(
+            mutation_cat.earned_points, 0.0,
+            "a check that never ran cannot earn points"
+        );
+        assert_eq!(
+            mutation_cat.max_points, 0,
+            "a check that never ran must leave the denominator"
+        );
+        assert_eq!(mutation_cat.grade, "N/A");
+        let details = mutation_cat
             .details
             .as_ref()
-            .is_some_and(|d| d.contains("fast mode")));
+            .expect("skipped category must say why");
+        assert!(
+            details.contains("Not measured") && details.contains("--fast"),
+            "unexpected details: {details}"
+        );
     }
 
     #[test]

--- a/src/services/proof_annotator.rs
+++ b/src/services/proof_annotator.rs
@@ -84,6 +84,13 @@ pub struct ProofAnnotator {
     sources: Vec<Box<dyn ProofSource>>,
     cache: Arc<RwLock<ProofCache>>,
     symbol_table: Arc<SymbolTable>,
+    /// Files the last `collect_proofs` could not read or parse.
+    ///
+    /// These used to be counted, logged once at `warn!` and thrown away, so a
+    /// run over this repo skipped files whose annotations are simply absent
+    /// from the report — and the report said "Total proofs: N" as if it had
+    /// seen everything. Retained so the renderers can disclose the gap.
+    collection_errors: std::sync::atomic::AtomicUsize,
 }
 
 /// Cache statistics

--- a/src/services/proof_annotator_core.rs
+++ b/src/services/proof_annotator_core.rs
@@ -10,7 +10,18 @@ impl ProofAnnotator {
             sources: Vec::new(),
             cache: Arc::new(RwLock::new(ProofCache::new())),
             symbol_table,
+            collection_errors: std::sync::atomic::AtomicUsize::new(0),
         }
+    }
+
+    /// How many files the last [`collect_proofs`](Self::collect_proofs) failed
+    /// to read or parse, and therefore did not contribute annotations.
+    ///
+    /// Zero before any collection has run.
+    #[must_use]
+    pub fn collection_errors(&self) -> usize {
+        self.collection_errors
+            .load(std::sync::atomic::Ordering::Relaxed)
     }
 
     /// Add a proof source to the annotator
@@ -71,7 +82,14 @@ impl ProofAnnotator {
         }
 
         // Merge results with conflict resolution
-        let proof_map = self.merge_with_conflict_resolution(all_results);
+        let (proof_map, total_errors) = self.merge_with_conflict_resolution(all_results);
+
+        // The per-file failures used to end here, as a single `warn!` line on
+        // stderr and nothing else: the stdout report claimed a total with no
+        // hint that N files had been skipped. Retained on the annotator so the
+        // renderers can disclose it alongside the total.
+        self.collection_errors
+            .store(total_errors, std::sync::atomic::Ordering::Relaxed);
 
         let elapsed = start.elapsed();
         let total_annotations = proof_map.values().map(std::vec::Vec::len).sum::<usize>();
@@ -86,8 +104,14 @@ impl ProofAnnotator {
         proof_map
     }
 
-    /// Merge results from multiple sources with conflict resolution
-    fn merge_with_conflict_resolution(&self, results: Vec<ProofCollectionResult>) -> ProofMap {
+    /// Merge results from multiple sources with conflict resolution.
+    ///
+    /// Returns the merged map and the number of per-file errors the sources
+    /// reported, which the caller records on the annotator.
+    fn merge_with_conflict_resolution(
+        &self,
+        results: Vec<ProofCollectionResult>,
+    ) -> (ProofMap, usize) {
         let mut proof_map: ProofMap = std::collections::HashMap::new();
         let mut total_errors = 0;
 
@@ -152,7 +176,7 @@ impl ProofAnnotator {
             );
         }
 
-        proof_map
+        (proof_map, total_errors)
     }
 
     /// Get cache statistics

--- a/src/services/quality_proxy_analysis.rs
+++ b/src/services/quality_proxy_analysis.rs
@@ -1,3 +1,42 @@
+/// Maximum cyclomatic complexity over every function in the file, including
+/// methods on impls/classes.
+///
+/// Deliberately unfiltered: this is the measurement the quality report
+/// publishes as `metrics.max_complexity`, and it must not depend on the
+/// threshold the caller happened to configure.
+pub(crate) fn max_function_cyclomatic(
+    file_metrics: &crate::services::complexity::FileComplexityMetrics,
+) -> u16 {
+    file_metrics
+        .functions
+        .iter()
+        .map(|f| f.metrics.cyclomatic)
+        .chain(
+            file_metrics
+                .classes
+                .iter()
+                .flat_map(|c| c.methods.iter().map(|m| m.metrics.cyclomatic)),
+        )
+        .max()
+        .unwrap_or(0)
+}
+
+/// Severity for one line of `cargo clippy` output.
+///
+/// Every lint finding used to be filed as a `Warning`, and `passed` is "all
+/// violations are warnings", so content that does not even compile
+/// ("error: could not compile … due to 1 previous error") was *accepted* by
+/// strict mode while a TODO comment rejected it. rustc's own level prefix
+/// decides: `error:`/`error[E0433]:` is an error.
+pub(crate) fn lint_line_severity(line: &str) -> ViolationSeverity {
+    let trimmed = line.trim_start();
+    if trimmed.starts_with("error:") || trimmed.starts_with("error[") {
+        ViolationSeverity::Error
+    } else {
+        ViolationSeverity::Warning
+    }
+}
+
 impl QualityProxyService {
     async fn analyze_content(
         &self,
@@ -30,21 +69,19 @@ impl QualityProxyService {
         // Analyze complexity
         let max_complexity = match analyze_rust_file_with_complexity(temp_path).await {
             Ok(file_metrics) => {
+                // `report.hotspots` is threshold-filtered, so reading the maximum
+                // from it published a 0 meaning "nothing exceeded the threshold"
+                // as if it were the measured maximum: the same content reported
+                // max_complexity 0 under the default threshold and 9 under
+                // max_complexity=1. The measurement comes from the unfiltered
+                // function list; the threshold only decides the violation.
+                let max_comp = u32::from(max_function_cyclomatic(&file_metrics));
+
                 // The result is already FileComplexityMetrics, use it directly
                 let report = aggregate_results_with_thresholds(
                     vec![file_metrics],
                     Some(config.max_complexity as u16),
                     Some(config.max_complexity as u16 + 5),
-                );
-
-                // Find max complexity from hotspots
-                let max_comp = u32::from(
-                    report
-                        .hotspots
-                        .iter()
-                        .map(|h| h.complexity)
-                        .max()
-                        .unwrap_or(0),
                 );
 
                 if max_comp > config.max_complexity {
@@ -101,7 +138,7 @@ impl QualityProxyService {
                 for (line, message) in &violations_found {
                     violations.push(QualityViolation {
                         violation_type: ViolationType::Lint,
-                        severity: ViolationSeverity::Warning,
+                        severity: lint_line_severity(message),
                         location: format!("{file_path}:{line}"),
                         message: message.clone(),
                         suggestion: Some("Fix lint issue".to_string()),
@@ -216,27 +253,30 @@ edition = "2021"
         cargo_file.write_all(cargo_toml.as_bytes())?;
         cargo_file.flush()?;
 
-        // Run cargo clippy
+        // Run cargo clippy.
+        //
+        // `-D warnings` used to be passed here, which relabelled every lint as
+        // "error:" and made rustc's own level prefix useless for telling a
+        // style lint apart from content that does not compile. Levels are left
+        // as rustc reports them so `lint_line_severity` can be trusted; the
+        // caller decides what fails the gate.
         let output = Command::new("cargo")
             .arg("clippy")
-            .arg("--")
-            .arg("-D")
-            .arg("warnings")
             .current_dir(temp_dir.path())
             .output()?;
 
         let mut violations = Vec::new();
 
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            // Parse basic clippy output
-            for line in stderr.lines() {
-                if line.contains("warning:") || line.contains("error:") {
-                    // Extract line number if possible
-                    let line_num = 1; // Default line number
-                    let message = line.to_string();
-                    violations.push((line_num, message));
-                }
+        // Warnings are reported on a *successful* run too, so the findings are
+        // collected regardless of exit status.
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        for line in stderr.lines() {
+            let trimmed = line.trim_start();
+            if trimmed.starts_with("warning:") || trimmed.starts_with("error:") || trimmed.starts_with("error[") {
+                // Extract line number if possible
+                let line_num = 1; // Default line number
+                let message = line.to_string();
+                violations.push((line_num, message));
             }
         }
 
@@ -261,6 +301,117 @@ edition = "2021"
                 "rustfmt failed: {}",
                 String::from_utf8_lossy(&output.stderr)
             ))
+        }
+    }
+}
+
+#[cfg(test)]
+mod analysis_measurement_tests {
+    //! Regressions for two fabricated values in the quality_proxy report:
+    //! a threshold-filtered `max_complexity`, and lint findings that were all
+    //! filed as warnings so non-compiling content passed strict mode.
+    use super::*;
+    use crate::services::complexity::{
+        ComplexityMetrics, FileComplexityMetrics, FunctionComplexity,
+    };
+
+    fn func(name: &str, cyclomatic: u16) -> FunctionComplexity {
+        FunctionComplexity {
+            name: name.to_string(),
+            line_start: 1,
+            line_end: 10,
+            metrics: ComplexityMetrics {
+                cyclomatic,
+                cognitive: cyclomatic,
+                nesting_max: 1,
+                lines: 10,
+                halstead: None,
+            },
+        }
+    }
+
+    fn file_with(functions: Vec<FunctionComplexity>) -> FileComplexityMetrics {
+        FileComplexityMetrics {
+            path: "qpa.rs".to_string(),
+            total_complexity: ComplexityMetrics {
+                cyclomatic: 0,
+                cognitive: 0,
+                nesting_max: 0,
+                lines: 0,
+                halstead: None,
+            },
+            functions,
+            classes: vec![],
+        }
+    }
+
+    #[test]
+    fn test_max_complexity_is_measured_not_threshold_filtered() {
+        // The reported maximum must not depend on the configured threshold:
+        // under the default 20 the hotspot list is empty, and reading the max
+        // from it published 0 for a function measured at 9.
+        let metrics = file_with(vec![func("nasty", 9), func("tidy", 2)]);
+
+        let report = aggregate_results_with_thresholds(vec![metrics.clone()], Some(20), Some(25));
+        assert!(
+            report.hotspots.iter().all(|h| h.complexity < 9),
+            "the 9-complexity function is filtered out at threshold 20; \
+             that filtered list must not be the source of the measurement"
+        );
+
+        assert_eq!(max_function_cyclomatic(&metrics), 9);
+    }
+
+    #[test]
+    fn test_max_complexity_includes_methods() {
+        let mut metrics = file_with(vec![func("plain", 3)]);
+        metrics.classes.push(crate::services::complexity::ClassComplexity {
+            name: "Impl".to_string(),
+            line_start: 1,
+            line_end: 20,
+            metrics: ComplexityMetrics {
+                cyclomatic: 0,
+                cognitive: 0,
+                nesting_max: 0,
+                lines: 0,
+                halstead: None,
+            },
+            methods: vec![func("method", 12)],
+        });
+        assert_eq!(max_function_cyclomatic(&metrics), 12);
+    }
+
+    #[test]
+    fn test_max_complexity_of_empty_file_is_zero() {
+        assert_eq!(max_function_cyclomatic(&file_with(vec![])), 0);
+    }
+
+    #[test]
+    fn test_compile_errors_are_errors_not_warnings() {
+        // These two lines are exactly what the shipped binary reported (as
+        // severity "warning") while ACCEPTING "this is not rust at all !!!".
+        for line in [
+            "error: expected one of `!` or `::`, found `is`",
+            "error: could not compile `temp_quality_check` (lib) due to 1 previous error",
+            "error[E0433]: failed to resolve: use of undeclared crate or module `foo`",
+        ] {
+            assert!(
+                matches!(lint_line_severity(line), ViolationSeverity::Error),
+                "{line} must fail a strict gate"
+            );
+        }
+    }
+
+    #[test]
+    fn test_style_lints_stay_warnings() {
+        for line in [
+            "warning: function `simple` is never used",
+            "warning: `temp_quality_check` (lib) generated 1 warning",
+        ] {
+            assert!(matches!(
+                lint_line_severity(line),
+                ViolationSeverity::Warning
+            ));
         }
     }
 }

--- a/src/services/quality_proxy_operations.rs
+++ b/src/services/quality_proxy_operations.rs
@@ -176,8 +176,18 @@ impl QualityProxyService {
                     Some(existing) => Ok(format!("{existing}\n{append_content}")),
                     None => match read_proxy_target(&request.file_path)? {
                         Some(existing) => Ok(join_appended(&existing, append_content)),
-                        // Appending to a file that does not exist yet creates it.
-                        None => Ok(append_content.clone()),
+                        // Appending to a file that does not exist yet creates
+                        // it — but only somewhere it could actually be created.
+                        // A path under a directory that does not exist was
+                        // silently treated as "an append to the empty file" and
+                        // came back accepted/passed:true, while `quality_gate`
+                        // rejected the very same path with "File does not
+                        // exist". Two tools in one session must not disagree
+                        // about whether a path is real.
+                        None => {
+                            ensure_appendable(&request.file_path)?;
+                            Ok(append_content.clone())
+                        }
                     },
                 }
             }
@@ -194,6 +204,21 @@ fn read_proxy_target(file_path: &str) -> Result<Option<String>> {
     std::fs::read_to_string(path)
         .map(Some)
         .with_context(|| format!("Failed to read {file_path} for quality proxy"))
+}
+
+/// Refuse an append to a path that could not be created if it were performed.
+///
+/// The file itself may legitimately not exist yet; its directory may not.
+fn ensure_appendable(file_path: &str) -> Result<()> {
+    let path = Path::new(file_path);
+    match path.parent().filter(|p| !p.as_os_str().is_empty()) {
+        Some(dir) if !dir.is_dir() => anyhow::bail!(
+            "Append rejected: {} does not exist and neither does its directory {}",
+            file_path,
+            dir.display()
+        ),
+        _ => Ok(()),
+    }
 }
 
 /// Concatenate appended text without inventing or losing a line break.
@@ -289,6 +314,33 @@ mod proxy_file_path_tests {
         let content = service.get_operation_content(&req).expect("append resolves");
         assert!(content.starts_with(THREE_LINES), "{content}");
         assert!(content.contains("line_four"), "{content}");
+    }
+
+    /// `quality_proxy` accepted edit/append on a path that cannot exist while
+    /// `quality_gate`, in the same session, rejected it with "File does not
+    /// exist". Both must refuse it.
+    #[test]
+    fn test_operations_on_an_impossible_path_are_rejected() {
+        let service = QualityProxyService::new();
+        let missing = std::path::Path::new("/does/not/exist/never_existed.rs");
+
+        let mut edit = request(ProxyOperation::Edit, missing);
+        edit.old_content = Some("x".to_string());
+        edit.new_content = Some("y".to_string());
+        let err = service
+            .get_operation_content(&edit)
+            .expect_err("editing a nonexistent file must fail loudly");
+        assert!(
+            err.to_string().contains("requires the file to exist"),
+            "{err}"
+        );
+
+        let mut append = request(ProxyOperation::Append, missing);
+        append.content = Some("pub fn added() {}\n".to_string());
+        let err = service
+            .get_operation_content(&append)
+            .expect_err("appending under a nonexistent directory must fail loudly");
+        assert!(err.to_string().contains("Append rejected"), "{err}");
     }
 
     /// Appending to a path that does not exist yet still creates it.

--- a/src/services/quality_proxy_operations.rs
+++ b/src/services/quality_proxy_operations.rs
@@ -120,6 +120,17 @@ impl QualityProxyService {
         })
     }
 
+    /// Resolve the post-operation content the quality gates will judge.
+    ///
+    /// `request.file_path` used to be ignored entirely: with no inline `content`
+    /// an Edit fell through to the replacement fragment alone and an Append to
+    /// the appended text alone, so a three-line file came back with
+    /// `final_content` holding one line and was graded on that fragment. Worse,
+    /// nothing checked that `old_content` actually occurred anywhere, so an edit
+    /// anchored to a string absent from the file was reported "accepted". Fall
+    /// back to the file on disk, and refuse an anchor that occurs nowhere in it.
+    /// (An anchor that occurs several times still replaces every occurrence —
+    /// that is the semantic the proxy's property tests pin.)
     fn get_operation_content(&self, request: &ProxyRequest) -> Result<String> {
         match request.operation {
             ProxyOperation::Write => request
@@ -136,11 +147,23 @@ impl QualityProxyService {
                     .as_ref()
                     .context("Edit operation requires new_content")?;
 
-                if let Some(existing_content) = &request.content {
-                    Ok(existing_content.replace(old, new))
-                } else {
-                    Ok(new.clone())
+                let existing = match &request.content {
+                    Some(inline) => inline.clone(),
+                    None => read_proxy_target(&request.file_path)?.with_context(|| {
+                        format!(
+                            "Edit operation on {} requires the file to exist or inline content",
+                            request.file_path
+                        )
+                    })?,
+                };
+
+                if !existing.contains(old.as_str()) {
+                    anyhow::bail!(
+                        "Edit rejected: old_content does not occur in {}",
+                        request.file_path
+                    );
                 }
+                Ok(existing.replace(old, new))
             }
             ProxyOperation::Append => {
                 let append_content = request
@@ -148,12 +171,136 @@ impl QualityProxyService {
                     .as_ref()
                     .context("Append operation requires content")?;
 
-                if let Some(existing) = &request.old_content {
-                    Ok(format!("{existing}\n{append_content}"))
-                } else {
-                    Ok(append_content.clone())
+                match &request.old_content {
+                    // Caller-supplied preceding text keeps its historical join.
+                    Some(existing) => Ok(format!("{existing}\n{append_content}")),
+                    None => match read_proxy_target(&request.file_path)? {
+                        Some(existing) => Ok(join_appended(&existing, append_content)),
+                        // Appending to a file that does not exist yet creates it.
+                        None => Ok(append_content.clone()),
+                    },
                 }
             }
         }
+    }
+}
+
+/// Read the file an operation targets; `None` when it does not exist yet.
+fn read_proxy_target(file_path: &str) -> Result<Option<String>> {
+    let path = Path::new(file_path);
+    if !path.is_file() {
+        return Ok(None);
+    }
+    std::fs::read_to_string(path)
+        .map(Some)
+        .with_context(|| format!("Failed to read {file_path} for quality proxy"))
+}
+
+/// Concatenate appended text without inventing or losing a line break.
+fn join_appended(existing: &str, addition: &str) -> String {
+    if existing.is_empty() || existing.ends_with('\n') {
+        format!("{existing}{addition}")
+    } else {
+        format!("{existing}\n{addition}")
+    }
+}
+
+#[cfg(test)]
+mod proxy_file_path_tests {
+    use super::*;
+
+    const THREE_LINES: &str = "pub fn line_one() -> i32 { 1 }\n\
+                               pub fn line_two() -> i32 { 2 }\n\
+                               pub fn line_three() -> i32 { 3 }\n";
+
+    fn request(op: ProxyOperation, path: &std::path::Path) -> ProxyRequest {
+        ProxyRequest {
+            operation: op,
+            file_path: path.display().to_string(),
+            content: None,
+            old_content: None,
+            new_content: None,
+            mode: ProxyMode::Strict,
+            quality_config: QualityConfig::default(),
+        }
+    }
+
+    fn fixture() -> (tempfile::TempDir, std::path::PathBuf) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("multi.rs");
+        std::fs::write(&path, THREE_LINES).expect("write fixture");
+        (dir, path)
+    }
+
+    /// An edit must be graded on the whole file, not on the replacement alone.
+    #[test]
+    fn test_edit_applies_to_the_file_on_disk() {
+        let (_dir, path) = fixture();
+        let service = QualityProxyService::new();
+        let mut req = request(ProxyOperation::Edit, &path);
+        req.old_content = Some("pub fn line_two() -> i32 { 2 }".to_string());
+        req.new_content = Some("pub fn line_two() -> i32 { 22 }".to_string());
+
+        let content = service.get_operation_content(&req).expect("edit resolves");
+        assert!(content.contains("line_one"), "{content}");
+        assert!(content.contains("line_three"), "{content}");
+        assert!(content.contains("{ 22 }"), "{content}");
+        assert!(!content.contains("{ 2 }"), "{content}");
+    }
+
+    /// An anchor that occurs nowhere in the file is not an edit — it is an error.
+    #[test]
+    fn test_edit_with_absent_old_content_is_rejected() {
+        let (_dir, path) = fixture();
+        let service = QualityProxyService::new();
+        let mut req = request(ProxyOperation::Edit, &path);
+        req.old_content = Some("THIS STRING IS NOT PRESENT".to_string());
+        req.new_content = Some("zzz".to_string());
+
+        let err = service
+            .get_operation_content(&req)
+            .expect_err("an impossible edit must not be accepted");
+        assert!(err.to_string().contains("does not occur"), "{err}");
+    }
+
+    /// A repeated anchor replaces every occurrence — in the file, not in a
+    /// fragment (the proxy's property tests pin the replace-all semantic).
+    #[test]
+    fn test_edit_replaces_every_occurrence_in_the_file() {
+        let (_dir, path) = fixture();
+        let service = QualityProxyService::new();
+        let mut req = request(ProxyOperation::Edit, &path);
+        req.old_content = Some("-> i32".to_string());
+        req.new_content = Some("-> u32".to_string());
+
+        let content = service.get_operation_content(&req).expect("edit resolves");
+        assert_eq!(content.matches("-> u32").count(), 3, "{content}");
+        assert!(!content.contains("-> i32"), "{content}");
+    }
+
+    /// Append must keep the file it appends to.
+    #[test]
+    fn test_append_keeps_the_existing_file() {
+        let (_dir, path) = fixture();
+        let service = QualityProxyService::new();
+        let mut req = request(ProxyOperation::Append, &path);
+        req.content = Some("pub fn line_four() -> i32 { 4 }\n".to_string());
+
+        let content = service.get_operation_content(&req).expect("append resolves");
+        assert!(content.starts_with(THREE_LINES), "{content}");
+        assert!(content.contains("line_four"), "{content}");
+    }
+
+    /// Appending to a path that does not exist yet still creates it.
+    #[test]
+    fn test_append_to_missing_file_is_just_the_addition() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let service = QualityProxyService::new();
+        let mut req = request(ProxyOperation::Append, &dir.path().join("new.rs"));
+        req.content = Some("pub fn only() {}\n".to_string());
+        assert_eq!(
+            service.get_operation_content(&req).expect("append resolves"),
+            "pub fn only() {}\n"
+        );
     }
 }

--- a/src/services/quality_proxy_property_tests.rs
+++ b/src/services/quality_proxy_property_tests.rs
@@ -133,9 +133,23 @@ mod property_tests {
         ) {
             let rt = tokio::runtime::Runtime::new().unwrap();
 
+            // The raw draws are NOT usable as identifiers: `[a-z_]+` happily
+            // produces a Rust keyword (`fn`, `match`, `in`) or a bare `_`, and
+            // the shrunk case proptest persisted for this test was exactly
+            // `param_name = "_"` — `pub fn a(_: i32) -> i32 { _ * 2 }` does not
+            // compile. The property claims "high-quality code is accepted", so
+            // it must not feed the gate content that is not even valid Rust:
+            // it used to pass only because strict mode filed rustc's
+            // "error: could not compile" as a *warning* and accepted it, i.e.
+            // the assertion was pinning the accept-anything defect rather than
+            // the property. Prefixing makes every draw a valid, non-keyword
+            // identifier while keeping the generated shapes varied.
+            let fn_name = format!("compute_{fn_name}");
+            let param_name = format!("value_{param_name}");
+
             let code = format!(
                 r#"/// A well-documented function
-/// 
+///
 /// This function performs a simple calculation.
 pub fn {}({}: i32) -> i32 {{
     {} * 2

--- a/src/services/repo_score/scorers/demo_scorer_g2_error_gracefulness.rs
+++ b/src/services/repo_score/scorers/demo_scorer_g2_error_gracefulness.rs
@@ -42,12 +42,15 @@ impl DemoScorer {
         max_score: f64,
     ) -> Result<SubcategoryScore> {
         let has_error_section = check_readme_error_section(repo_path).await;
-        let partial_score: f64 = if has_error_section { 2.0 } else { 1.5 };
-
+        // Absence of evidence used to be worth half credit: this branch handed
+        // out 1.5/3.0 (2.0 with a README error section) precisely when nothing
+        // had been analysed, so an EMPTY directory scored 15%. The sibling
+        // category G1 scores 0.0 for the same absence. Score only what was
+        // measured; documentation alone is not demo error handling.
         Ok(SubcategoryScore {
             id: "G2".to_string(),
             name: "Error Gracefulness".to_string(),
-            score: partial_score.min(max_score),
+            score: 0.0,
             max_score,
             findings: vec![Finding {
                 severity: Severity::Info,

--- a/src/services/repo_score/scorers/demo_scorer_tests_g2.inc.rs
+++ b/src/services/repo_score/scorers/demo_scorer_tests_g2.inc.rs
@@ -41,8 +41,10 @@
             .await
             .expect("Scoring failed");
 
-        // Should get partial credit (2.0) for having error docs
-        assert_eq!(result.score, 2.0);
+        // No demo files were analysed, so G2 measured nothing and scores 0.0 —
+        // a README section is documentation, not demo error handling. This
+        // asserted 2.0 while the branch handed out credit for absence.
+        assert_eq!(result.score, 0.0);
     }
 
     #[tokio::test]
@@ -62,7 +64,8 @@
             .await
             .expect("Scoring failed");
 
-        assert_eq!(result.score, 2.0);
+        // Nothing analysed ⇒ nothing scored (see the no-demo-files branch).
+        assert_eq!(result.score, 0.0);
     }
 
     #[tokio::test]
@@ -82,7 +85,30 @@
             .await
             .expect("Scoring failed");
 
-        assert_eq!(result.score, 2.0);
+        // Nothing analysed ⇒ nothing scored (see the no-demo-files branch).
+        assert_eq!(result.score, 0.0);
+    }
+
+    /// An EMPTY directory used to score 1.5/3.0 on G2 ("No demo files found to
+    /// analyze for error handling") and therefore 15% overall, while the
+    /// sibling G1 scored 0.0 for the same absence. Absence of evidence is not
+    /// half credit.
+    #[tokio::test]
+    async fn test_error_gracefulness_empty_repo_scores_zero() {
+        let temp_dir = create_temp_repo();
+        let repo_path = temp_dir.path();
+
+        let scorer = DemoScorer::new();
+        let result = scorer
+            .score_error_gracefulness(repo_path, RepoArchetype::DemoApp)
+            .await
+            .expect("Scoring failed");
+
+        assert_eq!(
+            result.score, 0.0,
+            "an empty repo has no demo files to analyse, but G2 awarded {} points",
+            result.score
+        );
     }
 
     #[tokio::test]

--- a/src/services/rust_borrow_checker_annotations.rs
+++ b/src/services/rust_borrow_checker_annotations.rs
@@ -1,6 +1,16 @@
 // Proof annotation factory methods for RustBorrowChecker
 // Included by rust_borrow_checker.rs - no `use` imports or `#!` attributes
 
+// CONFIDENCE: every factory below hardcoded `ConfidenceLevel::High`, so
+// `analyze proof-annotations` reported "High confidence: N (100.0%)" for every
+// annotation it has ever produced and `--high-confidence-only` filtered nothing
+// out — neither measured anything. `High` is documented on the enum as
+// "machine-checkable proof", and nothing here is machine checked: pmat never
+// invokes rustc, it walks the file with `syn` and each annotation carries an
+// explicit list of unverified `assumptions`. That is `Medium` ("sound static
+// analysis with assumptions"), and where the evidence is a name match against a
+// hardcoded list it is `Low` ("heuristic-based"). The level now follows the
+// evidence for each claim.
 impl RustBorrowChecker {
     /// Canonical seed for an annotation's id: the site plus the claim.
     ///
@@ -31,7 +41,9 @@ impl RustBorrowChecker {
             // "pmat-syn-static-analysis", not a compiler that never ran.
             tool_name: format!("pmat-{}", self.rustc_channel),
             tool_version: self.rustc_version.clone(),
-            confidence_level: ConfidenceLevel::High,
+            // Static: the signature is not `unsafe fn`. The body is not
+            // checked, and the assumptions below are not verified.
+            confidence_level: ConfidenceLevel::Medium,
             assumptions: vec![
                 "Safe Rust subset".to_string(),
                 "No compiler bugs".to_string(),
@@ -54,7 +66,9 @@ impl RustBorrowChecker {
             // "pmat-syn-static-analysis", not a compiler that never ran.
             tool_name: format!("pmat-{}", self.rustc_channel),
             tool_version: self.rustc_version.clone(),
-            confidence_level: ConfidenceLevel::High,
+            // Heuristic: `type_likely_implements_send_sync` matches parameter
+            // type names against a hardcoded allowlist. No bound is resolved.
+            confidence_level: ConfidenceLevel::Low,
             assumptions: vec![
                 "Send + Sync bounds satisfied".to_string(),
                 "No interior mutability without synchronization".to_string(),
@@ -77,7 +91,9 @@ impl RustBorrowChecker {
             // "pmat-syn-static-analysis", not a compiler that never ran.
             tool_name: format!("pmat-{}", self.rustc_channel),
             tool_version: self.rustc_version.clone(),
-            confidence_level: ConfidenceLevel::High,
+            // Static: `const fn` in the signature. Const evaluation permits
+            // loops, so termination rests on the assumption below.
+            confidence_level: ConfidenceLevel::Medium,
             assumptions: vec!["const fn restrictions guarantee termination".to_string()],
             evidence_type: EvidenceType::ImplicitTypeSystemGuarantee,
             evidence_location: None,
@@ -104,7 +120,9 @@ impl RustBorrowChecker {
             // "pmat-syn-static-analysis", not a compiler that never ran.
             tool_name: format!("pmat-{}", self.rustc_channel),
             tool_version: self.rustc_version.clone(),
-            confidence_level: ConfidenceLevel::High,
+            // Static: a safe `impl <auto trait>` was read out of the AST; the
+            // implementation itself is taken on trust.
+            confidence_level: ConfidenceLevel::Medium,
             assumptions: vec![format!("{} auto trait implementation", trait_name)],
             evidence_type: EvidenceType::ImplicitTypeSystemGuarantee,
             evidence_location: None,
@@ -136,7 +154,9 @@ impl RustBorrowChecker {
             // "pmat-syn-static-analysis", not a compiler that never ran.
             tool_name: format!("pmat-{}", self.rustc_channel),
             tool_version: self.rustc_version.clone(),
-            confidence_level: ConfidenceLevel::High,
+            // Static: a safe `impl <auto trait>` was read out of the AST; the
+            // implementation itself is taken on trust.
+            confidence_level: ConfidenceLevel::Medium,
             assumptions: vec![format!("{} auto trait implementation", trait_name)],
             evidence_type: EvidenceType::ImplicitTypeSystemGuarantee,
             evidence_location: None,

--- a/src/services/rust_borrow_checker_collection.rs
+++ b/src/services/rust_borrow_checker_collection.rs
@@ -9,9 +9,19 @@ impl RustBorrowChecker {
         rustc_version: &str,
         collection_state: &mut CollectionState,
     ) {
+        // Gitignore-aware: this walk used to be a bare `WalkDir` with
+        // `follow_links(true)`, so it descended into gitignored trees. On this
+        // repo the ephemeral `.claude/worktrees/` checkouts — full copies of the
+        // very files being scanned — supplied 90% of every proof-annotation
+        // total (177305 of 195846). `follow_links` stays off for the same
+        // reason: a symlinked copy is still a copy.
+        let ignore_matcher = Self::build_ignore_matcher(project_root);
         for entry in WalkDir::new(project_root)
-            .follow_links(true)
+            .follow_links(false)
             .into_iter()
+            .filter_entry(|e| {
+                !Self::is_ignored(ignore_matcher.as_ref(), e.path(), e.file_type().is_dir())
+            })
             .filter_map(std::result::Result::ok)
         {
             let path = entry.path();
@@ -19,6 +29,32 @@ impl RustBorrowChecker {
                 Self::process_single_rust_file(path, cache, rustc_version, collection_state).await;
             }
         }
+    }
+
+    /// Build a `.gitignore` matcher rooted at the project being analysed.
+    ///
+    /// Returns `None` when the project has no readable `.gitignore`; in that
+    /// case nothing is filtered and the walk behaves as it always did.
+    fn build_ignore_matcher(project_root: &Path) -> Option<ignore::gitignore::Gitignore> {
+        let mut builder = ignore::gitignore::GitignoreBuilder::new(project_root);
+        // add() returns Some(err) on failure — a missing .gitignore is normal.
+        if builder.add(project_root.join(".gitignore")).is_some() {
+            return None;
+        }
+        builder.build().ok()
+    }
+
+    /// True when `path` is excluded from the analysis: the git metadata
+    /// directory, or anything the project's `.gitignore` excludes.
+    fn is_ignored(
+        matcher: Option<&ignore::gitignore::Gitignore>,
+        path: &Path,
+        is_dir: bool,
+    ) -> bool {
+        if is_dir && path.file_name().and_then(|n| n.to_str()) == Some(".git") {
+            return true;
+        }
+        matcher.is_some_and(|m| m.matched_path_or_any_parents(path, is_dir).is_ignore())
     }
 
     /// Check if a path represents a Rust source file
@@ -178,5 +214,56 @@ impl ProofSource for RustBorrowChecker {
 
             Self::finalize_collection(start, collection_state)
         })
+    }
+}
+
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg(test)]
+mod gitignore_walk_tests {
+    use super::*;
+
+    /// The proof walk used to be a bare `WalkDir`, so it descended into
+    /// gitignored trees. On this repo the ephemeral `.claude/worktrees/`
+    /// checkouts — copies of the files being analysed — supplied 177305 of
+    /// 195846 reported proof annotations (90.5%).
+    #[test]
+    fn gitignored_trees_are_excluded_from_the_walk() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::write(root.join(".gitignore"), ".claude/worktrees\ntarget\n").unwrap();
+        std::fs::create_dir_all(root.join(".claude/worktrees/copy")).unwrap();
+        std::fs::create_dir_all(root.join("target/debug")).unwrap();
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::write(root.join("src/lib.rs"), "fn a() {}").unwrap();
+        std::fs::write(root.join(".claude/worktrees/copy/lib.rs"), "fn a() {}").unwrap();
+
+        let matcher = RustBorrowChecker::build_ignore_matcher(root);
+        assert!(matcher.is_some(), "the fixture has a .gitignore");
+
+        assert!(RustBorrowChecker::is_ignored(
+            matcher.as_ref(),
+            &root.join(".claude/worktrees"),
+            true
+        ));
+        assert!(RustBorrowChecker::is_ignored(
+            matcher.as_ref(),
+            &root.join(".claude/worktrees/copy/lib.rs"),
+            false
+        ));
+        assert!(RustBorrowChecker::is_ignored(
+            matcher.as_ref(),
+            &root.join("target/debug"),
+            true
+        ));
+        assert!(RustBorrowChecker::is_ignored(
+            matcher.as_ref(),
+            &root.join(".git"),
+            true
+        ));
+        assert!(!RustBorrowChecker::is_ignored(
+            matcher.as_ref(),
+            &root.join("src/lib.rs"),
+            false
+        ));
     }
 }

--- a/src/services/rust_borrow_checker_tests.rs
+++ b/src/services/rust_borrow_checker_tests.rs
@@ -148,7 +148,15 @@ mod tests {
 
         assert_eq!(annotation.property_proven, PropertyType::MemorySafety);
         assert_eq!(annotation.method, VerificationMethod::BorrowChecker);
-        assert_eq!(annotation.confidence_level, ConfidenceLevel::High);
+        // This used to require High -- "machine-checkable proof" per the enum's
+        // own docs -- for a claim produced by a syn walk that only looks at the
+        // signature and lists two unverified assumptions. Medium is "sound
+        // static analysis with assumptions", which is what this is.
+        assert_eq!(annotation.confidence_level, ConfidenceLevel::Medium);
+        assert!(
+            !annotation.assumptions.is_empty(),
+            "a claim that rests on assumptions cannot be a machine-checked proof"
+        );
 
         // This used to require tool_name == "rustc-stable", pinning a false
         // provenance claim: pmat never invokes rustc, it parses with syn and
@@ -170,7 +178,10 @@ mod tests {
 
         assert_eq!(annotation.property_proven, PropertyType::ThreadSafety);
         assert_eq!(annotation.method, VerificationMethod::BorrowChecker);
-        assert_eq!(annotation.confidence_level, ConfidenceLevel::High);
+        // Was High. The evidence is `type_likely_implements_send_sync`, which
+        // matches parameter type names against a hardcoded allowlist -- Low
+        // ("heuristic-based") by the enum's own definition.
+        assert_eq!(annotation.confidence_level, ConfidenceLevel::Low);
     }
 
     /// DETERMINISM regression (round-3 sweep): `annotation_id` was
@@ -214,5 +225,33 @@ mod tests {
             "a different property at the same site must not collide"
         );
     }
-}
 
+    /// Round-5 dogfood: `analyze proof-annotations` reported
+    /// "High confidence: N (100.0%)" over this repo and `--high-confidence-only`
+    /// removed nothing, because every production construction site wrote
+    /// `ConfidenceLevel::High`. Nothing pmat emits here is a machine-checked
+    /// proof, so no factory may claim the level reserved for one, and the level
+    /// must actually vary with the strength of the evidence.
+    #[test]
+    fn confidence_is_not_one_hardcoded_level_for_every_annotation() {
+        let checker = RustBorrowChecker::default();
+        let loc = seed_location();
+
+        let levels = [
+            checker.memory_safety_annotation(&loc).confidence_level,
+            checker.create_thread_safety_annotation(&loc).confidence_level,
+            checker.const_fn_termination(&loc).confidence_level,
+        ];
+
+        assert!(
+            !levels.contains(&ConfidenceLevel::High),
+            "pmat never runs a checker, so it cannot claim a machine-checkable proof: {levels:?}"
+        );
+        let distinct: std::collections::BTreeSet<_> =
+            levels.iter().map(|l| format!("{l:?}")).collect();
+        assert!(
+            distinct.len() > 1,
+            "confidence must follow the evidence, not be one constant: {levels:?}"
+        );
+    }
+}

--- a/src/services/rust_project_score/code_quality_scorer_tests.rs
+++ b/src/services/rust_project_score/code_quality_scorer_tests.rs
@@ -327,9 +327,21 @@ fn foo() {
             .score_with_mode(temp_dir.path(), ScoringMode::Fast)
             .unwrap();
 
-        // Fast mode: complexity(3) + unsafe(9) + mutation(4, skipped) + build(2, skipped) + dead_code(2) = 20
-        assert!(result.earned >= 18.0);
-        assert_eq!(result.max, 26.0);
+        // Fast mode runs complexity(3) + unsafe(9) + dead_code(2) = 14 points.
+        //
+        // This used to assert `earned >= 18.0` and `max == 26.0` — the comment it
+        // replaced even named the reason ("mutation(4, skipped) + build(2,
+        // skipped)"): fast mode was awarding heuristic partial credit for two
+        // checks it never ran, and counting their points in the denominator. A
+        // check that did not run can contribute to neither side of the ratio, so
+        // both numbers drop by 12.
+        assert_eq!(result.max, 14.0, "skipped checks must leave the denominator");
+        assert!(
+            result.earned <= result.max,
+            "earned {} exceeds max {}",
+            result.earned,
+            result.max
+        );
     }
 
     #[test]
@@ -355,8 +367,26 @@ fn foo() {
             .score_with_cache(temp_dir.path(), ScoringMode::Fast, Some(&cache))
             .unwrap();
 
-        assert!(result.earned >= 18.0);
-        assert_eq!(result.max, 26.0);
+        // Same correction as test_score_with_mode_fast above: this used to
+        // assert `earned >= 18.0` and `max == 26.0`, which only held because
+        // fast mode invented partial credit for mutation testing (8pts) and
+        // build time (4pts) — two checks it never runs. Fast mode scores the
+        // three checks it can run: complexity(3) + unsafe(9) + dead_code(2).
+        assert_eq!(result.max, 14.0, "skipped checks must leave the denominator");
+        assert!(
+            result.earned <= result.max,
+            "earned {} exceeds max {}",
+            result.earned,
+            result.max
+        );
+
+        // The cache is a read path for the same source, not a scoring input:
+        // it must not change the result.
+        let uncached = scorer
+            .score_with_mode(temp_dir.path(), ScoringMode::Fast)
+            .unwrap();
+        assert_eq!(result.earned, uncached.earned);
+        assert_eq!(result.max, uncached.max);
     }
 
     #[test]

--- a/src/services/rust_project_score/code_quality_scoring_methods.rs
+++ b/src/services/rust_project_score/code_quality_scoring_methods.rs
@@ -78,63 +78,10 @@ impl CodeQualityScorer {
         }
     }
 
-    /// Fast-mode mutation testing estimation
-    ///
-    /// Checks for mutation testing infrastructure (mutants.toml, cargo-mutants in Makefile)
-    /// and gives proportional credit without running the expensive tool.
-    fn estimate_mutation_fast(&self, project_path: &Path) -> f64 {
-        let has_config = project_path.join("mutants.toml").exists()
-            || project_path.join(".config/mutants.toml").exists();
-        let makefile_content =
-            std::fs::read_to_string(project_path.join("Makefile")).unwrap_or_default();
-        let has_makefile_target = makefile_content.contains("cargo mutants")
-            || makefile_content.contains("mutation");
-
-        if has_config && has_makefile_target {
-            5.0 // Infrastructure + build target = good credit
-        } else if has_config || has_makefile_target {
-            4.0 // Partial infrastructure
-        } else {
-            3.0 // Minimal credit (tests exist but no mutation setup)
-        }
-    }
-
-    /// Fast-mode build time estimation
-    ///
-    /// Checks build configuration quality (LTO, profiles, .cargo/config.toml)
-    /// and gives proportional credit without running a full build.
-    fn estimate_build_time_fast(
-        &self,
-        project_path: &Path,
-        cache: Option<&FileCache>,
-    ) -> f64 {
-        let cargo_content = cache
-            .and_then(|c| c.get(&project_path.join("Cargo.toml")))
-            .cloned()
-            .or_else(|| std::fs::read_to_string(project_path.join("Cargo.toml")).ok())
-            .unwrap_or_default();
-
-        let mut score: f64 = 1.0; // Base credit for having a Rust project
-
-        // Release profile optimization
-        if cargo_content.contains("[profile.release]") {
-            score += 0.5;
-        }
-        // LTO configured (build optimization)
-        if cargo_content.contains("lto = ") {
-            score += 0.5;
-        }
-        // .cargo/config.toml (build settings)
-        if project_path.join(".cargo/config.toml").exists() {
-            score += 0.5;
-        }
-        // Makefile or justfile (build automation)
-        if project_path.join("Makefile").exists() || project_path.join("justfile").exists() {
-            score += 0.5;
-        }
-
-        score.min(3.0) // Cap at 3.0 — reserve 4.0 for verified <30s builds
-    }
+    /// Points that only a `--full` run can measure: Mutation Testing (8) and
+    /// Build Time (4). In fast mode they are subtracted from the category
+    /// maximum rather than awarded a heuristic.
+    const UNMEASURED_IN_FAST_MODE: f64 = 12.0;
 
     /// Internal scoring logic that accepts optional cache
     fn score_internal(
@@ -161,29 +108,112 @@ impl CodeQualityScorer {
             Err(e) => return Err(e),
         }
 
-        if mode.is_full() {
+        // Mutation Testing (8pts) and Build Time (4pts) are only scored when
+        // they were actually run.
+        //
+        // Fast mode used to award `estimate_mutation_fast` (a flat 3/4/5 of 8
+        // decided by whether a mutants.toml or a Makefile mutation target
+        // exists) and `estimate_build_time_fast` (1.0 plus 0.5 per config
+        // heuristic, capped at 3 of 4). Neither measures anything about the
+        // code, and the invented partial credit put the two modes on the same
+        // 279-point scale while disagreeing about it: the same copy of the same
+        // fixture scored Code Quality 18.0/26.0 (69.2%) fast and 26.0/26.0
+        // (100.0%) under `--full`. A check that did not run is not a check that
+        // scored 3 out of 8 — it is N/A, exactly as GPU/SIMD Quality already
+        // reports when there is no GPU code to measure, so its points leave the
+        // denominator too.
+        let max_points = if mode.is_full() {
             match self.score_mutation(project_path) {
                 Ok(score) => total_earned += score,
                 Err(_) => total_earned += 4.0,
             }
-        } else {
-            total_earned += self.estimate_mutation_fast(project_path);
-        }
-
-        if mode.is_full() {
             match self.score_build_time(project_path) {
                 Ok(score) => total_earned += score,
                 Err(_) => total_earned += 2.0,
             }
+            self.max_points
         } else {
-            total_earned += self.estimate_build_time_fast(project_path, cache);
-        }
+            self.max_points - Self::UNMEASURED_IN_FAST_MODE
+        };
 
         match self.score_dead_code(project_path, cache) {
             Ok(score) => total_earned += score,
             Err(e) => return Err(e),
         }
 
-        Ok(CategoryScore::new(total_earned, self.max_points))
+        Ok(CategoryScore::new(total_earned, max_points))
+    }
+}
+
+#[cfg(test)]
+mod fast_mode_not_measured_tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn trivial_project() -> TempDir {
+        let temp = TempDir::new().unwrap();
+        std::fs::create_dir_all(temp.path().join("src")).unwrap();
+        std::fs::write(
+            temp.path().join("Cargo.toml"),
+            "[package]\nname = \"test\"\n",
+        )
+        .unwrap();
+        std::fs::write(temp.path().join("src/lib.rs"), "pub fn f() {}\n").unwrap();
+        temp
+    }
+
+    /// Fast mode scored two checks it never ran — Mutation Testing (8pts) and
+    /// Build Time (4pts) — with heuristics that measure no code at all, so the
+    /// same fixture reported Code Quality 69.2% fast and 100.0% under `--full`.
+    /// A check that did not run leaves the denominator.
+    #[test]
+    fn fast_mode_excludes_the_checks_it_never_ran() {
+        let temp = trivial_project();
+        let scorer = CodeQualityScorer::new();
+        let result = scorer
+            .score_internal(temp.path(), ScoringMode::Fast, None)
+            .expect("fast score");
+
+        assert_eq!(
+            result.max, 14.0,
+            "Mutation Testing (8) + Build Time (4) must leave the fast-mode maximum"
+        );
+        assert!(
+            result.earned <= result.max,
+            "earned {} exceeds the measured maximum {}",
+            result.earned,
+            result.max
+        );
+        // A project with nothing wrong in the three checks fast mode CAN run
+        // must read 100%, not the 69.2% the invented partial credit produced.
+        assert!(
+            (result.percentage() - 100.0).abs() < 0.01,
+            "expected 100% of the measured checks, got {}% ({} / {})",
+            result.percentage(),
+            result.earned,
+            result.max
+        );
+    }
+
+    /// The heuristics are gone, so no filesystem trinket can move the score:
+    /// a mutants.toml and a Makefile mutation target used to be worth 2 points
+    /// each way without a single mutant ever being run.
+    #[test]
+    fn mutation_infrastructure_files_do_not_move_the_fast_score() {
+        let bare = trivial_project();
+        let dressed = trivial_project();
+        std::fs::write(dressed.path().join("mutants.toml"), "exclude = []\n").unwrap();
+        std::fs::write(dressed.path().join("Makefile"), "mutation:\n\tcargo mutants\n").unwrap();
+
+        let scorer = CodeQualityScorer::new();
+        let bare_score = scorer
+            .score_internal(bare.path(), ScoringMode::Fast, None)
+            .expect("bare");
+        let dressed_score = scorer
+            .score_internal(dressed.path(), ScoringMode::Fast, None)
+            .expect("dressed");
+
+        assert_eq!(bare_score.earned, dressed_score.earned);
+        assert_eq!(bare_score.max, dressed_score.max);
     }
 }

--- a/src/services/rust_project_score/orchestrator.rs
+++ b/src/services/rust_project_score/orchestrator.rs
@@ -38,6 +38,26 @@ use std::path::Path;
 /// v3.0: Added Reproducibility category (Popper B-F absorption) + falsifiability gateway
 pub const SPEC_VERSION: &str = "3.0";
 
+/// Advice a category is still entitled to give.
+///
+/// Every scorer's `recommendations()` used to run unconditionally, so a
+/// category at full marks printed advice contradicting its own score:
+/// `Known Defects: 20.0/20.0 (100.0%)` was followed by "CRITICAL: 1 unwrap()
+/// calls in production code", and RustTooling/CodeQuality push `cargo fmt`,
+/// `cargo clippy --fix` and cargo-mutants with no condition at all. A category
+/// with nothing left to earn has nothing to recommend.
+fn recommendations_for(
+    scorer: &dyn Scorer,
+    project_path: &Path,
+    score: &CategoryScore,
+) -> Vec<String> {
+    if score.is_perfect() {
+        Vec::new()
+    } else {
+        scorer.recommendations(project_path)
+    }
+}
+
 /// Orchestrates all 11 category scorers to produce unified project score
 ///
 /// v3.0: Added Reproducibility scorer (Popper B-F absorption) + falsifiability gateway
@@ -194,7 +214,8 @@ impl RustProjectScoreOrchestrator {
             .filter_map(|scorer| {
                 match scorer.score_with_cache(project_path, mode, file_cache.as_ref()) {
                     Ok(category_score) => {
-                        let recommendations = scorer.recommendations(project_path);
+                        let recommendations =
+                            recommendations_for(scorer.as_ref(), project_path, &category_score);
                         Some((scorer.name().to_string(), category_score, recommendations))
                     }
                     Err(_) => {
@@ -511,6 +532,55 @@ unsafe impl Sync for RustProjectScoreOrchestrator {}
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A scorer whose advice is loud enough to notice when it should be silent.
+    struct LoudScorer {
+        earned: f64,
+    }
+
+    impl Scorer for LoudScorer {
+        fn name(&self) -> &str {
+            "Known Defects"
+        }
+        fn max_points(&self) -> f64 {
+            20.0
+        }
+        fn score_with_mode(
+            &self,
+            _project_path: &Path,
+            _mode: ScoringMode,
+        ) -> ScorerResult<CategoryScore> {
+            Ok(CategoryScore::new(self.earned, 20.0))
+        }
+        fn recommendations(&self, _project_path: &Path) -> Vec<String> {
+            vec!["CRITICAL: 1 unwrap() calls in production code".to_string()]
+        }
+    }
+
+    /// `Known Defects: 20.0/20.0 (100.0%)` printed
+    /// "CRITICAL: 1 unwrap() calls in production code" directly beneath itself:
+    /// recommendations were collected regardless of the score they described.
+    #[test]
+    fn a_category_at_full_marks_makes_no_recommendations() {
+        let perfect = LoudScorer { earned: 20.0 };
+        let score = perfect.score(Path::new(".")).unwrap();
+        assert!(score.is_perfect());
+        assert!(
+            recommendations_for(&perfect, Path::new("."), &score).is_empty(),
+            "a category with nothing left to earn must not advise on it"
+        );
+    }
+
+    /// …and the advice must still reach a category that did lose points.
+    #[test]
+    fn a_category_below_full_marks_still_makes_recommendations() {
+        let imperfect = LoudScorer { earned: 5.0 };
+        let score = imperfect.score(Path::new(".")).unwrap();
+        assert_eq!(
+            recommendations_for(&imperfect, Path::new("."), &score).len(),
+            1
+        );
+    }
 
     #[test]
     fn test_orchestrator_creation() {

--- a/src/services/satd_detector/detection_analysis.rs
+++ b/src/services/satd_detector/detection_analysis.rs
@@ -9,7 +9,7 @@ impl SATDDetector {
         root: &Path,
         include_tests: bool,
     ) -> Result<SATDAnalysisResult, TemplateError> {
-        let files = self.find_source_files(root).await?;
+        let files = self.discover_files(root, include_tests).await?;
         let mut analysis_stats = ProjectAnalysisStats::new();
 
         self.process_project_files(&files, include_tests, &mut analysis_stats)
@@ -19,6 +19,60 @@ impl SATDDetector {
             .await;
 
         Ok(self.build_analysis_result(analysis_stats, avg_age_days))
+    }
+
+    /// Discover the files an analysis will read.
+    ///
+    /// `find_source_files` filters every candidate through
+    /// `is_valid_source_file`, which is `is_source_file() && !is_test_file()`:
+    /// test files are dropped during DISCOVERY. So `--include-tests` — whose
+    /// only job is to add them — had nothing left to add, and pointing satd
+    /// straight at a `tests/` directory reported 0 violations. When tests are
+    /// wanted the walk below applies the same directory exclusions and the same
+    /// source-file test, minus that drop.
+    async fn discover_files(
+        &self,
+        root: &Path,
+        include_tests: bool,
+    ) -> Result<Vec<std::path::PathBuf>, TemplateError> {
+        if !include_tests {
+            return self.find_source_files(root).await;
+        }
+        let mut files = Vec::new();
+        self.collect_files_including_tests(root, &mut files).await?;
+        Ok(files)
+    }
+
+    fn collect_files_including_tests<'a>(
+        &'a self,
+        dir: &'a Path,
+        files: &'a mut Vec<std::path::PathBuf>,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<(), TemplateError>> + Send + 'a>>
+    {
+        Box::pin(async move {
+            if dir.is_file() {
+                if self.is_source_file(dir) {
+                    files.push(dir.to_path_buf());
+                }
+                return Ok(());
+            }
+            if !dir.is_dir() {
+                return Ok(());
+            }
+
+            let mut entries = tokio::fs::read_dir(dir).await.map_err(TemplateError::Io)?;
+            while let Some(entry) = entries.next_entry().await.map_err(TemplateError::Io)? {
+                let path = entry.path();
+                if path.is_dir() {
+                    if !self.should_skip_directory(&path) {
+                        self.collect_files_including_tests(&path, files).await?;
+                    }
+                } else if self.is_source_file(&path) {
+                    files.push(path);
+                }
+            }
+            Ok(())
+        })
     }
 
     /// Toyota Way: Extract Method - process all files in project (complexity <=8)
@@ -173,7 +227,7 @@ impl SATDDetector {
         include_tests: bool,
     ) -> Result<Vec<TechnicalDebt>, TemplateError> {
         let mut all_debts = Vec::new();
-        let files = self.find_source_files(root).await?;
+        let files = self.discover_files(root, include_tests).await?;
 
         for file_path in files {
             if self

--- a/src/services/simple_deep_context/analyzer.rs
+++ b/src/services/simple_deep_context/analyzer.rs
@@ -80,7 +80,18 @@ impl SimpleDeepContext {
             self.analyze_complexity(&source_files).await?;
 
         // Phase 3: Generate recommendations
-        let recommendations = self.generate_recommendations(&complexity_metrics);
+        //
+        // `analyze deep-context` is documented as "deep context analysis with
+        // defect detection", but only `--format sarif` ran a defect detector:
+        // json/markdown came through here and reported "Code complexity looks
+        // good! No immediate recommendations." for the very corpus whose SARIF
+        // run listed a High-severity self-admitted-debt finding. The same
+        // detector now runs for every format.
+        let debts = Self::detect_self_admitted_debt(&source_files);
+        let recommendations = Self::with_debt_recommendations(
+            self.generate_recommendations(&complexity_metrics),
+            &debts,
+        );
 
         let analysis_duration = start_time.elapsed();
 
@@ -357,6 +368,55 @@ impl SimpleDeepContext {
         })
     }
 
+    /// Detect self-admitted technical debt in the discovered source files.
+    ///
+    /// Uses the same `SATDDetector` the SARIF path reaches through
+    /// `DeepContextAnalyzer`, so one command cannot report a defect in one
+    /// format and "no immediate recommendations" in another.
+    pub(super) fn detect_self_admitted_debt(
+        source_files: &[PathBuf],
+    ) -> Vec<crate::services::satd_detector::TechnicalDebt> {
+        let detector = crate::services::satd_detector::SATDDetector::new();
+        let mut debts = Vec::new();
+        for file in source_files {
+            let Ok(content) = std::fs::read_to_string(file) else {
+                continue;
+            };
+            if let Ok(found) = detector.extract_from_content(&content, file) {
+                debts.extend(found);
+            }
+        }
+        // File-discovery order is not guaranteed; the report must be.
+        debts.sort_by(|a, b| (&a.file, a.line).cmp(&(&b.file, b.line)));
+        debts
+    }
+
+    /// Fold detected debt into the recommendation list.
+    ///
+    /// "Code complexity looks good! No immediate recommendations." must not
+    /// survive alongside a detected defect — that sentence was the whole
+    /// contradiction users saw between `--format json` and `--format sarif`.
+    pub(super) fn with_debt_recommendations(
+        mut recommendations: Vec<String>,
+        debts: &[crate::services::satd_detector::TechnicalDebt],
+    ) -> Vec<String> {
+        if debts.is_empty() {
+            return recommendations;
+        }
+        recommendations.retain(|r| !r.starts_with("Code complexity looks good"));
+        let sample: Vec<String> = debts
+            .iter()
+            .take(3)
+            .map(|d| format!("{}:{} {}", d.file.display(), d.line, d.text.trim()))
+            .collect();
+        recommendations.push(format!(
+            "Resolve {} self-admitted technical debt comment(s) (e.g. {})",
+            debts.len(),
+            sample.join("; ")
+        ));
+        recommendations
+    }
+
     /// Generate recommendations based on analysis
     pub(super) fn generate_recommendations(&self, metrics: &ComplexityMetrics) -> Vec<String> {
         let mut recommendations = Vec::new();
@@ -601,5 +661,33 @@ mod discovery_regression_tests {
             .await
             .expect_err("an unparseable pattern must not silently filter nothing");
         assert!(err.to_string().contains("--exclude-pattern"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn a_detected_defect_reaches_the_json_and_markdown_reports() {
+        // corpus/poly reproduced this: `--format sarif` listed a High-severity
+        // "FIXME: broken" in main.py while `--format json` reported "Code
+        // complexity looks good! No immediate recommendations."
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("main.py"),
+            "def f():\n    # FIXME: broken\n    return 1\n",
+        )
+        .unwrap();
+
+        let report = SimpleDeepContext::new()
+            .analyze(config(dir.path(), vec![]))
+            .await
+            .expect("analysis succeeds");
+
+        let recommendations = report.recommendations.join("\n");
+        assert!(
+            recommendations.contains("FIXME"),
+            "a detected defect must appear in the default report, got: {recommendations}"
+        );
+        assert!(
+            !recommendations.contains("Code complexity looks good"),
+            "must not claim all-clear next to a detected defect: {recommendations}"
+        );
     }
 }

--- a/src/services/simple_deep_context/analyzer.rs
+++ b/src/services/simple_deep_context/analyzer.rs
@@ -114,12 +114,32 @@ impl SimpleDeepContext {
         })
     }
 
+    /// Build the matcher for `--exclude-pattern` (and the common exclusions the
+    /// handler appends).
+    ///
+    /// `analyze deep-context --exclude-pattern '**/*.py'` used to produce a
+    /// byte-identical report to a run without it — `SimpleAnalysisConfig` stored
+    /// `exclude_patterns` and nothing ever read them. An unparseable pattern is
+    /// an error rather than a silently dropped filter, for the same reason.
+    pub(super) fn build_exclude_matcher(patterns: &[String]) -> Result<Option<globset::GlobSet>> {
+        if patterns.is_empty() {
+            return Ok(None);
+        }
+        let mut builder = globset::GlobSetBuilder::new();
+        for pattern in patterns {
+            let glob = globset::Glob::new(pattern)
+                .map_err(|e| anyhow::anyhow!("invalid --exclude-pattern '{pattern}': {e}"))?;
+            builder.add(glob);
+        }
+        Ok(Some(builder.build()?))
+    }
+
     /// Discover source files in the project
     pub(super) async fn discover_source_files(
         &self,
         config: &SimpleAnalysisConfig,
     ) -> Result<Vec<PathBuf>> {
-        use walkdir::WalkDir;
+        use ignore::WalkBuilder;
 
         let source_extensions = [
             "rs", "js", "ts", "jsx", "tsx", "py", "cpp", "c", "h", "wasm", "wat", "rb", "ruchy",
@@ -133,12 +153,25 @@ impl SimpleDeepContext {
             std::env::current_dir()?.join(&config.project_path)
         };
 
+        let excludes = Self::build_exclude_matcher(&config.exclude_patterns)?;
+
         let mut files = Vec::new();
-        for entry in WalkDir::new(&abs_project_path)
+        // Gitignore-aware walk. A bare `WalkDir` here counted every file under
+        // gitignored paths: on this repo the ephemeral `.claude/worktrees/`
+        // duplicate checkouts took `file_count` to 222022 for a tree with 5,497
+        // tracked files (and `total_functions` to 1,012,834 against 25,593).
+        // Duplicating a checkout must not change what the project measures.
+        for entry in WalkBuilder::new(&abs_project_path)
             .follow_links(false)
-            .into_iter()
+            .hidden(false)
+            .parents(true)
+            .ignore(true)
+            .git_ignore(true)
+            .git_global(true)
+            .git_exclude(true)
+            .build()
             .filter_map(std::result::Result::ok)
-            .filter(|e| e.file_type().is_file())
+            .filter(|e| e.file_type().is_some_and(|t| t.is_file()))
         {
             let path = entry.path();
 
@@ -156,6 +189,13 @@ impl SimpleDeepContext {
             };
             if !source_extensions.contains(&ext) {
                 continue;
+            }
+
+            if let Some(excludes) = &excludes {
+                let relative = path.strip_prefix(&abs_project_path).unwrap_or(path);
+                if excludes.is_match(path) || excludes.is_match(relative) {
+                    continue;
+                }
             }
 
             if config.include_patterns.is_empty()
@@ -486,5 +526,80 @@ impl SimpleDeepContext {
         }
 
         markdown
+    }
+}
+
+#[cfg(test)]
+mod discovery_regression_tests {
+    //! What `analyze deep-context` counts as "the project".
+    use super::*;
+
+    fn config(dir: &Path, exclude_patterns: Vec<String>) -> SimpleAnalysisConfig {
+        SimpleAnalysisConfig {
+            project_path: dir.to_path_buf(),
+            include_features: vec![],
+            include_patterns: vec![],
+            exclude_patterns,
+            enable_verbose: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn gitignored_paths_are_not_analyzed() {
+        let dir = tempfile::tempdir().unwrap();
+        // `ignore` applies .gitignore only inside a git repository.
+        std::fs::create_dir_all(dir.path().join(".git")).unwrap();
+        std::fs::write(dir.path().join(".gitignore"), "worktrees/\n").unwrap();
+        std::fs::write(dir.path().join("main.rs"), "fn main() {}\n").unwrap();
+        std::fs::create_dir_all(dir.path().join("worktrees/copy")).unwrap();
+        std::fs::write(dir.path().join("worktrees/copy/main.rs"), "fn main() {}\n").unwrap();
+
+        let files = SimpleDeepContext::new()
+            .discover_source_files(&config(dir.path(), vec![]))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            files.len(),
+            1,
+            "a gitignored duplicate checkout must not double the file count: {files:?}"
+        );
+        assert!(files[0].ends_with("main.rs"));
+    }
+
+    #[tokio::test]
+    async fn exclude_patterns_drop_matching_files() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("main.py"), "def main():\n    pass\n").unwrap();
+        std::fs::write(dir.path().join("main.rs"), "fn main() {}\n").unwrap();
+
+        let all = SimpleDeepContext::new()
+            .discover_source_files(&config(dir.path(), vec![]))
+            .await
+            .unwrap();
+        assert_eq!(all.len(), 2);
+
+        let filtered = SimpleDeepContext::new()
+            .discover_source_files(&config(dir.path(), vec!["**/*.py".to_string()]))
+            .await
+            .unwrap();
+        assert_eq!(
+            filtered.len(),
+            1,
+            "--exclude-pattern '**/*.py' must drop the python file: {filtered:?}"
+        );
+        assert!(filtered[0].ends_with("main.rs"));
+    }
+
+    #[tokio::test]
+    async fn an_unparseable_exclude_pattern_is_reported_not_dropped() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("main.rs"), "fn main() {}\n").unwrap();
+
+        let err = SimpleDeepContext::new()
+            .discover_source_files(&config(dir.path(), vec!["[".to_string()]))
+            .await
+            .expect_err("an unparseable pattern must not silently filter nothing");
+        assert!(err.to_string().contains("--exclude-pattern"), "{err}");
     }
 }

--- a/src/services/spec_parser_impl.rs
+++ b/src/services/spec_parser_impl.rs
@@ -466,6 +466,14 @@ impl SpecParser {
     pub fn find_specs(&self, dir: &Path) -> Result<Vec<PathBuf>> {
         let mut specs = Vec::new();
 
+        // A path that is neither a file nor a directory used to fall through to
+        // Ok(vec![]), which made a typo'd path indistinguishable from an empty
+        // spec directory - `spec list --failing-only /does/not/exit` reported
+        // "0 specs, 0 passing" and exited 0. Enforce the path_exists contract.
+        if !dir.exists() {
+            anyhow::bail!("Specification path does not exist: {}", dir.display());
+        }
+
         if dir.is_file() {
             if dir.extension().map(|e| e == "md").unwrap_or(false) {
                 specs.push(dir.to_path_buf());

--- a/src/services/spec_parser_tests.rs
+++ b/src/services/spec_parser_tests.rs
@@ -294,4 +294,29 @@ The API SHALL be backwards compatible.
         let deserialized: ClaimCategory = serde_json::from_str(&json).unwrap();
         assert_eq!(cat, deserialized);
     }
+
+    #[test]
+    fn test_find_specs_errors_on_missing_path() {
+        // Regression: a typo'd path used to yield Ok(vec![]), so `spec list`
+        // over /does/not/exist printed "0 specs, 0 passing" and exited 0.
+        let parser = SpecParser::new();
+        let err = parser
+            .find_specs(Path::new("/does/not/exist/pmat-spec-dir"))
+            .expect_err("nonexistent spec path must be an error, not an empty spec set");
+        assert!(
+            err.to_string().contains("does not exist"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_find_specs_empty_dir_is_ok() {
+        // An existing-but-empty directory is still legitimately zero specs.
+        let dir = std::env::temp_dir().join("pmat_spec_parser_empty_dir_test");
+        std::fs::create_dir_all(&dir).unwrap();
+        let parser = SpecParser::new();
+        let specs = parser.find_specs(&dir).expect("empty dir must be Ok");
+        assert!(specs.is_empty());
+        let _ = std::fs::remove_dir(&dir);
+    }
 }

--- a/src/services/wasm/binary.rs
+++ b/src/services/wasm/binary.rs
@@ -53,12 +53,23 @@ impl WasmBinaryAnalyzer {
             return Err(anyhow::anyhow!("Invalid WASM file format"));
         }
 
-        // Basic analysis - count sections
+        // Counts come from the decoded section stream. They used to come from
+        // byte frequencies over the whole file: function_count was "how many
+        // 0x01 bytes are in this file", import_count the 0x02 bytes, export_count
+        // the 0x07 bytes, and linear_memory_pages was literally `file size >
+        // 1000`. A module of magic+version and nothing else reported 1 function,
+        // and a hand-assembled module with exactly 1 function / 1 export
+        // reported 7 functions and 2 imports.
+        let sections = decode_sections(&content);
+
         let metrics = WasmMetrics {
-            function_count: count_occurrences(&content, &[0x01]), // Type section
-            import_count: count_occurrences(&content, &[0x02]),   // Import section
-            export_count: count_occurrences(&content, &[0x07]),   // Export section
-            linear_memory_pages: u32::from(content.len() > 1000),
+            // Defined functions live in the Function section (id 3); imported
+            // functions are counted in import_count, not here.
+            function_count: vector_count_in_sections(&sections, SECTION_FUNCTION),
+            import_count: vector_count_in_sections(&sections, SECTION_IMPORT),
+            export_count: vector_count_in_sections(&sections, SECTION_EXPORT),
+            linear_memory_pages: linear_memory_pages(&sections),
+            memory_sections: section_occurrences(&sections, SECTION_MEMORY),
             ..Default::default()
         };
 
@@ -131,6 +142,109 @@ impl Default for WasmBinaryAnalyzer {
     }
 }
 
+/// WebAssembly section ids used by the binary metrics.
+const SECTION_IMPORT: u8 = 2;
+const SECTION_FUNCTION: u8 = 3;
+const SECTION_MEMORY: u8 = 5;
+const SECTION_EXPORT: u8 = 7;
+
+/// Decode an unsigned LEB128 integer at `pos`, advancing `pos`.
+/// Returns `None` for a truncated or over-long encoding rather than guessing.
+fn read_uleb128(data: &[u8], pos: &mut usize) -> Option<u64> {
+    let mut value = 0u64;
+    let mut shift = 0u32;
+    loop {
+        let byte = *data.get(*pos)?;
+        *pos += 1;
+        value |= u64::from(byte & 0x7F) << shift;
+        if byte & 0x80 == 0 {
+            return Some(value);
+        }
+        shift += 7;
+        if shift > 63 {
+            return None;
+        }
+    }
+}
+
+/// Decode the section stream of a WASM module into `(id, payload)` pairs.
+///
+/// Decoding stops at the first section whose declared size does not fit in the
+/// file: a truncated stream contributes only the sections that decoded cleanly,
+/// so nothing is reported for bytes that were never parsed.
+fn decode_sections(data: &[u8]) -> Vec<(u8, &[u8])> {
+    let mut sections = Vec::new();
+    let mut pos = 8; // magic (4) + version (4)
+
+    while pos < data.len() {
+        let id = data[pos];
+        pos += 1;
+        let Some(size) = read_uleb128(data, &mut pos) else {
+            break;
+        };
+        let Ok(size) = usize::try_from(size) else {
+            break;
+        };
+        let Some(end) = pos.checked_add(size) else {
+            break;
+        };
+        if end > data.len() {
+            break;
+        }
+        sections.push((id, &data[pos..end]));
+        pos = end;
+    }
+
+    sections
+}
+
+/// Number of sections with the given id (0 when the module has none).
+fn section_occurrences(sections: &[(u8, &[u8])], id: u8) -> u32 {
+    sections.iter().filter(|(sid, _)| *sid == id).count() as u32
+}
+
+/// Every non-custom section body starts with a LEB128 vector length; sum those
+/// lengths for the requested section id. A section whose length cannot be
+/// decoded contributes nothing.
+fn vector_count_in_sections(sections: &[(u8, &[u8])], id: u8) -> u32 {
+    sections
+        .iter()
+        .filter(|(sid, _)| *sid == id)
+        .filter_map(|(_, payload)| {
+            let mut pos = 0;
+            read_uleb128(payload, &mut pos)
+        })
+        .map(|count| u32::try_from(count).unwrap_or(u32::MAX))
+        .fold(0u32, u32::saturating_add)
+}
+
+/// Initial linear memory size in 64KiB pages, summed over the memories the
+/// Memory section actually declares. A module with no Memory section has no
+/// linear memory, so this is 0 — not a function of the file's size.
+fn linear_memory_pages(sections: &[(u8, &[u8])]) -> u32 {
+    let mut pages = 0u32;
+    for (_, payload) in sections.iter().filter(|(id, _)| *id == SECTION_MEMORY) {
+        let mut pos = 0;
+        let Some(count) = read_uleb128(payload, &mut pos) else {
+            continue;
+        };
+        for _ in 0..count {
+            // limits := flags:u8 min:u32 [max:u32]
+            let Some(flags) = read_uleb128(payload, &mut pos) else {
+                break;
+            };
+            let Some(min) = read_uleb128(payload, &mut pos) else {
+                break;
+            };
+            pages = pages.saturating_add(u32::try_from(min).unwrap_or(u32::MAX));
+            if flags & 0x01 != 0 && read_uleb128(payload, &mut pos).is_none() {
+                break;
+            }
+        }
+    }
+    pages
+}
+
 /// Count occurrences of a byte pattern
 /// Counts non-overlapping occurrences of a byte pattern in data
 ///
@@ -176,6 +290,9 @@ mod tests {
     use tempfile::NamedTempFile;
     use tokio::io::AsyncWriteExt;
 
+    /// A module of magic+version and nothing else declares nothing. This test
+    /// used to assert `function_count == 1`, which was the byte-frequency count
+    /// of the 0x01 version byte, not a function.
     #[tokio::test]
     async fn test_wasm_binary_analyzer() {
         let analyzer = WasmBinaryAnalyzer::new();
@@ -191,7 +308,96 @@ mod tests {
         assert!(result.is_ok());
 
         let metrics = result.unwrap();
+        assert_eq!(metrics.function_count, 0);
+        assert_eq!(metrics.import_count, 0);
+        assert_eq!(metrics.export_count, 0);
+        assert_eq!(metrics.linear_memory_pages, 0);
+    }
+
+    /// Hand-assembled module: 1 type, 1 function, 1 export "f", no imports,
+    /// no memory. Byte counting reported 7 functions / 2 imports / 1 export
+    /// for this module.
+    fn one_function_module() -> Vec<u8> {
+        vec![
+            0x00, 0x61, 0x73, 0x6D, 0x01, 0x00, 0x00, 0x00, // magic + version
+            0x01, 0x04, 0x01, 0x60, 0x00, 0x00, // type: 1 × () -> ()
+            0x03, 0x02, 0x01, 0x00, // function: 1 function, type 0
+            0x07, 0x05, 0x01, 0x01, 0x66, 0x00, 0x00, // export: 1 × "f" func 0
+            0x0A, 0x04, 0x01, 0x02, 0x00, 0x0B, // code
+        ]
+    }
+
+    #[tokio::test]
+    async fn test_analyze_file_counts_decoded_sections_not_bytes() {
+        let analyzer = WasmBinaryAnalyzer::new();
+        let temp_file = NamedTempFile::new().unwrap();
+        tokio::fs::write(temp_file.path(), one_function_module())
+            .await
+            .unwrap();
+
+        let metrics = analyzer.analyze_file(temp_file.path()).await.unwrap();
         assert_eq!(metrics.function_count, 1);
+        assert_eq!(metrics.import_count, 0);
+        assert_eq!(metrics.export_count, 1);
+        assert_eq!(metrics.linear_memory_pages, 0);
+        assert_eq!(metrics.memory_sections, 0);
+    }
+
+    /// Padding a sectionless module with 4KB of zeros must not conjure a page of
+    /// linear memory: `linear_memory_pages` used to be `file size > 1000`.
+    #[tokio::test]
+    async fn test_analyze_file_memory_pages_come_from_the_memory_section() {
+        let analyzer = WasmBinaryAnalyzer::new();
+
+        let mut padded = b"\0asm\x01\x00\x00\x00".to_vec();
+        padded.extend(vec![0u8; 4096]);
+        let padded_file = NamedTempFile::new().unwrap();
+        tokio::fs::write(padded_file.path(), &padded).await.unwrap();
+        let metrics = analyzer.analyze_file(padded_file.path()).await.unwrap();
+        assert_eq!(metrics.linear_memory_pages, 0);
+
+        // Same module plus a Memory section declaring min = 3 pages.
+        let mut with_memory = b"\0asm\x01\x00\x00\x00".to_vec();
+        with_memory.extend([0x05, 0x03, 0x01, 0x00, 0x03]);
+        let mem_file = NamedTempFile::new().unwrap();
+        tokio::fs::write(mem_file.path(), &with_memory)
+            .await
+            .unwrap();
+        let metrics = analyzer.analyze_file(mem_file.path()).await.unwrap();
+        assert_eq!(metrics.linear_memory_pages, 3);
+        assert_eq!(metrics.memory_sections, 1);
+    }
+
+    #[test]
+    fn test_decode_sections_stops_at_truncated_section() {
+        // Type section declares 4 payload bytes but only 2 are present.
+        let data = b"\0asm\x01\x00\x00\x00\x01\x04\x60\x00";
+        let sections = decode_sections(data);
+        assert!(
+            sections.is_empty(),
+            "a section that runs off the end of the file must not be decoded"
+        );
+    }
+
+    #[test]
+    fn test_decode_sections_payload_boundaries() {
+        let module = one_function_module();
+        let sections = decode_sections(&module);
+        let ids: Vec<u8> = sections.iter().map(|(id, _)| *id).collect();
+        assert_eq!(ids, vec![1, 3, 7, 10]);
+        assert_eq!(vector_count_in_sections(&sections, SECTION_FUNCTION), 1);
+        assert_eq!(vector_count_in_sections(&sections, SECTION_IMPORT), 0);
+        assert_eq!(vector_count_in_sections(&sections, SECTION_EXPORT), 1);
+    }
+
+    #[test]
+    fn test_read_uleb128_multibyte_and_truncated() {
+        let mut pos = 0;
+        assert_eq!(read_uleb128(&[0xE5, 0x8E, 0x26], &mut pos), Some(624_485));
+        assert_eq!(pos, 3);
+
+        let mut pos = 0;
+        assert_eq!(read_uleb128(&[0x80], &mut pos), None);
     }
 
     #[test]

--- a/src/tdg/analyzer_ast/analyzer_impl1_file_analysis.rs
+++ b/src/tdg/analyzer_ast/analyzer_impl1_file_analysis.rs
@@ -68,7 +68,7 @@ impl TdgAnalyzerAst {
         start_time: SystemTime,
     ) -> Result<Option<TdgScore>> {
         if let Some(storage) = &self.storage {
-            if let Some(hot_entry) = storage.get_hot(content_hash) {
+            if storage.get_hot(content_hash).is_some() {
                 // Record performance sample for cache hit
                 if let Some(adaptive) = &self.adaptive_manager {
                     let duration = start_time.elapsed().unwrap_or_default();
@@ -76,17 +76,27 @@ impl TdgAnalyzerAst {
                     adaptive.record_sample(sample).await?;
                 }
 
-                // Return cached score with updated timestamp
-                let mut cached_score = TdgScore {
-                    total: hot_entry.total_score,
-                    grade: Grade::from_score(hot_entry.total_score),
-                    language,
-                    confidence: language.confidence(),
-                    file_path: Some(path.to_path_buf()),
-                    ..Default::default()
-                };
-                cached_score.calculate_total();
-                return Ok(Some(cached_score));
+                // A hot-cache entry carries only `total_score` and a grade byte, so
+                // the score used to be rebuilt as `TdgScore { total, ..Default::default() }`
+                // — and `TdgScore::default()` seeds every component with its category
+                // MAXIMUM (25+20+20+15+10+10 = 100). The `calculate_total()` call that
+                // followed re-derived `total` from those maxima, so every content-hash
+                // cache HIT was rewritten to 100.0 / A+, discarding the measured score.
+                // `pmat tdg compare <p> <p>` showed it plainly: source 1 88.0 (A-),
+                // source 2 (the cache hit) 100.0 (A+), "Winner: source2".
+                //
+                // Rebuild from the persisted full record, which carries the real
+                // component breakdown. If that record cannot be read, treat it as a
+                // miss and re-analyze rather than inventing a breakdown we never
+                // measured.
+                if let Some(record) = storage.retrieve_full(content_hash).await.ok().flatten() {
+                    let mut cached_score = record.score;
+                    cached_score.language = language;
+                    cached_score.confidence = language.confidence();
+                    cached_score.file_path = Some(path.to_path_buf());
+                    return Ok(Some(cached_score));
+                }
+                return Ok(None);
             }
         }
         Ok(None)
@@ -205,5 +215,96 @@ impl TdgAnalyzerAst {
 
         self.analyze_file_with_priority(path, OperationPriority::Low)
             .await
+    }
+}
+
+/// Regression tests for the hot-cache score reconstruction.
+///
+/// A cache HIT used to be rebuilt from `TdgScore::default()` (whose components
+/// are the category maxima) and then re-totalled, so the second analysis of the
+/// same content always came back as 100.0 / A+ regardless of what the first
+/// analysis measured.
+#[cfg(test)]
+mod hot_cache_score_regression_tests {
+    use super::*;
+
+    /// A file with enough branching and no documentation that it cannot score a
+    /// perfect 100 — the test is only meaningful when the measured score differs
+    /// from the maxed-out default.
+    const IMPERFECT_SOURCE: &str = r#"
+pub fn classify(a: i32, b: i32, c: i32) -> i32 {
+    let mut acc = 0;
+    for i in 0..a {
+        if i % 2 == 0 && b > 0 {
+            acc += i * b;
+        } else if i % 3 == 0 || c < 0 {
+            acc -= i;
+        } else {
+            match i % 5 {
+                0 => acc += 1,
+                1 => acc -= 1,
+                2 => acc *= 2,
+                _ => acc = acc.saturating_add(c),
+            }
+        }
+    }
+    while acc > 1000 {
+        acc /= 2;
+    }
+    acc
+}
+
+pub fn classify_again(a: i32, b: i32, c: i32) -> i32 {
+    let mut acc = 0;
+    for i in 0..a {
+        if i % 2 == 0 && b > 0 {
+            acc += i * b;
+        } else if i % 3 == 0 || c < 0 {
+            acc -= i;
+        } else {
+            match i % 5 {
+                0 => acc += 1,
+                1 => acc -= 1,
+                2 => acc *= 2,
+                _ => acc = acc.saturating_add(c),
+            }
+        }
+    }
+    acc
+}
+"#;
+
+    #[tokio::test]
+    async fn cache_hit_returns_the_measured_score_not_a_perfect_100() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let file = dir.path().join("hot.rs");
+        fs::write(&file, IMPERFECT_SOURCE).expect("write fixture");
+
+        let analyzer = TdgAnalyzerAst::with_in_memory_storage(TdgConfig::default());
+
+        let first = analyzer.analyze_file(&file).await.expect("first analysis");
+        assert!(
+            first.total < 99.9,
+            "fixture must not score a perfect 100 or the regression is untestable (got {})",
+            first.total
+        );
+
+        // Same content hash => hot-cache hit.
+        let second = analyzer
+            .analyze_file(&file)
+            .await
+            .expect("second analysis (cache hit)");
+
+        assert!(
+            (second.total - first.total).abs() < 0.01,
+            "cache hit returned {} but the file measures {}",
+            second.total,
+            first.total
+        );
+        assert_eq!(
+            second.grade, first.grade,
+            "cache hit regraded the file from {:?} to {:?}",
+            first.grade, second.grade
+        );
     }
 }

--- a/src/tdg/analyzer_ast/analyzer_impl2_metrics.rs
+++ b/src/tdg/analyzer_ast/analyzer_impl2_metrics.rs
@@ -189,34 +189,62 @@ impl TdgAnalyzerAst {
         Ok(crate::tdg::Comparison::new(score1, score2))
     }
 
+    /// Enumerate the files TDG will score under `dir`.
+    ///
+    /// This was a hand-rolled `read_dir` recursion that consulted nothing but a
+    /// hardcoded directory-name skip list — no `.gitignore`, no hidden-directory
+    /// handling — so it descended into ignored trees and scored them: on this
+    /// repo it discovered 133,825 files for 4,260 tracked ones, because
+    /// `.claude/worktrees/` holds whole copies of the very tree being analysed,
+    /// and every copy contributed its files to the project average. Both
+    /// `pmat tdg <dir>` and `pmat analyze tdg -p <dir>` reported scores over
+    /// that inflated universe. The walk is now `.gitignore`-aware, like the one
+    /// `check_for_critical_defects` already uses.
     fn discover_files(&self, dir: &Path) -> Result<Vec<PathBuf>> {
-        let mut files = Vec::new();
-        self.discover_files_recursive(dir, &mut files)?;
-        Ok(files)
-    }
+        use ignore::WalkBuilder;
 
-    fn discover_files_recursive(&self, dir: &Path, files: &mut Vec<PathBuf>) -> Result<()> {
+        let mut files = Vec::new();
         if !dir.is_dir() {
-            return Ok(());
+            return Ok(files);
         }
 
-        for entry in fs::read_dir(dir)? {
-            let entry = entry?;
-            let path = entry.path();
-
-            if path.is_dir() {
-                if !self.should_skip_directory(&path) {
-                    self.discover_files_recursive(&path, files)?;
+        for entry in WalkBuilder::new(dir)
+            .follow_links(false)
+            .hidden(true)
+            .parents(true)
+            .ignore(true)
+            .git_ignore(true)
+            .git_global(true)
+            .git_exclude(true)
+            // Honour a .gitignore even when the tree is not itself a checkout:
+            // an ignored directory is ignored because it is not source, and
+            // whether `.git` happens to sit above it does not change that.
+            .require_git(false)
+            .filter_entry(|entry| {
+                // Keep the historical name-based skip list on top of the ignore
+                // rules: `tests/`, `vendor/` and friends are analysed by other
+                // surfaces and are not part of the TDG population.
+                if entry.depth() == 0 {
+                    return true;
                 }
-            } else if self.should_analyze_file(&path) {
-                files.push(path);
+                if entry.file_type().is_some_and(|t| t.is_dir()) {
+                    return !Self::is_skipped_directory(entry.path());
+                }
+                true
+            })
+            .build()
+            .filter_map(std::result::Result::ok)
+        {
+            let path = entry.path();
+            if entry.file_type().is_some_and(|t| t.is_file()) && self.should_analyze_file(path) {
+                files.push(path.to_path_buf());
             }
         }
 
-        Ok(())
+        Ok(files)
     }
 
-    fn should_skip_directory(&self, path: &Path) -> bool {
+    fn is_skipped_directory(path: &Path) -> bool {
         if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
             matches!(
                 name,
@@ -278,4 +306,54 @@ impl TdgAnalyzerAst {
         }
     }
 
+}
+
+#[cfg(test)]
+mod discover_files_tests {
+    use super::*;
+
+    /// The 31x file inflation: `discover_files` used to walk gitignored and
+    /// hidden trees, so `.claude/worktrees/` — whole copies of the tree being
+    /// analysed — contributed their files to the project score.
+    #[test]
+    fn discover_files_honours_gitignore_and_hidden_directories() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        // A named subdirectory, because `tempfile` roots are themselves dot-
+        // prefixed and this walk skips hidden entries.
+        let root = &dir.path().join("proj");
+        std::fs::create_dir_all(root).expect("mkdir");
+
+        std::fs::write(root.join(".gitignore"), "ignored/\n").expect("write gitignore");
+        std::fs::write(root.join("kept.rs"), "pub fn kept() {}\n").expect("write");
+
+        std::fs::create_dir_all(root.join("ignored")).expect("mkdir");
+        std::fs::write(root.join("ignored/copy.rs"), "pub fn copy() {}\n").expect("write");
+
+        std::fs::create_dir_all(root.join(".worktrees/wt")).expect("mkdir");
+        std::fs::write(root.join(".worktrees/wt/copy.rs"), "pub fn copy() {}\n").expect("write");
+
+        std::fs::create_dir_all(root.join("tests")).expect("mkdir");
+        std::fs::write(root.join("tests/it.rs"), "pub fn it() {}\n").expect("write");
+
+        let analyzer = TdgAnalyzerAst::new().expect("analyzer");
+        let files = analyzer.discover_files(root).expect("discover");
+        let names: Vec<String> = files
+            .iter()
+            .map(|p| p.strip_prefix(root).unwrap_or(p).display().to_string())
+            .collect();
+
+        assert!(names.iter().any(|n| n.ends_with("kept.rs")), "{names:?}");
+        assert!(
+            !names.iter().any(|n| n.contains("ignored")),
+            "gitignored trees must not be scored: {names:?}"
+        );
+        assert!(
+            !names.iter().any(|n| n.contains(".worktrees")),
+            "hidden trees must not be scored: {names:?}"
+        );
+        assert!(
+            !names.iter().any(|n| n.starts_with("tests")),
+            "the historical tests/ skip must survive: {names:?}"
+        );
+    }
 }

--- a/src/tdg/analyzer_simple_core.rs
+++ b/src/tdg/analyzer_simple_core.rs
@@ -141,6 +141,34 @@ impl TdgAnalyzer {
     }
 }
 
+/// Refuse a file this build can *prove* does not parse.
+///
+/// The same gate `TdgAnalyzer::analyze_file` applies, minus its "TDG only
+/// grades source files" rule, so callers that legitimately scan Markdown or
+/// YAML (the SATD checks, for instance) are unaffected. Exposed because the
+/// guard was reachable only through the MCP `quality_gate` tool: the CLI's
+/// `quality-gate --file` ran its own checks and reported
+/// "✅ Quality Gate: PASSED / Total Violations: 0" for `def f(:` in a .py file —
+/// the two surfaces disagreeing about the same file, which is the contradiction
+/// class this sweep exists to remove.
+///
+/// `Ok(())` means "it parsed" OR "this build has no parser for that language",
+/// which are deliberately not distinguished: neither is grounds for refusal.
+pub fn ensure_parseable(path: &Path) -> Result<()> {
+    let language = Language::from_extension(path);
+    let Ok(source) = fs::read_to_string(path) else {
+        // Unreadable / non-UTF-8 is the caller's problem to report, not ours.
+        return Ok(());
+    };
+    if let Some(parse_error) = source_parse_error(&source, language) {
+        anyhow::bail!(
+            "{}: {parse_error}; refusing to report a quality verdict on a file that did not parse",
+            path.display()
+        );
+    }
+    Ok(())
+}
+
 /// Does `source` parse as `language`, in THIS build?
 ///
 /// `None` means either "it parsed" or "this build has no parser for that

--- a/src/tdg/analyzer_simple_core.rs
+++ b/src/tdg/analyzer_simple_core.rs
@@ -37,15 +37,16 @@ impl TdgAnalyzer {
             );
         }
         let source = fs::read_to_string(path)?;
-        // Only Rust has a parser here; the other languages stay heuristic, so
-        // their scores remain unverified by a parse.
-        if language == Language::Rust {
-            syn::parse_file(&source).map_err(|e| {
-                anyhow::anyhow!(
-                    "{}: not parseable as Rust ({e}); refusing to grade a file that did not parse",
-                    path.display()
-                )
-            })?;
+        // The parse gate used to be Rust-only, so `def f(:` in a .py file still
+        // collected the untouched component caps from the line heuristics — the
+        // same fabricated grade the Rust gate was added to stop. Every language
+        // with a grammar in this build is now gated the same way; languages
+        // without one still fall through to the heuristics, unverified.
+        if let Some(parse_error) = source_parse_error(&source, language) {
+            anyhow::bail!(
+                "{}: {parse_error}; refusing to grade a file that did not parse",
+                path.display()
+            );
         }
         self.analyze_source(&source, language, Some(path.to_path_buf()))
     }
@@ -140,6 +141,56 @@ impl TdgAnalyzer {
     }
 }
 
+/// Does `source` parse as `language`, in THIS build?
+///
+/// `None` means either "it parsed" or "this build has no parser for that
+/// language, so there is no verdict to give" — the two are deliberately not
+/// distinguished here, because both leave the heuristics as the only signal and
+/// neither is grounds for refusing the file. `Some(msg)` is a real syntax error.
+fn source_parse_error(source: &str, language: Language) -> Option<String> {
+    if language == Language::Rust {
+        return syn::parse_file(source)
+            .err()
+            .map(|e| format!("not parseable as Rust ({e})"));
+    }
+
+    #[cfg(feature = "tree-sitter")]
+    {
+        let grammar: Option<tree_sitter::Language> = match language {
+            #[cfg(feature = "python-ast")]
+            Language::Python => Some(tree_sitter_python::LANGUAGE.into()),
+            #[cfg(feature = "typescript-ast")]
+            Language::TypeScript => Some(tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into()),
+            #[cfg(feature = "javascript-ast")]
+            Language::JavaScript => Some(tree_sitter_javascript::LANGUAGE.into()),
+            #[cfg(feature = "c-ast")]
+            Language::C => Some(tree_sitter_c::LANGUAGE.into()),
+            #[cfg(feature = "cpp-ast")]
+            Language::Cpp => Some(tree_sitter_cpp::LANGUAGE.into()),
+            #[cfg(feature = "lua-ast")]
+            Language::Lua => Some(tree_sitter_lua::LANGUAGE.into()),
+            #[cfg(feature = "go-ast")]
+            Language::Go => Some(tree_sitter_go::LANGUAGE.into()),
+            _ => None,
+        };
+        if let Some(grammar) = grammar {
+            let mut parser = tree_sitter::Parser::new();
+            if parser.set_language(&grammar).is_err() {
+                // No usable grammar ⇒ no verdict, not a failed one.
+                return None;
+            }
+            let Some(tree) = parser.parse(source, None) else {
+                return Some(format!("not parseable as {language}"));
+            };
+            if tree.root_node().has_error() {
+                return Some(format!("not parseable as {language} (syntax error)"));
+            }
+        }
+    }
+
+    None
+}
+
 #[cfg(test)]
 mod unparseable_input_tests {
     use super::*;
@@ -174,6 +225,44 @@ mod unparseable_input_tests {
             .analyze_file(f.path())
             .expect_err("markdown is not source and must not get a score");
         assert!(err.to_string().contains("not one"), "{err}");
+    }
+
+    /// The parse gate used to be Rust-only, so unparseable Python collected the
+    /// untouched component caps from the line heuristics — a graded verdict for
+    /// a file nothing had parsed.
+    #[cfg(feature = "python-ast")]
+    #[test]
+    fn test_unparseable_python_is_not_graded() {
+        let f = write_temp(".py", "def f(:\n  ???\n");
+        let analyzer = TdgAnalyzer::new().expect("analyzer");
+        let err = analyzer
+            .analyze_file(f.path())
+            .expect_err("Python that does not parse must not get a score");
+        assert!(err.to_string().contains("not parseable as Python"), "{err}");
+    }
+
+    #[cfg(feature = "python-ast")]
+    #[test]
+    fn test_valid_python_still_scores() {
+        let f = write_temp(".py", "def add(a, b):\n    \"\"\"Adds.\"\"\"\n    return a + b\n");
+        let analyzer = TdgAnalyzer::new().expect("analyzer");
+        let score = analyzer.analyze_file(f.path()).expect("valid Python grades");
+        assert_eq!(score.language, Language::Python);
+        assert!(score.total > 0.0);
+    }
+
+    #[cfg(feature = "typescript-ast")]
+    #[test]
+    fn test_unparseable_typescript_is_not_graded() {
+        let f = write_temp(".ts", "function f( { return ;;; }\n");
+        let analyzer = TdgAnalyzer::new().expect("analyzer");
+        let err = analyzer
+            .analyze_file(f.path())
+            .expect_err("TypeScript that does not parse must not get a score");
+        assert!(
+            err.to_string().contains("not parseable as TypeScript"),
+            "{err}"
+        );
     }
 
     #[test]

--- a/src/tdg/analyzer_simple_core.rs
+++ b/src/tdg/analyzer_simple_core.rs
@@ -18,9 +18,35 @@ impl TdgAnalyzer {
 
     #[provable_contracts_macros::contract("pmat-core.yaml", equation = "path_exists")]
     /// Analyze file.
+    ///
+    /// Refuses anything it cannot read as source. The metrics below are
+    /// regex heuristics that only ever *subtract* from each component's cap, so
+    /// input they recognise nothing in came back with the untouched
+    /// 25/20/20/15/10 vector — 90.0 and an A, byte-identical for `README.md` and
+    /// for `fn main( { let x = ;;;`. A file the analyzer cannot parse must not
+    /// be graded at all, let alone graded perfect.
     pub fn analyze_file(&self, path: &Path) -> Result<TdgScore> {
         let language = Language::from_extension(path);
+        if matches!(
+            language,
+            Language::Unknown | Language::Yaml | Language::Markdown
+        ) {
+            anyhow::bail!(
+                "{}: TDG grades source files; {language} is not one",
+                path.display()
+            );
+        }
         let source = fs::read_to_string(path)?;
+        // Only Rust has a parser here; the other languages stay heuristic, so
+        // their scores remain unverified by a parse.
+        if language == Language::Rust {
+            syn::parse_file(&source).map_err(|e| {
+                anyhow::anyhow!(
+                    "{}: not parseable as Rust ({e}); refusing to grade a file that did not parse",
+                    path.display()
+                )
+            })?;
+        }
         self.analyze_source(&source, language, Some(path.to_path_buf()))
     }
 
@@ -111,6 +137,52 @@ impl TdgAnalyzer {
         };
 
         Ok(Comparison::new(score1, score2))
+    }
+}
+
+#[cfg(test)]
+mod unparseable_input_tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    fn write_temp(suffix: &str, body: &str) -> NamedTempFile {
+        let mut f = NamedTempFile::with_suffix(suffix).expect("temp file");
+        write!(f, "{body}").expect("write");
+        f.flush().expect("flush");
+        f
+    }
+
+    /// Rust that does not parse used to score 90.0/A — the untouched component
+    /// caps — because the heuristics simply matched nothing in it.
+    #[test]
+    fn test_unparseable_rust_is_not_graded() {
+        let f = write_temp(".rs", "fn main( { let x = ;;;\n");
+        let analyzer = TdgAnalyzer::new().expect("analyzer");
+        let err = analyzer
+            .analyze_file(f.path())
+            .expect_err("a file that does not parse must not get a score");
+        assert!(err.to_string().contains("not parseable as Rust"), "{err}");
+    }
+
+    /// Prose scored identically to source for the same reason.
+    #[test]
+    fn test_non_source_file_is_not_graded() {
+        let f = write_temp(".md", "# Readme\n\nSome prose about the project.\n");
+        let analyzer = TdgAnalyzer::new().expect("analyzer");
+        let err = analyzer
+            .analyze_file(f.path())
+            .expect_err("markdown is not source and must not get a score");
+        assert!(err.to_string().contains("not one"), "{err}");
+    }
+
+    #[test]
+    fn test_valid_rust_still_scores() {
+        let f = write_temp(".rs", "/// Doc\npub fn add(a: i32, b: i32) -> i32 { a + b }\n");
+        let analyzer = TdgAnalyzer::new().expect("analyzer");
+        let score = analyzer.analyze_file(f.path()).expect("valid Rust grades");
+        assert_eq!(score.language, Language::Rust);
+        assert!(score.total > 0.0);
     }
 }
 

--- a/src/tdg/core_tests.rs
+++ b/src/tdg/core_tests.rs
@@ -452,9 +452,23 @@ fn test_project_score_aggregate_multiple() {
 
 #[test]
 fn test_project_score_average_empty() {
+    // This used to assert `structural_complexity == 25.0` with the comment
+    // "Default values" — 25.0 is the STRUCT DEFAULT, i.e. full marks for that
+    // category, awarded to a project in which no file was analysed at all.
+    // That is what made `pmat tdg <dir> --include-components` print a
+    // 25/20/20/15/10/10 breakdown summing to 100 next to a total of 0.0, with
+    // an empty directory producing the byte-identical breakdown. Nothing was
+    // measured, so every component must claim zero.
     let project = ProjectScore::default();
     let avg = project.average();
-    assert_eq!(avg.structural_complexity, 25.0); // Default values
+    assert_eq!(avg.total, 0.0);
+    assert_eq!(avg.confidence, 0.0);
+    assert_eq!(avg.structural_complexity, 0.0);
+    assert_eq!(avg.semantic_complexity, 0.0);
+    assert_eq!(avg.duplication_ratio, 0.0);
+    assert_eq!(avg.coupling_score, 0.0);
+    assert_eq!(avg.doc_coverage, 0.0);
+    assert_eq!(avg.consistency_score, 0.0);
 }
 
 #[test]

--- a/src/tdg/cuda_simd/scoring_calculation.rs
+++ b/src/tdg/cuda_simd/scoring_calculation.rs
@@ -11,7 +11,14 @@ impl CudaSimdAnalyzer {
             .count();
 
         FalsifiabilityScore {
-            barrier_safety: if barrier_safety.unsafe_barriers.is_empty() {
+            // Absence of evidence is not evidence of safety: a tree with no
+            // barriers at all used to collect full marks here, which is how a
+            // plain Rust crate with zero CUDA/SIMD/WGPU code — and a file that
+            // does not even parse — scored "Barrier Safety 5.0/5" and passed
+            // the gateway. Nothing was verified, so nothing is awarded.
+            barrier_safety: if barrier_safety.total_barriers == 0 {
+                0.0
+            } else if barrier_safety.unsafe_barriers.is_empty() {
                 5.0
             } else {
                 5.0 * barrier_safety.safety_score
@@ -23,7 +30,10 @@ impl CudaSimdAnalyzer {
             },
             divergence_testing: if patterns.has_proptest_regressions { 5.0 } else { 2.5 },
             memory_race_detection: if patterns.has_miri_config { 5.0 } else { 2.5 },
-            occupancy_bounds: 5.0,
+            // This analyzer performs no occupancy analysis, so a literal 5.0
+            // was awarded to every input including an empty Rust crate. An
+            // unmeasured criterion scores nothing.
+            occupancy_bounds: 0.0,
         }
     }
 
@@ -89,18 +99,32 @@ impl CudaSimdAnalyzer {
 
         let falsifiability = Self::score_falsifiability(defects, barrier_safety, &patterns);
         let reproducibility = Self::score_reproducibility(&patterns);
+        // Transparency used to be four literals {3.0, 2.5, 2.5, 2.0} = exactly
+        // the 10.0/20 every run reported — the same 10.0 for a repo with no GPU
+        // code as for a source file that does not parse. Nothing in this
+        // analyzer inspects PTX, register allocation or SM occupancy, so those
+        // three criteria have no evidence behind them and score nothing;
+        // memory layout is credited only when the coalescing pass actually
+        // examined memory operations.
         let transparency = TransparencyScore {
-            ptx_inspection: 3.0,
-            register_allocation: 2.5,
-            occupancy_calculation: 2.5,
-            memory_layout: 2.0,
+            ptx_inspection: 0.0,
+            register_allocation: 0.0,
+            occupancy_calculation: 0.0,
+            memory_layout: if coalescing.total_operations > 0 { 2.0 } else { 0.0 },
         };
         let statistical_rigor = Self::score_statistical_rigor(&patterns);
         let historical_integrity = Self::score_historical_integrity(defects, &patterns);
+        // Same defect in category F: warp efficiency and instruction mix were
+        // literals (1.0 and 0.5) that no pass in this analyzer measures.
+        // `memory_throughput` is the only member derived from an observation.
         let gpu_simd_specific = GpuSimdSpecificScore {
-            warp_efficiency: 1.0,
-            memory_throughput: coalescing.efficiency * 2.0,
-            instruction_mix: 0.5,
+            warp_efficiency: 0.0,
+            memory_throughput: if coalescing.total_operations > 0 {
+                coalescing.efficiency * 2.0
+            } else {
+                0.0
+            },
+            instruction_mix: 0.0,
         };
 
         PopperScore::calculate(
@@ -161,5 +185,65 @@ impl CudaSimdAnalyzer {
         }
 
         result.score.total >= self.config.min_score
+    }
+}
+
+#[cfg(test)]
+mod unmeasured_subscore_tests {
+    //! Regression tests for the Popper sub-scores that were literal constants:
+    //! Transparency was always exactly 10.0/20 and category F always 1.5/5, and
+    //! Barrier Safety awarded a full 5.0 for a tree containing no barriers — so
+    //! a plain Rust crate with zero CUDA/SIMD/WGPU code passed the gateway with
+    //! the same 56.5/100 as a source file that does not parse.
+    use super::CudaSimdAnalyzer;
+
+    fn score_plain_rust(body: &str) -> super::PopperScore {
+        let temp = tempfile::tempdir().unwrap();
+        let file = temp.path().join("plain.rs");
+        std::fs::write(&file, body).unwrap();
+        CudaSimdAnalyzer::new().analyze(&file).unwrap().score
+    }
+
+    #[test]
+    fn test_no_gpu_evidence_scores_no_transparency_points() {
+        let score = score_plain_rust("pub fn add(a: i32, b: i32) -> i32 { a + b }\n");
+
+        assert_eq!(
+            score.transparency.ptx_inspection, 0.0,
+            "no PTX is ever inspected, so PTX inspection cannot score"
+        );
+        assert_eq!(score.transparency.occupancy_calculation, 0.0);
+        assert_eq!(
+            score.transparency.total(),
+            0.0,
+            "transparency was a constant 10.0/20 for every input"
+        );
+        assert_eq!(
+            score.gpu_simd_specific.warp_efficiency, 0.0,
+            "no warp analysis is performed, so warp efficiency cannot score"
+        );
+        assert_eq!(score.gpu_simd_specific.instruction_mix, 0.0);
+    }
+
+    #[test]
+    fn test_absent_barriers_do_not_pass_the_falsifiability_gateway() {
+        let score = score_plain_rust("pub fn add(a: i32, b: i32) -> i32 { a + b }\n");
+
+        assert_eq!(
+            score.falsifiability.barrier_safety, 0.0,
+            "zero barriers means nothing was verified, not that everything is safe"
+        );
+        assert_eq!(score.falsifiability.occupancy_bounds, 0.0);
+        assert!(
+            !score.gateway_passed,
+            "a crate with no GPU/SIMD code must not pass the CUDA falsifiability gateway"
+        );
+    }
+
+    #[test]
+    fn test_a_file_that_does_not_parse_is_not_graded_as_a_pass() {
+        let score = score_plain_rust("fn main( { let x = ;;;\n");
+        assert!(!score.gateway_passed);
+        assert_eq!(score.total, 0.0);
     }
 }

--- a/src/tdg/cuda_simd/scoring_calculation.rs
+++ b/src/tdg/cuda_simd/scoring_calculation.rs
@@ -121,12 +121,23 @@ impl CudaSimdAnalyzer {
 
         let resolved_count = defects.iter().filter(|d| d.defect_class.resolved).count() as u32;
 
+        // `pmat cuda-tdg kaizen` printed "Mean Time to Detect: 24.0 hours /
+        // Mean Time to Fix: 48.0 hours / Escape Rate: 5.0% / Regression Rate:
+        // 2.0%" for a one-file toy crate, for this 4000-file repo, and for the
+        // repo windowed with --since — byte-identical, because those four
+        // numbers were literals ("Default estimate") with no reference to any
+        // git or issue history. MTTD/MTTF/escape rate/regression rate need
+        // defect lifecycle data (when a defect was introduced, detected,
+        // fixed, reopened) that nothing in this analyzer collects, so they are
+        // reported as not-measured: NaN here, rendered as "not measured" in
+        // text/markdown and as JSON null. `tickets_resolved` and
+        // `ticket_references` below ARE derived from the scanned sources.
         KaizenMetrics {
             tickets_resolved: resolved_count,
-            mttd: 24.0,            // Default estimate
-            mttf: 48.0,            // Default estimate
-            escape_rate: 0.05,     // 5% default
-            regression_rate: 0.02, // 2% default
+            mttd: f64::NAN,
+            mttf: f64::NAN,
+            escape_rate: f64::NAN,
+            regression_rate: f64::NAN,
             ticket_references,
         }
     }

--- a/src/tdg/grade.rs
+++ b/src/tdg/grade.rs
@@ -112,6 +112,42 @@ impl Grade {
             .find(|(floor, _)| score >= *floor)
             .map_or(Grade::F, |(_, grade)| *grade)
     }
+
+    /// The half-open score band this grade covers, `[floor, ceiling)` — the top
+    /// grade's band is closed at 100.0.
+    ///
+    /// Exists so nothing has to restate the bands in prose. `pmat explain`
+    /// used to carry a hand-written five-grade table (A = "Score 85-94") that
+    /// contradicted this one (A = 90..95, and A-/B+/B-/C+/C-/D were not listed
+    /// at all), so `explain TDG-A-` answered "No checks matching 'TDG-A-'" for a
+    /// grade `pmat tdg` prints routinely.
+    #[must_use]
+    pub fn score_band(self) -> (f32, f32) {
+        match GRADE_BANDS.iter().position(|(_, grade)| *grade == self) {
+            // `F` is everything below the last floor.
+            None => (0.0, GRADE_BANDS[GRADE_BANDS.len() - 1].0),
+            Some(0) => (GRADE_BANDS[0].0, 100.0),
+            Some(i) => (GRADE_BANDS[i].0, GRADE_BANDS[i - 1].0),
+        }
+    }
+
+    /// Every grade, best first — the population `pmat explain` must document.
+    #[must_use]
+    pub fn all() -> [Grade; 11] {
+        [
+            Grade::APlus,
+            Grade::A,
+            Grade::AMinus,
+            Grade::BPlus,
+            Grade::B,
+            Grade::BMinus,
+            Grade::CPlus,
+            Grade::C,
+            Grade::CMinus,
+            Grade::D,
+            Grade::F,
+        ]
+    }
 }
 
 /// Score floors, best grade first. `F` is everything below the last floor.
@@ -379,6 +415,29 @@ mod tests {
                 serde_json::from_str(&encoded).unwrap();
             assert_eq!(decoded.get(&grade), Some(&3));
         }
+    }
+
+    /// `score_band` must agree with `from_score` at every boundary, or the
+    /// documentation generated from it would restate the same contradiction
+    /// `pmat explain` used to carry.
+    #[test]
+    fn test_score_band_agrees_with_from_score() {
+        for grade in Grade::all() {
+            let (floor, ceiling) = grade.score_band();
+            assert_eq!(
+                Grade::from_score(floor),
+                grade,
+                "{grade}'s floor {floor} does not map back to {grade}"
+            );
+            // Just under the ceiling is still this grade; at the ceiling it is
+            // the next better one (except for the top band, closed at 100).
+            assert_eq!(Grade::from_score(ceiling - 0.1), grade, "{grade} ceiling");
+            if grade != Grade::APlus {
+                assert_ne!(Grade::from_score(ceiling), grade, "{grade} ceiling is open");
+            }
+        }
+        assert_eq!(Grade::APlus.score_band(), (95.0, 100.0));
+        assert_eq!(Grade::F.score_band(), (0.0, 50.0));
     }
 
     #[test]

--- a/src/tdg/hooks_cache/helpers.rs
+++ b/src/tdg/hooks_cache/helpers.rs
@@ -34,10 +34,23 @@ impl HooksCacheManager {
         Ok(hasher.finalize().to_hex().to_string())
     }
 
-    /// Get git tree hash for HEAD
+    /// Get the tree hash of the content the gates are about to check.
+    ///
+    /// This used to be `git rev-parse HEAD^{tree}` — the tree of the *last
+    /// commit*. A pre-commit run keyed that way is invariant to exactly the
+    /// change it is gating: staging a new FIXME and re-running produced the same
+    /// key, so the hook reported "All quality gates passed (cached)" without
+    /// looking at the staged code. `git write-tree` hashes the index — the
+    /// content a commit would actually contain — which is what must key the
+    /// cache. (It writes the tree objects into the object store, the same
+    /// harmless side effect `git commit` has.)
     pub(super) fn get_tree_hash(&self) -> Result<String> {
-        // Use HEAD^{tree} to get the tree hash of the root tree
-        // This is more reliable than HEAD:. across different git versions
+        if let Some(index_tree) = self.git_stdout(&["write-tree"]) {
+            return Ok(index_tree);
+        }
+
+        // No usable index (unmerged state, bare repo): fall back to the last
+        // commit's tree so whole-tree/CI style runs still get a key.
         let output = Command::new("git")
             .args(["rev-parse", "HEAD^{tree}"])
             .current_dir(&self.project_path)
@@ -52,6 +65,24 @@ impl HooksCacheManager {
         }
 
         Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    }
+
+    /// Run a git command in the project, returning trimmed stdout on success
+    fn git_stdout(&self, args: &[&str]) -> Option<String> {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(&self.project_path)
+            .output()
+            .ok()?;
+        if !output.status.success() {
+            return None;
+        }
+        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if stdout.is_empty() {
+            None
+        } else {
+            Some(stdout)
+        }
     }
 
     /// Get hash of config files
@@ -97,5 +128,61 @@ impl HooksCacheManager {
             }
         }
         Ok(size)
+    }
+}
+
+#[cfg(test)]
+mod tree_hash_tests {
+    use super::HooksCacheManager;
+    use std::process::Command;
+
+    fn git(dir: &std::path::Path, args: &[&str]) -> String {
+        let out = Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .output()
+            .unwrap_or_else(|e| panic!("git {args:?} failed to spawn: {e}"));
+        assert!(
+            out.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        String::from_utf8_lossy(&out.stdout).trim().to_string()
+    }
+
+    fn repo_with_one_commit() -> tempfile::TempDir {
+        let temp = tempfile::TempDir::new().unwrap();
+        git(temp.path(), &["init"]);
+        git(temp.path(), &["config", "user.email", "test@test.com"]);
+        git(temp.path(), &["config", "user.name", "Test User"]);
+        std::fs::write(temp.path().join("lib.rs"), "pub fn ok() {}\n").unwrap();
+        git(temp.path(), &["add", "-A"]);
+        git(temp.path(), &["commit", "-m", "initial"]);
+        temp
+    }
+
+    #[test]
+    fn test_tree_hash_follows_the_staged_index_not_the_last_commit() {
+        // Regression: keyed on HEAD^{tree}, a pre-commit run was invariant to
+        // the very change it was gating — stage a FIXME, get a cached pass.
+        let temp = repo_with_one_commit();
+        let manager = HooksCacheManager::new(temp.path());
+
+        let before = manager.get_tree_hash().unwrap();
+
+        std::fs::write(
+            temp.path().join("lib.rs"),
+            "pub fn ok() {}\n// FIXME: broken\n",
+        )
+        .unwrap();
+        git(temp.path(), &["add", "-A"]);
+
+        let after = manager.get_tree_hash().unwrap();
+        assert_ne!(
+            before, after,
+            "staged content must change the hooks cache key"
+        );
+        assert_eq!(after, git(temp.path(), &["write-tree"]));
+        assert_ne!(after, git(temp.path(), &["rev-parse", "HEAD^{tree}"]));
     }
 }

--- a/src/tdg/mod.rs
+++ b/src/tdg/mod.rs
@@ -64,7 +64,7 @@ pub use adaptive::{
 };
 // Use AST analyzer by default (proper implementation)
 pub use analyzer_ast::TdgAnalyzerAst as TdgAnalyzer;
-pub use analyzer_simple::TdgAnalyzer as TdgAnalyzerSimple;
+pub use analyzer_simple::{ensure_parseable, TdgAnalyzer as TdgAnalyzerSimple};
 pub use baseline::{
     BaselineComparison, BaselineEntry, BaselineSummary, FileComparison, TdgBaseline,
 };

--- a/src/tdg/project_score.rs
+++ b/src/tdg/project_score.rs
@@ -136,16 +136,43 @@ impl ProjectScore {
         self.files_reported = self.files.len();
     }
 
+    /// The grade `average_score` maps to BEFORE the F-grade cap.
+    ///
+    /// `average_grade` alone is not enough to render an honest headline: when
+    /// `grade_capped` is true the printed grade is deliberately worse than the
+    /// printed score, and a reader needs to be told what it would otherwise
+    /// have been.
+    #[must_use]
+    pub fn uncapped_grade(&self) -> Grade {
+        Grade::from_score(self.average_score)
+    }
+
     #[must_use]
     #[provable_contracts_macros::contract("pmat-core.yaml", equation = "check_compliance")]
     /// Calculate the average.
     pub fn average(&self) -> TdgScore {
         if self.files.is_empty() {
-            // No files analyzed — return zero score, not perfect score
+            // No files analyzed — return zero score, not perfect score.
+            //
+            // The COMPONENTS have to be zeroed by hand: `..TdgScore::default()`
+            // seeds every component at its category maximum (25/20/20/15/10/10,
+            // which is exactly 100), so `pmat tdg <dir> --include-components`
+            // over a directory where every file failed to parse printed a
+            // full-marks breakdown summing to 100 beside a total of 0.0 — and
+            // an EMPTY directory printed the byte-identical breakdown, which is
+            // how you can tell it measured nothing. Nothing was measured here,
+            // so nothing is claimed.
             return TdgScore {
                 total: 0.0,
                 grade: crate::tdg::Grade::F,
                 confidence: 0.0,
+                structural_complexity: 0.0,
+                semantic_complexity: 0.0,
+                duplication_ratio: 0.0,
+                coupling_score: 0.0,
+                doc_coverage: 0.0,
+                consistency_score: 0.0,
+                entropy_score: 0.0,
                 ..TdgScore::default()
             };
         }
@@ -476,6 +503,69 @@ mod no_contradiction_tests {
                 .expect("known grade")
         });
         assert_eq!(order, expected, "grade keys must be in grade order");
+    }
+
+    /// `pmat tdg <dir> --include-components` over a directory where nothing
+    /// could be analysed printed the FULL-MARKS component defaults
+    /// (25/20/20/15/10/10, summing to 100) beside `"total": 0.0`, and an empty
+    /// directory printed the byte-identical breakdown — proof it was the struct
+    /// default and not a measurement.
+    #[test]
+    fn empty_project_claims_no_component_measurements() {
+        let empty = ProjectScore::aggregate(vec![]);
+        let avg = empty.average();
+
+        assert_eq!(avg.total, 0.0);
+        assert_eq!(avg.grade, Grade::F);
+        assert_eq!(avg.confidence, 0.0);
+        for (name, value) in [
+            ("structural", avg.structural_complexity),
+            ("semantic", avg.semantic_complexity),
+            ("duplication", avg.duplication_ratio),
+            ("coupling", avg.coupling_score),
+            ("documentation", avg.doc_coverage),
+            ("consistency", avg.consistency_score),
+            ("entropy", avg.entropy_score),
+        ] {
+            assert_eq!(
+                value, 0.0,
+                "{name} claims {value} points for a project where no file was analysed"
+            );
+        }
+        // The old defect in one line: the components must not sum to full marks
+        // under a total of zero.
+        let breakdown_sum = avg.structural_complexity
+            + avg.semantic_complexity
+            + avg.duplication_ratio
+            + avg.coupling_score
+            + avg.doc_coverage
+            + avg.consistency_score;
+        assert_eq!(breakdown_sum, 0.0, "breakdown sums to {breakdown_sum}");
+    }
+
+    /// The F-grade cap makes the grade non-monotone in the score on purpose, so
+    /// the aggregate has to be able to say what the grade would have been.
+    #[test]
+    fn capped_project_reports_the_grade_it_would_have_had() {
+        let mut files = vec![file_score(100.0, Language::Rust, false); 19];
+        files.push(file_score(10.0, Language::Rust, false));
+        let project = ProjectScore::aggregate(files);
+
+        assert_eq!(project.f_grade_count, 1);
+        assert!(
+            project.grade_capped,
+            "one F-grade file must cap the project"
+        );
+        assert_eq!(project.average_grade, Grade::B);
+        assert_eq!(
+            project.uncapped_grade(),
+            Grade::from_score(project.average_score),
+            "the uncapped grade is the score's own band"
+        );
+        assert!(
+            project.uncapped_grade() < Grade::B,
+            "the fixture must actually exercise the cap"
+        );
     }
 
     /// A clear majority still wins; the tiebreak only settles equal counts.

--- a/src/tdg/storage_backend_inmemory.rs
+++ b/src/tdg/storage_backend_inmemory.rs
@@ -1,3 +1,13 @@
+/// Key under which every backend's `get_stats()` reports its live row count.
+///
+/// `TieredStore::get_statistics` used to look this value up as `"entry_count"`,
+/// a key no backend has ever written, so the lookup fell through to
+/// `unwrap_or(0)` and warm/cold/total were structurally always zero -- the TDG
+/// dashboard served `"warm_entries":0` inside the same payload whose raw
+/// `backend_stats` read `"entries":"73448"`. Both the writers and the reader now
+/// name this const, so the two halves cannot drift apart again.
+pub const STAT_KEY_ENTRIES: &str = "entries";
+
 /// In-memory backend for testing and development
 pub struct InMemoryBackend {
     data: Arc<DashMap<Vec<u8>, Vec<u8>>>,
@@ -73,7 +83,7 @@ impl StorageBackend for InMemoryBackend {
 
     fn get_stats(&self) -> HashMap<String, String> {
         let mut stats = HashMap::new();
-        stats.insert("entries".to_string(), self.data.len().to_string());
+        stats.insert(STAT_KEY_ENTRIES.to_string(), self.data.len().to_string());
         let size: usize = self
             .data
             .iter()

--- a/src/tdg/storage_backend_libsql.rs
+++ b/src/tdg/storage_backend_libsql.rs
@@ -165,7 +165,7 @@ impl StorageBackend for LibsqlBackend {
         if let Ok(count) =
             db.query_row::<i64, _, _>("SELECT COUNT(*) FROM tdg_storage", [], |row| row.get(0))
         {
-            stats.insert("entries".to_string(), count.to_string());
+            stats.insert(STAT_KEY_ENTRIES.to_string(), count.to_string());
         }
 
         // Get database size

--- a/src/tdg/storage_impl_tiered.rs
+++ b/src/tdg/storage_impl_tiered.rs
@@ -203,6 +203,53 @@ impl TieredStore {
         Ok(())
     }
 
+    /// Warm entries above which the compression ratio is left unmeasured.
+    ///
+    /// Measuring it means reading the stored values back, and the backend
+    /// iterator materialises the whole tier; doing that to a 100 MB warm store
+    /// just to print one percentage is not a trade worth making. Past this
+    /// point `get_statistics` reports the ratio as unmeasured (0.0) rather than
+    /// guessing at it.
+    const COMPRESSION_SAMPLE_MAX_ENTRIES: usize = 4096;
+
+    /// The warm tier's real compressed:uncompressed ratio, or `None` when there
+    /// is nothing to measure.
+    ///
+    /// `get_statistics` used to hand back the literal `compression_ratio: 0.33,
+    /// // Default compression ratio`, which every renderer printed as
+    /// "Compression ratio: 33.0%" — including over a store holding zero
+    /// entries, and identically for an empty directory and a 4260-file repo.
+    /// (The 0.33000001311302185 seen in JSON is only that literal's f32
+    /// round-trip.) `store()` writes warm values through
+    /// `lz4_flex::compress_prepend_size`, which prefixes each blob with its
+    /// uncompressed length as a little-endian u32, so the true ratio can be
+    /// read straight back out of the bytes that are actually stored.
+    fn measure_warm_compression_ratio(&self, warm_entries: usize) -> Option<f32> {
+        if warm_entries == 0 || warm_entries > Self::COMPRESSION_SAMPLE_MAX_ENTRIES {
+            return None;
+        }
+
+        let mut compressed_total: u64 = 0;
+        let mut raw_total: u64 = 0;
+        for item in self.warm_backend.iter().ok()? {
+            let Ok((_, value)) = item else { continue };
+            let Some(header) = value.get(..4) else {
+                continue;
+            };
+            raw_total += u64::from(u32::from_le_bytes([
+                header[0], header[1], header[2], header[3],
+            ]));
+            compressed_total += value.len() as u64;
+        }
+
+        if raw_total == 0 {
+            return None;
+        }
+
+        #[allow(clippy::cast_precision_loss)]
+        Some(compressed_total as f32 / raw_total as f32)
+    }
+
     /// Get storage statistics for monitoring and dogfooding
     #[must_use]
     #[provable_contracts_macros::contract("pmat-core.yaml", equation = "check_compliance")]
@@ -214,12 +261,16 @@ impl TieredStore {
         let warm_stats = self.warm_backend.get_stats();
         let cold_stats = self.cold_backend.get_stats();
 
+        // Ask for the key the backends actually write. This read used to be
+        // `.get("entry_count")`, a key no backend has ever inserted, so it fell
+        // through to unwrap_or(0) and every tier count was zero regardless of
+        // what was stored — see STAT_KEY_ENTRIES.
         let warm_entries = warm_stats
-            .get("entry_count")
+            .get(crate::tdg::storage_backend::STAT_KEY_ENTRIES)
             .and_then(|v| v.parse::<usize>().ok())
             .unwrap_or(0);
         let cold_entries = cold_stats
-            .get("entry_count")
+            .get(crate::tdg::storage_backend::STAT_KEY_ENTRIES)
             .and_then(|v| v.parse::<usize>().ok())
             .unwrap_or(0);
 
@@ -235,10 +286,105 @@ impl TieredStore {
             cold_entries,
             total_entries,
             hot_memory_kb,
-            compression_ratio: 0.33,          // Default compression ratio
-            warm_backend: "sled".to_string(), // Default backend type
-            cold_backend: "sled".to_string(), // Default backend type
+            // 0.0 means "not measured"; see measure_warm_compression_ratio.
+            compression_ratio: self
+                .measure_warm_compression_ratio(warm_entries)
+                .unwrap_or(0.0),
+            // The backends name themselves. Both of these were the literal
+            // "sled" — a backend that was deleted from this tree entirely — so
+            // diagnostics announced "Warm (sled backend)" over libsql files.
+            warm_backend: self.warm_backend.backend_name().to_string(),
+            cold_backend: self.cold_backend.backend_name().to_string(),
             backend_stats,
         }
+    }
+}
+
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg(test)]
+mod tiered_statistics_tests {
+    use super::*;
+
+    fn record_for(content: &[u8]) -> FullTdgRecord {
+        FullTdgRecord {
+            identity: FileIdentity {
+                path: PathBuf::from("test.rs"),
+                content_hash: blake3::hash(content),
+                size_bytes: content.len() as u64,
+                modified_time: SystemTime::now(),
+            },
+            score: TdgScore::default(),
+            components: ComponentScores::default(),
+            semantic_sig: SemanticSignature {
+                ast_structure_hash: 1,
+                identifier_pattern: String::new(),
+                control_flow_pattern: String::new(),
+                import_dependencies: Vec::new(),
+            },
+            metadata: AnalysisMetadata {
+                analyzer_version: "test".to_string(),
+                analysis_duration_ms: 1,
+                language_confidence: 1.0,
+                analysis_timestamp: SystemTime::now(),
+                cache_hit: false,
+            },
+            git_context: None,
+        }
+    }
+
+    /// The reported tier counts must come from the backend the same report
+    /// embeds. They were read under the key "entry_count", which no backend
+    /// writes, so warm/cold/total were always 0 while `backend_stats` in the
+    /// very same payload carried the real count.
+    #[tokio::test]
+    async fn test_warm_entries_match_the_backend_they_describe() {
+        let storage = TieredStore::in_memory();
+        storage.store(record_for(b"fn a() {}")).await.unwrap();
+        storage.store(record_for(b"fn b() {}")).await.unwrap();
+
+        let stats = storage.get_statistics();
+        let backend_entries: usize = stats.backend_stats["warm"]
+            [crate::tdg::storage_backend::STAT_KEY_ENTRIES]
+            .parse()
+            .unwrap();
+
+        assert_eq!(backend_entries, 2, "two records were stored");
+        assert_eq!(
+            stats.warm_entries, backend_entries,
+            "warm_entries must equal the backend count reported beside it"
+        );
+        assert_eq!(stats.total_entries, stats.hot_entries + backend_entries);
+    }
+
+    /// The ratio was the literal 0.33 for every store, empty or not.
+    #[tokio::test]
+    async fn test_compression_ratio_is_measured_not_a_constant() {
+        let empty = TieredStore::in_memory();
+        assert_eq!(
+            empty.get_statistics().compression_ratio,
+            0.0,
+            "nothing is stored, so there is no ratio to report"
+        );
+
+        let storage = TieredStore::in_memory();
+        storage.store(record_for(b"fn a() {}")).await.unwrap();
+        let ratio = storage.get_statistics().compression_ratio;
+        assert!(
+            ratio > 0.0 && ratio < 1.0,
+            "expected a measured lz4 ratio, got {ratio}"
+        );
+        assert!(
+            (ratio - 0.33).abs() > f32::EPSILON,
+            "0.33 is the old hardcoded literal"
+        );
+    }
+
+    /// Both backend names were the literal "sled" — a backend deleted from the
+    /// tree — so diagnostics announced "Warm (sled backend)" over libsql files.
+    #[test]
+    fn test_backend_names_come_from_the_backends() {
+        let stats = TieredStore::in_memory().get_statistics();
+        assert_eq!(stats.warm_backend, "in-memory");
+        assert_eq!(stats.cold_backend, "in-memory");
     }
 }

--- a/src/tdg/storage_impl_types.rs
+++ b/src/tdg/storage_impl_types.rs
@@ -88,6 +88,12 @@ pub struct StorageStatistics {
     pub cold_entries: usize,
     pub total_entries: usize,
     pub hot_memory_kb: usize,
+    /// Measured compressed:uncompressed ratio of the warm tier.
+    ///
+    /// `0.0` means **not measured** — nothing is stored, or the tier is too
+    /// large to read back cheaply. It was previously a hardcoded 0.33 that
+    /// rendered as "Compression ratio: 33.0%" over empty stores; renderers must
+    /// say "not measured" for 0.0 rather than print "0.0%" as a measurement.
     pub compression_ratio: f32,
     pub warm_backend: String,
     pub cold_backend: String,
@@ -95,6 +101,22 @@ pub struct StorageStatistics {
 }
 
 impl StorageStatistics {
+    /// The compression ratio as text, or why there is no ratio to show.
+    ///
+    /// A ratio cannot be derived from zero stored entries, yet this line read
+    /// "Compression ratio: 33.0%" for every store pmat has ever printed
+    /// diagnostics for — see the `compression_ratio` field.
+    #[must_use]
+    pub fn compression_ratio_display(&self) -> String {
+        if self.compression_ratio > 0.0 {
+            format!("{:.1}%", self.compression_ratio * 100.0)
+        } else if self.total_entries == 0 {
+            "not measured (nothing stored)".to_string()
+        } else {
+            "not measured".to_string()
+        }
+    }
+
     /// Format statistics for diagnostic display
     #[must_use]
     #[provable_contracts_macros::contract("pmat-core.yaml", equation = "check_compliance")]
@@ -105,7 +127,7 @@ impl StorageStatistics {
              - Warm ({} backend): {} entries\n\
              - Cold ({} backend): {} entries\n\
              - Total: {} entries\n\
-             - Compression ratio: {:.1}%",
+             - Compression ratio: {}",
             self.hot_entries,
             self.hot_memory_kb,
             self.warm_backend,
@@ -113,7 +135,7 @@ impl StorageStatistics {
             self.cold_backend,
             self.cold_entries,
             self.total_entries,
-            self.compression_ratio * 100.0
+            self.compression_ratio_display()
         )
     }
 }

--- a/src/tdg/storage_tests.rs
+++ b/src/tdg/storage_tests.rs
@@ -876,7 +876,11 @@ mod extended_tests {
 
         let output = stats.format_diagnostic();
         assert!(output.contains("Hot (memory): 0 entries"));
-        assert!(output.contains("0.0%"));
+        // This used to assert `output.contains("0.0%")` — i.e. it pinned the
+        // very thing the diagnostics defect was about: a ratio rendered as a
+        // measurement over a store holding nothing. 0.0 means unmeasured.
+        assert!(!output.contains("0.0%"), "{output}");
+        assert!(output.contains("not measured"), "{output}");
     }
 
     #[test]

--- a/src/tdg/web_dashboard.rs
+++ b/src/tdg/web_dashboard.rs
@@ -26,14 +26,11 @@ use serde_json::{json, Value};
 use std::{
     path::PathBuf,
     sync::Arc,
-    time::{Duration, SystemTime},
+    time::{Duration, Instant, SystemTime},
 };
 use tokio::sync::RwLock;
 use tower::ServiceBuilder;
-use tower_http::{
-    cors::{Any, CorsLayer},
-    trace::TraceLayer,
-};
+use tower_http::trace::TraceLayer;
 use tracing::{debug, error, info};
 
 /// Shared state for the TDG dashboard
@@ -45,6 +42,12 @@ pub struct DashboardState {
     pub analyzer: Arc<TdgAnalyzer>,
     /// Real-time metrics cache
     pub metrics_cache: Arc<RwLock<SystemMetrics>>,
+    /// When this dashboard process started serving.
+    ///
+    /// `/api/health` reported `uptime_seconds` as seconds since the UNIX epoch
+    /// (≈56.6 years, and byte-identical to the payload's own `timestamp`), which
+    /// never changed as the server ran. Uptime is measured from here.
+    pub started_at: Instant,
 }
 
 /// System metrics for dashboard display
@@ -60,7 +63,14 @@ pub struct SystemMetrics {
 /// Storage metrics.
 pub struct StorageMetrics {
     pub total_entries: u64,
-    pub cache_hit_ratio: f64,
+    /// Hit ratio of the tiered cache, or `None` when it was not measured.
+    ///
+    /// This was the literal `0.85` in both `/api/metrics` and
+    /// `/api/storage/stats` — reported over a store holding zero entries, and
+    /// fed straight into the `< 0.7` "Low cache hit ratio" health check, which
+    /// therefore could never fire. `TieredStore` keeps no hit/miss counters, so
+    /// until it does the honest answer is `null`, not an estimate.
+    pub cache_hit_ratio: Option<f64>,
     pub compression_ratio: f64,
     pub backend_type: String,
     pub storage_size_mb: f64,
@@ -113,7 +123,7 @@ impl DashboardState {
             timestamp: SystemTime::now(),
             storage_stats: StorageMetrics {
                 total_entries: 0,
-                cache_hit_ratio: 0.0,
+                cache_hit_ratio: None,
                 compression_ratio: 0.0,
                 backend_type: "sled".to_string(),
                 storage_size_mb: 0.0,
@@ -137,6 +147,7 @@ impl DashboardState {
             storage,
             analyzer,
             metrics_cache: Arc::new(RwLock::new(initial_metrics)),
+            started_at: Instant::now(),
         })
     }
 
@@ -154,7 +165,8 @@ impl DashboardState {
         metrics.timestamp = SystemTime::now();
         metrics.storage_stats = StorageMetrics {
             total_entries: storage_stats.total_entries as u64,
-            cache_hit_ratio: 0.85, // Estimated - hot entries / total entries
+            // Not measured: nothing counts cache hits or misses. See the field.
+            cache_hit_ratio: None,
             compression_ratio: f64::from(storage_stats.compression_ratio),
             backend_type: storage_stats.warm_backend.clone(),
             storage_size_mb: storage_stats.hot_memory_kb as f64 / 1024.0, // Convert KB to MB
@@ -178,7 +190,13 @@ impl DashboardState {
                 .push("Consider increasing cache size or optimizing queries".to_string());
         }
 
-        if metrics.storage_stats.cache_hit_ratio < 0.7 {
+        // Only a measured ratio can fail this check. It used to be applied to
+        // the hardcoded 0.85 above, so "Low cache hit ratio" was unreachable.
+        if metrics
+            .storage_stats
+            .cache_hit_ratio
+            .is_some_and(|ratio| ratio < 0.7)
+        {
             issues.push("Low cache hit ratio".to_string());
             recommendations.push("Review access patterns and consider cache tuning".to_string());
         }
@@ -195,10 +213,8 @@ impl DashboardState {
             overall,
             issues,
             recommendations,
-            uptime_seconds: SystemTime::now()
-                .duration_since(SystemTime::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_secs(),
+            // Uptime is time since this server started, not time since 1970.
+            uptime_seconds: self.started_at.elapsed().as_secs(),
         };
 
         debug!(
@@ -225,16 +241,15 @@ pub fn create_dashboard_router(state: DashboardState) -> Router {
         .route("/api/diagnostics", get(get_diagnostics))
         // Real-time updates via Server-Sent Events
         .route("/api/events", get(metrics_stream))
-        .layer(
-            ServiceBuilder::new()
-                .layer(TraceLayer::new_for_http())
-                .layer(
-                    CorsLayer::new()
-                        .allow_origin(Any)
-                        .allow_methods(Any)
-                        .allow_headers(Any),
-                ),
-        )
+        // No CORS layer: the dashboard page is served from this same origin, so
+        // it needs none. What used to sit here was
+        // `CorsLayer::new().allow_origin(Any).allow_methods(Any).allow_headers(Any)`
+        // with no flag guarding it, which let any page the user happened to have
+        // open read `/api/analysis?path=<any filesystem path>` and POST to
+        // `/api/storage/operation`. `pmat serve` gates the same behaviour behind
+        // an explicit `--cors` opt-in; this dashboard has no such flag, so the
+        // permissive policy is simply gone rather than on by default.
+        .layer(ServiceBuilder::new().layer(TraceLayer::new_for_http()))
         .with_state(state)
 }
 
@@ -272,7 +287,8 @@ async fn get_storage_stats(State(state): State<DashboardState>) -> impl IntoResp
     let stats = state.storage.get_statistics();
     Json(json!({
         "total_entries": stats.total_entries,
-        "cache_hit_ratio": 0.85, // Estimated
+        // null, not an estimate: nothing counts hits or misses (see StorageMetrics).
+        "cache_hit_ratio": Value::Null,
         "compression_ratio": stats.compression_ratio,
         "backend_type": stats.warm_backend,
         "hot_memory_kb": stats.hot_memory_kb,
@@ -292,24 +308,66 @@ async fn storage_operation(
     debug!("Executing storage operation: {}", operation.action);
 
     match operation.action.as_str() {
-        "flush" => {
-            // Flush hot cache to persistent storage
-            Json(json!({
+        // Both of these arms used to be success literals that never touched
+        // `state.storage`: "flush" answered "Cache flushed successfully" without
+        // calling `TieredStore::flush()`, and "cleanup" answered
+        // "Cleanup completed" with a hardcoded `entries_cleaned: 0`. They now
+        // do the work and report what actually happened.
+        "flush" => match state.storage.flush() {
+            Ok(()) => Json(json!({
                 "status": "completed",
                 "message": "Cache flushed successfully",
                 "action": "flush"
             }))
-            .into_response()
-        }
+            .into_response(),
+            Err(e) => {
+                error!("Storage flush failed: {}", e);
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(json!({
+                        "status": "failed",
+                        "action": "flush",
+                        "error": "Storage flush failed",
+                        "message": e.to_string()
+                    })),
+                )
+                    .into_response()
+            }
+        },
         "cleanup" => {
-            // Clean up old entries
-            Json(json!({
-                "status": "completed",
-                "message": "Cleanup completed",
-                "action": "cleanup",
-                "entries_cleaned": 0
-            }))
-            .into_response()
+            // The only cleanup the store implements is evicting hot-cache
+            // entries older than a caller-chosen age. Guessing that age would be
+            // inventing a retention policy, so it is required rather than
+            // defaulted.
+            let max_age_seconds = operation
+                .options
+                .as_ref()
+                .and_then(|options| options.get("max_age_seconds"))
+                .and_then(Value::as_u64);
+
+            match max_age_seconds {
+                Some(max_age_seconds) => {
+                    let entries_cleaned = state.storage.cleanup_hot_cache(max_age_seconds);
+                    Json(json!({
+                        "status": "completed",
+                        "message": format!(
+                            "Evicted {entries_cleaned} hot cache entries older than {max_age_seconds}s"
+                        ),
+                        "action": "cleanup",
+                        "entries_cleaned": entries_cleaned
+                    }))
+                    .into_response()
+                }
+                None => (
+                    StatusCode::BAD_REQUEST,
+                    Json(json!({
+                        "status": "failed",
+                        "action": "cleanup",
+                        "error": "cleanup requires options.max_age_seconds (in seconds)"
+                    })),
+                )
+                    .into_response(),
+            }
         }
         "stats" => {
             let stats = state.storage.get_statistics();

--- a/src/tdg/web_dashboard_tests.rs
+++ b/src/tdg/web_dashboard_tests.rs
@@ -68,14 +68,14 @@ mod tests {
     fn test_storage_metrics_creation() {
         let metrics = StorageMetrics {
             total_entries: 100,
-            cache_hit_ratio: 0.85,
+            cache_hit_ratio: Some(0.85),
             compression_ratio: 0.65,
             backend_type: "sled".to_string(),
             storage_size_mb: 25.5,
         };
 
         assert_eq!(metrics.total_entries, 100);
-        assert!((metrics.cache_hit_ratio - 0.85).abs() < f64::EPSILON);
+        assert_eq!(metrics.cache_hit_ratio, Some(0.85));
         assert!((metrics.compression_ratio - 0.65).abs() < f64::EPSILON);
         assert_eq!(metrics.backend_type, "sled");
         assert!((metrics.storage_size_mb - 25.5).abs() < f64::EPSILON);
@@ -85,7 +85,7 @@ mod tests {
     fn test_storage_metrics_serialization() {
         let metrics = StorageMetrics {
             total_entries: 42,
-            cache_hit_ratio: 0.9,
+            cache_hit_ratio: Some(0.9),
             compression_ratio: 0.5,
             backend_type: "rocksdb".to_string(),
             storage_size_mb: 128.0,
@@ -212,7 +212,7 @@ mod tests {
             timestamp: SystemTime::now(),
             storage_stats: StorageMetrics {
                 total_entries: 50,
-                cache_hit_ratio: 0.8,
+                cache_hit_ratio: Some(0.8),
                 compression_ratio: 0.6,
                 backend_type: "libsql".to_string(),
                 storage_size_mb: 64.0,
@@ -244,7 +244,7 @@ mod tests {
             timestamp: SystemTime::UNIX_EPOCH + Duration::from_secs(1000000),
             storage_stats: StorageMetrics {
                 total_entries: 100,
-                cache_hit_ratio: 0.9,
+                cache_hit_ratio: Some(0.9),
                 compression_ratio: 0.7,
                 backend_type: "sled".to_string(),
                 storage_size_mb: 128.0,
@@ -470,28 +470,28 @@ mod tests {
     fn test_storage_metrics_zero_values() {
         let metrics = StorageMetrics {
             total_entries: 0,
-            cache_hit_ratio: 0.0,
+            cache_hit_ratio: Some(0.0),
             compression_ratio: 0.0,
             backend_type: String::new(),
             storage_size_mb: 0.0,
         };
 
         assert_eq!(metrics.total_entries, 0);
-        assert!(metrics.cache_hit_ratio.abs() < f64::EPSILON);
+        assert_eq!(metrics.cache_hit_ratio, Some(0.0));
     }
 
     #[test]
     fn test_storage_metrics_max_values() {
         let metrics = StorageMetrics {
             total_entries: u64::MAX,
-            cache_hit_ratio: 1.0,
+            cache_hit_ratio: Some(1.0),
             compression_ratio: 1.0,
             backend_type: "a".repeat(1000),
             storage_size_mb: f64::MAX,
         };
 
         assert_eq!(metrics.total_entries, u64::MAX);
-        assert!((metrics.cache_hit_ratio - 1.0).abs() < f64::EPSILON);
+        assert_eq!(metrics.cache_hit_ratio, Some(1.0));
     }
 
     #[test]
@@ -539,7 +539,7 @@ mod tests {
             timestamp: SystemTime::now(),
             storage_stats: StorageMetrics {
                 total_entries: 100,
-                cache_hit_ratio: 0.85,
+                cache_hit_ratio: Some(0.85),
                 compression_ratio: 0.6,
                 backend_type: "sled".to_string(),
                 storage_size_mb: 64.0,
@@ -578,7 +578,7 @@ mod tests {
     fn test_storage_metrics_json_roundtrip() {
         let original = StorageMetrics {
             total_entries: 12345,
-            cache_hit_ratio: 0.78,
+            cache_hit_ratio: Some(0.78),
             compression_ratio: 0.55,
             backend_type: "libsql".to_string(),
             storage_size_mb: 256.75,
@@ -588,7 +588,7 @@ mod tests {
         let roundtrip: StorageMetrics = serde_json::from_str(&json).unwrap();
 
         assert_eq!(roundtrip.total_entries, original.total_entries);
-        assert!((roundtrip.cache_hit_ratio - original.cache_hit_ratio).abs() < 0.001);
+        assert_eq!(roundtrip.cache_hit_ratio, original.cache_hit_ratio);
         assert_eq!(roundtrip.backend_type, original.backend_type);
     }
 
@@ -635,7 +635,7 @@ mod tests {
     fn test_storage_metrics_debug() {
         let metrics = StorageMetrics {
             total_entries: 50,
-            cache_hit_ratio: 0.75,
+            cache_hit_ratio: Some(0.75),
             compression_ratio: 0.5,
             backend_type: "test".to_string(),
             storage_size_mb: 32.0,
@@ -680,7 +680,7 @@ mod tests {
             timestamp: SystemTime::UNIX_EPOCH,
             storage_stats: StorageMetrics {
                 total_entries: 0,
-                cache_hit_ratio: 0.0,
+                cache_hit_ratio: Some(0.0),
                 compression_ratio: 0.0,
                 backend_type: String::new(),
                 storage_size_mb: 0.0,
@@ -812,7 +812,7 @@ mod property_tests {
         ) {
             let metrics = StorageMetrics {
                 total_entries,
-                cache_hit_ratio,
+                cache_hit_ratio: Some(cache_hit_ratio),
                 compression_ratio,
                 backend_type: "test".to_string(),
                 storage_size_mb,
@@ -822,7 +822,7 @@ mod property_tests {
             let roundtrip: StorageMetrics = serde_json::from_str(&json).unwrap();
 
             prop_assert_eq!(roundtrip.total_entries, total_entries);
-            prop_assert!((roundtrip.cache_hit_ratio - cache_hit_ratio).abs() < 0.0001);
+            prop_assert!((roundtrip.cache_hit_ratio.unwrap() - cache_hit_ratio).abs() < 0.0001);
         }
 
         #[test]
@@ -926,7 +926,7 @@ mod property_tests {
         ) {
             let original = StorageMetrics {
                 total_entries,
-                cache_hit_ratio,
+                cache_hit_ratio: Some(cache_hit_ratio),
                 compression_ratio: 0.5,
                 backend_type: "test".to_string(),
                 storage_size_mb: 64.0,
@@ -935,7 +935,7 @@ mod property_tests {
             let cloned = original.clone();
 
             prop_assert_eq!(cloned.total_entries, original.total_entries);
-            prop_assert!((cloned.cache_hit_ratio - original.cache_hit_ratio).abs() < f64::EPSILON);
+            prop_assert!((cloned.cache_hit_ratio.unwrap() - original.cache_hit_ratio.unwrap()).abs() < f64::EPSILON);
         }
 
         #[test]
@@ -947,7 +947,7 @@ mod property_tests {
                 timestamp,
                 storage_stats: StorageMetrics {
                     total_entries: 0,
-                    cache_hit_ratio: 0.0,
+                    cache_hit_ratio: Some(0.0),
                     compression_ratio: 0.0,
                     backend_type: String::new(),
                     storage_size_mb: 0.0,
@@ -990,7 +990,7 @@ mod integration_tests {
             timestamp: SystemTime::now(),
             storage_stats: StorageMetrics {
                 total_entries: 0,
-                cache_hit_ratio: 0.0,
+                cache_hit_ratio: Some(0.0),
                 compression_ratio: 0.0,
                 backend_type: "in-memory".to_string(),
                 storage_size_mb: 0.0,
@@ -1014,6 +1014,7 @@ mod integration_tests {
             storage,
             analyzer,
             metrics_cache: Arc::new(RwLock::new(initial_metrics)),
+            started_at: Instant::now(),
         }
     }
 
@@ -1159,8 +1160,11 @@ mod integration_tests {
         assert_eq!(response.status(), AxumStatusCode::OK);
     }
 
+    /// `{"action":"cleanup"}` used to answer 200 {"status":"completed",
+    /// "entries_cleaned":0} without touching storage. With no retention age to
+    /// work from there is nothing to clean, so it must not claim success.
     #[tokio::test]
-    async fn test_storage_operation_cleanup() {
+    async fn test_storage_operation_cleanup_without_max_age_is_rejected() {
         let state = create_test_state().await;
         let app = create_dashboard_router(state);
 
@@ -1176,7 +1180,38 @@ mod integration_tests {
             .await
             .unwrap();
 
+        assert_eq!(response.status(), AxumStatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_storage_operation_cleanup_reports_real_eviction_count() {
+        let state = create_test_state().await;
+        let app = create_dashboard_router(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/storage/operation")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        r#"{"action": "cleanup", "options": {"max_age_seconds": 0}}"#,
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
         assert_eq!(response.status(), AxumStatusCode::OK);
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        // An empty in-memory store really has nothing to evict; the point is
+        // that the number now comes from cleanup_hot_cache().
+        assert_eq!(json["entries_cleaned"], 0);
+        assert!(json["message"].as_str().unwrap().contains("hot cache"));
     }
 
     #[tokio::test]
@@ -1281,5 +1316,116 @@ mod integration_tests {
         // In-memory storage should report minimal statistics
         assert_eq!(stats.hot_entries, 0);
         assert_eq!(stats.warm_entries, 0);
+    }
+
+    /// `/api/health` reported `uptime_seconds` as seconds since the UNIX epoch
+    /// (1786295016, i.e. ~56.6 years, identical to the payload's own timestamp
+    /// and unchanged four seconds later), never as time since the server came
+    /// up.
+    #[tokio::test]
+    async fn uptime_is_measured_from_server_start_not_from_1970() {
+        let state = create_test_state().await;
+        state.update_metrics().await.unwrap();
+
+        let uptime = state.metrics_cache.read().await.health_status.uptime_seconds;
+        assert!(
+            uptime < 60,
+            "a server that just started cannot have been up {uptime}s"
+        );
+
+        let secs_since_epoch = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        assert_ne!(uptime, secs_since_epoch);
+    }
+
+    /// `cache_hit_ratio` was the literal 0.85 in both `/api/metrics` and
+    /// `/api/storage/stats`, and the `< 0.7` "Low cache hit ratio" check was
+    /// then evaluated against that same constant, so it could never fire.
+    #[tokio::test]
+    async fn cache_hit_ratio_is_reported_as_unmeasured() {
+        let state = create_test_state().await;
+        state.update_metrics().await.unwrap();
+
+        assert_eq!(
+            state.metrics_cache.read().await.storage_stats.cache_hit_ratio,
+            None,
+            "nothing counts cache hits, so no ratio may be reported"
+        );
+
+        let app = create_dashboard_router(state);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/storage/stats")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(
+            json["cache_hit_ratio"].is_null(),
+            "expected null, got {}",
+            json["cache_hit_ratio"]
+        );
+    }
+
+    /// The "Low cache hit ratio" issue must still be reachable for a measured
+    /// ratio below the threshold — otherwise the check is dead either way.
+    #[tokio::test]
+    async fn low_measured_cache_hit_ratio_is_still_an_issue() {
+        let state = create_test_state().await;
+        {
+            let mut metrics = state.metrics_cache.write().await;
+            metrics.storage_stats.cache_hit_ratio = Some(0.5);
+        }
+
+        let issues: Vec<String> = {
+            let metrics = state.metrics_cache.read().await;
+            let mut issues = Vec::new();
+            if metrics
+                .storage_stats
+                .cache_hit_ratio
+                .is_some_and(|ratio| ratio < 0.7)
+            {
+                issues.push("Low cache hit ratio".to_string());
+            }
+            issues
+        };
+        assert_eq!(issues, vec!["Low cache hit ratio".to_string()]);
+    }
+
+    /// The dashboard used to attach `CorsLayer::new().allow_origin(Any)
+    /// .allow_methods(Any).allow_headers(Any)` unconditionally, so any page the
+    /// user had open could read `/api/analysis?path=<any file>` and POST to
+    /// `/api/storage/operation`. Its own HTML is same-origin and needs no CORS.
+    #[tokio::test]
+    async fn no_cross_origin_access_is_granted() {
+        let state = create_test_state().await;
+        let app = create_dashboard_router(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/health")
+                    .header("origin", "https://evil.example")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            response
+                .headers()
+                .get("access-control-allow-origin")
+                .is_none(),
+            "dashboard must not advertise cross-origin access"
+        );
     }
 }

--- a/src/test_performance_suite.rs
+++ b/src/test_performance_suite.rs
@@ -1,3 +1,22 @@
+/// Report a throughput measurement against its target — and fail when it misses.
+///
+/// These checks used to compute the comparison, emit a `Warning:` line on
+/// stderr, then print the ✅ marker and return `Ok(())` unconditionally, so
+/// `pmat test throughput` reported
+/// "✅ Single-threaded throughput: 1593 LOC/s (target: ≥487000 LOC/s)" and
+/// exited 0 — a measurement 300x under its own target read as a pass. The
+/// comparison now decides both the marker and the return value.
+fn report_throughput(label: &str, actual: f64, required: f64, extra: &str) -> Result<()> {
+    println!(
+        "{} {label}: {actual:.0} LOC/s (target: ≥{required:.0} LOC/s){extra}",
+        if actual < required { "❌" } else { "✅" }
+    );
+    if actual < required {
+        anyhow::bail!("{label}: {actual:.0} LOC/s is below the required {required:.0} LOC/s");
+    }
+    Ok(())
+}
+
 /// Test single-threaded analysis throughput
 pub async fn test_single_threaded_throughput() -> Result<()> {
     let targets = PerformanceTargets::default();
@@ -33,20 +52,9 @@ pub async fn test_single_threaded_throughput() -> Result<()> {
     let duration = start.elapsed();
     let actual_throughput = (test_lines as f64) / duration.as_secs_f64();
 
-    // Performance may vary in test environment
-    if actual_throughput < targets.loc_per_sec_st as f64 * 0.8 {
-        eprintln!(
-            "Warning: Single-threaded throughput: {:.0} LOC/s, expected ≥{} LOC/s",
-            actual_throughput, targets.loc_per_sec_st
-        );
-    }
-
-    println!(
-        "✅ Single-threaded throughput: {:.0} LOC/s (target: ≥{} LOC/s)",
-        actual_throughput, targets.loc_per_sec_st
-    );
-
-    Ok(())
+    // 20% slack for test-environment variance; past that the measurement decides.
+    let required = targets.loc_per_sec_st as f64 * 0.8;
+    report_throughput("Single-threaded throughput", actual_throughput, required, "")
 }
 
 /// Test analysis performance with realistic project size
@@ -90,13 +98,12 @@ pub async fn test_realistic_project_analysis() -> Result<()> {
 
     // More lenient threshold for multi-file analysis due to I/O overhead
     let min_throughput = 100_000; // 100K LOC/s
-    if actual_throughput < f64::from(min_throughput) {
-        eprintln!("Warning: Multi-file analysis throughput: {actual_throughput:.0} LOC/s, expected ≥{min_throughput} LOC/s");
-    }
-
-    println!("✅ Multi-file analysis: {actual_throughput:.0} LOC/s, duration: {duration:?}");
-
-    Ok(())
+    report_throughput(
+        "Multi-file analysis",
+        actual_throughput,
+        f64::from(min_throughput),
+        &format!(", duration: {duration:?}"),
+    )
 }
 
 /// Test large file handling performance
@@ -133,15 +140,20 @@ pub async fn test_large_file_performance() -> Result<()> {
 
     // Large files should still be processed reasonably quickly
     let max_duration_secs = 30; // More lenient for test environments
+    let throughput = (test_lines as f64) / duration.as_secs_f64();
+    // Same defect as the throughput checks above: this used to warn on stderr
+    // and print ✅ anyway.
     if duration.as_secs() > max_duration_secs {
-        eprintln!(
-            "Warning: Large file analysis took {}s, expected ≤{}s for 100K LOC",
+        println!(
+            "❌ Large file performance: {throughput:.0} LOC/s, duration: {duration:?} (budget: ≤{max_duration_secs}s for 100K LOC)"
+        );
+        anyhow::bail!(
+            "Large file analysis took {}s, over the {}s budget for 100K LOC",
             duration.as_secs(),
             max_duration_secs
         );
     }
 
-    let throughput = (test_lines as f64) / duration.as_secs_f64();
     println!("✅ Large file performance: {throughput:.0} LOC/s, duration: {duration:?}");
 
     Ok(())
@@ -284,6 +296,30 @@ pub fn get_memory_usage_mb() -> u64 {
 
     // Fallback for other platforms or if reading fails
     0
+}
+
+#[cfg(test)]
+mod throughput_verdict_tests {
+    use super::*;
+
+    /// A measurement below its target must not report success.
+    #[test]
+    fn test_report_throughput_fails_below_target() {
+        // The exact numbers `pmat test throughput` printed a ✅ for.
+        let err = report_throughput("Single-threaded throughput", 1593.0, 487_000.0, "")
+            .expect_err("1593 LOC/s against a 487000 LOC/s target is a failure");
+        assert!(err.to_string().contains("below the required"), "{err}");
+        assert!(
+            report_throughput("Multi-file analysis", 67944.0, 100_000.0, "").is_err(),
+            "67944 LOC/s against a 100000 LOC/s target is a failure"
+        );
+    }
+
+    #[test]
+    fn test_report_throughput_passes_at_or_above_target() {
+        assert!(report_throughput("t", 100_000.0, 100_000.0, "").is_ok());
+        assert!(report_throughput("t", 500_000.0, 487_000.0, "").is_ok());
+    }
 }
 
 /// Run comprehensive performance test suite

--- a/src/test_performance_suite.rs
+++ b/src/test_performance_suite.rs
@@ -106,6 +106,17 @@ pub async fn test_realistic_project_analysis() -> Result<()> {
     )
 }
 
+/// Seconds a single analysis in this suite is allowed to take.
+///
+/// `handle_analyze_complexity` takes a `timeout` argument and prints
+/// "⏰ Analysis timeout set to 60 seconds", but nothing enforces it: `pmat test
+/// throughput` sat in `test_large_file_performance` for the whole of a 170s
+/// external `timeout` and was killed at exit 124, having printed the "Analyzing
+/// complexity of file" line and then nothing. Until the handler honours its own
+/// argument, the suite enforces the budget it advertises at the call site — a
+/// perf suite that never returns cannot report anything.
+const ANALYSIS_BUDGET_SECS: u64 = 60;
+
 /// Test large file handling performance
 pub async fn test_large_file_performance() -> Result<()> {
     let test_lines = 100_000; // 100K LOC single file
@@ -119,7 +130,10 @@ pub async fn test_large_file_performance() -> Result<()> {
     let start = Instant::now();
 
     use crate::cli::handlers::complexity_handlers;
-    complexity_handlers::handle_analyze_complexity(
+    // Spawned rather than awaited inline: the analysis is CPU-bound and does
+    // not yield, and `tokio::time::timeout` cannot interrupt a future that
+    // holds its worker thread. Off on its own task, the timer still fires.
+    let analysis = tokio::spawn(complexity_handlers::handle_analyze_complexity(
         temp_dir.path().to_path_buf(),
         Some(test_file), // file
         vec![],          // files
@@ -132,9 +146,20 @@ pub async fn test_large_file_performance() -> Result<()> {
         false,    // watch
         10,       // top_files
         false,    // fail_on_violation
-        60,       // timeout
-    )
-    .await?;
+        ANALYSIS_BUDGET_SECS, // timeout
+    ));
+
+    match tokio::time::timeout(Duration::from_secs(ANALYSIS_BUDGET_SECS), analysis).await {
+        Ok(joined) => joined??,
+        Err(_) => {
+            println!(
+                "❌ Large file performance: no result within {ANALYSIS_BUDGET_SECS}s for {test_lines} LOC"
+            );
+            anyhow::bail!(
+                "Large file analysis exceeded its own {ANALYSIS_BUDGET_SECS}s budget for {test_lines} LOC"
+            );
+        }
+    }
 
     let duration = start.elapsed();
 
@@ -169,8 +194,14 @@ pub async fn test_memory_usage_patterns() -> Result<()> {
     let test_code = generate_test_code(test_lines);
     fs::write(&test_file, &test_code)?;
 
-    // Get initial memory usage (approximate)
-    let initial_memory = get_memory_usage_mb();
+    // Peak resident set, in KB, before the analysis. This used to be
+    // `get_memory_usage_mb()` — VmRSS truncated to whole MB — and the "usage"
+    // was `final.saturating_sub(initial)`, a difference of two rounded-down MB
+    // figures over a transient allocation. It reported "✅ Memory usage: 0MB
+    // for 20K LOC" every single run, so `memory_used <= 10` could not fail and
+    // "Memory tests passed!" was unconditional. VmHWM in KB is the peak the
+    // analysis actually reached, at 1024x the resolution.
+    let before = MemorySample::read()?;
 
     // Run analysis
     use crate::cli::handlers::complexity_handlers;
@@ -191,22 +222,27 @@ pub async fn test_memory_usage_patterns() -> Result<()> {
     )
     .await?;
 
-    let final_memory = get_memory_usage_mb();
-    let memory_used = final_memory.saturating_sub(initial_memory);
+    let after = MemorySample::read()?;
+    let peak_growth_kb = after.peak_kb.saturating_sub(before.peak_kb);
 
     // Memory usage should be reasonable for 20K LOC
-    let expected_memory_mb = 10; // Conservative estimate
-    assert!(
-        memory_used <= expected_memory_mb,
-        "Memory usage: {}MB for {}K LOC, expected ≤{}MB",
-        memory_used,
-        test_lines / 1000,
-        expected_memory_mb
-    );
+    const BUDGET_KB: u64 = 10 * 1024; // 10 MB, as before — now in KB
+    if peak_growth_kb > BUDGET_KB {
+        println!(
+            "❌ Memory usage: peak grew {peak_growth_kb} KB for {}K LOC (budget: ≤{BUDGET_KB} KB)",
+            test_lines / 1000
+        );
+        anyhow::bail!(
+            "Peak resident memory grew {peak_growth_kb} KB for {}K LOC, over the {BUDGET_KB} KB budget",
+            test_lines / 1000
+        );
+    }
 
     println!(
-        "✅ Memory usage: {}MB for {}K LOC",
-        memory_used,
+        "✅ Memory usage: peak RSS {} KB (was {} KB), analysis added {} KB for {}K LOC",
+        after.peak_kb,
+        before.peak_kb,
+        peak_growth_kb,
         test_lines / 1000
     );
 
@@ -277,11 +313,53 @@ pub async fn test_performance_regression_detection() -> Result<()> {
 }
 
 fn parse_vmrss_kb(status: &str) -> Option<u64> {
+    parse_status_kb(status, "VmRSS:")
+}
+
+/// A `/proc/self/status` size field, in KB.
+fn parse_status_kb(status: &str, field: &str) -> Option<u64> {
     status
         .lines()
-        .find(|line| line.starts_with("VmRSS:"))
+        .find(|line| line.starts_with(field))
         .and_then(|line| line.split_whitespace().nth(1))
         .and_then(|kb_str| kb_str.parse::<u64>().ok())
+}
+
+/// Resident memory in KB: current (`VmRSS`) and peak (`VmHWM`).
+///
+/// `read()` fails rather than substituting 0 when the figures are unavailable.
+/// The memory gate used to source its numbers from a function that returned 0
+/// on any read or parse failure, so a platform where nothing could be measured
+/// printed "Memory usage: 0MB" and passed — a gate that cannot measure must not
+/// report a pass.
+#[derive(Debug, Clone, Copy)]
+pub struct MemorySample {
+    pub rss_kb: u64,
+    pub peak_kb: u64,
+}
+
+impl MemorySample {
+    /// Read the current process's resident memory.
+    ///
+    /// # Errors
+    /// Returns an error when `/proc/self/status` cannot be read or does not
+    /// carry `VmRSS`/`VmHWM` — i.e. when the measurement does not exist.
+    pub fn read() -> Result<Self> {
+        #[cfg(target_os = "linux")]
+        {
+            let status = std::fs::read_to_string("/proc/self/status").map_err(|e| {
+                anyhow::anyhow!("cannot measure memory: /proc/self/status unreadable: {e}")
+            })?;
+            let rss_kb = parse_status_kb(&status, "VmRSS:")
+                .ok_or_else(|| anyhow::anyhow!("cannot measure memory: no VmRSS in status"))?;
+            let peak_kb = parse_status_kb(&status, "VmHWM:")
+                .ok_or_else(|| anyhow::anyhow!("cannot measure memory: no VmHWM in status"))?;
+            Ok(Self { rss_kb, peak_kb })
+        }
+
+        #[cfg(not(target_os = "linux"))]
+        anyhow::bail!("cannot measure memory: resident-set reporting is Linux-only on this build")
+    }
 }
 
 /// Approximate memory usage in MB (platform-specific)
@@ -320,12 +398,78 @@ mod throughput_verdict_tests {
         assert!(report_throughput("t", 100_000.0, 100_000.0, "").is_ok());
         assert!(report_throughput("t", 500_000.0, 487_000.0, "").is_ok());
     }
+
+    /// Running zero tests is not a pass. `pmat test performance` reached this
+    /// function with every sub-suite disabled and printed
+    /// "✅ All performance tests passed!".
+    #[tokio::test]
+    async fn test_suite_with_nothing_enabled_is_an_error() {
+        let config = PerformanceTestConfig {
+            enable_regression_tests: false,
+            enable_memory_tests: false,
+            enable_throughput_tests: false,
+            test_iterations: 3,
+        };
+        let err = run_performance_test_suite(config)
+            .await
+            .expect_err("a run that measured nothing must not report success");
+        assert!(err.to_string().contains("nothing was measured"), "{err}");
+    }
+
+    /// The memory gate read whole MB and reported the difference of two rounded
+    /// figures, which was 0 on every run. KB resolution is the point.
+    #[test]
+    fn test_memory_sample_reads_kb_resolution() {
+        let sample = MemorySample::read().expect("linux test host exposes /proc/self/status");
+        assert!(
+            sample.rss_kb > 1024,
+            "RSS {} KB looks unmeasured",
+            sample.rss_kb
+        );
+        assert!(
+            sample.peak_kb >= sample.rss_kb,
+            "peak {} KB below current {} KB",
+            sample.peak_kb,
+            sample.rss_kb
+        );
+
+        // The resolution the old reading threw away: a 500 KB growth is 0 MB
+        // on both sides of the subtraction the gate used to perform.
+        let before = "VmRSS:\t  102400 kB\nVmHWM:\t  102400 kB\n";
+        let after = "VmRSS:\t  102900 kB\nVmHWM:\t  102900 kB\n";
+        let before_kb = parse_status_kb(before, "VmHWM:").unwrap();
+        let after_kb = parse_status_kb(after, "VmHWM:").unwrap();
+        assert_eq!(after_kb - before_kb, 500);
+        assert_eq!(after_kb / 1024 - before_kb / 1024, 0, "the old MB view");
+    }
+
+    #[test]
+    fn test_parse_status_kb_reads_peak_field() {
+        let status = "Name:\tpmat\nVmRSS:\t  123456 kB\nVmHWM:\t  234567 kB\n";
+        assert_eq!(parse_status_kb(status, "VmRSS:"), Some(123_456));
+        assert_eq!(parse_status_kb(status, "VmHWM:"), Some(234_567));
+        assert_eq!(parse_status_kb(status, "VmNope:"), None);
+    }
 }
 
 /// Run comprehensive performance test suite
 pub async fn run_performance_test_suite(config: PerformanceTestConfig) -> Result<()> {
     println!("🏃 Running PMAT Performance Test Suite (SPECIFICATION.md Section 30)");
     println!("================================================================");
+
+    // With every sub-suite disabled this function skipped all three blocks and
+    // printed "✅ All performance tests passed!" anyway — which is what
+    // `pmat test performance` (the CLI default suite) did on every invocation,
+    // byte-identically in an empty directory and in a 4260-file repository.
+    // Zero tests run is not a pass.
+    if !config.enable_throughput_tests
+        && !config.enable_regression_tests
+        && !config.enable_memory_tests
+    {
+        anyhow::bail!(
+            "no performance sub-suite was enabled, so nothing was measured (expected at least one of throughput/regression/memory)"
+        );
+    }
 
     if config.enable_throughput_tests {
         println!("\n📊 Throughput Tests:");

--- a/src/tests/diagnose_tests.rs
+++ b/src/tests/diagnose_tests.rs
@@ -82,7 +82,7 @@ mod tests {
             degraded: 1,
             skipped: 1,
             all_passed: false,
-            success_rate: 70.0,
+            success_rate: Some(70.0),
         };
 
         assert_eq!(summary.total, 10);
@@ -90,7 +90,7 @@ mod tests {
         assert_eq!(summary.failed, 1);
         assert_eq!(summary.degraded, 1);
         assert!(!summary.all_passed);
-        assert!((summary.success_rate - 70.0).abs() < f64::EPSILON);
+        assert!((summary.success_rate.unwrap() - 70.0).abs() < f64::EPSILON);
     }
 
     #[test]
@@ -218,10 +218,10 @@ mod tests {
             degraded: 0,
             skipped: 0,
             all_passed: true,
-            success_rate: 100.0,
+            success_rate: Some(100.0),
         };
 
         assert!(summary.all_passed);
-        assert!((summary.success_rate - 100.0).abs() < f64::EPSILON);
+        assert!((summary.success_rate.unwrap() - 100.0).abs() < f64::EPSILON);
     }
 }

--- a/src/utils/command_suggestions_comprehensive_tests.rs
+++ b/src/utils/command_suggestions_comprehensive_tests.rs
@@ -276,7 +276,12 @@ mod comprehensive_coverage_tests {
         assert!(examples.contains("Find dead code"));
         assert!(examples.contains("Generate project context"));
         assert!(examples.contains("Run quality gates"));
-        assert!(examples.contains("Start agent daemon"));
+        // Was `assert!(examples.contains("Start agent daemon"))` — the third
+        // test pinning an example that cannot run in the shipped build, where
+        // `pmat agent start` exits 1 with "Agent daemon feature not enabled"
+        // (#675). Assert the inverse so it cannot silently return.
+        assert!(examples.contains("Pre-flight the CI gate set"));
+        assert!(!examples.contains("pmat agent start"));
         assert!(examples.contains("--path"));
     }
 

--- a/src/utils/command_suggestions_suggester.rs
+++ b/src/utils/command_suggestions_suggester.rs
@@ -133,8 +133,13 @@ impl CommandSuggester {
             "# Run quality gates",
             "pmat quality-gate",
             "",
-            "# Start agent daemon",
-            "pmat agent start",
+            // Not `pmat agent start`: the agent daemon is compiled out unless
+            // `--features agent-daemon` is set, so in the shipped build that
+            // example exits 1 with "Agent daemon feature not enabled" (#675).
+            // These are advertised as *working* examples, so every line here
+            // must run in the default build.
+            "# Pre-flight the CI gate set before committing",
+            "pmat verify --format json",
         ];
 
         format!("\nEXAMPLES:\n{}", examples.join("\n"))

--- a/src/utils/command_suggestions_tests.rs
+++ b/src/utils/command_suggestions_tests.rs
@@ -68,7 +68,14 @@ mod extended_tests {
         assert!(examples.contains("pmat analyze dead-code"));
         assert!(examples.contains("pmat context"));
         assert!(examples.contains("pmat quality-gate"));
-        assert!(examples.contains("pmat agent start"));
+        assert!(examples.contains("pmat verify"));
+        // The old assertion pinned `pmat agent start` here, which is compiled
+        // out of the shipped build (#675) — the test was holding the defect in
+        // place. Assert the inverse so it can never come back.
+        assert!(
+            !examples.contains("pmat agent start"),
+            "help examples must run in the default build; the agent daemon does not"
+        );
     }
 
     #[test]

--- a/tests/modules/debug_replay_tests.rs
+++ b/tests/modules/debug_replay_tests.rs
@@ -3,129 +3,61 @@
 //
 // Tests for `pmat debug replay` command implementation
 // These tests drive the creation of replay handler and Timeline UI integration
+//
+// `handle_debug_replay` now exits the process with
+// DEBUG_UNIMPLEMENTED_EXIT_CODE (2) instead of returning `Err`, matching
+// `pmat serve`'s honest-failure policy. Calling it from a test would take the
+// whole test binary down with it, and the assertions here were
+// `result.is_ok() || result.is_err()` — true for every possible Result, so they
+// never checked anything. They now pin the signature and the diagnostic, which
+// is what "the handler exists and is callable with these parameters" was
+// trying to say.
 
 use std::path::PathBuf;
 use tempfile::NamedTempFile;
 
-// RED Test 1: Handler function exists and is callable
-#[tokio::test]
-async fn test_replay_handler_exists() {
-    // This test drives the creation of the handle_debug_replay function
-    // Expected: pmat::cli::handlers::debug_handlers::handle_debug_replay exists
-
+/// The handler exists with the documented signature.
+#[test]
+fn test_replay_handler_exists() {
+    // Building the future type-checks the signature without running it.
     let recording = PathBuf::from("test_recording.pmat");
-    let position = None;
-    let interactive = false;
-
-    // Try to call the handler (will fail until GREEN phase)
-    let result =
-        pmat::cli::handlers::debug_handlers::handle_debug_replay(recording, position, interactive)
-            .await;
-
-    // Handler should either succeed or return a meaningful error
-    // (not panic or fail to compile)
-    assert!(
-        result.is_ok() || result.is_err(),
-        "Handler should return a Result type"
-    );
+    let _future = pmat::cli::handlers::debug_handlers::handle_debug_replay(recording, None, false);
 }
 
-// RED Test 2: Handler validates recording file exists
-#[tokio::test]
-#[ignore = "RED phase test - debug replay validation not yet implemented"]
-async fn test_replay_validates_file_exists() {
-    // This test ensures the handler checks if recording file exists
-    // before attempting to load it
-
-    let nonexistent = PathBuf::from("/nonexistent/recording.pmat");
-
-    let result =
-        pmat::cli::handlers::debug_handlers::handle_debug_replay(nonexistent.clone(), None, false)
-            .await;
-
-    // Should return an error for nonexistent file
-    assert!(result.is_err(), "Should fail for nonexistent file");
-
-    let error_msg = result.unwrap_err().to_string();
-    assert!(
-        error_msg.contains("not found")
-            || error_msg.contains("does not exist")
-            || error_msg.contains("No such file"),
-        "Error should indicate file not found: {}",
-        error_msg
-    );
-}
-
-// RED Test 3: Handler accepts position parameter
-#[tokio::test]
-async fn test_replay_accepts_position() {
-    // This test verifies the handler accepts --position parameter
-    // for jumping to a specific point in the recording
-
-    // Create a temporary file to simulate a recording
+/// The handler accepts a recording path, a `--position` and `--interactive`.
+#[test]
+fn test_replay_accepts_position_and_interactive() {
     let temp_file = NamedTempFile::new().expect("Failed to create temp file");
     let recording = temp_file.path().to_path_buf();
-
-    // Write minimal recording data
     std::fs::write(&recording, b"mock_recording_data").expect("Failed to write mock data");
 
-    let position = Some(5);
-    let result =
-        pmat::cli::handlers::debug_handlers::handle_debug_replay(recording, position, false).await;
-
-    // Handler should accept the position parameter
-    // (may fail for invalid format, but shouldn't panic)
-    assert!(
-        result.is_ok() || result.is_err(),
-        "Handler should process position parameter"
-    );
+    // Building the future type-checks every parameter without running it — the
+    // handler exits the process, so it must not be awaited here.
+    let _future =
+        pmat::cli::handlers::debug_handlers::handle_debug_replay(recording.clone(), Some(5), true);
+    let _future = pmat::cli::handlers::debug_handlers::handle_debug_replay(recording, None, false);
 }
 
-// RED Test 4: Handler supports interactive mode
-#[tokio::test]
-async fn test_replay_interactive_mode() {
-    // This test verifies the handler supports --interactive flag
-    // for step-through debugging
-
-    // Create a temporary file to simulate a recording
-    let temp_file = NamedTempFile::new().expect("Failed to create temp file");
-    let recording = temp_file.path().to_path_buf();
-
-    // Write minimal recording data
-    std::fs::write(&recording, b"mock_recording_data").expect("Failed to write mock data");
-
-    let interactive = true;
-    let result =
-        pmat::cli::handlers::debug_handlers::handle_debug_replay(recording, None, interactive)
-            .await;
-
-    // Handler should accept the interactive parameter
-    assert!(
-        result.is_ok() || result.is_err(),
-        "Handler should process interactive parameter"
-    );
-}
-
-// RED Test 5: Handler displays Timeline UI output
-#[tokio::test]
-async fn test_replay_displays_timeline() {
-    // This test verifies the handler integrates with Timeline UI
-    // Sprint 72-73: Terminal-based visualization
-
-    // Create a temporary file to simulate a recording
-    let temp_file = NamedTempFile::new().expect("Failed to create temp file");
-    let recording = temp_file.path().to_path_buf();
-
-    // Write minimal recording data (should be valid format)
-    std::fs::write(&recording, b"mock_recording_data").expect("Failed to write mock data");
-
-    let result =
-        pmat::cli::handlers::debug_handlers::handle_debug_replay(recording, None, false).await;
-
-    // Handler should attempt to display Timeline UI
-    // (may fail for invalid format, but function should exist)
-    assert!(
-        result.is_ok() || result.is_err(),
-        "Handler should attempt to display timeline"
+/// The diagnostic names DEBUG-003 and says plainly that nothing replays yet.
+///
+/// Replaces "Handler should attempt to display timeline", which asserted
+/// nothing: no timeline is displayed and none was checked for.
+#[test]
+fn test_replay_reports_it_is_not_implemented() {
+    let mut buf = Vec::new();
+    pmat::cli::handlers::debug_handlers::write_debug_unimplemented_message(
+        &mut buf,
+        "replay",
+        "DEBUG-003",
+        "recording=\"/tmp/recording.pmat\" position=Some(5) interactive=true",
+    )
+    .expect("write");
+    let s = String::from_utf8(buf).expect("utf8");
+    assert!(s.contains("DEBUG-003"), "got: {s}");
+    assert!(s.contains("not implemented"), "got: {s}");
+    assert_eq!(
+        pmat::cli::handlers::debug_handlers::DEBUG_UNIMPLEMENTED_EXIT_CODE,
+        2,
+        "unimplemented must exit 2 (misuse), not 1"
     );
 }

--- a/tests/modules/debug_serve_tests.rs
+++ b/tests/modules/debug_serve_tests.rs
@@ -10,31 +10,39 @@ use pmat::services::dap::DapServer;
 use tokio::net::TcpListener;
 use tokio::time::{timeout, Duration};
 
-// RED Test 1: Handler function exists and is callable
-#[tokio::test]
-async fn test_debug_serve_handler_exists() {
-    // This test drives the creation of the debug_handlers module
-    // Expected: pmat::cli::handlers::debug_handlers::handle_debug_serve exists
+// RED Test 1: Handler function exists and reports itself unimplemented
+//
+// This used to spawn `handle_debug_serve` and comment "Server should be running
+// now" — it never was; the handler bailed immediately and the task's Err was
+// discarded, so the test passed on a handler that binds no socket at all. The
+// handler now exits the process with DEBUG_UNIMPLEMENTED_EXIT_CODE, so awaiting
+// it here would take the test binary down. Pin the signature and the honest
+// diagnostic instead.
+#[test]
+fn test_debug_serve_handler_exists() {
+    // Building the future type-checks the signature without running it.
+    let _future = pmat::cli::handlers::debug_handlers::handle_debug_serve(
+        15678,
+        "127.0.0.1".to_string(),
+        None,
+    );
 
-    let port = 15678; // Use non-standard port for tests
-    let host = "127.0.0.1".to_string();
-
-    // Spawn handler in background task (server runs indefinitely)
-    let handler_task = tokio::spawn(async move {
-        pmat::cli::handlers::debug_handlers::handle_debug_serve(port, host, None).await
-    });
-
-    // Give server time to start
-    tokio::time::sleep(Duration::from_millis(100)).await;
-
-    // Server should be running now - abort the task
-    handler_task.abort();
-
-    // Wait for cleanup
-    tokio::time::sleep(Duration::from_millis(50)).await;
-
-    // Test passes if handler was callable and started successfully
-    // (The fact that we got here means the handler exists and didn't panic)
+    let mut buf = Vec::new();
+    pmat::cli::handlers::debug_handlers::write_debug_unimplemented_message(
+        &mut buf,
+        "serve",
+        "DEBUG-002",
+        "host=127.0.0.1 port=15678 record_dir=None",
+    )
+    .expect("write");
+    let s = String::from_utf8(buf).expect("utf8");
+    assert!(s.contains("DEBUG-002"), "got: {s}");
+    assert!(s.contains("not implemented"), "got: {s}");
+    assert_eq!(
+        pmat::cli::handlers::debug_handlers::DEBUG_UNIMPLEMENTED_EXIT_CODE,
+        2,
+        "unimplemented must exit 2 (misuse), not 1"
+    );
 }
 
 // RED Test 2: DAP server can start on specified port


### PR DESCRIPTION
Dogfood of the **released 3.29.0 artifact** — a fresh `cargo install pmat --version 3.29.0` from crates.io into an isolated root, not a working-tree build.

## What the sweep did

14 parallel probes ran **1,154 real invocations** across the whole surface: 259 CLI leaf/group commands, all 20 MCP stdio tools, and the HTTP/serve surface. Every metric was checked for movement between an empty directory, a 1-file crate, a polyglot tree, an unparseable crate and the 4,260-file repo — a number that does not move between those measures nothing.

Every candidate was re-run by an independent adversarial verifier instructed to default to REFUTED. **30 were refuted, 12 were duplicates, 3 were already fixed on HEAD**, and **243 survived**: 48 blocker, 137 major, 58 minor. Filed as #730–#912 individually, #913 (minors, batched), #914 (tracking).

## What this PR fixes

**All 243.** 48 blockers, 137 majors, 58 minors, in six commits. Nearly every fix carries a regression test that was checked to *fail* without it — the wave agents reverted each fix in place, confirmed the test went red, then restored.

The dominant class is unchanged from the last three sweeps — output pmat never measured, presented as a measurement — so most of these fixes **remove** a number rather than correct one. Where a gate could not measure a signal it now says so and declines to report a pass. That is a deliberate, user-visible behaviour change in several commands.

### Cross-surface contradiction (new to this sweep)

The MCP tool and its CLI equivalent disagreeing about the same file:

- MCP `analyze_dag` always returned an empty call graph — `add_call_edges` was only ever wired into the CLI handler, so the service path filtered every edge away and reported the empty result as success.
- MCP `analyze_complexity` used the heuristic counter while the CLI project scan used the AST analyzer — 10/18 vs 6/9 for one function. They now agree exactly.
- MCP `quality_gate` graded a file that does not parse, and a README, at the maximum 90.0/A.
- MCP `quality_proxy` edit/append never opened the target file, so an edit whose anchor text was absent was still "accepted".

### Flags that parse but change nothing (49 of them)

`enforce --profile` returned the same profile from every match arm — three names, one profile, and a typo silently enforced the strictest thresholds. `ci-local --format` was destructured as `format: _`. `comply diff` ignored `--from/--to`. `pmat_query_code`'s `path_pattern`, advertised as a glob, was a substring match. `-f markdown` on `analyze provability` and `analyze tdg` emitted ANSI-escaped plain text byte-identical to the terminal renderer; `--color never` leaked escapes through several commands.

### Fabricated values removed

`enforce extreme` pushed literal violations naming a path that exists in no project and a hardcoded `coverage 65.0`, so every project read 15 points under the 80% floor. `analyze provability --functions <name>` turned any string into a FunctionId with no lookup. `analyze entropy` and `analyze big-o` walked hidden dot-directories every other analyzer excludes. `cache stats` printed byte-identical output for an empty directory and the whole repo. `qdd refactor` printed coverage from a `#[test]-count × 10 / lines` guess.

### False green lights

`verify --stage <typo>` selected no stages, so `ok:true` and exit 0 came back from a tree whose format stage was red. `cuda-tdg validate-tiles` printed "Status: INVALID / shared memory overflow" and exited 0 — CI gating on it passed overflowing configurations.

## Tests that asserted the defects

Fourteen tests broke across the waves. All were triaged independently and **none was an over-reaching fix**. They asserted the defect itself — a "simulated" 65% coverage, a stub that "always returns empty", an unknown `--profile` resolving to the extreme thresholds, a shared-memory overflow returning `Ok`, a `-f markdown` arm whose own comment said it used the detailed renderer. Two proptests had the stub written down as an invariant ("every changelog entry has the current version"). Five vacuous tests asserted `result.is_ok() || result.is_err()`. All were rewritten to assert correct behaviour with their coverage intent intact, not deleted.

## Verified at the artifact level, not just in tests

The binary was rebuilt and the repros re-run, which is how the last commit's defect was found — fixing MCP `quality_gate`'s parse guard left the CLI's `quality-gate --file` still reporting PASSED for the same unparseable file.

| Defect | Released 3.29.0 | This branch |
|---|---|---|
| `query --format json` | 2 concatenated JSON docs, unparseable | one valid document |
| MCP vs CLI `analyze_complexity` | 10/18 vs 6/9 | identical |
| MCP `quality_gate`, unparseable file | 90.0 / grade A | refuses to grade |
| CLI `quality-gate --file`, unparseable .py | PASSED, exit 0 | refuses, exit 4 |
| `analyze big-o` function count | 2,650,897 | 54,837 |
| `cache stats` | byte-identical, empty dir vs repo | "not measured" |
| `verify --stage <typo>` | `ok:true`, exit 0 | exit nonzero |
| `cuda-tdg validate-tiles` overflow | "INVALID", exit 0 | exit 2 |
| `technical_debt_hours` | `-0.0` | `0.0` |
| tdg grade histogram | every bucket ≥30 drawn identically | scales (1416→30, 64→2) |
| `analyze provability -f markdown` | ANSI, identical to `-f full` | real Markdown, no escapes |
| `debug serve` | claimed a DAP server, bound nothing | exits 2 with the reason |

## Gate

19,066 lib tests pass, 0 fail. Clippy clean under the flags `ci / lint` uses.

## Notes

- #639 was closed separately: it no longer reproduces in released 3.29.0.
- This branch stacks on the unmerged #724 (3.29.1).
- Tracking issue #914 stays open until this merges.

Closes #730, Closes #731, Closes #732, Closes #733, Closes #734, Closes #735
Closes #736, Closes #737, Closes #738, Closes #739, Closes #740, Closes #741
Closes #742, Closes #743, Closes #744, Closes #745, Closes #746, Closes #747
Closes #748, Closes #749, Closes #750, Closes #751, Closes #752, Closes #753
Closes #754, Closes #755, Closes #756, Closes #757, Closes #758, Closes #759
Closes #760, Closes #761, Closes #762, Closes #763, Closes #764, Closes #765
Closes #766, Closes #767, Closes #768, Closes #769, Closes #770, Closes #771
Closes #772, Closes #773, Closes #774, Closes #775, Closes #776, Closes #777
Closes #778, Closes #779, Closes #780, Closes #781, Closes #782, Closes #783
Closes #784, Closes #785, Closes #786, Closes #787, Closes #788, Closes #789
Closes #790, Closes #791, Closes #792, Closes #793, Closes #794, Closes #795
Closes #796, Closes #797, Closes #798, Closes #799, Closes #800, Closes #801
Closes #802, Closes #803, Closes #804, Closes #805, Closes #806, Closes #807
Closes #808, Closes #809, Closes #810, Closes #811, Closes #812, Closes #813
Closes #814, Closes #815, Closes #816, Closes #817, Closes #818, Closes #819
Closes #820, Closes #821, Closes #822, Closes #823, Closes #824, Closes #825
Closes #826, Closes #827, Closes #828, Closes #829, Closes #830, Closes #831
Closes #832, Closes #833, Closes #834, Closes #835, Closes #836, Closes #837
Closes #838, Closes #839, Closes #840, Closes #841, Closes #842, Closes #843
Closes #844, Closes #845, Closes #846, Closes #847, Closes #848, Closes #849
Closes #850, Closes #851, Closes #852, Closes #853, Closes #854, Closes #855
Closes #856, Closes #857, Closes #858, Closes #859, Closes #860, Closes #861
Closes #862, Closes #863, Closes #864, Closes #865, Closes #866, Closes #867
Closes #868, Closes #869, Closes #870, Closes #871, Closes #872, Closes #873
Closes #874, Closes #875, Closes #876, Closes #877, Closes #878, Closes #879
Closes #880, Closes #881, Closes #882, Closes #883, Closes #884, Closes #885
Closes #886, Closes #887, Closes #888, Closes #889, Closes #890, Closes #891
Closes #892, Closes #893, Closes #894, Closes #895, Closes #896, Closes #897
Closes #898, Closes #899, Closes #900, Closes #901, Closes #902, Closes #903
Closes #904, Closes #905, Closes #906, Closes #907, Closes #908, Closes #909
Closes #910, Closes #911, Closes #912, Closes #913

🤖 Generated with [Claude Code](https://claude.com/claude-code)
