### PR TITLE
fix: AGENTS.md claimed 80% coverage and grade A for every project

### DIFF
--- a/src/agents_md/discovery/tests.rs
+++ b/src/agents_md/discovery/tests.rs
@@ -4,13 +4,9 @@
 #[cfg_attr(coverage_nightly, coverage(off))]
 #[cfg(test)]
 mod tests {
-    use super::super::types::{
-        AgentsMdDiscovery, AgentsMdFile, AgentsMdHierarchy, DiscoveryConfig, HierarchyNode,
-    };
-    use std::collections::HashMap;
+    use super::super::types::{AgentsMdDiscovery, DiscoveryConfig};
     use std::fs;
     use std::path::{Path, PathBuf};
-    use std::time::SystemTime;
     use tempfile::TempDir;
 
     // =============================================================================

--- a/src/agents_md/executor/tests.rs
+++ b/src/agents_md/executor/tests.rs
@@ -2,6 +2,7 @@
 //! Tests for the command executor module.
 
 use super::*;
+use std::path::PathBuf;
 use std::time::Duration;
 
 #[test]

--- a/src/agents_md/generator.rs
+++ b/src/agents_md/generator.rs
@@ -97,7 +97,15 @@ pub struct PmatAnalysis {
     pub commands: Vec<Command>,
 
     /// Quality metrics
-    pub quality_metrics: QualityMetrics,
+    /// Measured quality, or `None` when nothing measured it.
+    ///
+    /// `generate_from_project` used to fabricate this — `test_coverage: 80.0`,
+    /// `grade: "A"`, `satd_count: 0` for EVERY repository — and the renderers
+    /// wrote it into AGENTS.md as "Ensure 80%+ coverage maintained" and
+    /// "Current quality grade: A". AGENTS.md is mounted natively into agent
+    /// sandboxes, so that is a fabricated quality claim delivered to an agent
+    /// as fact about the project it is editing. `None` omits the lines instead.
+    pub quality_metrics: Option<QualityMetrics>,
 
     /// Dependencies
     pub dependencies: Vec<String>,
@@ -287,12 +295,12 @@ impl AgentsMdGenerator {
             description: project.description.clone(),
             project_type: self.detect_project_type(&project.root)?,
             commands: self.detect_commands(&project.root)?,
-            quality_metrics: QualityMetrics {
-                avg_complexity: 10.0,
-                test_coverage: 80.0,
-                satd_count: 0,
-                grade: "A".to_string(),
-            },
+            // NOT fabricated. This constructor is handed a `ProjectInfo` —
+            // a name, a description and a root path. It runs no analysis, so
+            // it has no coverage figure, no grade and no SATD count, and must
+            // not invent them. Callers with real measurements build
+            // `PmatAnalysis` directly and pass `Some(..)`.
+            quality_metrics: None,
             dependencies: vec![],
         };
 
@@ -377,11 +385,13 @@ impl AgentsMdGenerator {
     fn generate_testing(&self, output: &mut String, analysis: &PmatAnalysis) -> Result<()> {
         writeln!(output, "## Testing Instructions")?;
         writeln!(output, "- Run tests before committing")?;
-        writeln!(
-            output,
-            "- Ensure {}%+ coverage maintained",
-            analysis.quality_metrics.test_coverage as u32
-        )?;
+        if let Some(m) = &analysis.quality_metrics {
+            writeln!(
+                output,
+                "- Ensure {}%+ coverage maintained",
+                m.test_coverage as u32
+            )?;
+        }
         writeln!(output, "- All functions must have complexity ≤{}", 10)?;
         writeln!(output)?;
         Ok(())
@@ -391,11 +401,9 @@ impl AgentsMdGenerator {
     fn generate_code_style(&self, output: &mut String, analysis: &PmatAnalysis) -> Result<()> {
         writeln!(output, "## Code Style")?;
         writeln!(output, "- Follow project coding standards")?;
-        writeln!(
-            output,
-            "- Current quality grade: {}",
-            analysis.quality_metrics.grade
-        )?;
+        if let Some(m) = &analysis.quality_metrics {
+            writeln!(output, "- Current quality grade: {}", m.grade)?;
+        }
         writeln!(output, "- Zero SATD tolerance")?;
         writeln!(output)?;
         Ok(())

--- a/src/agents_md/generator_tests.rs
+++ b/src/agents_md/generator_tests.rs
@@ -110,12 +110,12 @@ mod tests {
                 timeout: Some(60),
                 safe: true,
             }],
-            quality_metrics: QualityMetrics {
+            quality_metrics: Some(QualityMetrics {
                 avg_complexity: 8.5,
                 test_coverage: 85.0,
                 satd_count: 0,
                 grade: "A".to_string(),
-            },
+            }),
             dependencies: vec![],
         };
 
@@ -152,12 +152,12 @@ mod tests {
                     safe: true,
                 },
             ],
-            quality_metrics: QualityMetrics {
+            quality_metrics: Some(QualityMetrics {
                 avg_complexity: 5.0,
                 test_coverage: 90.0,
                 satd_count: 2,
                 grade: "B".to_string(),
-            },
+            }),
             dependencies: vec!["dep1".to_string(), "dep2".to_string()],
         };
 
@@ -196,12 +196,12 @@ mod tests {
             description: "A minimal project".to_string(),
             project_type: ProjectType::Rust,
             commands: vec![],
-            quality_metrics: QualityMetrics {
+            quality_metrics: Some(QualityMetrics {
                 avg_complexity: 10.0,
                 test_coverage: 80.0,
                 satd_count: 0,
                 grade: "A".to_string(),
-            },
+            }),
             dependencies: vec![],
         };
 
@@ -239,12 +239,12 @@ mod tests {
             description: "Project with many commands".to_string(),
             project_type: ProjectType::Rust,
             commands,
-            quality_metrics: QualityMetrics {
+            quality_metrics: Some(QualityMetrics {
                 avg_complexity: 10.0,
                 test_coverage: 80.0,
                 satd_count: 0,
                 grade: "A".to_string(),
-            },
+            }),
             dependencies: vec![],
         };
 
@@ -266,12 +266,12 @@ mod tests {
             description: "Project with no commands".to_string(),
             project_type: ProjectType::Rust,
             commands: vec![],
-            quality_metrics: QualityMetrics {
+            quality_metrics: Some(QualityMetrics {
                 avg_complexity: 10.0,
                 test_coverage: 80.0,
                 satd_count: 0,
                 grade: "A".to_string(),
-            },
+            }),
             dependencies: vec![],
         };
 
@@ -812,12 +812,12 @@ Test Project
             description: "Testing metrics".to_string(),
             project_type: ProjectType::Rust,
             commands: vec![],
-            quality_metrics: QualityMetrics {
+            quality_metrics: Some(QualityMetrics {
                 avg_complexity: 15.5,
                 test_coverage: 95.5,
                 satd_count: 5,
                 grade: "A+".to_string(),
-            },
+            }),
             dependencies: vec![],
         };
 
@@ -980,12 +980,12 @@ Test Project
             description: "Testing analysis".to_string(),
             project_type: ProjectType::Go,
             commands: vec![],
-            quality_metrics: QualityMetrics {
+            quality_metrics: Some(QualityMetrics {
                 avg_complexity: 5.0,
                 test_coverage: 100.0,
                 satd_count: 0,
                 grade: "A".to_string(),
-            },
+            }),
             dependencies: vec!["dep1".to_string()],
         };
 
