### PR TITLE
fix: satd --include-tests could not reach an inline #[cfg(test)] block

### DIFF
--- a/src/services/satd_detector/detection.rs
+++ b/src/services/satd_detector/detection.rs
@@ -705,3 +705,69 @@ mod build_script_exclusion_regression_tests {
         assert_eq!(found.len(), 1, "{found:?}");
     }
 }
+
+#[cfg(test)]
+mod include_tests_reaches_inline_blocks {
+    //! REGRESSION (#994): `--include-tests` could not reach an inline
+    //! `#[cfg(test)]` block, so the two halves of "test code" behaved
+    //! differently and one of them was unreachable by any invocation.
+    //!
+    //! | where the debt lives | before | after |
+    //! |---|---|---|
+    //! | `tests/it.rs` | included by the flag | unchanged |
+    //! | `src/lib.rs`, in `#[cfg(test)] mod tests` | **no flag could reach it** | included by the flag |
+    //!
+    //! `include_tests` reached file DISCOVERY only, so it chose which paths to
+    //! open and had no say over what was read inside them.
+    use crate::services::satd_detector::SATDDetector;
+    use std::path::Path;
+
+    const INLINE: &str = "pub fn f() -> i32 { 1 }\n\
+                          \n\
+                          #[cfg(test)]\n\
+                          mod tests {\n\
+                          \x20   // TODO: debt inside an inline test module\n\
+                          \x20   // FIXME: and more of it\n\
+                          \x20   #[test] fn t() { assert_eq!(1, 1); }\n\
+                          }\n";
+
+    /// The default stays as it was: inline test blocks are production-clean.
+    #[test]
+    fn excluded_by_default() {
+        let found = SATDDetector::new()
+            .extract_from_content(INLINE, Path::new("src/lib.rs"))
+            .expect("extraction");
+        assert!(
+            found.is_empty(),
+            "inline test debt must stay out of a production scan, got {found:?}"
+        );
+    }
+
+    /// …and is now reachable, which is the whole defect.
+    #[test]
+    fn reachable_when_tests_are_requested() {
+        let found = SATDDetector::new()
+            .extract_from_content_with_tests(INLINE, Path::new("src/lib.rs"), true)
+            .expect("extraction");
+        assert_eq!(
+            found.len(),
+            2,
+            "both markers must be reachable with include_tests, got {found:?}"
+        );
+    }
+
+    /// Production debt is reported either way — the flag adds, never replaces.
+    #[test]
+    fn production_debt_is_unaffected_by_the_flag() {
+        let mixed = format!("// TODO: production\n{INLINE}");
+        let d = SATDDetector::new();
+        let without = d
+            .extract_from_content(&mixed, Path::new("src/lib.rs"))
+            .expect("extraction");
+        let with = d
+            .extract_from_content_with_tests(&mixed, Path::new("src/lib.rs"), true)
+            .expect("extraction");
+        assert_eq!(without.len(), 1, "production marker only: {without:?}");
+        assert_eq!(with.len(), 3, "production + both inline markers: {with:?}");
+    }
+}

--- a/src/services/satd_detector/detection_analysis.rs
+++ b/src/services/satd_detector/detection_analysis.rs
@@ -88,7 +88,8 @@ impl SATDDetector {
             }
 
             stats.total_files_analyzed += 1;
-            self.process_single_file(file_path, stats).await;
+            self.process_single_file(file_path, include_tests, stats)
+                .await;
         }
     }
 
