### PR TITLE
feat: dual-client quality hooks, labelled feedback because that is what they are

### DIFF
--- a/.agents/hooks.json
+++ b/.agents/hooks.json
@@ -1,0 +1,12 @@
+{
+  "hooks": [
+    {
+      "event": "pre_tool_execution",
+      "matcher": "write_file|code_execution",
+      "handler": {
+        "type": "command",
+        "command": ".agents/hooks/pmat-quality-feedback.sh antigravity"
+      }
+    }
+  ]
+}

--- a/.agents/hooks/README.md
+++ b/.agents/hooks/README.md
@@ -1,0 +1,53 @@
+# pmat quality hooks — feedback, not gates
+
+`pmat-quality-feedback.sh` runs `pmat quality-gate --file <edited file>` when an
+agent writes a Rust file, in Claude Code and in the Google Antigravity Agent.
+
+## These are not gates, and cannot be
+
+Both clients **fail open**.
+
+> **Antigravity**, verbatim: *"If a hook script crashes (non-zero exit status),
+> an HTTP hook returns a non-2xx status code, or an operation times out or
+> returns unrecognized JSON, the runtime treats it as an approval (`allow`)."*
+
+> **Claude Code**: exit 2 blocks; exit 1 blocks nothing. A hook binary that
+> fails to launch is not a deny.
+
+Demonstrated, not asserted — with `pmat` off `PATH`:
+
+```
+PATH=/usr/bin:/bin .agents/hooks/pmat-quality-feedback.sh claude       -> exit 0
+PATH=/usr/bin:/bin .agents/hooks/pmat-quality-feedback.sh antigravity  -> {"decision":"allow"}
+```
+
+A quality gate that returns *allow* when it crashes is the inverse of Jidoka.
+**The gate is `ci / gate` on protected `master`**, alongside `feature-gate`,
+`docs build (docs.rs environment)` and `pmat score`. These hooks only shorten
+the feedback loop from "CI, in 20 minutes" to "this edit, now".
+
+Antigravity is additionally self-tamperable — an agent with filesystem write
+tools can edit `.agents/hooks.json` or this script. Mount `.agents/` from a
+read-only source if that matters.
+
+## Exit-code translation, and why it is here
+
+`pmat quality-gate` exits **1** on violations. Neither client treats 1 as a
+block: Claude Code needs **2**, Antigravity needs `{"decision":"deny"}` on
+stdout. The script translates; wiring either client straight to `pmat` would
+produce a hook that runs, reports, and blocks nothing.
+
+`pmat comply check --strict` is the wrong command for this, for three reasons:
+it is project-scoped with no `--file`, it takes tens of seconds, and its exit
+code does not separate failure from warnings.
+
+## Behaviour
+
+| situation | result |
+|---|---|
+| Rust file, violations | Claude `exit 2` / Antigravity `deny` |
+| Rust file, clean | allow |
+| non-Rust file, missing file, unparseable payload | allow |
+| `pmat` not installed | **allow** — the documented fail-open limit |
+
+Sub-second, because `--file` scopes it to the one file that changed.