@@ -1004,12 +1004,12 @@ Test Project
             description: "Description with 'quotes' and special chars: @#$%".to_string(),
             project_type: ProjectType::Rust,
             commands: vec![],
-            quality_metrics: QualityMetrics {
+            quality_metrics: Some(QualityMetrics {
                 avg_complexity: 10.0,
                 test_coverage: 80.0,
                 satd_count: 0,
                 grade: "B".to_string(),
-            },
+            }),
             dependencies: vec![],
         };
 
@@ -1027,12 +1027,12 @@ Test Project
             description: "".to_string(),
             project_type: ProjectType::Rust,
             commands: vec![],
-            quality_metrics: QualityMetrics {
+            quality_metrics: Some(QualityMetrics {
                 avg_complexity: 10.0,
                 test_coverage: 80.0,
                 satd_count: 0,
                 grade: "A".to_string(),
-            },
+            }),
             dependencies: vec![],
         };
 
@@ -1050,12 +1050,12 @@ Test Project
             description: "A project with emojis and unicode chars".to_string(),
             project_type: ProjectType::Rust,
             commands: vec![],
-            quality_metrics: QualityMetrics {
+            quality_metrics: Some(QualityMetrics {
                 avg_complexity: 10.0,
                 test_coverage: 80.0,
                 satd_count: 0,
                 grade: "A".to_string(),
-            },
+            }),
             dependencies: vec![],
         };
 
@@ -1210,5 +1210,70 @@ Test Project
         let debug_str = format!("{:?}", metrics);
         assert!(debug_str.contains("QualityMetrics"));
         assert!(debug_str.contains("avg_complexity"));
