### PR TITLE
feat: serve the MCP tool surface over streamable HTTP, and refuse to serve it open

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -869,6 +869,7 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -908,6 +909,7 @@ dependencies = [
  "sync_wrapper",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -5193,6 +5195,7 @@ checksum = "3683fa1ad34aefe9e0d6d01a9bb405f5f6505db20633cbda56b565d9eb656fe0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "axum 0.8.9",
  "base64",
  "bytes",
  "chrono",
@@ -5200,12 +5203,14 @@ dependencies = [
  "futures",
  "futures-channel",
  "futures-locks",
+ "futures-util",
  "garde",
  "getrandom 0.4.3",
  "glob",
  "http",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "indexmap",
  "js-sys",
@@ -5214,6 +5219,7 @@ dependencies = [
  "pmcp-widget-utils",
  "regex",
  "reqwest",
+ "rustls",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -5224,6 +5230,8 @@ dependencies = [
  "tokio-tungstenite",
  "tokio-util",
  "toml 1.1.4+spec-1.1.0",
+ "tower",
+ "tower-http 0.7.0",
  "tracing",
  "tracing-subscriber",
  "url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,6 +111,12 @@ minijinja = { version = "2.16", default-features = false, optional = true }
 # MCP SDK - now core dependency for MCP server functionality
 # Sprint 46 Phase 4: Switched from "full" to explicit features (saves 150-250 KB)
 pmcp = { version = "2.17", features = ["websocket", "http", "sse", "validation"] }
+# Streamable-HTTP MCP transport (EV-6, #999). Opt-in rather than default: it is
+# the only thing that needs pmcp's `streamable-http`, which adds axum 0.8,
+# axum-core, matchit and tower-http 0.7 — four crates, and two of them are
+# DUPLICATE MAJORS of crates already in the tree (axum 0.7.9, tower-http 0.6.11).
+# Measured: 442 -> 446 unique crates, packaged size unchanged at 7.4 MiB. It
+# adds no rustls/hyper-rustls, which are already present via pmcp's `http`.
 
 # Caching
 lru = { version = "0.18", features = ["hashbrown"], optional = true }
@@ -320,6 +326,11 @@ sha2 = { version = "0.11", optional = true }  # For O(1) build artifact hash cac
 # capnpc = "0.20" # REMOVED: Unused Cap'n Proto compiler
 
 [features]
+# EV-6 (#999): serve the MCP tool surface over streamable HTTP, for clients that
+# cannot use stdio (the Google Antigravity Agent registers `{"type":"mcp_server",
+# "url": ...}` and supports streamable HTTP only — no SSE, and loopback is
+# blocked by its egress proxy).
+mcp-http = ["pmcp/streamable-http"]
 # Phase 2 Build Performance (Issue #89): Minimal defaults for fast builds
 # Default: Rust + TypeScript/JavaScript (most common use case)
 # - Opt-in for other languages: --features extended-languages or all-languages

--- a/src/cli/handlers/utility_serve_handlers.rs
+++ b/src/cli/handlers/utility_serve_handlers.rs
@@ -82,8 +82,43 @@ pub async fn handle_serve(
         crate::cli::commands::ServeTransport::All => "http+websocket+sse",
     };
 
+    // `http` is implemented now (EV-6, #999): the streamable-HTTP MCP transport.
+    // The other transports are not, and still say so rather than pretending.
+    if matches!(transport, crate::cli::commands::ServeTransport::Http) {
+        return serve_streamable_http(&host, port).await;
+    }
+
     let _ = write_serve_unimplemented_message(std::io::stderr(), &host, port, transport_label);
     std::process::exit(SERVE_UNIMPLEMENTED_EXIT_CODE);
+}
+
+/// Serve the MCP tool surface over streamable HTTP.
+///
+/// Refuses to start without `PMAT_MCP_HTTP_TOKEN`. That is not a convenience
+/// check: pmcp's HTTP layer only consults an auth provider if one is wired, and
+/// with none it serves every request — so a "working" endpoint with no token
+/// would publish the whole tool surface to anyone who can reach the port.
+async fn serve_streamable_http(host: &str, port: u16) -> Result<()> {
+    use crate::mcp_pmcp::http_server::{serve, BearerToken, TOKEN_ENV};
+
+    let auth = BearerToken::from_env()?;
+    let addr: std::net::SocketAddr = format!("{host}:{port}")
+        .parse()
+        .map_err(|e| anyhow::anyhow!("could not parse {host}:{port} as a socket address: {e}"))?;
+
+    let (bound, handle) = serve(addr, auth).await?;
+    eprintln!("pmat MCP (streamable HTTP) listening on http://{bound}/");
+    eprintln!("  auth: Bearer, from {TOKEN_ENV}; unauthenticated requests get 401");
+    eprintln!(
+        "  tools: {}",
+        crate::mcp_pmcp::tool_manifest::LIVE_MCP_TOOLS.len()
+    );
+    // Note for Antigravity: its egress proxy blocks loopback, so bind an
+    // address reachable from the sandbox and register the URL with the bearer
+    // injected via `network.allowlist[].transform` — never mounted in-sandbox.
+    handle
+        .await
+        .map_err(|e| anyhow::anyhow!("the MCP HTTP server task ended abnormally: {e}"))
 }
 
 #[cfg_attr(coverage_nightly, coverage(off))]

--- a/src/mcp_pmcp/http_server.rs
+++ b/src/mcp_pmcp/http_server.rs
@@ -1,0 +1,338 @@
+//! Streamable-HTTP MCP transport (EV-6, #999).
+//!
+//! Serves the same tool surface as the stdio server — `build_server` is shared,
+//! so "which tools does pmat advertise" keeps one answer — over pmcp's
+//! `StreamableHttpServer`.
+//!
+//! # Why streamable HTTP specifically
+//!
+//! The Google Antigravity Agent registers remote MCP servers as
+//! `{"type": "mcp_server", "name": ..., "url": ...}` and supports **streamable
+//! HTTP only** — SSE is explicitly unsupported — so stdio cannot reach it. Its
+//! egress proxy also blocks loopback, so the endpoint has to be a reachable
+//! allowlisted host rather than `localhost`.
+//!
+//! # It fails closed
+//!
+//! [`serve`] REFUSES TO START without a token. That is deliberate and it is the
+//! whole point of the module: pmcp's HTTP layer calls
+//! `server.get_auth_provider()` and, when there is none, falls through to
+//! `extract_auth_from_proxy_headers` and returns `Ok(None)` — i.e. it serves
+//! every request. A naive wiring would satisfy the sentence "unauthenticated
+//! request → 401" in a ticket while doing the opposite in production, because
+//! nothing would ever be unauthenticated. Requiring the token at construction
+//! makes that state unreachable rather than merely discouraged.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use anyhow::{bail, Result};
+use pmcp::server::auth::{AuthContext, AuthProvider};
+
+/// Environment variable carrying the bearer token.
+///
+/// A token belongs in the environment, not in a flag: an argument is visible in
+/// `ps` and lands in shell history. On Antigravity the bearer is injected at the
+/// egress proxy via `network.allowlist[].transform`, so it never sits inside the
+/// sandbox at all — that is the sovereign-safe shape and this variable is the
+/// server's half of it.
+pub const TOKEN_ENV: &str = "PMAT_MCP_HTTP_TOKEN";
+
+/// Shortest token this will accept.
+///
+/// Not security theatre: the failure mode being prevented is a deployment that
+/// sets `PMAT_MCP_HTTP_TOKEN=x`, passes its smoke test, and is effectively open.
+const MIN_TOKEN_LEN: usize = 16;
+
+/// Bearer-token auth over a single shared secret.
+#[derive(Clone)]
+pub struct BearerToken {
+    token: Arc<String>,
+}
+
+impl BearerToken {
+    /// Reject a token too short to be worth having.
+    pub fn new(token: impl Into<String>) -> Result<Self> {
+        let token = token.into();
+        if token.len() < MIN_TOKEN_LEN {
+            bail!(
+                "{TOKEN_ENV} must be at least {MIN_TOKEN_LEN} characters; got {}",
+                token.len()
+            );
+        }
+        Ok(Self {
+            token: Arc::new(token),
+        })
+    }
+
+    /// Read the token from the environment.
+    pub fn from_env() -> Result<Self> {
+        match std::env::var(TOKEN_ENV) {
+            Ok(t) => Self::new(t),
+            Err(_) => bail!(
+                "{TOKEN_ENV} is not set. `pmat serve` will not start an unauthenticated MCP \
+                 endpoint: pmcp serves every request when no auth provider is configured, so \
+                 starting without a token would publish the full tool surface to anyone who \
+                 can reach the port."
+            ),
+        }
+    }
+
+    /// Constant-time comparison.
+    ///
+    /// `==` on `String` short-circuits at the first differing byte, which leaks
+    /// a matching prefix to anyone who can time the response. The cost here is
+    /// nil and the alternative is a real, if unglamorous, oracle.
+    fn matches(&self, candidate: &str) -> bool {
+        let expected = self.token.as_bytes();
+        let got = candidate.as_bytes();
+        if expected.len() != got.len() {
+            return false;
+        }
+        let mut diff = 0u8;
+        for (a, b) in expected.iter().zip(got.iter()) {
+            diff |= a ^ b;
+        }
+        diff == 0
+    }
+}
+
+/// Redacted on purpose. `#[derive(Debug)]` would print the shared secret into
+/// any log line, panic message or `expect` that formats this value — and the
+/// test below formats it.
+impl std::fmt::Debug for BearerToken {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BearerToken")
+            .field("token", &"<redacted>")
+            .finish()
+    }
+}
+
+#[async_trait::async_trait]
+impl AuthProvider for BearerToken {
+    async fn validate_request(
+        &self,
+        authorization_header: Option<&str>,
+    ) -> pmcp::error::Result<Option<AuthContext>> {
+        // `None` here means "no credentials", and pmcp turns a validation error
+        // into 401. Returning Ok(None) instead would be a pass.
+        let header = authorization_header.ok_or_else(|| {
+            pmcp::error::Error::Internal("missing Authorization header".to_string())
+        })?;
+        let presented = header.strip_prefix("Bearer ").ok_or_else(|| {
+            pmcp::error::Error::Internal("Authorization header is not a Bearer token".to_string())
+        })?;
+        if !self.matches(presented.trim()) {
+            return Err(pmcp::error::Error::Internal("invalid bearer token".to_string()));
+        }
+        Ok(Some(AuthContext {
+            subject: "pmat-mcp-http".to_string(),
+            scopes: vec![],
+            ..AuthContext::default()
+        }))
+    }
+
+    fn auth_scheme(&self) -> &'static str {
+        "Bearer"
+    }
+
+    fn is_required(&self) -> bool {
+        true
+    }
+}
+
+/// Start the streamable-HTTP MCP endpoint. Returns the bound address and the
+/// server task.
+///
+/// Stateless by construction (`session_id_generator: None`): MCP revision
+/// 2026-07-28 removes the initialize/initialized handshake and
+/// `Mcp-Session-Id` entirely, and server-held session state is the pattern it
+/// dropped. Starting stateless means the transport does not have to be
+/// re-architected when pmat moves to that revision.
+#[cfg(feature = "mcp-http")]
+pub async fn serve(
+    addr: SocketAddr,
+    auth: BearerToken,
+) -> Result<(SocketAddr, tokio::task::JoinHandle<()>)> {
+    use pmcp::server::streamable_http_server::{StreamableHttpServer, StreamableHttpServerConfig};
+
+    let provider: Arc<dyn AuthProvider> = Arc::new(auth);
+    let server = crate::mcp_pmcp::simple_unified_server::SimpleUnifiedServer::build_server(Some(
+        provider,
+    ))
+    .map_err(|e| anyhow::anyhow!("building the MCP tool surface failed: {e}"))?;
+
+    let config = StreamableHttpServerConfig {
+        session_id_generator: None, // stateless
+        enable_json_response: true,
+        ..Default::default()
+    };
+    let http = StreamableHttpServer::with_config(
+        addr,
+        Arc::new(tokio::sync::Mutex::new(server)),
+        config,
+    );
+    http.start()
+        .await
+        .map_err(|e| anyhow::anyhow!("starting the streamable-HTTP MCP server failed: {e}"))
+}
+
+/// The build without the feature: say so rather than pretend.
+#[cfg(not(feature = "mcp-http"))]
+pub async fn serve(
+    _addr: SocketAddr,
+    _auth: BearerToken,
+) -> Result<(SocketAddr, tokio::task::JoinHandle<()>)> {
+    bail!(
+        "this pmat was built without the `mcp-http` feature, so the streamable-HTTP MCP \
+         transport is not compiled in. Rebuild with `--features mcp-http`."
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_short_token_is_refused() {
+        assert!(
+            BearerToken::new("tooshort").is_err(),
+            "a token short enough to guess must not be accepted"
+        );
+        assert!(BearerToken::new("0123456789abcdef").is_ok());
+    }
+
+    /// The invariant: no token, no server. Asserted because the failure mode is
+    /// silent — pmcp serves every request when no auth provider is configured,
+    /// so a `serve` that started without one would look healthy and be open.
+    #[test]
+    fn without_a_token_the_server_refuses_to_start() {
+        let saved = std::env::var(TOKEN_ENV).ok();
+        std::env::remove_var(TOKEN_ENV);
+        let got = BearerToken::from_env();
+        if let Some(v) = saved {
+            std::env::set_var(TOKEN_ENV, v);
+        }
+        let err = got.expect_err("must refuse without a token").to_string();
+        assert!(
+            err.contains("will not start an unauthenticated MCP endpoint"),
+            "the error must say why, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_request_without_credentials_is_rejected() {
+        let auth = BearerToken::new("0123456789abcdef0123").expect("token");
+        assert!(
+            auth.validate_request(None).await.is_err(),
+            "no Authorization header must not authenticate"
+        );
+        assert!(
+            auth.validate_request(Some("Basic 0123456789abcdef0123"))
+                .await
+                .is_err(),
+            "a non-Bearer scheme must not authenticate"
+        );
+        assert!(
+            auth.validate_request(Some("Bearer wrongwrongwrongwrong"))
+                .await
+                .is_err(),
+            "a wrong token must not authenticate"
+        );
+        assert!(
+            auth.validate_request(Some("Bearer 0123456789abcdef0123"))
+                .await
+                .expect("valid token")
+                .is_some(),
+            "the correct token must authenticate"
+        );
+    }
+
+    /// A prefix match must not pass, and must not be distinguishable by length.
+    #[test]
+    fn comparison_is_length_checked_and_constant_time() {
+        let auth = BearerToken::new("0123456789abcdef0123").expect("token");
+        assert!(!auth.matches("0123456789abcdef012"), "prefix must not match");
+        assert!(!auth.matches("0123456789abcdef01234"), "suffix must not match");
+        assert!(auth.matches("0123456789abcdef0123"));
+    }
+
+    #[test]
+    fn auth_is_required_and_advertises_bearer() {
+        let auth = BearerToken::new("0123456789abcdef0123").expect("token");
+        assert!(auth.is_required(), "optional auth is not auth");
+        assert_eq!(auth.auth_scheme(), "Bearer");
+    }
+}
+
+#[cfg(all(test, feature = "mcp-http"))]
+mod http_e2e_tests {
+    //! The invariant EV-6 exists for, asserted against a REAL bound socket
+    //! rather than against the provider in isolation: pmcp only consults the
+    //! auth provider if one is wired, and the whole hazard is a wiring that
+    //! looks right and serves open.
+    use super::*;
+
+    async fn start() -> (std::net::SocketAddr, tokio::task::JoinHandle<()>) {
+        let auth = BearerToken::new("0123456789abcdef0123").expect("token");
+        serve("127.0.0.1:0".parse().expect("addr"), auth)
+            .await
+            .expect("server starts")
+    }
+
+    #[tokio::test]
+    async fn unauthenticated_request_is_401_and_a_valid_token_is_not() {
+        let (addr, handle) = start().await;
+        // pmcp mounts the MCP endpoint at the ROOT of the server it starts
+        // (`build_mcp_router` routes POST/GET/DELETE on "/"), not at /mcp. An
+        // earlier version of this test used /mcp, got 404, and would have
+        // "passed" a 401 assertion against a path that does not exist.
+        let url = format!("http://{addr}/");
+        let client = reqwest::Client::new();
+        // Streamable HTTP negotiates content before it authenticates: without
+        // this the server answers 406 and the 401 assertion below would be
+        // testing content negotiation, not auth.
+        const ACCEPT: &str = "application/json, text/event-stream";
+        let body = serde_json::json!({
+            "jsonrpc":"2.0","id":1,"method":"tools/list","params":{}
+        });
+
+        let no_auth = client
+            .post(&url)
+            .header("Accept", ACCEPT)
+            .json(&body)
+            .send()
+            .await
+            .expect("request");
+        assert_eq!(
+            no_auth.status().as_u16(),
+            401,
+            "an unauthenticated request must be refused, not served"
+        );
+
+        let bad = client
+            .post(&url)
+            .header("Accept", ACCEPT)
+            .header("Authorization", "Bearer wrongwrongwrongwrong")
+            .json(&body)
+            .send()
+            .await
+            .expect("request");
+        assert_eq!(bad.status().as_u16(), 401, "a wrong token must be refused");
+
+        let good = client
+            .post(&url)
+            .header("Accept", ACCEPT)
+            .header("Authorization", "Bearer 0123456789abcdef0123")
+            .json(&body)
+            .send()
+            .await
+            .expect("request");
+        assert!(
+            good.status().is_success(),
+            "the correct token must be served, got {}",
+            good.status()
+        );
+        handle.abort();
+    }
+}

--- a/src/mcp_pmcp/mod.rs
+++ b/src/mcp_pmcp/mod.rs
@@ -101,6 +101,7 @@
 //! // Memory usage: 50MB (50% reduction)
 //! ```
 
+pub mod http_server;
 pub mod agent_context_handlers;
 pub mod analyze_handlers;
 pub mod context_handlers;

--- a/src/mcp_pmcp/simple_unified_server.rs
+++ b/src/mcp_pmcp/simple_unified_server.rs
@@ -321,6 +321,27 @@ pub struct SimpleUnifiedServer {
     state_manager: Arc<Mutex<StateManager>>,
 }
 
+/// Forwards an `Arc<dyn AuthProvider>` to `ServerBuilder::auth_provider`,
+/// which takes `impl AuthProvider + 'static` and so will not accept the trait
+/// object directly.
+struct ArcAuthProvider(std::sync::Arc<dyn pmcp::server::auth::AuthProvider>);
+
+#[async_trait::async_trait]
+impl pmcp::server::auth::AuthProvider for ArcAuthProvider {
+    async fn validate_request(
+        &self,
+        authorization_header: Option<&str>,
+    ) -> pmcp::error::Result<Option<pmcp::server::auth::AuthContext>> {
+        self.0.validate_request(authorization_header).await
+    }
+    fn auth_scheme(&self) -> &'static str {
+        self.0.auth_scheme()
+    }
+    fn is_required(&self) -> bool {
+        self.0.is_required()
+    }
+}
+
 impl SimpleUnifiedServer {
     #[provable_contracts_macros::contract("pmat-core.yaml", equation = "check_compliance")]
     /// Create a new instance.
@@ -333,7 +354,23 @@ impl SimpleUnifiedServer {
     #[provable_contracts_macros::contract("pmat-core.yaml", equation = "check_compliance")]
     pub async fn run(&self) -> Result<(), Box<dyn std::error::Error>> {
         info!("Starting PMAT Simple Unified MCP server (pmcp SDK)");
+        let server = Self::build_server(None)?;
+        self.run_stdio(server).await
+    }
 
+    /// Build the tool surface, independent of transport.
+    ///
+    /// Extracted from `run()` so the SAME registrations serve stdio and
+    /// streamable HTTP (EV-6, #999). A second builder would be a second answer
+    /// to "which tools does pmat advertise", and this file already carries a
+    /// drift-guard test because that question has had two answers before.
+    ///
+    /// `auth` is applied when present. It is `None` for stdio, where the
+    /// transport is the process boundary; over HTTP it is REQUIRED by the
+    /// caller — see `serve_http`.
+    pub fn build_server(
+        auth: Option<std::sync::Arc<dyn pmcp::server::auth::AuthProvider>>,
+    ) -> Result<Server, Box<dyn std::error::Error>> {
         // KAIZEN-0165: shared IndexManager for the 4 pmat_* AgentContextTools.
         // Construction is cheap (no disk I/O); first tool call triggers index build.
         let index_manager = Arc::new(IndexManager::new(
@@ -341,7 +378,7 @@ impl SimpleUnifiedServer {
         ));
 
         // Build server with core PMAT tools that are already working
-        let server = Server::builder()
+        let builder = Server::builder()
             .name("paiml-mcp-agent-toolkit")
             .version(env!("CARGO_PKG_VERSION"))
             .capabilities(ServerCapabilities::tools_only())
@@ -396,9 +433,20 @@ impl SimpleUnifiedServer {
                 "pmat_index_stats",
                 PmatIndexStatsHandler::new(index_manager.clone()),
             )
-            .build()?;
+            ;
+        let builder = match auth {
+            Some(provider) => builder.auth_provider(ArcAuthProvider(provider)),
+            None => builder,
+        };
+        Ok(builder.build()?)
+    }
 
-        info!("PMAT Simple Unified MCP server ready with 20 tools (16 core + 4 agent_context), listening on stdio");
+    /// Serve the built tool surface over stdio.
+    async fn run_stdio(&self, server: Server) -> Result<(), Box<dyn std::error::Error>> {
+        info!(
+            "PMAT Simple Unified MCP server ready with {} tools, listening on stdio",
+            crate::mcp_pmcp::tool_manifest::LIVE_MCP_TOOLS.len()
+        );
 
         // Run server with stdio transport, racing against stdin EOF. pmcp's
         // `Server::run` keep-alive future never completes (even after the


### PR DESCRIPTION
EV-6 from #999. `pmat serve --transport http` now starts a streamable-HTTP MCP endpoint
instead of exiting 2 with "not yet implemented". Other transports still say they are
unimplemented, because they are.

## Verified against the built binary

```
no PMAT_MCP_HTTP_TOKEN   -> refuses to start, with the reason
unauthenticated POST     -> HTTP 401
wrong bearer             -> HTTP 401
correct bearer           -> HTTP 200, tools/list returns 16 tools
```

## It fails closed, and that is the module's point

pmcp's HTTP layer calls `server.get_auth_provider()` and, **with none, falls through and
serves every request**. A wiring with no token would satisfy the sentence "unauthenticated
request → 401" while doing the opposite in production, because nothing would ever *be*
unauthenticated. Requiring the token at construction makes that state unreachable rather than
discouraged.

Token comes from the environment, not a flag — an argument is visible in `ps` and lands in
shell history. On Antigravity the bearer is injected at the egress proxy via
`network.allowlist[].transform`, so it never sits in the sandbox.

## One builder, two transports

`SimpleUnifiedServer::build_server` is extracted so stdio and HTTP share **one** set of tool
registrations. A second builder would be a second answer to "which tools does pmat advertise",
and this file already carries a drift-guard test because that question has had two answers
before. The stdio log line that said *"ready with 20 tools"* now reads the count from
`LIVE_MCP_TOOLS` — it was stale within a day of EV-0.

Stateless by construction (`session_id_generator: None`): MCP 2026-07-28 removes the
initialize handshake and `Mcp-Session-Id`, so the transport won't need re-architecting when
pmat moves to it.

## Cost: measured, and the earlier assessment was wrong

Behind an **opt-in `mcp-http` feature**. pmcp's `streamable-http` adds axum 0.8, axum-core,
matchit, tower-http 0.7 — 442 → **446** crates — of which two are *duplicate majors* of crates
already present. It adds **no rustls or hyper-rustls**; both are already in the tree via pmcp's
`http`. Packaged size **unchanged at 7.4 MiB**.

The verification put EV-6's risk as "rustls/hyper-rustls against the size ceiling". Wrong on
both counts. The real cost is the duplicate majors — which nobody should pay by default, hence
opt-in.

## The end-to-end test earned its keep three times

Against the provider alone, everything passed. Against a real socket the first version got
**404** (pmcp mounts the router at `/`, not `/mcp`) and the second got **406** (streamable HTTP
negotiates content *before* it authenticates, so without an `Accept` header the 401 assertion
was testing content negotiation). Either would have shipped a green test proving nothing about
auth.

Constant-time comparison; `Debug` implemented by hand to **redact** — `derive` would print the
shared secret into any log line or `expect` that formats it, including in these tests.

`cargo test --lib`: 19,808 passing. clippy clean with and without the feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)