### PR TITLE
fix: stop advertising four MCP tools whose engine matches on a path substring

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@
 - **Compliance Governance** - 30+ checks across code quality, best practices, and reproducibility
 - **Design by Contract** - Toyota Way contract profiles with checkpoint validation and rescue protocols
 - **Autonomous Kaizen** - Toyota Way continuous improvement with auto-fix and commit
-- **MCP Integration** - 20 tools for Claude Code, Cline, and AI agents, validated end-to-end for concurrent multi-agent (ultracode) workflows
+- **MCP Integration** - 16 tools for Claude Code, Cline, and AI agents, validated end-to-end for concurrent multi-agent (ultracode) workflows
 - **Quality Gates** - Pre-commit hooks, CI/CD integration, `.pmat-gates.toml` config
 - **20+ Languages** - Rust, TypeScript, Python, Go, Java, C/C++, Lua, Lean, and more
 
@@ -110,7 +110,7 @@ dynamic-workflow orchestration — as both the test harness and the target
 workload:
 
 - **Full CLI sweep**: 111 commands exercised by parallel agent fleets per release
-- **MCP surface**: all 20 tools validated over stdio JSON-RPC — per-tool calls
+- **MCP surface**: all 16 tools validated over stdio JSON-RPC — per-tool calls
   with schema-derived arguments, 8-way concurrent server sessions against one
   working tree (zero lock errors, zero scratch leftovers), and byte-level
   framing checks (stdout is exclusively JSON-RPC)

--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ pmat/
 | Coverage | 99.66% |
 | Mutation Score | >80% |
 | Languages | 20 supported + MLOps model formats |
-| MCP Tools | 20 available |
+| MCP Tools | 16 available |
 
 ### Falsifiable Quality Commitments
 

--- a/docs/mcp/TOOLS.md
+++ b/docs/mcp/TOOLS.md
@@ -71,10 +71,24 @@ Returns the current refactoring session state.
 ### 10. `refactor.stop`
 Ends the refactoring session.
 
-> Note: the `refactor.*` analysis engine is currently **simulated** — violations are
-> synthesized from filename patterns rather than real AST analysis. The tool
-> descriptions disclose this (v3.18.2) so agents don't act on the output as if it
-> were a real refactoring engine.
+> **REMOVED (EV-0, #999).** `refactor.start` / `nextIteration` / `getState` /
+> `stop` are no longer advertised: they are absent from `tools/list` and from
+> `mcp.json`, and the surface is 16 tools, not 20.
+>
+> They were removed rather than documented because the engine behind them is not
+> an analyzer. `find_violations` (`src/models/refactor_impls.rs:140-145`) returns
+> a hardcoded `HighComplexity` violation at *"line 100, column 1"* for any file
+> whose **path contains the substring `"complex"`**, and nothing otherwise. It
+> reads no source and builds no AST.
+>
+> This note previously disclosed that, and a test asserted the disclosure was
+> present in each tool's description. A disclosure is not a guard: an agent calls
+> `tools/list`, sees four tools, and acts on fabricated line numbers and a
+> `suggested_fix`. The test now asserts **absence** instead.
+>
+> The state machine, handlers and tests remain in the tree. Re-registering is
+> four lines in `SimpleUnifiedServer::run()` — do it when the engine analyses
+> something.
 
 ---
 

--- a/mcp.json
+++ b/mcp.json
@@ -13,7 +13,7 @@
         "MCP_VERSION": "1"
       }
     },
-    "tool_count": 20,
+    "tool_count": 16,
     "tools": [
       {
         "name": "analyze_complexity",
@@ -103,48 +103,6 @@
               }
             }
           }
