### PR TITLE
fix: MCP and the CLI answered the same SATD question with different numbers

### DIFF
--- a/examples/issue_053_mcp_tools.rs
+++ b/examples/issue_053_mcp_tools.rs
@@ -130,6 +130,7 @@ fn main() {
     let satd_result = tool_functions::analyze_satd(
         std::slice::from_ref(&satd_file),
         false, // don't include resolved
+        false, // don't include test files — matches `analyze satd`'s default
     )
     .await?;
 

--- a/src/mcp_pmcp/analyze_debt_handlers.rs
+++ b/src/mcp_pmcp/analyze_debt_handlers.rs
@@ -6,6 +6,9 @@ struct SatdArgs {
     paths: Vec<String>,
     #[serde(default)]
     include_resolved: bool,
+    /// Include test files. Defaults to false, matching `analyze satd` (#997).
+    #[serde(default)]
+    include_tests: bool,
 }
 
 /// Tool handler for detecting self-admitted technical debt in code comments.
@@ -18,7 +21,8 @@ struct SatdArgs {
 /// ```json
 /// {
 ///   "paths": ["src/"],              // Required: paths to analyze
-///   "include_resolved": false       // Optional: include resolved items
+///   "include_resolved": false,      // Optional: include resolved items
+///   "include_tests": false          // Optional: include test files (CLI default: false)
 /// }
 /// ```ignore
 ///
@@ -64,9 +68,10 @@ impl ToolHandler for SatdTool {
 
         let paths = crate::mcp_pmcp::tool_schemas::resolve_existing_paths(params.paths)?;
 
-        let results = tool_functions::analyze_satd(&paths, params.include_resolved)
-            .await
-            .map_err(|e| Error::internal(format!("SATD analysis failed: {e}")))?;
+        let results =
+            tool_functions::analyze_satd(&paths, params.include_resolved, params.include_tests)
+                .await
+                .map_err(|e| Error::internal(format!("SATD analysis failed: {e}")))?;
 
         Ok(results)
     }

--- a/src/mcp_pmcp/tool_functions/analysis_tools.rs
+++ b/src/mcp_pmcp/tool_functions/analysis_tools.rs
@@ -101,7 +101,17 @@ pub async fn analyze_complexity(
 }
 
 #[provable_contracts_macros::contract("pmat-core.yaml", equation = "path_exists")]
-pub async fn analyze_satd(paths: &[PathBuf], _include_resolved: bool) -> Result<Value> {
+/// `include_tests` exists because this tool used to have no concept of test
+/// files at all, while the CLI excludes them by default. For the same fixture
+/// the two surfaces answered 3 and 2, and the MCP schema offered no way to ask
+/// for the CLI's answer — so neither could be made to agree with the other
+/// (#997). It defaults to `false`, matching `analyze satd`'s default and
+/// `AnalysisOptions::default()`.
+pub async fn analyze_satd(
+    paths: &[PathBuf],
+    _include_resolved: bool,
+    include_tests: bool,
+) -> Result<Value> {
     use crate::services::satd_detector::SATDDetector;
 
     // Validate input
@@ -110,7 +120,12 @@ pub async fn analyze_satd(paths: &[PathBuf], _include_resolved: bool) -> Result<
     }
 
     let detector = SATDDetector::new();
-    let files = expand_paths_to_source_files(paths);
+    let mut files = expand_paths_to_source_files(paths);
+    // The SAME predicate the CLI's discovery uses. A second opinion about what
+    // "a test file" means is how these two surfaces drifted apart.
+    if !include_tests {
+        files.retain(|f| !detector.is_test_file(f));
+    }
 
     let mut total_satd = 0;
     let mut file_results = Vec::new();
@@ -526,7 +541,8 @@ pub async fn analyze_big_o(paths: &[PathBuf], top_files: Option<usize>) -> Resul
     // `_truncated`); keep the two surfaces telling the same story.
     let listed = high_complexity.len();
     let dist = &report.complexity_distribution;
-    let found = (dist.quadratic + dist.cubic + dist.exponential).max(report.high_complexity_functions.len());
+    let found = (dist.quadratic + dist.cubic + dist.exponential)
+        .max(report.high_complexity_functions.len());
 
     Ok(json!({
         "status": "completed",
@@ -805,9 +821,9 @@ mod big_o_payload_tests {
         );
         for func in functions {
             // A notation string ("O(n²)"), not the packed bound struct.
-            let time = func["time_complexity"].as_str().unwrap_or_else(|| {
-                panic!("time_complexity must be a notation string: {func}")
-            });
+            let time = func["time_complexity"]
+                .as_str()
+                .unwrap_or_else(|| panic!("time_complexity must be a notation string: {func}"));
             assert!(time.starts_with("O("), "unexpected notation {time:?}");
             assert!(func["time_complexity_confidence"].is_number());
             assert!(func["space_complexity"].is_string());
@@ -896,5 +912,101 @@ mod dead_code_include_tests_tests {
             Some("multi-language-reachability"),
             "the payload must name which analyzer produced these numbers"
         );
+    }
+}
+
+#[cfg(test)]
+mod satd_surface_agreement_tests {
+    //! REGRESSION (#997): the MCP tool and `analyze satd` answered the same
+    //! question differently, and the MCP schema offered no way to ask for the
+    //! CLI's answer — so neither surface could be made to agree with the other.
+    //!
+    //! ```text
+    //! MCP  analyze_satd {"paths":[fixture]}      -> 3
+    //! CLI  analyze satd -p fixture               -> 2
+    //! CLI  analyze satd -p fixture --include-tests -> 3
+    //! ```
+    //!
+    //! This tool had no concept of a test file at all: it walked
+    //! `expand_paths_to_source_files` and scanned whatever came back. It is the
+    //! THIRD independent SATD implementation — the CLI goes through
+    //! `SatdFacade::analyze_directory_with_tests`, and
+    //! `analysis_service_analyzers::analyze_satd` hardcodes `true` while
+    //! ignoring its own options argument.
+    use super::*;
+
+    fn fixture() -> tempfile::TempDir {
+        let d = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir_all(d.path().join("src")).expect("src");
+        std::fs::create_dir_all(d.path().join("tests")).expect("tests");
+        std::fs::write(
+            d.path().join("Cargo.toml"),
+            "[package]\nname=\"f\"\nversion=\"0.1.0\"\nedition=\"2021\"\n",
+        )
+        .expect("manifest");
+        std::fs::write(
+            d.path().join("src/lib.rs"),
+            "// TODO: production marker\n// FIXME: production fixme\npub fn f() -> i32 { 1 }\n",
+        )
+        .expect("lib");
+        std::fs::write(
+            d.path().join("tests/it.rs"),
+            "// TODO: integration-test marker\n#[test] fn t() { assert_eq!(1,1); }\n",
+        )
+        .expect("it");
+        d
+    }
+
+    fn total(v: &serde_json::Value) -> u64 {
+        v.get("results")
+            .and_then(|r| r.get("total_satd"))
+            .and_then(serde_json::Value::as_u64)
+            .expect("total_satd in the payload")
+    }
+
+    /// The default must match the CLI's default: production only.
+    #[tokio::test]
+    async fn default_excludes_test_files_like_the_cli() {
+        let d = fixture();
+        let out = analyze_satd(&[d.path().to_path_buf()], false, false)
+            .await
+            .expect("analysis");
+        assert_eq!(
+            total(&out),
+            2,
+            "MCP default must agree with `analyze satd` (2 production markers): {out}"
+        );
+    }
+
+    /// And the flag must be able to reach the CLI's `--include-tests` answer.
+    #[tokio::test]
+    async fn include_tests_reaches_the_cli_include_tests_answer() {
+        let d = fixture();
+        let out = analyze_satd(&[d.path().to_path_buf()], false, true)
+            .await
+            .expect("analysis");
+        assert_eq!(
+            total(&out),
+            3,
+            "include_tests must agree with `--include-tests` (3 markers): {out}"
+        );
+    }
+
+    /// The two must never be the same number, or the test above proves nothing
+    /// about the flag.
+    #[tokio::test]
+    async fn the_flag_actually_moves_the_answer() {
+        let d = fixture();
+        let off = total(
+            &analyze_satd(&[d.path().to_path_buf()], false, false)
+                .await
+                .unwrap(),
+        );
+        let on = total(
+            &analyze_satd(&[d.path().to_path_buf()], false, true)
+                .await
+                .unwrap(),
+        );
+        assert!(on > off, "include_tests changed nothing: {off} vs {on}");
     }
 }

--- a/src/mcp_pmcp/tool_functions_tests.rs
+++ b/src/mcp_pmcp/tool_functions_tests.rs
@@ -96,7 +96,7 @@ mod coverage_tests {
 
     #[tokio::test]
     async fn test_analyze_satd_empty_paths() {
-        let result = analyze_satd(&[], false).await;
+        let result = analyze_satd(&[], false, false).await;
         assert!(result.is_err());
         assert!(result
             .unwrap_err()
@@ -715,7 +715,7 @@ mod coverage_tests {
     #[tokio::test]
     async fn test_analyze_satd_with_nonexistent_paths() {
         let paths = vec![PathBuf::from("/tmp/nonexistent_12345.rs")];
-        let result = analyze_satd(&paths, false).await;
+        let result = analyze_satd(&paths, false, false).await;
 
         assert!(result.is_ok());
         let json = result.unwrap();
@@ -768,7 +768,7 @@ mod coverage_tests {
         )?;
 
         let paths = vec![file_path];
-        let result = analyze_satd(&paths, false).await;
+        let result = analyze_satd(&paths, false, false).await;
 
         assert!(result.is_ok());
         let json = result.unwrap();
@@ -997,7 +997,7 @@ mod coverage_tests {
         )?;
 
         let paths = vec![temp_dir.path().to_path_buf()];
-        let json = analyze_satd(&paths, false).await.unwrap();
+        let json = analyze_satd(&paths, false, false).await.unwrap();
 
         let total = json["results"]["total_satd"].as_u64().unwrap_or(0);
         assert!(
@@ -1214,7 +1214,7 @@ mod coverage_tests {
         )?;
 
         let pattern = temp.path().join("**/*.rs");
-        let json = analyze_satd(&[pattern], false).await?;
+        let json = analyze_satd(&[pattern], false, false).await?;
 
         let total = json["results"]["total_satd"].as_u64().unwrap_or(0);
         assert!(

--- a/src/services/satd_detector/detection_file_discovery.rs
+++ b/src/services/satd_detector/detection_file_discovery.rs
@@ -156,7 +156,7 @@ impl SATDDetector {
     /// a segment — classified every file in the project as test code and
     /// reported the whole tree clean.
     #[provable_contracts_macros::contract("pmat-core.yaml", equation = "path_exists")]
-    pub(crate) fn is_test_file(&self, path: &Path) -> bool {
+    pub fn is_test_file(&self, path: &Path) -> bool {
         // Check if path contains test directories
         let path_str = source_scope::project_relative_str(path);
         if source_scope::has_dir_component(&path_str, &["tests", "test"]) {

--- a/tests/modules/issue_053_mcp_tool_placeholders.rs
+++ b/tests/modules/issue_053_mcp_tool_placeholders.rs
@@ -104,7 +104,7 @@ async fn test_analyze_satd_calls_real_service() {
     );
 
     // Call analyze_satd with the test file
-    let result = tool_functions::analyze_satd(std::slice::from_ref(&file_path), false)
+    let result = tool_functions::analyze_satd(std::slice::from_ref(&file_path), false, false)
         .await
         .unwrap();
 
@@ -202,7 +202,7 @@ async fn test_analyze_complexity_empty_paths_error() {
 #[ignore = "Issue #53: RED test - analyze_satd with empty paths returns error"]
 async fn test_analyze_satd_empty_paths_error() {
     // Call with empty paths array
-    let result = tool_functions::analyze_satd(&[], false).await;
+    let result = tool_functions::analyze_satd(&[], false, false).await;
 
     // Should return an error for empty paths
     assert!(
@@ -287,14 +287,14 @@ async fn test_analyze_satd_respects_include_resolved() {
     );
 
     // Test without resolved comments
-    let result_without = tool_functions::analyze_satd(std::slice::from_ref(&file_path), false)
+    let result_without = tool_functions::analyze_satd(std::slice::from_ref(&file_path), false, false)
         .await
         .unwrap();
 
     let total_without = result_without["results"]["total_satd"].as_u64().unwrap();
 
     // Test with resolved comments
-    let result_with = tool_functions::analyze_satd(std::slice::from_ref(&file_path), true)
+    let result_with = tool_functions::analyze_satd(std::slice::from_ref(&file_path), true, false)
         .await
         .unwrap();
 

--- a/tests/modules/tool_functions_tests.rs
+++ b/tests/modules/tool_functions_tests.rs
@@ -29,7 +29,7 @@ async fn test_analyze_complexity_empty_paths() {
 #[tokio::test]
 async fn test_analyze_satd_empty_paths() {
     // RED: Should error when paths array is empty
-    let result = analyze_satd(&[], false).await;
+    let result = analyze_satd(&[], false, false).await;
 
     assert!(result.is_err());
     let err = result.unwrap_err();
@@ -96,7 +96,7 @@ async fn test_analyze_complexity_nonexistent_path() {
 async fn test_analyze_satd_nonexistent_path() {
     // RED: Should handle nonexistent paths gracefully
     let nonexistent = PathBuf::from("/nonexistent/file.rs");
-    let result = analyze_satd(&[nonexistent], false).await;
+    let result = analyze_satd(&[nonexistent], false, false).await;
 
     // Should succeed with 0 SATD found
     assert!(result.is_ok());
@@ -225,7 +225,7 @@ async fn test_analyze_satd_detects_todo_comments() {
     )
     .unwrap();
 
-    let result = analyze_satd(&[rust_file], false).await;
+    let result = analyze_satd(&[rust_file], false, false).await;
 
     // Should detect at least 1 SATD marker
     assert!(result.is_ok());
@@ -249,7 +249,7 @@ async fn test_analyze_satd_no_markers() {
     )
     .unwrap();
 
-    let result = analyze_satd(&[rust_file], false).await;
+    let result = analyze_satd(&[rust_file], false, false).await;
 
     // Should succeed with 0 SATD
     assert!(result.is_ok());
@@ -541,7 +541,7 @@ async fn test_analyze_satd_output_structure() {
     let rust_file = temp_dir.path().join("test.rs");
     fs::write(&rust_file, "// TODO: test\nfn test() {}").unwrap();
 
-    let result = analyze_satd(&[rust_file], false).await;
+    let result = analyze_satd(&[rust_file], false, false).await;
 
     assert!(result.is_ok());
     let output = result.unwrap();


### PR DESCRIPTION
Found dogfooding the published **3.30.1** artifact. Closes #997.

One fixture — 2 markers in `src/lib.rs`, 1 in `tests/it.rs`:

```
MCP  analyze_satd {"paths":[fixture]}          -> total_satd 3
CLI  analyze satd -p fixture                   -> 2
CLI  analyze satd -p fixture --include-tests   -> 3
```

The MCP tool answered as though `--include-tests` were always passed, and its schema offered
only `paths` and `include_resolved`. So the CLI's default was **unreachable over MCP**, and the
MCP behaviour was unreachable-by-default over the CLI — neither surface could be made to agree
with the other. An agent driving pmat over MCP and a human driving the CLI, on the same
repository, disagreed about how much debt exists, silently.

## Cause: a third independent implementation

`tool_functions::analyze_satd` walks `expand_paths_to_source_files` and scans whatever comes
back — it had no concept of a test file at all.

| surface | implementation | test handling |
|---|---|---|
| CLI | `SatdFacade` → `analyze_directory_with_tests` | honours the flag |
| MCP | `tool_functions::analyze_satd` | **no such concept** |
| service | `analysis_service_analyzers::analyze_satd` | hardcodes `true`, ignores its own `_options` |

One rule, three implementations, agreeing by accident where they agreed at all.
`analyze_dead_code`, directly below the third in the same file, does it correctly
(`include_tests: options.include_tests`).

## Fix

`include_tests` is now a parameter of the MCP tool, defaulting to **false** to match
`analyze satd` and `AnalysisOptions::default()`. The filter reuses the detector's own
`is_test_file` — the same predicate the CLI's discovery uses, because a second opinion about
what "a test file" means is how these drifted apart.

```
                 this PR          published 3.30.1
default        MCP=2 CLI=2  ✓     MCP=3 CLI=2  ✗
include_tests  MCP=3 CLI=3  ✓     MCP=3 CLI=3  ✓ (by accident — the arg was ignored)
```

Three tests, including one asserting the two answers **differ**, since a flag that moves
nothing would satisfy the other two. `cargo test --lib satd`: 419 passing; `mcp_pmcp`: 563.

## Method note

Three probes were wrong before this one was right, each looking like a finding: `pmat mcp` is
manifest management rather than the server (`--mode mcp`), `analyze_satd` takes `paths` not
`project_path`, and my parser read `items`/`violations` while the payload nests
`results.total_satd` — so a missing key counted as **0** and manufactured a false
"MCP=0 CLI=2". The raw JSON-RPC response is quoted in #997 because of that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)