### PR TITLE
fix: the docs.rs gate could not tell "not built yet" from "build failed"

### DIFF
--- a/.github/workflows/docsrs.yml
+++ b/.github/workflows/docsrs.yml
@@ -176,8 +176,24 @@ jobs:
           cat /tmp/st.json
 
           status=$(python3 -c "import json;print(json.load(open('/tmp/st.json')).get('doc_status'))")
-          if [ "$status" != "True" ]; then
-            echo "::error::docs.rs reports doc_status=$status for pmat $ver — the published crate has NO documentation. https://docs.rs/crate/pmat/$ver/builds"
-            exit 1
+          if [ "$status" = "True" ]; then
+            echo "pmat $ver documents cleanly on docs.rs"
+            exit 0
           fi
-          echo "pmat $ver documents cleanly on docs.rs"
+
+          # `doc_status: false` means BOTH "the build failed" and "the build has
+          # not run yet", and a freshly published version sits in the queue for
+          # minutes. Reporting a failure for a build that never ran is the same
+          # unmeasured-passes-as-measured defect this gate exists to catch, with
+          # the sign flipped — so distinguish before failing.
+          #
+          # The queue page is the discriminator, verified against both states at
+          # the 3.30.1 release: it listed `pmat 3.30.1` while queued, and does
+          # not list `pmat 3.30.0`, which genuinely failed.
+          if curl -sf https://docs.rs/releases/queue | grep -qE "pmat[[:space:]]+${ver//./\.}([^0-9]|$)"; then
+            echo "::notice::pmat $ver is still in the docs.rs build queue — not built yet, so there is nothing to report. Re-run once it leaves the queue."
+            exit 0
+          fi
+
+          echo "::error::docs.rs reports doc_status=$status for pmat $ver, and it is not in the build queue — the published crate has NO documentation. https://docs.rs/crate/pmat/$ver/builds"
+          exit 1


### PR DESCRIPTION
`status.json` returns `doc_status: false` for **both** "the build failed" and "the build has
not run yet", and a freshly published version sits in the docs.rs queue for minutes.

Watching 3.30.1 publish, there was a window where this gate would have reported that the
release had no documentation — about a build that had not started. That is the same defect
the gate exists to catch, with the sign flipped: reporting on something unmeasured as though
it had been measured. A gate that cries wolf right after every release is one people learn to
ignore, which costs exactly the signal it was added for.

## The discriminator, verified against both real states

| version | `doc_status` | in queue | verdict |
|---|---|---|---|
| 3.30.1 | `True` | — | PASS |
| 3.30.0 | `False` | no | FAIL — genuinely never built |
| 3.29.0 | `False` | no | FAIL — genuinely never built |

And while 3.30.1 was building, `https://docs.rs/releases/queue` listed `pmat 3.30.1` and did
**not** list `pmat 3.30.0`. So presence in the queue is a real signal, not a guess about
timing.

Queued now emits a notice and exits 0. A genuine failure still fails, and the error names the
builds URL. An unreachable status API still fails closed.

Found by using the gate on a real release rather than reasoning about it — which is also how
3.30.1 itself got here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)