+    }
+
+    // ==================== Fabricated-claims regression ====================
+
+    /// REGRESSION: `generate_from_project` invented quality numbers.
+    ///
+    /// It hardcoded `test_coverage: 80.0`, `grade: "A"`, `satd_count: 0` and
+    /// `avg_complexity: 10.0` for EVERY repository, and the renderers wrote
+    /// them into AGENTS.md as "Ensure 80%+ coverage maintained" and "Current
+    /// quality grade: A".
+    ///
+    /// AGENTS.md is mounted natively into agent sandboxes, so that is a
+    /// fabricated quality claim handed to an agent as fact about the project it
+    /// is editing — and this constructor is given only a name, a description
+    /// and a path. It runs no analysis, so it has nothing to report.
+    #[test]
+    fn generate_from_project_invents_no_quality_numbers() {
+        let tmp = TempDir::new().expect("tempdir");
+        fs::write(
+            tmp.path().join("Cargo.toml"),
+            "[package]\nname=\"p\"\nversion=\"0.1.0\"\nedition=\"2021\"\n",
+        )
+        .expect("manifest");
+        let project = ProjectInfo {
+            root: tmp.path().to_path_buf(),
+            name: "p".to_string(),
+            version: "0.1.0".to_string(),
+            description: "a project nobody measured".to_string(),
+            readme: None,
+        };
+        let out = AgentsMdGenerator::new()
+            .generate_from_project(&project)
+            .expect("generate");
+
+        assert!(
+            !out.contains("80%+ coverage"),
+            "invented a coverage figure for an unmeasured project:\n{out}"
+        );
+        assert!(
+            !out.contains("quality grade:"),
+            "invented a quality grade for an unmeasured project:\n{out}"
+        );
+    }
+
+    /// …and a caller that HAS measured something still gets it rendered.
+    #[test]
+    fn measured_quality_is_still_rendered() {
+        let analysis = PmatAnalysis {
+            project_name: "p".to_string(),
+            description: "d".to_string(),
+            project_type: ProjectType::Rust,
+            commands: vec![],
+            quality_metrics: Some(QualityMetrics {
+                avg_complexity: 4.0,
+                test_coverage: 91.0,
+                satd_count: 2,
+                grade: "A-".to_string(),
+            }),
+            dependencies: vec![],
+        };
+        let out = AgentsMdGenerator::new()
+            .generate_from_analysis(&analysis)
+            .expect("generate");
+        assert!(out.contains("91%+ coverage"), "got:\n{out}");
+        assert!(out.contains("quality grade: A-"), "got:\n{out}");
     }
 }


### PR DESCRIPTION
Refs #999 (EV-2b). Two findings, the second larger than the first.

## 1. Fabricated quality claims in an agent-facing file

`generate_from_project` receives a `ProjectInfo` — name, version, description, root path. It
runs no analysis. It nevertheless built:

```rust
quality_metrics: QualityMetrics {
    avg_complexity: 10.0,
    test_coverage: 80.0,
    satd_count: 0,
    grade: "A".to_string(),
}
```

and the renderers wrote that into AGENTS.md as:

```
- Ensure 80%+ coverage maintained
- Current quality grade: A
```

for **every** repository, measured or not. AGENTS.md is mounted natively into agent sandboxes,
so this is a fabricated quality claim delivered to an agent as fact about the project it is
editing — the same defect as `Rust-Score: 0.0/134`, in the file whose entire purpose is to
brief an agent.

`quality_metrics` is now `Option<QualityMetrics>`; this constructor passes `None` and the lines
are omitted. A caller that *has* measured something still renders it — pinned by a second test,
since "omit everything" would satisfy the first test alone.

## 2. The module's 255 tests had never compiled

`src/agents_md/` is 27 files / 4,299 lines behind
`#[cfg(all(feature = "standard-deps", feature = "agents-md"))]`, and `agents-md` is not a
default feature.

**A deliberate syntax error appended to `quality.rs` produced zero build errors** on a default
`cargo build --lib`. That is how I noticed. `cargo test --lib -- --list` shows 19,946 tests and
not one is from this module — which contains 255 `#[test]` functions.

Under the feature they did not compile either — **12 errors on clean master**: `PathBuf` used
but never imported in `executor/tests.rs`, three unused imports in `discovery/tests.rs`.

The feature-matrix job added in #990 compiles every feature with `cargo check --lib`, which
does **not** build test targets — so it could not see this. Worth considering whether that job
should grow a `--tests` leg.

Fixed. The suite runs for the first time: **240 passing**.

## A note on my own work

Because the module wasn't compiled, my `Option` change compiled "clean" against nothing. Its 10
knock-on errors in `generator_tests.rs` only surfaced once the tests built at all. A green
build of a feature-gated module proves nothing about that module.

Verification: the regression test was confirmed to **fail** on the pre-fix code (restored the
fabrication, watched it go red, restored the fix). Default suite unaffected; clippy clean with
the feature enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)