### PR TITLE
fix: three defects the integration-plan verification surfaced

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,21 @@ jobs:
   # GH-275: Post-merge mutation testing for RPS Rust Tooling score.
   # Runs only on push to master (never on PRs — takes 30-120 min).
   # `continue-on-error: true` keeps this informational, not blocking.
+  # NOT a gate yet, deliberately, and the order matters.
+  #
+  # This job has never executed a single mutant (see the run step), so
+  # `min_mutation_score_pct = 80.0` in .pmat-metrics.toml names a quantity that
+  # has never been measured. Removing `continue-on-error` before a run reports a
+  # non-zero caught/missed count would replace a silent no-op with a gate whose
+  # threshold nobody has ever seen a real value for.
+  #
+  # Sequence to make it real, in this order:
+  #   1. this commit — fix the baseline timeout and the inert mutants.toml
+  #   2. observe one master run that reports an actual caught/missed count
+  #   3. `needs: [gate]` must go: adding `mutants` to gate's `needs` while it
+  #      needs `gate` is a cycle. Scope to changed files and run on PRs instead.
+  #   4. ratchet from the measured baseline, not the absolute 80.0
+  #   5. only then remove both `continue-on-error`
   mutants:
     runs-on: [self-hosted, X64, Linux]
     continue-on-error: true
@@ -68,7 +83,20 @@ jobs:
       - name: Install cargo-mutants
         run: cargo install cargo-mutants --locked
       - name: Run mutation testing
-        run: cargo mutants --no-times --timeout 300 --in-place -- --lib
+        # `--timeout 300` was the defect: it is an absolute per-test budget
+        # that applies to the UNMUTATED BASELINE too, and this crate's
+        # `cargo test --lib` takes ~367 s. So every run died with
+        # `TIMEOUT Unmutated baseline` -> exit 4, having executed ZERO mutants,
+        # and the two `continue-on-error` below painted that green. The job has
+        # never mutation-tested anything.
+        #
+        # Derive from the measured baseline instead of guessing an absolute,
+        # with a floor so fast mutants are not killed by jitter.
+        run: |
+          cargo mutants --no-times --in-place \
+            --timeout-multiplier 1.5 --minimum-test-timeout 600 \
+            --file 'src/services/**' --file 'src/models/**' \
+            -- --lib
         continue-on-error: true
       - name: Upload mutation results
         uses: actions/upload-artifact@v7

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,7 +224,7 @@ pmat context --output deep_context.md --format llm-optimized
 
 # Step 2: Validate documentation accuracy (--deep-context is REQUIRED)
 pmat validate-readme \
-    --targets README.md CLAUDE.md GEMINI.md AGENT.md \
+    --targets README.md CLAUDE.md \
     --deep-context deep_context.md \
     --fail-on-contradiction --verbose
 ```

--- a/Makefile
+++ b/Makefile
@@ -2651,11 +2651,17 @@ bench-all: bench-baseline ## Run all dependency reduction benchmarks
 
 .PHONY: pmat-validate-docs
 pmat-validate-docs: ## Validate documentation accuracy (hallucination detection - Phase 3.5)
+# NOTE: --targets must list files that EXIST. `validate-readme` hard-errors on
+# the first unreadable target BEFORE validating anything, so naming a missing
+# file makes this target fail for that reason and never reach
+# --fail-on-contradiction. AGENT.md was listed here and has never existed, so
+# the hallucination detector validated zero files. Add a file here only after
+# creating it.
 	@echo "📚 Validating documentation accuracy (Phase 3.5)..."
 	@which pmat > /dev/null 2>&1 || { echo "❌ PMAT not found! Install with: cargo install --path server"; exit 1; }
 	@cargo run --release --bin pmat -- context --output deep_context.md --format llm-optimized
 	@cargo run --release --bin pmat -- validate-readme \
-		--targets README.md CLAUDE.md AGENT.md \
+		--targets README.md CLAUDE.md \
 		--deep-context deep_context.md \
 		--fail-on-contradiction \
 		--verbose || { \

--- a/docs/agent-instructions/pmat-work-quality-principles.md
+++ b/docs/agent-instructions/pmat-work-quality-principles.md
@@ -195,7 +195,7 @@ git commit -m "feat: ${TITLE}
 Work-Item: ${ID}
 TDG-Score: ${TDG_SCORE}/100
 Repo-Score: ${REPO_SCORE}/100
-Rust-Score: ${RUST_SCORE}/134
+Rust-Score: ${RUST_SCORE}/289
 
 Metrics: .pmat-metrics/commit-${SHORT_SHA}-meta.json"
 ```
@@ -276,7 +276,7 @@ pmat work complete <id>
    🦀 Rust project detected...
       📦 Checking examples...
       ✅ Examples compile (5 examples)
-      📊 Capturing rust-project-score... (82.5/134)
+      📊 Capturing rust-project-score... (82.5/289)
 
    🎯 Golden traces detected...
       ✅ Golden traces match (3/3 scenarios)
@@ -287,7 +287,7 @@ pmat work complete <id>
    📊 Capturing commit metadata...
       ✅ TDG Score: 87.3/100
       ✅ Repo Score: 92.1/100
-      ✅ Rust Project Score: 82.5/134
+      ✅ Rust Project Score: 82.5/289
 
 ✅ Marked as complete: Continue unwrap elimination
 ✅ Updated roadmap: ./docs/roadmaps/roadmap.yaml
@@ -299,7 +299,7 @@ pmat work complete <id>
    Work-Item: Continue unwrap elimination: 27 more unwraps...
    TDG-Score: 87.3/100
    Repo-Score: 92.1/100
