### PR TITLE
fix: a 60s dead-code budget reported "could not be measured" for measurable projects

### DIFF
--- a/src/cli/handlers/dead_code_handlers_budget_tests.rs
+++ b/src/cli/handlers/dead_code_handlers_budget_tests.rs
@@ -61,7 +61,13 @@ async fn a_suppressed_function_is_counted_and_typed_as_a_function() {
         None,
     );
 
-    let outcome = run_dead_code_analysis_with_filters(root, filters(0), Duration::from_secs(120))
+    // Generous on purpose: this test asserts what the analysis FOUND, not how
+    // fast it ran, and the budget is wall clock over a `cargo check` of a fresh
+    // crate. At 120s it failed in CI — not because the two-function fixture is
+    // slow, but because a runner executing ~19,800 tests starved the blocking
+    // task. A timing bound in a test that is not about timing is a flake with no
+    // upside; the one test that IS about the budget uses 1 second, below.
+    let outcome = run_dead_code_analysis_with_filters(root, filters(0), Duration::from_secs(600))
         .await
         .expect("analysis runs");
 

--- a/src/cli/handlers/enforce_handlers/analysis.rs
+++ b/src/cli/handlers/enforce_handlers/analysis.rs
@@ -566,8 +566,26 @@ pub async fn run_tdg_analysis(
     Ok(PhaseOutcome::measured(violations))
 }
 
+/// Wall-clock budget for the dead-code phase of an `enforce` run.
+///
+/// Was 60. Dead-code analysis shells out to `cargo check`, and that budget is
+/// wall clock — it covers waiting for the build, not just the analysis — so on
+/// a cold target directory, a large workspace, or a loaded machine it expired
+/// on work that was progressing normally, and the phase reported
+/// "dead code could not be measured" for a project that is perfectly
+/// measurable. A false "not measured" is the worse failure here: it is exactly
+/// the absence-rendered-as-a-result that the surrounding code goes to lengths
+/// to avoid, and 60 seconds is not enough of a wall to be worth hitting.
+///
+/// It fires on a genuine hang, which is what a budget is for. This also stops
+/// four tests flaking in CI, where a contended runner starved the blocking task
+/// long enough to trip the old value — but the user-facing false negative is
+/// the reason to change it.
+const DEAD_CODE_BUDGET_SECS: u64 = 300;
+
 /// Run dead code analysis - extracted from `list_all_violations` (complexity: ≤10)
 #[provable_contracts_macros::contract("pmat-core.yaml", equation = "path_exists")]
+
 pub async fn run_dead_code_analysis(
     project_path: &Path,
     _profile: &QualityProfile,
@@ -592,7 +610,7 @@ pub async fn run_dead_code_analysis(
         Some(capture.clone()), // output
         false,                 // fail_on_violation
         15.0,                  // max_percentage
-        60,                    // timeout
+        DEAD_CODE_BUDGET_SECS, // timeout
         Vec::new(),            // include
         Vec::new(),            // exclude
         8,                     // max_depth


### PR DESCRIPTION
`enforce`'s dead-code phase passed a hardcoded 60-second timeout. That budget is **wall
clock around a `cargo check`** — it covers waiting for a build, not just the analysis — so it
expired on work that was progressing normally whenever the target directory was cold, the
workspace large, or the machine loaded. The phase then reported:

```
dead code could not be measured (dead code not measured: Dead code analysis timed out after 60 seconds)
```

for a project that is perfectly measurable.

That is precisely the absence-rendered-as-a-result the surrounding file goes to lengths to
avoid — `warn_not_measured` exists so a missing signal travels with the outcome rather than
being silently substituted — and then the budget manufactured missing signals.

Raised to **300s**, as a named constant with the reasoning attached. It still fires on a
genuine hang, which is what a budget is for.

## How it surfaced

Four tests failed on #990's CI run and passed on a re-run of the **identical commit**:

- `enforce_handlers::states::composite_score_regression_tests::score_distinguishes_an_empty_directory_from_a_violating_project`
- `enforce_handlers::surface_agreement_tests::the_refactoring_state_reports_the_run_it_did_not_change`
- `enforce_handlers::surface_agreement_tests::apply_suggestions_agrees_with_every_other_surface_and_terminates`
- `dead_code_handlers::budget_tests::a_suppressed_function_is_counted_and_typed_as_a_function`

All four are the same timeout, and the fixtures are tiny — one is a two-function temp crate.
They did not fail because the analysis is slow: a runner executing ~19,800 tests starved the
blocking task `run_multi_language_dead_code_within` spawns, and the timer fired against a task
that had barely been scheduled.

**The flake is worth fixing on its own, but the user-facing false negative is the reason to
change the constant.** A required check that fails at random is a gate nobody can trust; a
false "not measured" is a wrong answer shipped to users.

## Also

The budget test that asserts what the analysis *found* gets 600s — a timing bound in a test
that is not about timing is a flake with no upside. `a_cargo_check_that_outruns_the_budget_is_killed_and_reported`
keeps its 1 second: that one **is** about the budget, and its fixture sleeps 20s in a build
script so it stays deterministic regardless of machine speed.

Verified: the 15 tests across all three affected modules pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)