--- a/.agents/hooks/pmat-quality-feedback.sh
+++ b/.agents/hooks/pmat-quality-feedback.sh
@@ -1,0 +1,89 @@
+#!/bin/sh
+# pmat quality feedback for agent edits — FEEDBACK, NOT A GATE.
+#
+# Read this before treating it as enforcement:
+#
+#   Antigravity, verbatim: "If a hook script crashes (non-zero exit status), an
+#   HTTP hook returns a non-2xx status code, or an operation times out or
+#   returns unrecognized JSON, the runtime treats it as an approval (allow)."
+#
+#   Claude Code: exit 2 blocks; exit 1 blocks nothing. A hook binary that fails
+#   to launch is not a deny.
+#
+# So if pmat is missing, slow, or broken, BOTH clients allow the edit. A gate
+# that returns "allow" when it crashes is the inverse of Jidoka. The gate is
+# `ci / gate` on protected master; this only shortens the feedback loop.
+#
+# Antigravity additionally lets an agent with write access edit this file.
+# Mount `.agents/` read-only if that matters to you.
+#
+# Usage:  pmat-quality-feedback.sh <mode> <file>
+#   mode = claude      -> exit 2 to block, 0 to allow
+#   mode = antigravity -> {"decision":"deny"|"allow"} on stdout, always exit 0
+set -u
+
+mode="${1:-claude}"
+file="${2:-}"
+
+allow() {
+    case "$mode" in
+        antigravity) printf '{"decision":"allow"}\n' ;;
+    esac
+    exit 0
+}
+
+deny() {
+    reason="$1"
+    case "$mode" in
+        antigravity)
+            # JSON-escape the reason: unrecognized JSON is treated as approval.
+            esc=$(printf '%s' "$reason" | sed 's/\\/\\\\/g; s/"/\\"/g' | tr -d '\n')
+            printf '{"decision":"deny","reason":"%s"}\n' "$esc"
+            exit 0
+            ;;
+        *)
+            printf '%s\n' "$reason" >&2
+            exit 2   # Claude Code: only exit 2 blocks
+            ;;
+    esac
+}
+
+# Both clients deliver the tool call as JSON on stdin; the file argument is for
+# testing and for direct invocation. Extracted with sed rather than a Node or
+# Python shim: adding an interpreter dependency to reach a Rust binary is the
+# thing this stack is trying not to do, and the only documented Antigravity
+# `command` hook examples are python3.
+#
+# Claude Code:  {"tool_input": {"file_path": "..."}}
+# Antigravity:  {"tool_call": {"args": {"file_path"|"path": "..."}}}
+#
+# A crude extractor is acceptable here precisely because failure is ALLOW: a
+# path this cannot parse is a check that does not run, which is the documented
+# fail-open behaviour and not a new hazard.
+if [ -z "$file" ] && [ ! -t 0 ]; then
+    payload=$(cat 2>/dev/null || true)
+    file=$(printf '%s' "$payload" \
+        | tr ',' '\n' \
+        | sed -n 's/.*"\(file_path\|path\|absolute_path\)"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\2/p' \
+        | head -1)
+fi
+
+# No file, or not a Rust source file: nothing this checker can say.
+[ -n "$file" ] || allow
+case "$file" in *.rs) ;; *) allow ;; esac
+[ -f "$file" ] || allow
+
+command -v pmat >/dev/null 2>&1 || allow   # fail-open, and it is documented above
+
+# --file keeps this sub-second; --format json puts the report on stdout and the
+# human chatter on stderr, so the reason below is machine-derived.
+out=$(pmat quality-gate --file "$file" --fail-on-violation --format json 2>/dev/null)
+rc=$?
+
+[ "$rc" -eq 0 ] && allow
+
+# pmat exits 1 on violations. Claude Code needs 2 to block, Antigravity needs a
+# deny decision — neither is "1", so the translation happens here rather than
+# being assumed.
+count=$(printf '%s' "$out" | tr -d ' \n' | grep -o '"check_type"' | wc -l | tr -d ' ')
+deny "pmat quality-gate: ${count:-1} violation(s) in ${file}. Run: pmat quality-gate --file ${file}"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.agents/hooks/pmat-quality-feedback.sh claude"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/cli/handlers/qa_mcp_sweep.rs
+++ b/src/cli/handlers/qa_mcp_sweep.rs
@@ -1248,3 +1248,134 @@ mod tests {
         }
     }
 }
+
+#[cfg(test)]
+mod agent_quality_hook_tests {
+    //! EV-3 (#999): the dual-client quality hook bundle.
+    //!
+    //! These are FEEDBACK hooks, not gates, and the tests say so — including
+    //! the clause the ticket makes mandatory: with `pmat` unavailable, both
+    //! clients allow the edit. That is not a bug to be fixed later, it is the
+    //! documented limit of the mechanism, and a test that did not assert it
+    //! would let someone come to believe the hook enforces something.
+    use std::path::Path;
+    use std::process::{Command, Stdio};
+
+    fn hook() -> &'static Path {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+    }
+
+    fn script() -> std::path::PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR")).join(".agents/hooks/pmat-quality-feedback.sh")
+    }
+
+    /// Both client configs must exist, parse, and point at the one entrypoint.
+    #[test]
+    fn both_client_configs_point_at_the_same_entrypoint() {
+        let root = hook();
+        let claude: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(root.join(".claude/settings.json")).expect("claude settings"),
+        )
+        .expect("claude settings parse");
+        let anti: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(root.join(".agents/hooks.json")).expect("agents hooks"),
+        )
+        .expect("agents hooks parse");
+
+        let claude_cmd = claude["hooks"]["PreToolUse"][0]["hooks"][0]["command"]
+            .as_str()
+            .expect("claude command");
+        let anti_cmd = anti["hooks"][0]["handler"]["command"]
+            .as_str()
+            .expect("antigravity command");
+
+        assert!(
+            claude_cmd.contains("pmat-quality-feedback.sh") && claude_cmd.ends_with("claude"),
+            "claude hook must invoke the shared entrypoint in claude mode: {claude_cmd}"
+        );
+        assert!(
+            anti_cmd.contains("pmat-quality-feedback.sh") && anti_cmd.ends_with("antigravity"),
+            "antigravity hook must invoke the shared entrypoint in antigravity mode: {anti_cmd}"
+        );
+        assert!(
+            script().is_file(),
+            "the entrypoint both configs name must exist"
+        );
+    }
+
+    /// Antigravity blocks only on the exact string `{"decision": "deny"}`;
+    /// anything else — including a crash — is an approval. So the script must
+    /// emit parseable JSON on BOTH paths.
+    #[test]
+    fn antigravity_mode_always_emits_parseable_json() {
+        for (label, payload) in [
+            ("clean", r#"{"tool_call":{"args":{"path":"src/lib.rs"}}}"#),
+            ("no path", r#"{"tool_call":{"args":{}}}"#),
+            ("garbage", "not json at all"),
+        ] {
+            let out = run(&["antigravity"], payload);
+            let parsed: serde_json::Value = serde_json::from_str(out.trim())
+                .unwrap_or_else(|e| panic!("{label}: unrecognized JSON is treated as approval by the runtime, so this must parse. got {out:?}: {e}"));
+            assert!(
+                parsed["decision"].is_string(),
+                "{label}: must carry a decision, got {parsed}"
+            );
+        }
+    }
+
+    /// The mandatory acceptance clause: no pmat, no enforcement, on both
+    /// clients. Asserted so it cannot quietly stop being true and be mistaken
+    /// for a gate.
+    #[test]
+    fn without_pmat_both_clients_allow_the_edit() {
+        let payload = r#"{"tool_input":{"file_path":"src/lib.rs"}}"#;
+        let claude = run_without_pmat(&["claude"], payload);
+        assert_eq!(
+            claude.0, 0,
+            "Claude Code blocks only on exit 2; with pmat missing the hook must NOT block, and does not"
+        );
+        let anti = run_without_pmat(&["antigravity"], payload);
+        assert_eq!(anti.0, 0, "antigravity handler must exit 0");
+        assert!(
+            anti.1.contains("allow"),
+            "with pmat missing the decision must be allow, got {:?}",
+            anti.1
+        );
+    }
+
+    fn run(args: &[&str], stdin: &str) -> String {
+        run_with_path(args, stdin, None).1
+    }
+
+    fn run_without_pmat(args: &[&str], stdin: &str) -> (i32, String) {
+        run_with_path(args, stdin, Some("/usr/bin:/bin"))
+    }
+
+    fn run_with_path(args: &[&str], stdin: &str, path: Option<&str>) -> (i32, String) {
+        use std::io::Write;
+        let mut cmd = Command::new("sh");
+        cmd.arg(script());
+        for a in args {
+            cmd.arg(a);
+        }
+        cmd.current_dir(hook())
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null());
+        if let Some(p) = path {
+            cmd.env("PATH", p);
+        }
+        let mut child = cmd.spawn().expect("spawn hook");
+        child
+            .stdin
+            .as_mut()
+            .expect("stdin")
+            .write_all(stdin.as_bytes())
+            .expect("write stdin");
+        let out = child.wait_with_output().expect("wait");
+        (
+            out.status.code().unwrap_or(-1),
+            String::from_utf8_lossy(&out.stdout).to_string(),
+        )
+    }
+}