-   Rust-Score: 82.5/134
+   Rust-Score: 82.5/289
 
    Metrics: .pmat-metrics/commit-abc123-meta.json"
 ```

--- a/mcp.json
+++ b/mcp.json
@@ -1,10 +1,10 @@
 {
   "name": "pmat",
-  "version": "3.21.0",
+  "version": "3.30.1",
   "description": "Project Analysis and Intelligence Modeling Toolkit",
-  "main": "target/release/pmat",
+  "main": "pmat",
   "bin": {
-    "pmat": "target/release/pmat"
+    "pmat": "pmat"
   },
   "mcp": {
     "runtime": "binary",

--- a/mutants.toml
+++ b/mutants.toml
@@ -1,33 +1,41 @@
-# Mutation Testing Configuration for PMAT
-# Used by cargo-mutants to improve test quality
-# https://mutants.rs/
+# cargo-mutants configuration.
+#
+# WARNING, learned the hard way: cargo-mutants SILENTLY IGNORES unknown keys.
+# It does not warn and it does not fail. Verified against cargo-mutants 27.0.0
+# with a throwaway crate — a file containing `include = [...]` and
+# `minimum_pass_rate = 80` produced exactly the same mutant list as a file
+# containing neither.
+#
+# This file previously held:
+#
+#     exclude = ["target/**", "**/tests/**", ...]
+#     include = ["server/src/services/**", "server/src/models/**", ...]
+#     minimum_pass_rate = 80
+#     package = "pmat"
+#     jobs = 4
+#     timeout = 60
+#
+# None of `include`, `exclude` or `minimum_pass_rate` is a cargo-mutants key
+# (they are `examine_globs` and `exclude_globs`; there is no pass-rate key at
+# all — that is a CI-side comparison). So the config narrowed nothing: the last
+# master run reported `Found 23258 mutants to test` over the whole crate.
+#
+# The `server/src/**` paths compounded it — `git ls-files server/ | wc -l` is 0.
+# That directory does not exist in this repository and has not for some time.
+#
+# So: every key here must be a real one, and a change to this file proves
+# nothing until a run reports a non-zero caught/missed count.
 
-# Timeout per mutant (in seconds) - prevent hangs on infinite loops
-timeout = 60
-
-# Package to test (workspace-aware)
-package = "pmat"
-
-# Paths to exclude from mutation (auto-generated, tests themselves, build artifacts)
-exclude = [
-    "target/**",
+# Test-target scoping. The `--lib` restriction is passed on the command line so
+# it stays visible next to the invocation.
+exclude_globs = [
     "**/tests/**",
     "**/benches/**",
-    "**/build.rs",
     "**/examples/**",
+    "**/build.rs",
+    "**/*_tests.rs",
+    "**/*_test.rs",
 ]
 
-# High-priority mutation targets for code quality
-# Focus on business logic rather than boilerplate
-include = [
-    "server/src/services/**",
-    "server/src/models/**",
-    "server/src/quality/**",
-]
-
-# Minimum test pass rate required
-# Set to 80% to allow gradual improvement
-minimum_pass_rate = 80
-
-# Cap concurrent jobs to prevent OOM on large codebases
-jobs = 4
+# Timeouts are NOT set here. They are on the command line in ci.yml, where the
+# measured baseline that justifies them is documented next to the number.

