### PR TITLE
fix: a full wgpu struct literal turns every new field into a build break

### DIFF
--- a/src/services/analytics_backend_gpu.rs
+++ b/src/services/analytics_backend_gpu.rs
@@ -7,9 +7,9 @@ static INIT: Once = Once::new();
 /// Manages wgpu device lifecycle and compute shader dispatch.
 /// Includes PCIe bandwidth calibration for query optimization.
 pub struct GpuDevice {
-     // Used for GPU compute operations
+    // Used for GPU compute operations
     device: wgpu::Device,
-     // Used for GPU command submission
+    // Used for GPU command submission
     queue: wgpu::Queue,
     pcie_bandwidth_gbps: f64,
 }
@@ -42,10 +42,19 @@ impl GpuDevice {
 
         // Request adapter (GPU device)
         let adapter =
+            // `..Default::default()` on purpose: wgpu adds fields to this
+            // struct across majors, and a full literal turns every such
+            // addition into a compile error in a feature nothing routinely
+            // builds. wgpu 30.0.0 added `apply_limit_buckets` and broke
+            // `--features analytics-gpu` with E0063 — caught only because the
+            // feature matrix added this release compiles every advertised
+            // feature. The three fields below are the ones this code has an
+            // opinion about; the rest are wgpu's defaults by intent.
             pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
                 power_preference: wgpu::PowerPreference::HighPerformance,
                 force_fallback_adapter: false,
                 compatible_surface: None,
+                ..Default::default()
             }))
             .context("Failed to find GPU adapter. Ensure GPU drivers are installed.")?;
 
@@ -57,16 +66,15 @@ impl GpuDevice {
         );
 
         // Request device and queue
-        let (device, queue) =
-            pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
-                label: Some("PMAT Analytics GPU"),
-                required_features: wgpu::Features::empty(),
-                required_limits: wgpu::Limits::default(),
-                memory_hints: Default::default(),
-                experimental_features: Default::default(),
-                trace: Default::default(),
-            }))
-            .context("Failed to create GPU device")?;
+        let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
+            label: Some("PMAT Analytics GPU"),
+            required_features: wgpu::Features::empty(),
+            required_limits: wgpu::Limits::default(),
+            memory_hints: Default::default(),
+            experimental_features: Default::default(),
+            trace: Default::default(),
+        }))
+        .context("Failed to create GPU device")?;
 
         // Calibrate PCIe bandwidth
         let pcie_bandwidth_gbps = Self::calibrate_pcie_bandwidth(&device, &queue)?;
@@ -111,13 +119,7 @@ impl GpuDevice {
         let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
             label: Some("PCIe Calibration Encoder"),
         });
-        encoder.copy_buffer_to_buffer(
-            &gpu_buffer,
-            0,
-            &staging_buffer,
-            0,
-            test_bytes.len() as u64,
-        );
+        encoder.copy_buffer_to_buffer(&gpu_buffer, 0, &staging_buffer, 0, test_bytes.len() as u64);
         queue.submit(std::iter::once(encoder.finish()));
 
         // Wait for GPU operations to complete


### PR DESCRIPTION
wgpu 30.0.0 adds `apply_limit_buckets` to `RequestAdapterOptions`, and this initializer listed
every field, so dependabot #728 failed with:

```
error[E0063]: missing field `apply_limit_buckets` in initializer of
              `RequestAdapterOptions<&wgpu::Surface<'_>>`
```

in `--features analytics-gpu`.

## Why this matters beyond the one bump

**Nothing would have caught it before this release.** `ci.yml` compiles `--bin pmat` with
default features, and `analytics-gpu` is not among them — so the bump would have merged green
and shipped a feature that does not build. That is precisely how six advertised features
shipped broken in 3.30.0.

The feature matrix added in #990 is the only thing that saw this, and it is the first real
defect it has caught on a change not already known to be bad.

## The fix

`..Default::default()`, keeping explicit the three fields this code has an opinion about.

wgpu adds fields to this struct across majors — this is the second time — and a full literal
makes each addition a compile error in a configuration nothing routinely builds. The identical
shape broke three full literals of `TdgScore` in 3.30.0 when a field was added to it, in
`benches/`, `examples/` and a feature-gated module.

Compiles against the wgpu 29 in the lockfile, so master is unaffected; #728 should go green on
rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)