### PR DESCRIPTION
EV-3 from #999. `.claude/settings.json` and `.agents/hooks.json` both shell to one POSIX
entrypoint running `pmat quality-gate --file <edited file>` when an agent writes a Rust file.

## They are not gates, and the code says so

The plan's own v1 called a PreToolUse hook "a blocking gate". That was wrong by this stack's
doctrine — **both clients fail open**:

> **Antigravity**, verbatim: *"If a hook script crashes (non-zero exit status), an HTTP hook
> returns a non-2xx status code, or an operation times out or returns unrecognized JSON, the
> runtime treats it as an approval (`allow`)."*

> **Claude Code**: exit 2 blocks; exit 1 blocks nothing.

The mandatory acceptance clause is **demonstrated, not asserted**:

```
PATH=/usr/bin:/bin  hook claude       -> exit 0
PATH=/usr/bin:/bin  hook antigravity  -> {"decision":"allow"}
```

and pinned by `without_pmat_both_clients_allow_the_edit`, so it cannot quietly stop being true
and leave someone believing the hook enforces something. **The gate remains `ci / gate`** on
protected master, now beside `feature-gate`, `docs build (docs.rs environment)` and
`pmat score`.

## Three corrections to the proposed mechanism, each measured

1. **`comply check --strict` is the wrong command.** Project-scoped with no `--file`, tens of
   seconds, and its exit code does not separate failure from warnings — it returned **2** on a
   fixture whose findings were warnings. `quality-gate --file` is sub-second, exits 0/1.
2. **Neither client treats exit 1 as a block.** Wiring either straight to pmat gives a hook
   that runs, reports, and blocks nothing. The translation to exit 2 / `{"decision":"deny"}` is
   explicit.
3. **Both clients deliver the tool call as JSON on stdin**, not as an argument. Extracted with
   `sed`, not a Node/Python shim — the only documented Antigravity `command` hook examples are
   `python3`, and adding an interpreter to reach a Rust binary is what this stack avoids. An
   unparseable payload falls through to allow: the already-documented behaviour, not a new
   hazard.

`antigravity_mode_always_emits_parseable_json` covers clean / no-path / garbage input, because
unrecognized JSON is an *approval* — emitting nothing on an error path would silently disable
the hook.

## Verified against both real payload shapes

```
{"tool_name":"Edit","tool_input":{"file_path": <violating>}}          -> exit 2
{"tool_name":"Edit","tool_input":{"file_path": <clean>}}              -> exit 0
{"tool_call":{"name":"write_file","args":{"path": <violating>}}}      -> {"decision":"deny", ...}
```

bashrs: **0 errors**. Full lib suite: **19,803 passing**. clippy clean.

## One thing checked and deliberately not filed

`quality-gate --format json` appeared to interleave human text with JSON — until I separated
the streams. stdout is pure JSON; the chatter is on stderr. My `2>&1` manufactured it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)