--- a/src/cli/handlers/work_falsification/cache.rs
+++ b/src/cli/handlers/work_falsification/cache.rs
@@ -162,7 +162,10 @@ pub async fn capture_baseline(project_path: &Path) -> Result<(f64, f64, Option<f
 
     println!("      TDG: {:.1}, Coverage: {:.1}%", tdg_score, coverage);
     if let Some(rs) = rust_score {
-        println!("      Rust Score: {:.1}/134", rs);
+        println!(
+            "      Rust Score: {rs:.1}/{:.0}",
+            crate::services::rust_project_score::rubric_max_points()
+        );
     }
 
     Ok((tdg_score, coverage, rust_score))

--- a/src/cli/handlers/work_handlers/core_handlers/commit.rs
+++ b/src/cli/handlers/work_handlers/core_handlers/commit.rs
@@ -42,21 +42,47 @@ pub(super) async fn capture_repo_score(project_path: &PathBuf) -> Result<f64> {
     Ok(0.0)
 }
 
-/// Capture rust project score (O(1) from cache)
-pub(super) async fn capture_rust_project_score(project_path: &PathBuf) -> Result<f64> {
-    let metrics_dir = project_path.join(".pmat-metrics");
-    let rust_file = metrics_dir.join("rust-project-score.json");
+/// The denominator for a `Rust-Score` trailer: the rubric's own total.
+///
+/// Was the literal `134`, while the numerator is `total_earned` from the
+/// **289**-point rubric (`RustProjectScoreOrchestrator::max_points()`, asserted
+/// at `orchestrator.rs:690` as 130+26+20+15+10+12+16+20+10+15+15). A recorded
+/// run of 236.9 therefore rendered as `Rust-Score: 236.9/134` — 176.8% — into a
+/// git commit trailer, where it is permanent and machine-read.
+///
+/// Taken from the orchestrator rather than re-hardcoded, so adding a scorer
+/// cannot reintroduce the drift. Construction allocates the scorer set and
+/// touches no I/O.
+/// One `Rust-Score:` trailer line, or nothing when the score was not measured.
+pub(super) fn rust_score_trailer(score: Option<f64>) -> String {
+    score.map_or_else(String::new, |s| {
+        format!(
+            "Rust-Score: {s:.1}/{:.0}\n",
+            crate::services::rust_project_score::rubric_max_points()
+        )
+    })
+}
 
-    if rust_file.exists() {
-        let content = std::fs::read_to_string(&rust_file)?;
-        let json: serde_json::Value = serde_json::from_str(&content)?;
-        if let Some(score) = json.get("total_earned").and_then(|v| v.as_f64()) {
-            return Ok(score);
-        }
+/// Capture rust project score (O(1) from cache).
+///
+/// `None` means NOT MEASURED. It used to return `Ok(0.0)` when the cache was
+/// absent — and nothing in this repository writes
+/// `.pmat-metrics/rust-project-score.json`: `grep -rn` finds two readers (here
+/// and `work_falsification/cache.rs`), two test fixtures, and zero writers. So
+/// on any real checkout every `pmat work complete` stamped
+/// `Rust-Score: 0.0/134` into the commit message — a score nobody computed,
+/// formatted as if it had been, and indistinguishable from a genuine zero.
+pub(super) async fn capture_rust_project_score(project_path: &PathBuf) -> Result<Option<f64>> {
+    let rust_file = project_path
+        .join(".pmat-metrics")
+        .join("rust-project-score.json");
+
+    if !rust_file.exists() {
+        return Ok(None);
     }
-
-    // Fallback: compute score if cache doesn't exist
-    Ok(0.0)
+    let content = std::fs::read_to_string(&rust_file)?;
+    let json: serde_json::Value = serde_json::from_str(&content)?;
+    Ok(json.get("total_earned").and_then(serde_json::Value::as_f64))
 }
 
 /// Capture commit metadata (O(1) from .pmat-metrics/ cache)
@@ -77,12 +103,13 @@ pub(super) async fn capture_commit_metadata(
     // Capture scores (O(1) from cache)
     let tdg_score = capture_tdg_score(project_path).await.unwrap_or(0.0);
     let repo_score = capture_repo_score(project_path).await.unwrap_or(0.0);
+    // A non-Rust project has no score, and a Rust project with no cached score
+    // has no score either. Both are `None` — the trailer is then omitted rather
+    // than asserting 0.0.
     let rust_score = if project_path.join("Cargo.toml").exists() {
-        Some(
-            capture_rust_project_score(project_path)
-                .await
-                .unwrap_or(0.0),
-        )
+        capture_rust_project_score(project_path)
+            .await
+            .unwrap_or(None)
     } else {
         None
     };
@@ -139,10 +166,8 @@ pub(super) fn update_changelog(project_path: &PathBuf, item: &RoadmapItem) {
 /// Print completion next steps with commit metadata (helper for handle_work_complete)
 pub(super) fn print_complete_next_steps(item: &RoadmapItem, id: &str, metadata: &CommitMetadata) {
     println!("{}", c::subheader("🎯 Next steps:"));
-    let rust_score_line = metadata
-        .rust_project_score
-        .map(|s| format!("Rust-Score: {:.1}/134\n", s))
-        .unwrap_or_default();
+    let rust_score_line = metadata.rust_project_score;
+    let rust_score_line = rust_score_trailer(rust_score_line);
     let commit_msg = format!(
         "feat: {} (Refs {})\n\nWork-Item: {}\nTDG-Score: {:.1}/100\nRepo-Score: {:.1}/100\n{}Metrics: .pmat-metrics/commit-*-meta.json",
         item.title, id, item.id, metadata.tdg_score, metadata.repo_score, rust_score_line
@@ -206,10 +231,8 @@ pub(super) fn auto_commit_work_files(
     }
 
     // Build commit message
-    let rust_score_line = metadata
-        .rust_project_score
-        .map(|s| format!("Rust-Score: {:.1}/134\n", s))
-        .unwrap_or_default();
+    let rust_score_line = metadata.rust_project_score;
+    let rust_score_line = rust_score_trailer(rust_score_line);
     let commit_msg = format!(
         "feat: {} (Refs {})\n\nWork-Item: {}\nTDG-Score: {:.1}/100\nRepo-Score: {:.1}/100\n{}Metrics: .pmat-metrics/commit-*-meta.json",
         item.title, id, item.id, metadata.tdg_score, metadata.repo_score, rust_score_line
@@ -241,5 +264,87 @@ pub(super) fn auto_commit_work_files(
             println!();
             print_complete_next_steps(item, id, metadata);
         }
+    }
+}
+
+#[cfg(test)]
+mod rust_score_trailer_tests {
+    //! REGRESSION: the `Rust-Score` trailer carried a hardcoded `/134`
+    //! denominator over a numerator drawn from the **289**-point rubric, and
+    //! rendered an unmeasured score as `0.0`.
+    //!
+    //! Both are permanent: `pmat work complete` writes this into a git commit
+    //! message, where it is machine-read by the agent instructions
+    //! (`docs/agent-instructions/pmat-work-quality-principles.md`).
+    //!
+    //! The pre-existing tests in `src/tests/coverage_boost_work_core_handlers.rs`
+    //! did not catch it because they rebuild the format string locally and
+    //! assert against their own copy — they never call this module, so they
+    //! would pass whatever the shipped code did.
+    use super::*;
+
+    /// The denominator must be the rubric's own total, not a literal.
+    #[test]
+    fn denominator_is_the_rubric_total_not_134() {
+        let line = rust_score_trailer(Some(236.9));
+        let max = crate::services::rust_project_score::rubric_max_points();
+        assert!(
+            (max - 289.0).abs() < f64::EPSILON,
+            "rubric total moved to {max}; update this test deliberately, not by reflex"
+        );
+        assert_eq!(line, "Rust-Score: 236.9/289\n");
+        assert!(
+            !line.contains("/134"),
+            "236.9/134 is 176.8% — a score above its own maximum: {line}"
+        );
+    }
+
+    /// Not measured must print NOTHING, never `0.0`.
+    ///
+    /// Nothing in this repository writes `.pmat-metrics/rust-project-score.json`
+    /// — two readers, two test fixtures, zero writers — so on a real checkout
+    /// this was every commit.
+    #[test]
+    fn an_unmeasured_score_emits_no_trailer() {
+        assert_eq!(
+            rust_score_trailer(None),
+            "",
+            "an unmeasured score must not be rendered as a measurement"
+        );
+    }
+
+    /// A genuine zero is still reportable, and must not be confused with the
+    /// absence above.
+    #[test]
+    fn a_measured_zero_is_still_reported() {
+        assert_eq!(rust_score_trailer(Some(0.0)), "Rust-Score: 0.0/289\n");
+    }
+
+    /// The cache reader returns None for a project with no cached score, rather
+    /// than a fabricated 0.0.
+    #[tokio::test]
+    async fn missing_cache_reads_as_not_measured() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let got = capture_rust_project_score(&dir.path().to_path_buf())
+            .await
+            .expect("read");
+        assert_eq!(got, None, "a missing cache is not a score of zero");
+    }
+
+    /// …and a present cache still reads.
+    #[tokio::test]
+    async fn present_cache_reads_the_total_earned() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let m = dir.path().join(".pmat-metrics");
+        std::fs::create_dir_all(&m).expect("mkdir");
+        std::fs::write(
+            m.join("rust-project-score.json"),
+            r#"{"total_earned": 236.9}"#,
+        )
+        .expect("write");
+        let got = capture_rust_project_score(&dir.path().to_path_buf())
+            .await
+            .expect("read");
+        assert_eq!(got, Some(236.9));
     }
 }

--- a/src/cli/handlers/work_handlers/core_handlers/contract.rs
+++ b/src/cli/handlers/work_handlers/core_handlers/contract.rs
@@ -98,7 +98,10 @@ pub(super) async fn create_work_contract(
             contract.baseline_rust_score = rust_score;
             println!("      TDG: {:.1}, Coverage: {:.1}%", tdg, coverage);
             if let Some(rs) = rust_score {
-                println!("      Rust Score: {:.1}/134", rs);
+                println!(
+                    "      Rust Score: {rs:.1}/{:.0}",
+                    crate::services::rust_project_score::rubric_max_points()
+                );
             }
         }
         Err(e) => {

--- a/src/cli/handlers/work_handlers/core_handlers/handlers.rs
+++ b/src/cli/handlers/work_handlers/core_handlers/handlers.rs
@@ -682,7 +682,10 @@ pub async fn handle_work_complete(
         println!(
             "      {} Rust Project Score: {}",
             c::pass(""),
-            c::number(&format!("{:.1}/134", rust_score))
+            c::number(&format!(
+                "{rust_score:.1}/{:.0}",
+                crate::services::rust_project_score::rubric_max_points()
+            ))
         );
     }
     let meta_file = project_path

--- a/src/mcp_pmcp/tool_manifest.rs
+++ b/src/mcp_pmcp/tool_manifest.rs
@@ -123,8 +123,13 @@ pub fn render_manifest(version: &str) -> String {
         "name": "pmat",
         "version": version,
         "description": "Project Analysis and Intelligence Modeling Toolkit",
-        "main": "target/release/pmat",
-        "bin": {"pmat": "target/release/pmat"},
+        // NOT "target/release/pmat". This manifest ships inside the published
+        // crate, and a build-artifact path only resolves on a machine that has
+        // built from source in this exact layout — for anyone who ran
+        // `cargo install pmat` it points at nothing. The installed binary is on
+        // PATH under its own name, which is what a client can actually launch.
+        "main": "pmat",
+        "bin": {"pmat": "pmat"},
         "mcp": {
             "runtime": "binary",
             "launch": {"env": {"MCP_VERSION": "1"}},
@@ -205,6 +210,38 @@ mod tests {
             manifest["mcp"]["tool_count"].as_u64(),
             Some(LIVE_MCP_TOOLS.len() as u64)
         );
+    }
+
+    /// The manifest must not advertise a build-artifact path.
+    ///
+    /// `mcp.json` ships inside the published crate (verified: it is present in
+    /// pmat-3.30.1.crate). It carried `target/release/pmat`, which resolves
+    /// only on a machine that has built from source in that layout — for a
+    /// `cargo install pmat` user it names a file that does not exist.
+    ///
+    /// This pins the property rather than the version: CB-1656 deliberately
+    /// ignores version churn so a release bump does not turn it red
+    /// (`check_macs_artifacts.rs:5-6`), and a version-equality assertion here
+    /// would fight that decision and redden every release.
+    #[test]
+    fn manifest_advertises_no_build_artifact_path() {
+        let rendered = render_manifest("9.9.9");
+        for bad in ["target/release", "target/debug", "../target"] {
+            assert!(
+                !rendered.contains(bad),
+                "manifest advertises the build-artifact path '{bad}', which does not exist for an installed binary:\n{rendered}"
+            );
+        }
+        let committed = std::fs::read_to_string(
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("mcp.json"),
+        )
+        .expect("committed mcp.json");
+        for bad in ["target/release", "target/debug"] {
+            assert!(
+                !committed.contains(bad),
+                "committed mcp.json still advertises '{bad}' — regenerate it: cargo test --lib regenerate_mcp_json -- --ignored"
+            );
+        }
     }
 
     #[test]

--- a/src/services/rust_project_score/orchestrator.rs
+++ b/src/services/rust_project_score/orchestrator.rs
@@ -100,6 +100,18 @@ pub struct RustProjectScoreOrchestrator {
     scorers: Vec<Box<dyn Scorer>>,
 }
 
+/// The rubric's total, for callers that need the denominator without running a
+/// scoring pass.
+///
+/// A literal `134` was hardcoded at five display sites and in two commit-trailer
+/// writers while this rubric totalled 289, so a recorded 236.9 rendered as
+/// `236.9/134` = 176.8%. Derived from the scorers so adding one cannot
+/// reintroduce the drift.
+#[must_use]
+pub fn rubric_max_points() -> f64 {
+    RustProjectScoreOrchestrator::new().max_points()
+}
+
 impl RustProjectScoreOrchestrator {
     /// Create a new orchestrator with all 11 scorers (v3.0)
     #[provable_contracts_macros::contract("pmat-core.yaml", equation = "check_compliance")]

--- a/src/tests/coverage_boost_work_core_handlers.rs
+++ b/src/tests/coverage_boost_work_core_handlers.rs
@@ -10,11 +10,11 @@
 //! - Falsification report processing helpers
 //! - Score capture helper functions
 
-use crate::cli::handlers::work_contract::{
-    EvidenceType, FalsificationMethod, FalsificationResult,
-};
+use crate::cli::handlers::work_contract::{EvidenceType, FalsificationMethod, FalsificationResult};
 use crate::cli::handlers::work_falsification::{ClaimResult, FalsificationReport};
-use crate::models::roadmap::{ItemStatus, ItemType, Priority, RoadmapItem, Roadmap, Phase, SubTask};
+use crate::models::roadmap::{
+    ItemStatus, ItemType, Phase, Priority, Roadmap, RoadmapItem, SubTask,
+};
 use std::path::PathBuf;
 
 // ============================================================================
@@ -175,7 +175,10 @@ fn test_parse_github_url_ssh_no_git() {
 #[test]
 fn test_parse_github_url_nested_path() {
     let url = "https://github.com/org/project/subproject.git";
-    assert_eq!(parse_github_url_test(url), Some("org/project/subproject".to_string()));
+    assert_eq!(
+        parse_github_url_test(url),
+        Some("org/project/subproject".to_string())
+    );
 }
 
 #[test]
@@ -203,21 +206,51 @@ fn test_parse_github_url_invalid() {
 /// Pattern-based lookup for claim_to_override_name
 const CLAIM_PATTERNS: &[(&[&str], &str)] = &[
     (&["manifest", "files deleted"], "manifest"),
-    (&["meta-falsification", "falsification system"], "meta-falsification"),
-    (&["coverage gaming", "coverage exclusion", "cfg(not(coverage))"], "coverage-gaming"),
-    (&["differential coverage", "new code", "changed lines"], "differential-coverage"),
-    (&["total coverage", "absolute coverage", "coverage does not decrease", "coverage >= 95"], "coverage"),
+    (
+        &["meta-falsification", "falsification system"],
+        "meta-falsification",
+    ),
+    (
+        &[
+            "coverage gaming",
+            "coverage exclusion",
+            "cfg(not(coverage))",
+        ],
+        "coverage-gaming",
+    ),
+    (
+        &["differential coverage", "new code", "changed lines"],
+        "differential-coverage",
+    ),
+    (
+        &[
+            "total coverage",
+            "absolute coverage",
+            "coverage does not decrease",
+            "coverage >= 95",
+        ],
+        "coverage",
+    ),
     (&["tdg", "test-driven grade"], "tdg"),
     (&["complexity", "cyclomatic"], "complexity"),
-    (&["supply chain", "dependencies", "vulnerable dependencies"], "supply-chain"),
+    (
+        &["supply chain", "dependencies", "vulnerable dependencies"],
+        "supply-chain",
+    ),
     (&["file size", "500 lines"], "file-size"),
     (&["spec", "specification"], "spec-quality"),
-    (&["github", "sync", "changes pushed", "uncommitted"], "github-sync"),
+    (
+        &["github", "sync", "changes pushed", "uncommitted"],
+        "github-sync",
+    ),
     (&["examples", "compile"], "examples"),
     (&["book", "pmat-book"], "book"),
     (&["satd", "todo/fixme/hack"], "satd"),
     (&["dead code introduced", "dead code detected"], "dead-code"),
-    (&["per-file coverage", "files have >= 95%", "all files have"], "per-file-coverage"),
+    (
+        &["per-file coverage", "files have >= 95%", "all files have"],
+        "per-file-coverage",
+    ),
     (&["lint passes", "make lint"], "lint"),
 ];
 
@@ -240,35 +273,74 @@ fn claim_to_override_name_test(hypothesis: &str) -> String {
 
 #[test]
 fn test_claim_to_override_manifest() {
-    assert_eq!(claim_to_override_name_test("All manifest files exist"), "manifest");
-    assert_eq!(claim_to_override_name_test("No files deleted from baseline"), "manifest");
+    assert_eq!(
+        claim_to_override_name_test("All manifest files exist"),
+        "manifest"
+    );
+    assert_eq!(
+        claim_to_override_name_test("No files deleted from baseline"),
+        "manifest"
+    );
 }
 
 #[test]
 fn test_claim_to_override_meta_falsification() {
-    assert_eq!(claim_to_override_name_test("The meta-falsification check passes"), "meta-falsification");
-    assert_eq!(claim_to_override_name_test("The falsification system is working"), "meta-falsification");
+    assert_eq!(
+        claim_to_override_name_test("The meta-falsification check passes"),
+        "meta-falsification"
+    );
+    assert_eq!(
+        claim_to_override_name_test("The falsification system is working"),
+        "meta-falsification"
+    );
 }
 
 #[test]
 fn test_claim_to_override_coverage_gaming() {
-    assert_eq!(claim_to_override_name_test("No coverage gaming detected"), "coverage-gaming");
-    assert_eq!(claim_to_override_name_test("No coverage exclusion patterns"), "coverage-gaming");
-    assert_eq!(claim_to_override_name_test("No cfg(not(coverage)) found"), "coverage-gaming");
+    assert_eq!(
+        claim_to_override_name_test("No coverage gaming detected"),
+        "coverage-gaming"
+    );
+    assert_eq!(
+        claim_to_override_name_test("No coverage exclusion patterns"),
+        "coverage-gaming"
+    );
+    assert_eq!(
+        claim_to_override_name_test("No cfg(not(coverage)) found"),
+        "coverage-gaming"
+    );
 }
 
 #[test]
 fn test_claim_to_override_differential_coverage() {
-    assert_eq!(claim_to_override_name_test("All changed lines are covered"), "differential-coverage");
-    assert_eq!(claim_to_override_name_test("New code is tested"), "differential-coverage");
-    assert_eq!(claim_to_override_name_test("Differential coverage met"), "differential-coverage");
+    assert_eq!(
+        claim_to_override_name_test("All changed lines are covered"),
+        "differential-coverage"
+    );
+    assert_eq!(
+        claim_to_override_name_test("New code is tested"),
+        "differential-coverage"
+    );
+    assert_eq!(
+        claim_to_override_name_test("Differential coverage met"),
+        "differential-coverage"
+    );
 }
 
 #[test]
 fn test_claim_to_override_total_coverage() {
-    assert_eq!(claim_to_override_name_test("Total coverage >= 95%"), "coverage");
-    assert_eq!(claim_to_override_name_test("Absolute coverage threshold met"), "coverage");
-    assert_eq!(claim_to_override_name_test("Coverage does not decrease"), "coverage");
+    assert_eq!(
+        claim_to_override_name_test("Total coverage >= 95%"),
+        "coverage"
+    );
+    assert_eq!(
+        claim_to_override_name_test("Absolute coverage threshold met"),
+        "coverage"
+    );
+    assert_eq!(
+        claim_to_override_name_test("Coverage does not decrease"),
+        "coverage"
+    );
 }
 
 #[test]
@@ -279,70 +351,136 @@ fn test_claim_to_override_tdg() {
 
 #[test]
 fn test_claim_to_override_complexity() {
-    assert_eq!(claim_to_override_name_test("No function exceeds complexity 20"), "complexity");
-    assert_eq!(claim_to_override_name_test("Cyclomatic complexity under threshold"), "complexity");
+    assert_eq!(
+        claim_to_override_name_test("No function exceeds complexity 20"),
+        "complexity"
+    );
+    assert_eq!(
+        claim_to_override_name_test("Cyclomatic complexity under threshold"),
+        "complexity"
+    );
 }
 
 #[test]
 fn test_claim_to_override_supply_chain() {
-    assert_eq!(claim_to_override_name_test("No vulnerable dependencies added"), "supply-chain");
-    assert_eq!(claim_to_override_name_test("Supply chain integrity verified"), "supply-chain");
-    assert_eq!(claim_to_override_name_test("Dependencies are secure"), "supply-chain");
+    assert_eq!(
+        claim_to_override_name_test("No vulnerable dependencies added"),
+        "supply-chain"
+    );
+    assert_eq!(
+        claim_to_override_name_test("Supply chain integrity verified"),
+        "supply-chain"
+    );
+    assert_eq!(
+        claim_to_override_name_test("Dependencies are secure"),
+        "supply-chain"
+    );
 }
 
 #[test]
 fn test_claim_to_override_file_size() {
-    assert_eq!(claim_to_override_name_test("No file exceeds 500 lines"), "file-size");
-    assert_eq!(claim_to_override_name_test("File size limit respected"), "file-size");
+    assert_eq!(
+        claim_to_override_name_test("No file exceeds 500 lines"),
+        "file-size"
+    );
+    assert_eq!(
+        claim_to_override_name_test("File size limit respected"),
+        "file-size"
+    );
 }
 
 #[test]
 fn test_claim_to_override_spec_quality() {
-    assert_eq!(claim_to_override_name_test("Spec score above threshold"), "spec-quality");
-    assert_eq!(claim_to_override_name_test("Specification quality met"), "spec-quality");
+    assert_eq!(
+        claim_to_override_name_test("Spec score above threshold"),
+        "spec-quality"
+    );
+    assert_eq!(
+        claim_to_override_name_test("Specification quality met"),
+        "spec-quality"
+    );
 }
 
 #[test]
 fn test_claim_to_override_github_sync() {
-    assert_eq!(claim_to_override_name_test("All changes pushed to GitHub"), "github-sync");
-    assert_eq!(claim_to_override_name_test("No uncommitted changes"), "github-sync");
-    assert_eq!(claim_to_override_name_test("Sync status verified"), "github-sync");
+    assert_eq!(
+        claim_to_override_name_test("All changes pushed to GitHub"),
+        "github-sync"
+    );
+    assert_eq!(
+        claim_to_override_name_test("No uncommitted changes"),
+        "github-sync"
+    );
+    assert_eq!(
+        claim_to_override_name_test("Sync status verified"),
+        "github-sync"
+    );
 }
 
 #[test]
 fn test_claim_to_override_examples() {
-    assert_eq!(claim_to_override_name_test("All examples compile"), "examples");
-    assert_eq!(claim_to_override_name_test("Examples run successfully"), "examples");
+    assert_eq!(
+        claim_to_override_name_test("All examples compile"),
+        "examples"
+    );
+    assert_eq!(
+        claim_to_override_name_test("Examples run successfully"),
+        "examples"
+    );
 }
 
 #[test]
 fn test_claim_to_override_book() {
-    assert_eq!(claim_to_override_name_test("pmat-book validation passes"), "book");
-    assert_eq!(claim_to_override_name_test("Book documentation correct"), "book");
+    assert_eq!(
+        claim_to_override_name_test("pmat-book validation passes"),
+        "book"
+    );
+    assert_eq!(
+        claim_to_override_name_test("Book documentation correct"),
+        "book"
+    );
 }
 
 #[test]
 fn test_claim_to_override_satd() {
     assert_eq!(claim_to_override_name_test("No new SATD markers"), "satd");
-    assert_eq!(claim_to_override_name_test("No TODO/FIXME/HACK added"), "satd");
+    assert_eq!(
+        claim_to_override_name_test("No TODO/FIXME/HACK added"),
+        "satd"
+    );
 }
 
 #[test]
 fn test_claim_to_override_dead_code() {
-    assert_eq!(claim_to_override_name_test("No dead code introduced"), "dead-code");
-    assert_eq!(claim_to_override_name_test("Dead code detected and removed"), "dead-code");
+    assert_eq!(
+        claim_to_override_name_test("No dead code introduced"),
+        "dead-code"
+    );
+    assert_eq!(
+        claim_to_override_name_test("Dead code detected and removed"),
+        "dead-code"
+    );
 }
 
 #[test]
 fn test_claim_to_override_per_file_coverage() {
-    assert_eq!(claim_to_override_name_test("All files have >= 95% coverage"), "per-file-coverage");
-    assert_eq!(claim_to_override_name_test("Per-file coverage threshold met"), "per-file-coverage");
+    assert_eq!(
+        claim_to_override_name_test("All files have >= 95% coverage"),
+        "per-file-coverage"
+    );
+    assert_eq!(
+        claim_to_override_name_test("Per-file coverage threshold met"),
+        "per-file-coverage"
+    );
 }
 
 #[test]
 fn test_claim_to_override_lint() {
     assert_eq!(claim_to_override_name_test("make lint passes"), "lint");
-    assert_eq!(claim_to_override_name_test("Lint passes with no errors"), "lint");
+    assert_eq!(
+        claim_to_override_name_test("Lint passes with no errors"),
+        "lint"
+    );
 }
 
 #[test]
@@ -350,14 +488,22 @@ fn test_claim_to_override_unknown() {
     let result = claim_to_override_name_test("Some completely unknown claim");
     // Should sanitize and truncate
     assert!(result.len() <= 30);
-    assert!(result.chars().all(|c| c.is_alphanumeric() || c == '-' || c == '_'));
+    assert!(result
+        .chars()
+        .all(|c| c.is_alphanumeric() || c == '-' || c == '_'));
 }
 
 #[test]
 fn test_claim_to_override_case_insensitive() {
     assert_eq!(claim_to_override_name_test("TDG SCORE"), "tdg");
-    assert_eq!(claim_to_override_name_test("Complexity Check"), "complexity");
-    assert_eq!(claim_to_override_name_test("COVERAGE GAMING"), "coverage-gaming");
+    assert_eq!(
+        claim_to_override_name_test("Complexity Check"),
+        "complexity"
+    );
+    assert_eq!(
+        claim_to_override_name_test("COVERAGE GAMING"),
+        "coverage-gaming"
+    );
 }
 
 // ============================================================================
@@ -494,7 +640,9 @@ fn filter_unoverriden_failures_test<'a>(
         .filter(|failure| {
             let claim_name = claim_to_override_name_test(&failure.hypothesis);
             if let Some(overrides) = override_claims {
-                !overrides.iter().any(|o| o.to_lowercase() == claim_name.to_lowercase())
+                !overrides
+                    .iter()
+                    .any(|o| o.to_lowercase() == claim_name.to_lowercase())
             } else {
                 true
             }
@@ -698,7 +846,12 @@ fn test_roadmap_item_completion_percentage_all_statuses() {
     for (status, expected) in test_cases {
         let mut item = RoadmapItem::new("TEST".to_string(), "Test".to_string());
         item.status = status;
-        assert_eq!(item.completion_percentage(), expected, "Failed for status: {:?}", status);
+        assert_eq!(
+            item.completion_percentage(),
+            expected,
+            "Failed for status: {:?}",
+            status
+        );
     }
 }
 
@@ -872,7 +1025,10 @@ fn test_rust_project_score_json_parsing() {
     let json = r#"{"total_earned": 78.3, "total_possible": 106}"#;
     let value: serde_json::Value = serde_json::from_str(json).unwrap();
 
-    let score = value.get("total_earned").and_then(|v| v.as_f64()).unwrap_or(0.0);
+    let score = value
+        .get("total_earned")
+        .and_then(|v| v.as_f64())
+        .unwrap_or(0.0);
     assert!((score - 78.3).abs() < f64::EPSILON);
 }
 
@@ -924,7 +1080,7 @@ fn test_commit_message_with_rust_score() {
     let rust_score = Some(78.3);
 
     let rust_line = if let Some(rs) = rust_score {
-        format!("Rust-Score: {:.1}/134\n", rs)
+        format!("Rust-Score: {rs:.1}/289\n")
     } else {
         String::new()
     };
@@ -934,7 +1090,11 @@ fn test_commit_message_with_rust_score() {
         title, id, id, tdg_score, repo_score, rust_line
     );
 
-    assert!(commit_msg.contains("Rust-Score: 78.3/134"));
+    // NOTE: this test rebuilds the format string locally, so it pins its own
+    // copy rather than the shipped code — which is why it did not catch the
+    // /134-over-a-289-rubric defect. The real assertions live in
+    // `commit::rust_score_trailer_tests`, which call the function.
+    assert!(commit_msg.contains("Rust-Score: 78.3/289"));
 }
 
 #[test]
@@ -942,7 +1102,7 @@ fn test_commit_message_no_rust_score() {
     let rust_score: Option<f64> = None;
 
     let rust_line = if let Some(rs) = rust_score {
-        format!("Rust-Score: {:.1}/134\n", rs)
+        format!("Rust-Score: {rs:.1}/289\n")
     } else {
         String::new()
     };
@@ -990,7 +1150,11 @@ fn test_evidence_type_git_state() {
         dirty_files: 2,
     };
 
-    if let EvidenceType::GitState { unpushed_commits, dirty_files } = evidence {
+    if let EvidenceType::GitState {
+        unpushed_commits,
+        dirty_files,
+    } = evidence
+    {
         assert_eq!(unpushed_commits, 3);
         assert_eq!(dirty_files, 2);
     } else {
@@ -1041,7 +1205,10 @@ fn test_spec_path_github_issue() {
         project_path.join(format!("docs/specifications/{}-spec.md", id.to_lowercase()))
     };
 
-    assert_eq!(spec_path, PathBuf::from("/project/docs/specifications/042-spec.md"));
+    assert_eq!(
+        spec_path,
+        PathBuf::from("/project/docs/specifications/042-spec.md")
+    );
 }
 
 #[test]
@@ -1051,7 +1218,10 @@ fn test_spec_path_yaml_ticket() {
 
     let spec_path = project_path.join(format!("docs/specifications/{}-spec.md", id.to_lowercase()));
 
-    assert_eq!(spec_path, PathBuf::from("/project/docs/specifications/pmat-new-feature-spec.md"));
+    assert_eq!(
+        spec_path,
+        PathBuf::from("/project/docs/specifications/pmat-new-feature-spec.md")
+    );
 }
 
 // ============================================================================


### PR DESCRIPTION
Implements items 2–3 of the next-five in #999. All three were found by the 12-agent
verification sweep; none was in the plan being verified.

## 1. A score above its own maximum, written into git commit trailers

`pmat work complete` wrote `Rust-Score: {:.1}/134` where the numerator is `total_earned` from
the **289**-point rubric (`orchestrator.rs:690` asserts
130+26+20+15+10+12+16+20+10+15+15 = 289). Using the run in this repo's own source comment that
renders **`Rust-Score: 236.9/134` = 176.8%** — into a git commit message, where it is permanent
and machine-read by `docs/agent-instructions/pmat-work-quality-principles.md`. Five display
sites carried the same literal.

**The second half is worse.** `capture_rust_project_score` fell through to `Ok(0.0)` when the
cache was absent — and nothing in this repository writes
`.pmat-metrics/rust-project-score.json`:

```
grep -rn "rust-project-score.json" src/ Makefile scripts/ .github/
  -> two readers, two test fixtures, ZERO writers
```

So on any real checkout every commit was stamped `Rust-Score: 0.0/134` — a score nobody
computed, formatted exactly like one that was, indistinguishable from a genuine zero. That is
absence-rendered-as-measurement in the one place whose output cannot be edited afterwards.

Now `Option<f64>`, `None` = not measured, trailer omitted. A measured zero still prints and is
distinguishable. The denominator comes from `rubric_max_points()`, derived from the scorer set,
so adding a scorer cannot reintroduce the drift.

**Why the existing tests missed it:** `src/tests/coverage_boost_work_core_handlers.rs`
*rebuilds* the format string locally and asserts against its own copy — it never calls the
shipped code, so it would pass whatever that code did. Corrected and labelled; five new tests
in `commit::rust_score_trailer_tests` call the real function, including one pinning the rubric
total so a change to it is deliberate.

## 2. A doc gate that validated zero files

`make pmat-validate-docs` passed `--targets README.md CLAUDE.md AGENT.md`, and `AGENT.md` has
never existed. `validate-readme` hard-errors on the first unreadable target **before**
validating anything, so the hallucination detector reached `--fail-on-contradiction` never.
`CLAUDE.md:227` documents the same command with **two** missing files.

```
before   Files validated: 0   (hard error on AGENT.md)
after    Files validated: 2   Verified claims: 21   Contradictions: 0
```

## 3. A shipped manifest pointing into target/

`mcp.json` advertised `"main": "target/release/pmat"`. That file **ships inside the published
crate**, and a build-artifact path resolves only on a machine that built from source in that
layout — for a `cargo install pmat` user it names nothing. Generated at
`tool_manifest.rs:126-127`, so the committed JSON was output, not the defect.

The new test pins the **property** — no manifest may contain a `target/release`/`target/debug`
path — deliberately *not* version equality: CB-1656 already ignores version churn "so a release
bump does not turn this red" (`check_macs_artifacts.rs:5-6`), and a version assertion would
fight that and redden every release. CB-1656 stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)