@@ -116,12 +117,18 @@ impl SATDDetector {
         // Check file size constraints
         if let Ok(metadata) = tokio::fs::metadata(file_path).await {
             if metadata.len() > crate::services::file_classifier::LARGE_FILE_THRESHOLD as u64 {
-                eprintln!("Warning: Skipped: {} (large file >500KB)", file_path.display());
+                eprintln!(
+                    "Warning: Skipped: {} (large file >500KB)",
+                    file_path.display()
+                );
                 return true;
             }
 
             if metadata.len() > 1_000_000 && self.is_likely_minified_content(file_path).await {
-                eprintln!("Warning: Skipped: {} (minified content)", file_path.display());
+                eprintln!(
+                    "Warning: Skipped: {} (minified content)",
+                    file_path.display()
+                );
                 return true;
             }
         }
@@ -130,7 +137,12 @@ impl SATDDetector {
     }
 
     /// Toyota Way: Extract Method - process individual file (complexity <=8)
-    async fn process_single_file(&self, file_path: &Path, stats: &mut ProjectAnalysisStats) {
+    async fn process_single_file(
+        &self,
+        file_path: &Path,
+        include_tests: bool,
+        stats: &mut ProjectAnalysisStats,
+    ) {
         match tokio::fs::read_to_string(file_path).await {
             Ok(content) => {
                 if content.len() > 10_000_000 {
@@ -142,7 +154,7 @@ impl SATDDetector {
                     return;
                 }
 
-                match self.extract_from_content(&content, file_path) {
+                match self.extract_from_content_with_tests(&content, file_path, include_tests) {
                     Ok(debts) => {
                         if !debts.is_empty() {
                             stats.files_with_debt += 1;
@@ -249,7 +261,7 @@ impl SATDDetector {
             }
 
             analyzed += 1;
-            let debts = self.process_file_for_debts(&file_path).await;
+            let debts = self.process_file_for_debts(&file_path, include_tests).await;
             all_debts.extend(debts);
         }
 
@@ -320,9 +332,13 @@ impl SATDDetector {
         false
     }
 
-    async fn process_file_for_debts(&self, file_path: &Path) -> Vec<TechnicalDebt> {
+    async fn process_file_for_debts(
+        &self,
+        file_path: &Path,
+        include_tests: bool,
+    ) -> Vec<TechnicalDebt> {
         match tokio::fs::read_to_string(file_path).await {
-            Ok(content) => self.extract_debts_from_content(&content, file_path),
+            Ok(content) => self.extract_debts_from_content(&content, file_path, include_tests),
             Err(_e) => {
                 // Silently skip unreadable files
                 // BUG-010: Removed noisy warning that interleaved with progress
@@ -331,7 +347,12 @@ impl SATDDetector {
         }
     }
 
-    fn extract_debts_from_content(&self, content: &str, file_path: &Path) -> Vec<TechnicalDebt> {
+    fn extract_debts_from_content(
+        &self,
+        content: &str,
+        file_path: &Path,
+        include_tests: bool,
+    ) -> Vec<TechnicalDebt> {
         // Validate file size before processing
         if content.len() > 10_000_000 {
             eprintln!(
@@ -343,7 +364,7 @@ impl SATDDetector {
         }
 
         // Silently skip files that fail parsing (BUG-010: Removed noisy warning)
-        self.extract_from_content(content, file_path)
+        self.extract_from_content_with_tests(content, file_path, include_tests)
             .unwrap_or_default()
     }
 }

--- a/src/services/satd_detector/detection_extraction.rs
+++ b/src/services/satd_detector/detection_extraction.rs
@@ -40,12 +40,43 @@ impl SATDDetector {
         Self { debt_classifier }
     }
 
-    /// Extract technical debt from source code content
+    /// Extract technical debt from source code content, excluding inline
+    /// `#[cfg(test)]` blocks.
+    ///
+    /// Equivalent to [`Self::extract_from_content_with_tests`] with
+    /// `include_tests = false`.
     #[provable_contracts_macros::contract("pmat-core.yaml", equation = "path_exists")]
     pub fn extract_from_content(
         &self,
         content: &str,
         file_path: &Path,
+    ) -> Result<Vec<TechnicalDebt>, TemplateError> {
+        self.extract_from_content_with_tests(content, file_path, false)
+    }
+
+    /// Extract technical debt from source code content.
+    ///
+    /// `include_tests` reaches the inline `#[cfg(test)]` skip below. It did not
+    /// before, and the two halves of "test code" were treated differently as a
+    /// result (#994):
+    ///
+    /// | where the debt lives | reported under `--include-tests`? |
+    /// |---|---|
+    /// | `tests/it.rs` | yes |
+    /// | `src/lib.rs`, inside `#[cfg(test)] mod tests` | **no, and no flag could** |
+    ///
+    /// `include_tests` only ever reached file *discovery*
+    /// (`discover_files`, `should_skip_file`), so it selected which paths to
+    /// open and had no say over what was read inside them. In Rust the inline
+    /// `#[cfg(test)] mod tests` is the dominant idiom, so the majority of test
+    /// code sat in the half no invocation could reach — a marker that is
+    /// present, and that every invocation reports as absent.
+    #[provable_contracts_macros::contract("pmat-core.yaml", equation = "path_exists")]
+    pub fn extract_from_content_with_tests(
+        &self,
+        content: &str,
+        file_path: &Path,
+        include_tests: bool,
     ) -> Result<Vec<TechnicalDebt>, TemplateError> {
         let mut debts = Vec::new();
 
@@ -70,7 +101,7 @@ impl SATDDetector {
             test_tracker.update_from_line(line.trim());
             let comment = scanner.scan_line(line);
 
-            if test_tracker.is_in_test_block() {
+            if !include_tests && test_tracker.is_in_test_block() {
                 continue;
             }
             if let Some(debt) = self.debt_of(comment, file_path, line_num as u32 + 1) {


### PR DESCRIPTION
Found dogfooding the published **3.30.1** artifact. Closes #994.

Two SATD markers inside `#[cfg(test)] mod tests` in a production source file were reported by
**no invocation**:

```
pmat analyze satd -p fix --format json                  -> 0 items
pmat analyze satd -p fix --format json --include-tests  -> 0 items
grep -c 'TODO\|FIXME' fix/src/lib.rs                    -> 2
```

## Cause

`include_tests` only ever reached file **discovery** (`discover_files`, `should_skip_file`), so
it chose which paths to open and had no say over what was read inside them. The inline skip was
unconditional:

```rust
if test_tracker.is_in_test_block() { continue; }
```

So "test code" split in two, and the halves behaved differently:

| where the debt lives | before |
|---|---|
| `tests/it.rs` | included by `--include-tests` |
| `src/lib.rs`, in `#[cfg(test)] mod tests` | **no flag could reach it** |

In Rust the inline `#[cfg(test)] mod tests` is the dominant idiom, so the unreachable half is
the larger one — a marker that is present, which every invocation reports as absent.

## What the fix touched

`extract_from_content_with_tests` threads the flag to the one place that decides.
`extract_from_content` keeps its signature and delegates with `false`, so every other caller is
unchanged and the default scan stays production-only.

Threading it took **four hops** — `process_project_files` → `process_single_file` →
`process_file_for_debts` → `extract_debts_from_content` — because the CLI does not use the
entry point the flag was already plumbed through. `analyze satd` goes `SatdFacade` →
`analyze_directory_with_tests`, while `analyze_project` is a separate path, and
`analysis_service_analyzers::analyze_satd` hardcodes `true` while ignoring its own `_options`
argument. One rule, several implementations, the flag reaching some of them.

## Verification

```
/tmp/dogfood-satd  (2 markers, both inline)
  before   baseline 0   --include-tests 0
  after    baseline 0   --include-tests 2

mixed fixture (2 production + 1 inline + 1 in tests/)
  before   baseline 2   --include-tests 3
  after    baseline 2   --include-tests 4
```

Three regression tests pin all three properties: excluded by default, reachable when requested,
and production debt unaffected either way. `cargo test --lib satd`: **419 passing**.

## Method note

This sweep produced **5** candidate no-ops against the shipped artifact. **Four were faults in
my fixtures, not in pmat** — `--include-tests` and `--include-unreachable` on a fixture with no
test files or no unreachable code, `--fail-on-violation` with no violations, `--strict` without
the markers it filters. Each behaved correctly once given a fixture that could exercise it.
Only this one survived. The ratio is in #994, because a sweep that does not say how many of its
own findings were harness bugs is not reporting a measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)