-        }
-      },
-      {
-        "name": "refactor.start",
-        "description": "Start an automated refactoring session",
-        "inputSchema": {
-          "type": "object",
-          "properties": {
-            "paths": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        }
-      },
-      {
-        "name": "refactor.nextIteration",
-        "description": "Advance the active refactoring session",
-        "inputSchema": {
-          "type": "object",
-          "properties": {},
-          "additionalProperties": false
-        }
-      },
-      {
-        "name": "refactor.getState",
-        "description": "Return the active refactoring session state",
-        "inputSchema": {
-          "type": "object",
-          "properties": {},
-          "additionalProperties": false
-        }
-      },
-      {
-        "name": "refactor.stop",
-        "description": "Stop the active refactoring session",
-        "inputSchema": {
-          "type": "object",
-          "properties": {},
-          "additionalProperties": false
         }
       },
       {

--- a/src/mcp_pmcp/simple_unified_server.rs
+++ b/src/mcp_pmcp/simple_unified_server.rs
@@ -7,9 +7,6 @@ use crate::mcp_pmcp::analyze_handlers::{
     AnalyzeDeepContextTool, AnalyzeSatdTool,
 };
 use crate::mcp_pmcp::context_handlers::{GenerateContextTool, GitTool, ScaffoldProjectTool};
-use crate::mcp_pmcp::handlers::{
-    RefactorGetStateTool, RefactorNextIterationTool, RefactorStartTool, RefactorStopTool,
-};
 use crate::mcp_pmcp::pdmt_handler::PdmtTool;
 use crate::mcp_pmcp::quality_handlers::QualityGateTool;
 use crate::mcp_pmcp::quality_proxy_handler::QualityProxyTool;
@@ -355,23 +352,25 @@ impl SimpleUnifiedServer {
             .tool("analyze_dag", AnalyzeDagTool)
             .tool("analyze_deep_context", AnalyzeDeepContextTool)
             .tool("analyze_big_o", AnalyzeBigOTool)
-            // === Refactoring Tools (4) ===
-            .tool(
-                "refactor.start",
-                RefactorStartTool::new(self.state_manager.clone()),
-            )
-            .tool(
-                "refactor.nextIteration",
-                RefactorNextIterationTool::new(self.state_manager.clone()),
-            )
-            .tool(
-                "refactor.getState",
-                RefactorGetStateTool::new(self.state_manager.clone()),
-            )
-            .tool(
-                "refactor.stop",
-                RefactorStopTool::new(self.state_manager.clone()),
-            )
+            // === Refactoring Tools: REMOVED (EV-0, #999) ===
+            // `refactor.start` / `nextIteration` / `getState` / `stop` were 4 of
+            // 20 advertised tools — 20% of the agent-facing surface — and the
+            // engine behind them is not an analyzer. `find_violations`
+            // (models/refactor_impls.rs:140-145) returns a hardcoded
+            // HighComplexity violation at "line 100, column 1" for any file
+            // whose PATH CONTAINS THE SUBSTRING "complex", and nothing at all
+            // otherwise. It reads no source and builds no AST.
+            //
+            // docs/mcp/TOOLS.md disclosed this in prose ("currently
+            // simulated — violations are synthesized from filename patterns"),
+            // but a disclosure in a document is not a guard: an agent calls
+            // `tools/list` and gets four tools that answer confidently with
+            // fabricated line numbers and a "suggested_fix".
+            //
+            // Unregistered rather than deleted: the state machine, its
+            // handlers and their tests remain, so implementing real AST
+            // analysis is re-registering four lines, not rebuilding. Until
+            // then it is not advertised.
             // === Quality Tools (3) ===
             .tool("quality_gate", QualityGateTool)
             .tool("quality_proxy", QualityProxyTool)
@@ -661,10 +660,10 @@ mod active_tests {
     /// with no `metadata()` after R17-1 replaced the aliased handlers with
     /// new structs.
     #[test]
-    fn test_all_20_live_tools_advertise_description_and_schema() {
+    fn test_all_16_live_tools_advertise_description_and_schema() {
         use pmcp::ToolHandler;
 
-        let state_manager = Arc::new(Mutex::new(StateManager::new()));
+        let _state_manager = Arc::new(Mutex::new(StateManager::new()));
         let index_manager = Arc::new(IndexManager::new(PathBuf::from(".")));
 
         // (registered name, metadata, takes_arguments) — mirrors the
@@ -682,26 +681,7 @@ mod active_tests {
                 true,
             ),
             ("analyze_big_o", AnalyzeBigOTool.metadata(), true),
-            (
-                "refactor.start",
-                RefactorStartTool::new(state_manager.clone()).metadata(),
-                true,
-            ),
-            (
-                "refactor.nextIteration",
-                RefactorNextIterationTool::new(state_manager.clone()).metadata(),
-                false,
-            ),
-            (
-                "refactor.getState",
-                RefactorGetStateTool::new(state_manager.clone()).metadata(),
-                false,
-            ),
-            (
-                "refactor.stop",
-                RefactorStopTool::new(state_manager).metadata(),
-                false,
-            ),
+            // refactor.* unregistered in EV-0 (#999) — see run()
             ("quality_gate", QualityGateTool.metadata(), true),
             ("quality_proxy", QualityProxyTool.metadata(), true),
             ("pdmt_deterministic_todos", PdmtTool::new().metadata(), true),
@@ -732,7 +712,7 @@ mod active_tests {
 
         assert_eq!(
             tools.len(),
-            20,
+            16,
             "registry drift: update this test when tools are added or removed"
         );
 
@@ -776,44 +756,43 @@ mod active_tests {
         }
     }
 
-    /// v3.18.2: the refactor.* tools run a simulated analysis engine
-    /// (violations are synthesized from filename patterns in
-    /// `src/models/refactor_impls.rs`); their descriptions must disclose
-    /// this so agents are not misled.
+    /// EV-0 acceptance (b): the simulated `refactor.*` tools must NOT be
+    /// advertised.
+    ///
+    /// They used to be, with descriptions disclosing the simulation — and a
+    /// test asserted that the disclosure was present. But a disclosure is not a
+    /// guard. An agent calls `tools/list`, sees four tools, and calls them; the
+    /// engine behind them (`models/refactor_impls.rs:140-145`) returns a
+    /// hardcoded HighComplexity violation at "line 100, column 1" for any file
+    /// whose PATH CONTAINS THE SUBSTRING "complex", and nothing otherwise. It
+    /// reads no source and builds no AST.
+    ///
+    /// So the assertion is now absence, not disclosure. Re-registering them is
+    /// four lines in `run()` — do that when the engine analyses something.
     #[test]
-    fn test_refactor_tool_descriptions_disclose_simulation() {
-        use pmcp::ToolHandler;
-
-        let state_manager = Arc::new(Mutex::new(StateManager::new()));
-        let descriptions = [
-            (
-                "refactor.start",
-                RefactorStartTool::new(state_manager.clone()).metadata(),
-            ),
-            (
-                "refactor.nextIteration",
-                RefactorNextIterationTool::new(state_manager.clone()).metadata(),
-            ),
-            (
-                "refactor.getState",
-                RefactorGetStateTool::new(state_manager.clone()).metadata(),
-            ),
-            (
-                "refactor.stop",
-                RefactorStopTool::new(state_manager).metadata(),
-            ),
-        ];
-
-        for (name, metadata) in descriptions {
-            let description = metadata
-                .and_then(|info| info.description)
-                .unwrap_or_default();
+    fn simulated_refactor_tools_are_not_advertised() {
+        let declared: Vec<&str> = crate::mcp_pmcp::tool_manifest::LIVE_MCP_TOOLS
+            .iter()
+            .map(|(n, _)| *n)
+            .collect();
+        for name in [
+            "refactor.start",
+            "refactor.nextIteration",
+            "refactor.getState",
+            "refactor.stop",
+        ] {
             assert!(
-                description.contains("simulated analysis engine"),
-                "{name}: description must disclose the simulated analysis \
-                 engine, got: {description}"
+                !declared.contains(&name),
+                "{name} is advertised again — its engine synthesizes violations \
+                 from a path substring, so an agent calling it acts on fabricated \
+                 line numbers (EV-0, #999)"
             );
         }
+        assert_eq!(
+            declared.len(),
+            16,
+            "the surface should be 16 tools after removing the 4 simulated ones"
+        );
     }
 }
 

--- a/src/mcp_pmcp/tool_manifest.rs
+++ b/src/mcp_pmcp/tool_manifest.rs
@@ -11,7 +11,7 @@
 //! drift-guard test pins this list to the server's actual `.tool(...)`
 //! registrations so the two can never silently diverge.
 
-/// The 20 tools registered by `SimpleUnifiedServer::run()`, in registration
+/// The 16 tools registered by `SimpleUnifiedServer::run()`, in registration
 /// order, with their catalog descriptions. Source of truth for `mcp.json`.
 pub const LIVE_MCP_TOOLS: &[(&str, &str)] = &[
     (
@@ -38,16 +38,6 @@ pub const LIVE_MCP_TOOLS: &[(&str, &str)] = &[
         "analyze_big_o",
         "Estimate algorithmic complexity of functions",
     ),
-    ("refactor.start", "Start an automated refactoring session"),
-    (
-        "refactor.nextIteration",
-        "Advance the active refactoring session",
-    ),
-    (
-        "refactor.getState",
-        "Return the active refactoring session state",
-    ),
-    ("refactor.stop", "Stop the active refactoring session"),
     (
         "quality_gate",
         "Run the quality gate (complexity, satd, lint, tests)",
@@ -176,13 +166,19 @@ mod tests {
     fn manifest_matches_server() {
         // Drift guard: LIVE_MCP_TOOLS must equal the server's actual
         // `.tool(...)` registrations in run(). If a tool is added/removed,
-        // this fails until the const is updated (mirrors the 20-tool pin).
+        // this fails until the const is updated (mirrors the 16-tool pin).
         let src = include_str!("simple_unified_server.rs");
         let run_start = src.find("pub async fn run").expect("run() present");
+        // Sentinel must not embed the tool COUNT: it was `fn test_all_20`, so
+        // renaming that test to `test_all_16` silently widened this scan to the
+        // whole file — including test fixtures that also contain `.tool(` —
+        // and the guard started comparing against the wrong set. A guard keyed
+        // on a number that changes when the thing it guards changes is not a
+        // guard.
         let run_end = src[run_start..]
-            .find("fn test_all_20")
+            .find("fn test_all_")
             .map(|i| run_start + i)
-            .unwrap_or(src.len());
+            .expect("the registry drift sentinel `fn test_all_` must exist");
         let registered: Vec<String> = src[run_start..run_end]
             .split(".tool(")
             .skip(1)
@@ -198,7 +194,11 @@ mod tests {
             registered, declared,
             "LIVE_MCP_TOOLS drifted from server .tool() registrations"
         );
-        assert_eq!(declared.len(), 20, "the live server advertises 20 tools");
+        assert_eq!(
+            declared.len(),
+            16,
+            "the live server advertises 16 tools; the 4 refactor.* tools were unregistered in EV-0 (#999) because their engine synthesizes violations from a path substring"
+        );
     }
 
     #[test]


### PR DESCRIPTION
**EV-0 acceptance (b)** from the integration-plan verification (#999). The `refactor.*` tools
are unregistered; the agent-facing surface drops **20 → 16**.

## The engine is not an analyzer

`src/models/refactor_impls.rs:140-145`:

```rust
// Simulate finding a high complexity violation
if file_id.path.to_string_lossy().contains("complex") {
    violations.push(Violation {
        violation_type: ViolationType::HighComplexity,
        location: Location { file: ..., line: 100, column: 1 },
        suggested_fix: Some(RefactorOp::ExtractFunction { ... })
```

A hardcoded violation at *"line 100, column 1"* for any file whose **path contains the
substring `"complex"`**, and nothing otherwise. No source read, no AST built. Four of twenty
advertised tools answered from that.

## Why removal rather than more documentation

This **was** disclosed — in `docs/mcp/TOOLS.md` and in each tool's description — with a test
asserting the disclosure was present.

**A disclosure is not a guard.** An agent calls `tools/list`, gets four tools with confident
descriptions, and acts on fabricated line numbers and a `suggested_fix`. Prose in a document it
never reads does not stop it. The test now asserts **absence** from `LIVE_MCP_TOOLS` instead of
disclosure in a string.

Unregistered, not deleted: the state machine, handlers and tests stay, so implementing real
analysis is re-registering four lines in `SimpleUnifiedServer::run()`. The CLI's
`pmat refactor` is unaffected — it uses `RefactorConfig`/`Summary` types but never drives
`find_violations`.

## Verified against the built binary, not just the const

```
tools/list over --mode mcp  ->  16 tools, refactor.* NONE
CB-1656                     ->  green, "mcp.json advertises all 16 live tools"
cargo test --lib mcp_pmcp   ->  564 passed
```

## One defect found while doing it

The registry drift-guard scanned from `pub async fn run` to the sentinel **`fn test_all_20`** —
a sentinel with the tool *count* baked in. Renaming that test to `test_all_16` silently widened
the scan to the whole file, including fixtures that also contain `.tool(`, so the guard
compared the wrong set. It is now `fn test_all_` and `expect`s the sentinel rather than falling
back to end-of-file.

A guard keyed on a number that changes whenever the guarded thing changes is not a guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)