### PR TITLE
fix: gates that could not fail, and reports that called absence success

### DIFF
--- a/.github/required-status-checks.txt
+++ b/.github/required-status-checks.txt
@@ -16,6 +16,7 @@ ci / gate
 feature-gate
 docs build (docs.rs environment)
 pmat score
+provable ladder
 #
 # NOT LISTED, DELIBERATELY: `mutation-diff`. It was added to live branch
 # protection mid-session by an agent, and reverted. The workflow that produces
@@ -65,3 +66,23 @@ pmat score
 # What is NOT weakened, and must not be: `enforce_admins` stays false only
 # because the admin override is the break-glass path; force pushes and deletions
 # remain disabled; `strict` remains true so a stale branch cannot merge.
+#
+# `provable ladder` ADDED 2026-08-20. It runs the L1-L5 contract ladder: the
+# binding registry at L1, `lake build` over contracts/lean/Theorems/ at L5, and
+# a grep that fails the job on any `sorry` or `admit`. Until now it reported and
+# could not block, so a Lean proof failure could not stop a merge — 13 theorems
+# proving the TDG grade order sat behind a check nothing required, which is the
+# same shape as CB-2100's original finding (155 registered rules, 0 reachable)
+# one layer up.
+#
+# Safe to require because it passes: five consecutive successes on
+# release/3.32.0 before it was added, and PR #1021 merged with it green.
+#
+# ORDERING, which matters more than it looks. The job still carries
+# `Ladder gate - pmat comply` under `continue-on-error: true`
+# (quality-gate.yml:171). Requiring the job is safe BECAUSE of that flag.
+# Removing the flag while the job is required would deadlock every pull request
+# on comply's four current failures. The sequence is: require the job, add the
+# pv obligation gate, and only then remove `continue-on-error` once comply is
+# green. An agent nearly deadlocked this repository by requiring `mutation-diff`
+# in the other order.

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -199,6 +199,28 @@ jobs:
       - name: L1 — binding registry AllImplemented (build.rs, already enforced by install)
         run: echo "contracts/binding.yaml AllImplemented enforced at build time (build.rs)."
 
+      # ── L2/L3: the contracts must be readable BY THE TOOL THAT AUDITS THEM.
+      #
+      # `pv` reads `falsification_tests:`. Thirteen contracts carried their
+      # obligations under `falsification:`, so `pv status` reported 0 for them
+      # and 135 of this repository's 179 obligations were invisible to the audit
+      # meant to cover them — including all 90 test-bearing ones, in three
+      # contracts written on this very branch.
+      #
+      # This step is blocking and `provable ladder` is a required check, so an
+      # obligation that pv cannot read now fails the merge instead of reporting
+      # a confident zero. Entries with no `test:` field are left alone: those
+      # are alert thresholds, not falsification tests, and forcing them into
+      # the schema would fabricate tests that do not exist.
+      # PINNED. This gate is blocking and `provable ladder` is required, so an
+      # upstream release that tightens validation would redden every pull
+      # request without a commit here. 0.63.0 is the version the gate was
+      # verified against; bump it deliberately and re-run the gate locally.
+      - name: Install pv (provable-contracts CLI)
+        run: cargo install aprender-contracts-cli --version 0.63.0 --locked
+      - name: L2/L3 — every contract validates and its obligations are visible to pv
+        run: python3 scripts/pv-obligation-gate.py
+
       # ── Ladder gate: activates CB-1205/1206/1308/1330/1614/1618/1619 at once.
       # Advisory during the 30-day grace period (ALADR-012); flip
       # `continue-on-error` to false to make `provable ladder / comply` a

--- a/contracts/comply-gate-effect-v1.yaml
+++ b/contracts/comply-gate-effect-v1.yaml
@@ -227,112 +227,184 @@ postconditions:
   - "CB-2100's Fail message names the job and the key responsible"
   - "CB-2100 fails when docs/status/comply-enforcement-ledger.md is missing or has drifted"
 
-falsification:
-  - condition: "F-1: the job invoking `pmat comply check` carries `continue-on-error: true` and CB-2100 still passes"
-    severity: P0
+falsification_tests:
+  - id: f_1
+    rule: "F-1: the job invoking `pmat comply check` carries `continue-on-error: true` and CB-2100 still passes"
+    prediction: "the named test fails when this condition holds"
     test: src/services/gate_effect/tests_cb2100.rs::f1_job_level_continue_on_error_fails_citing_job_and_key
-  - condition: "F-2: the step is `pmat comply check || true` and CB-2100 still passes"
-    severity: P0
+    if_fails: "P0 — this contract's guarantee does not hold"
+  - id: f_2
+    rule: "F-2: the step is `pmat comply check || true` and CB-2100 still passes"
+    prediction: "the named test fails when this condition holds"
     test: src/services/gate_effect/tests_cb2100.rs::f2_or_true_fails
-  - condition: "F-3: a job whose DISPLAY NAME equals the required context string is credited as the job that reports it"
-    severity: P0
+    if_fails: "P0 — this contract's guarantee does not hold"
+  - id: f_3
+    rule: "F-3: a job whose DISPLAY NAME equals the required context string is credited as the job that reports it"
+    prediction: "the named test fails when this condition holds"
     test: src/services/gate_effect/tests_cb2100.rs::f3_a_display_name_equal_to_the_required_context_is_not_a_match
-  - condition: "F-4: a workflow with zero jobs yields a pass instead of a fail"
-    severity: P0
+    if_fails: "P0 — this contract's guarantee does not hold"
+  - id: f_4
+    rule: "F-4: a workflow with zero jobs yields a pass instead of a fail"
+    prediction: "the named test fails when this condition holds"
     test: src/services/gate_effect/tests_cb2100.rs::f4_zero_jobs_fails_closed
-  - condition: "F-5: an unfetchable branch-protection API yields a pass instead of a fail"
-    severity: P0
+    if_fails: "P0 — this contract's guarantee does not hold"
+  - id: f_5
+    rule: "F-5: an unfetchable branch-protection API yields a pass instead of a fail"
+    prediction: "the named test fails when this condition holds"
     test: src/services/gate_effect/tests_cb2100.rs::f5_unresolvable_required_contexts_fail_closed
-  - condition: "F-6 (the control): the live shape — required context `ci / gate` beside an unrequired job literally named `gate` — fails, so every other fixture proves nothing"
-    severity: P0
+    if_fails: "P0 — this contract's guarantee does not hold"
+  - id: f_6_control
+    rule: "F-6 (the control): the live shape — required context `ci / gate` beside an unrequired job literally named `gate` — fails, so every other fixture proves nothing"
+    prediction: "the named test fails when this condition holds"
     test: src/services/gate_effect/tests_cb2100.rs::f6_required_context_beside_an_unrequired_job_named_the_same_thing_passes
-  - condition: "INV-2100-4: a wrapper that prints a failure verdict and exits 0 is credited as a gate"
-    severity: P0
+    if_fails: "P0 — this contract's guarantee does not hold"
+  - id: f
+    rule: "INV-2100-4: a wrapper that prints a failure verdict and exits 0 is credited as a gate"
+    prediction: "the named test fails when this condition holds"
     test: src/services/gate_effect/tests_cb2100.rs::inv_2100_4_a_wrapper_that_prints_failed_and_exits_zero_does_not_gate
-  - condition: "INV-2100-5: an invocation inside a job that can never succeed is credited as a gate"
-    severity: P0
+    if_fails: "P0 — this contract's guarantee does not hold"
+  - id: f_6
+    rule: "INV-2100-5: an invocation inside a job that can never succeed is credited as a gate"
+    prediction: "the named test fails when this condition holds"
     test: src/services/gate_effect/tests_cb2100.rs::inv_2100_5_a_job_that_can_never_succeed_does_not_gate
-  - condition: "INV-2100-5 control: `exit 1` inside an `if` is misread as an impossibility, failing every correctly-written workflow"
-    severity: P0
+    if_fails: "P0 — this contract's guarantee does not hold"
+  - id: f_control
+    rule: "INV-2100-5 control: `exit 1` inside an `if` is misread as an impossibility, failing every correctly-written workflow"
+    prediction: "the named test fails when this condition holds"
     test: src/services/gate_effect/tests_cb2100.rs::inv_2100_5_a_guarded_exit_is_a_gate_not_an_impossibility
-  - condition: "INV-2100-6: a job that compiles a test suite without running it establishes reachability for those tests"
-    severity: P0
+    if_fails: "P0 — this contract's guarantee does not hold"
+  - id: f_7
+    rule: "INV-2100-6: a job that compiles a test suite without running it establishes reachability for those tests"
+    prediction: "the named test fails when this condition holds"
     test: src/services/gate_effect/tests_cb2100.rs::inv_2100_6_compiling_a_test_is_not_running_it
-  - condition: "INV-2100-7: the rule hardcodes a gate name and so stops checking the day a job is renamed"
-    severity: P0
+    if_fails: "P0 — this contract's guarantee does not hold"
+  - id: f_8
+    rule: "INV-2100-7: the rule hardcodes a gate name and so stops checking the day a job is renamed"
+    prediction: "the named test fails when this condition holds"
     test: src/services/gate_effect/tests_cb2100.rs::inv_2100_7_no_gate_name_is_hardcoded_in_the_rule
-  - condition: "INV-2100-1: the roots are taken one at a time, so one healthy required check answers for four"
-    severity: P0
+    if_fails: "P0 — this contract's guarantee does not hold"
+  - id: f_9
+    rule: "INV-2100-1: the roots are taken one at a time, so one healthy required check answers for four"
+    prediction: "the named test fails when this condition holds"
     test: src/services/gate_effect/tests_cb2100.rs::inv_2100_1_any_root_may_carry_the_roster
-  - condition: "an empty severity=error roster yields a vacuous pass"
-    severity: P0
+    if_fails: "P0 — this contract's guarantee does not hold"
+  - id: f_10
+    rule: "an empty severity=error roster yields a vacuous pass"
+    prediction: "the named test fails when this condition holds"
     test: src/services/gate_effect/tests.rs::control_roster_is_not_empty
-  - condition: "an empty CB rule roster yields an empty ledger instead of an error"
-    severity: P0
+    if_fails: "P0 — this contract's guarantee does not hold"
+  - id: f_11
+    rule: "an empty CB rule roster yields an empty ledger instead of an error"
+    prediction: "the named test fails when this condition holds"
     test: src/services/gate_effect/tests_cb2100.rs::ledger_over_an_empty_roster_is_an_error_not_a_clean_sheet
-  - condition: "the ledger invents or omits rows because it recounts the rules instead of reading the registry"
-    severity: P0
+    if_fails: "P0 — this contract's guarantee does not hold"
+  - id: f_12
+    rule: "the ledger invents or omits rows because it recounts the rules instead of reading the registry"
+    prediction: "the named test fails when this condition holds"
     test: src/services/gate_effect/tests_cb2100.rs::the_roster_is_exactly_the_registered_rule_set
-  - condition: "a configuration that declares rules and grades none of them error is reported as a clean roster"
-    severity: P0
+    if_fails: "P0 — this contract's guarantee does not hold"
+  - id: f_13
+    rule: "a configuration that declares rules and grades none of them error is reported as a clean roster"
+    prediction: "the named test fails when this condition holds"
     test: src/services/gate_effect/tests_cb2100.rs::a_config_whose_checks_are_all_sub_error_is_a_hole_with_a_diagnosis
-  - condition: "the contract names kani harnesses that do not exist, or that were renamed out from under it — `#[cfg(kani)]` code is never compiled by `cargo test`, so nothing would notice"
-    severity: P1
+    if_fails: "P0 — this contract's guarantee does not hold"
+  - id: f_14
+    rule: "the contract names kani harnesses that do not exist, or that were renamed out from under it — `#[cfg(kani)]` code is never compiled by `cargo test`, so nothing would notice"
+    prediction: "the named test fails when this condition holds"
     test: src/services/gate_effect/tests_cb2100.rs::every_kani_harness_the_contract_names_exists
-  - condition: "`kind: kernel` plus a `kani_harness` per equation is read as a discharged proof, though nothing in this repository can run one"
-    severity: P0
+    if_fails: "P1 — this contract's guarantee does not hold"
+  - id: f_15
+    rule: "`kind: kernel` plus a `kani_harness` per equation is read as a discharged proof, though nothing in this repository can run one"
+    prediction: "the named test fails when this condition holds"
     test: src/services/gate_effect/tests_cb2100.rs::the_contract_states_whether_its_kani_harnesses_discharge
-  - condition: "the not_discharged note rots into a false claim: the contract says the harnesses are discharged while nothing runs kani, or a runner is added and the note is left stale"
-    severity: P0
+    if_fails: "P0 — this contract's guarantee does not hold"
+  - id: f_16
+    rule: "the not_discharged note rots into a false claim: the contract says the harnesses are discharged while nothing runs kani, or a runner is added and the note is left stale"
+    prediction: "the named test fails when this condition holds"
     test: src/services/gate_effect/tests_cb2100.rs::a_discharged_claim_requires_something_that_actually_runs_kani
-  - condition: "an opaque required context — one resolving into a workflow this repository cannot read — renders identically to a context that was read in full and reaches nothing, so a hole is reported as a measured zero"
-    severity: P0
+    if_fails: "P0 — this contract's guarantee does not hold"
+  - id: f_17
+    rule: "an opaque required context — one resolving into a workflow this repository cannot read — renders identically to a context that was read in full and reaches nothing, so a hole is reported as a measured zero"
+    prediction: "the named test fails when this condition holds"
     test: src/services/gate_effect/tests_cb2100.rs::an_opaque_root_is_not_rendered_as_a_measured_zero
-  - condition: "a phantom required context renders as a measured zero"
-    severity: P1
+    if_fails: "P0 — this contract's guarantee does not hold"
+  - id: f_18
+    rule: "a phantom required context renders as a measured zero"
+    prediction: "the named test fails when this condition holds"
     test: src/services/gate_effect/tests_cb2100.rs::a_phantom_root_is_not_rendered_as_a_measured_zero
-  - condition: "the control: every root is rendered `unknown`, which satisfies the two tests above and destroys the table"
-    severity: P0
+    if_fails: "P1 — this contract's guarantee does not hold"
+  - id: f_control_2
+    rule: "the control: every root is rendered `unknown`, which satisfies the two tests above and destroys the table"
+    prediction: "the named test fails when this condition holds"
     test: src/services/gate_effect/tests_cb2100.rs::a_root_that_carries_the_roster_still_reads_as_yes
-  - condition: "a ledger row renders a blank Title, which is indistinguishable from `has no title`, `never names itself` and `the scanner lost it`"
-    severity: P1
+    if_fails: "P0 — this contract's guarantee does not hold"
+  - id: f_19
+    rule: "a ledger row renders a blank Title, which is indistinguishable from `has no title`, `never names itself` and `the scanner lost it`"
+    prediction: "the named test fails when this condition holds"
     test: src/services/gate_effect/tests_cb2100.rs::the_ledger_never_renders_a_blank_title
-  - condition: "the roster's `#[cfg(test)]` guard is a substring match, so a file that MENTIONS the attribute in a comment loses every rule declared below the mention"
-    severity: P1
+    if_fails: "P1 — this contract's guarantee does not hold"
+  - id: f_20
+    rule: "the roster's `#[cfg(test)]` guard is a substring match, so a file that MENTIONS the attribute in a comment loses every rule declared below the mention"
+    prediction: "the named test fails when this condition holds"
     test: src/services/gate_effect/tests_cb2100.rs::a_cfg_test_mention_in_a_comment_does_not_truncate_the_roster_scan
-  - condition: "the control: loosening that guard makes the roster cite lines that do not declare the rule they are attributed to"
-    severity: P0
+    if_fails: "P1 — this contract's guarantee does not hold"
+  - id: f_control_3
+    rule: "the control: loosening that guard makes the roster cite lines that do not declare the rule they are attributed to"
+    prediction: "the named test fails when this condition holds"
     test: src/services/gate_effect/tests_cb2100.rs::every_citation_points_at_a_line_that_names_its_rule
-  - condition: "a check owns a CB id and never reports it, so no finding it emits can be tied back to its ledger row"
-    severity: P1
+    if_fails: "P0 — this contract's guarantee does not hold"
+  - id: f_21
+    rule: "a check owns a CB id and never reports it, so no finding it emits can be tied back to its ledger row"
+    prediction: "the named test fails when this condition holds"
     test: src/services/gate_effect/tests_cb2100.rs::every_rule_that_owns_a_cb_id_reports_it_at_runtime
-  - condition: "an edit two lines above a rule declaration moves its citation and is reported as ledger drift, so the gate reddens on changes it does not measure"
-    severity: P1
+    if_fails: "P1 — this contract's guarantee does not hold"
+  - id: f_22
+    rule: "an edit two lines above a rule declaration moves its citation and is reported as ledger drift, so the gate reddens on changes it does not measure"
+    prediction: "the named test fails when this condition holds"
     test: src/services/gate_effect/tests_cb2100.rs::an_edit_above_a_rule_declaration_is_not_ledger_drift
-  - condition: "supplying the IDENTICAL required contexts through PMAT_REQUIRED_STATUS_CHECKS instead of the manifest is reported as ledger drift"
-    severity: P1
+    if_fails: "P1 — this contract's guarantee does not hold"
+  - id: f_23
+    rule: "supplying the IDENTICAL required contexts through PMAT_REQUIRED_STATUS_CHECKS instead of the manifest is reported as ledger drift"
+    prediction: "the named test fails when this condition holds"
     test: src/services/gate_effect/tests_cb2100.rs::the_provenance_of_the_root_list_is_not_ledger_drift
-  - condition: "the control: drift is loosened until a changed status, carrier, declaring file, severity, title or id no longer registers"
-    severity: P0
+    if_fails: "P1 — this contract's guarantee does not hold"
+  - id: f_control_4
+    rule: "the control: drift is loosened until a changed status, carrier, declaring file, severity, title or id no longer registers"
+    prediction: "the named test fails when this condition holds"
     test: src/services/gate_effect/tests_cb2100.rs::a_changed_status_carrier_or_file_is_still_ledger_drift
-  - condition: "the control: drift is loosened until a ledger missing a whole rule still reads as up to date"
-    severity: P0
+    if_fails: "P0 — this contract's guarantee does not hold"
+  - id: f_control_5
+    rule: "the control: drift is loosened until a ledger missing a whole rule still reads as up to date"
+    prediction: "the named test fails when this condition holds"
     test: src/services/gate_effect/tests_cb2100.rs::a_missing_row_is_still_ledger_drift
-  - condition: "the ledger is non-deterministic, so nobody can diff it and drift goes unnoticed"
-    severity: P1
+    if_fails: "P0 — this contract's guarantee does not hold"
+  - id: f_24
+    rule: "the ledger is non-deterministic, so nobody can diff it and drift goes unnoticed"
+    prediction: "the named test fails when this condition holds"
     test: src/services/gate_effect/tests_cb2100.rs::the_rendered_ledger_is_deterministic
-  - condition: "a required context that no job produces is treated as absence of evidence rather than a phantom gate"
-    severity: P1
+    if_fails: "P1 — this contract's guarantee does not hold"
+  - id: f_25
+    rule: "a required context that no job produces is treated as absence of evidence rather than a phantom gate"
+    prediction: "the named test fails when this condition holds"
     test: src/services/gate_effect/tests.rs::a_phantom_required_context_fails
-  - condition: "an unreadable external reusable workflow is credited as enforcement"
-    severity: P0
+    if_fails: "P1 — this contract's guarantee does not hold"
+  - id: f_26
+    rule: "an unreadable external reusable workflow is credited as enforcement"
+    prediction: "the named test fails when this condition holds"
     test: src/services/gate_effect/tests.rs::falsify_2100_3b_external_reusable_workflow_is_opaque_not_compliant
-  - condition: "a `run:` block that pipes the invocation is credited with its exit code although bash -e leaves pipefail off"
-    severity: P1
+    if_fails: "P0 — this contract's guarantee does not hold"
+  - id: f_27
+    rule: "a `run:` block that pipes the invocation is credited with its exit code although bash -e leaves pipefail off"
+    prediction: "the named test fails when this condition holds"
     test: src/services/gate_effect/tests.rs::falsify_2100_2c_piped_invocation_loses_its_status
-  - condition: "an `if: always()` summary job is credited with its needs' failures although it never inspects needs.<id>.result"
-    severity: P0
+    if_fails: "P1 — this contract's guarantee does not hold"
+  - id: f_28
+    rule: "an `if: always()` summary job is credited with its needs' failures although it never inspects needs.<id>.result"
+    prediction: "the named test fails when this condition holds"
     test: src/services/gate_effect/tests.rs::if_always_without_a_result_check_breaks_the_edge
-  - condition: "every fixture fails, including the healthy one, so the rule proves nothing"
-    severity: P0
+    if_fails: "P0 — this contract's guarantee does not hold"
+  - id: f_29
+    rule: "every fixture fails, including the healthy one, so the rule proves nothing"
+    prediction: "the named test fails when this condition holds"
     test: src/services/gate_effect/tests.rs::control_a_plain_enforcing_job_passes
+    if_fails: "P0 — this contract's guarantee does not hold"

--- a/contracts/comply-ratchet-v1.yaml
+++ b/contracts/comply-ratchet-v1.yaml
@@ -154,91 +154,149 @@ postconditions:
   - "CB-2102 reports Fail with severity=error whenever any invariant above is violated"
   - "CB-2102's Fail message names the metric and both numbers"
 
-falsification:
-  - condition: "F-1: a change adds one to a metric (B+1) and the ratchet still passes"
-    severity: P0
+falsification_tests:
+  - id: f_1
+    rule: "F-1: a change adds one to a metric (B+1) and the ratchet still passes"
+    prediction: "the named test fails when this condition holds"
     test: src/services/metrics_ratchet/kernel_tests.rs::falsify_2102_1_one_added_unwrap_fails_against_the_measured_baseline
-  - condition: "F-2: an improvement (B-3) fails, or the lowering pass does not rewrite the baseline to B-3"
-    severity: P0
+    if_fails: "P0 — this contract's guarantee does not hold"
+  - id: f_2
+    rule: "F-2: an improvement (B-3) fails, or the lowering pass does not rewrite the baseline to B-3"
+    prediction: "the named test fails when this condition holds"
     test: src/services/metrics_ratchet/kernel_tests.rs::falsify_2102_2_removing_three_passes_and_lowers_the_baseline
-  - condition: "F-3: the file is edited upward with no justification and the ratchet still passes — the ratchet must not be silently loosenable, which is the whole point"
-    severity: P0
+    if_fails: "P0 — this contract's guarantee does not hold"
+  - id: f_3
+    rule: "F-3: the file is edited upward with no justification and the ratchet still passes — the ratchet must not be silently loosenable, which is the whole point"
+    prediction: "the named test fails when this condition holds"
     test: src/services/metrics_ratchet/kernel_tests.rs::falsify_2102_3_raising_a_baseline_without_justification_fails
-  - condition: "F-3 control: raise detection reads the direction of the edit rather than the sign of the metric"
-    severity: P1
+    if_fails: "P0 — this contract's guarantee does not hold"
+  - id: f_3_control
+    rule: "F-3 control: raise detection reads the direction of the edit rather than the sign of the metric"
+    prediction: "the named test fails when this condition holds"
     test: src/services/metrics_ratchet/kernel_tests.rs::falsify_2102_3_raise_detection_is_direction_free
-  - condition: "F-4: a metric absent from the measurement run passes"
-    severity: P0
+    if_fails: "P1 — this contract's guarantee does not hold"
+  - id: f_4
+    rule: "F-4: a metric absent from the measurement run passes"
+    prediction: "the named test fails when this condition holds"
     test: src/services/metrics_ratchet/kernel_tests.rs::falsify_2102_4_missing_measurement_fails_it_does_not_pass
-  - condition: "INV-2102-1: the verdict does not fail exactly when the observation exceeds the baseline"
-    severity: P0
+    if_fails: "P0 — this contract's guarantee does not hold"
+  - id: f
+    rule: "INV-2102-1: the verdict does not fail exactly when the observation exceeds the baseline"
+    prediction: "the named test fails when this condition holds"
     test: src/services/metrics_ratchet/kernel_tests.rs::inv_2102_1_verdict_fails_exactly_when_observed_exceeds_baseline
-  - condition: "INV-2102-2: the lowering arithmetic raises a baseline"
-    severity: P0
+    if_fails: "P0 — this contract's guarantee does not hold"
+  - id: f_5
+    rule: "INV-2102-2: the lowering arithmetic raises a baseline"
+    prediction: "the named test fails when this condition holds"
     test: src/services/metrics_ratchet/kernel_tests.rs::inv_2102_2_next_baseline_is_monotone_non_increasing
-  - condition: "INV-2102-3: running the lowering pass twice differs from running it once"
-    severity: P1
+    if_fails: "P0 — this contract's guarantee does not hold"
+  - id: f_6
+    rule: "INV-2102-3: running the lowering pass twice differs from running it once"
+    prediction: "the named test fails when this condition holds"
     test: src/services/metrics_ratchet/kernel_tests.rs::inv_2102_3_next_baseline_is_idempotent
-  - condition: "a ratchet declaring no metrics folds to Ok and passes every run forever while reading as a gate — the live bug this rule's own module carried while it was orphaned"
-    severity: P0
+    if_fails: "P1 — this contract's guarantee does not hold"
+  - id: f_7
+    rule: "a ratchet declaring no metrics folds to Ok and passes every run forever while reading as a gate — the live bug this rule's own module carried while it was orphaned"
+    prediction: "the named test fails when this condition holds"
     test: src/services/metrics_ratchet/config_tests.rs::an_empty_metric_set_is_a_failure_not_a_clean_sheet
-  - condition: "`<producer> | wc -l` with a failing producer is read as a count of zero — the single most dangerous shape in the design, and invisible to a gate that only looks upward"
-    severity: P0
+    if_fails: "P0 — this contract's guarantee does not hold"
+  - id: f_8
+    rule: "`<producer> | wc -l` with a failing producer is read as a count of zero — the single most dangerous shape in the design, and invisible to a gate that only looks upward"
+    prediction: "the named test fails when this condition holds"
     test: src/services/metrics_ratchet/drive_tests.rs::a_failing_producer_in_a_pipeline_is_unavailable_not_a_zero
-  - condition: "the control: an honest pipeline of exactly that shape stops measuring, so the guard above has broken every metric"
-    severity: P0
+    if_fails: "P0 — this contract's guarantee does not hold"
+  - id: f_control
+    rule: "the control: an honest pipeline of exactly that shape stops measuring, so the guard above has broken every metric"
+    prediction: "the named test fails when this condition holds"
     test: src/services/metrics_ratchet/drive_tests.rs::an_honest_pipeline_measures
-  - condition: "grep's exit 1 for 'no matches' is treated as a broken measurement, so a metric can never legitimately reach zero"
-    severity: P1
+    if_fails: "P0 — this contract's guarantee does not hold"
+  - id: f_9
+    rule: "grep's exit 1 for 'no matches' is treated as a broken measurement, so a metric can never legitimately reach zero"
+    prediction: "the named test fails when this condition holds"
     test: src/services/metrics_ratchet/drive_tests.rs::no_matches_is_a_zero_not_a_failure
-  - condition: "prose, or nothing, is parsed as a count"
-    severity: P0
+    if_fails: "P1 — this contract's guarantee does not hold"
+  - id: f_10
+    rule: "prose, or nothing, is parsed as a count"
+    prediction: "the named test fails when this condition holds"
     test: src/services/metrics_ratchet/drive_tests.rs::non_numeric_output_is_not_a_measurement
-  - condition: "an unreadable git history is passed through as `None`, which means 'initial capture' — so an unjustified raise becomes invisible"
-    severity: P0
+    if_fails: "P0 — this contract's guarantee does not hold"
+  - id: f_11
+    rule: "an unreadable git history is passed through as `None`, which means 'initial capture' — so an unjustified raise becomes invisible"
+    prediction: "the named test fails when this condition holds"
     test: src/services/metrics_ratchet/drive_tests.rs::an_unreadable_prior_is_a_hole_not_an_initial_capture
-  - condition: "deleting .pmat-ratchet.toml is a way of passing CB-2102"
-    severity: P0
+    if_fails: "P0 — this contract's guarantee does not hold"
+  - id: f_12
+    rule: "deleting .pmat-ratchet.toml is a way of passing CB-2102"
+    prediction: "the named test fails when this condition holds"
     test: src/services/metrics_ratchet/drive_tests.rs::deleting_the_ratchet_file_is_not_a_way_of_passing
-  - condition: "the lowering pass destroys the file's comments, or writes a number it did not verify"
-    severity: P0
+    if_fails: "P0 — this contract's guarantee does not hold"
+  - id: f_13
+    rule: "the lowering pass destroys the file's comments, or writes a number it did not verify"
+    prediction: "the named test fails when this condition holds"
     test: src/services/metrics_ratchet/drive_tests.rs::lowering_preserves_comments_and_verifies_what_it_wrote
-  - condition: "the lowering pass raises a baseline when the measurement grew"
-    severity: P0
+    if_fails: "P0 — this contract's guarantee does not hold"
+  - id: f_14
+    rule: "the lowering pass raises a baseline when the measurement grew"
+    prediction: "the named test fails when this condition holds"
     test: src/services/metrics_ratchet/drive_tests.rs::lowering_never_raises_a_baseline
-  - condition: "a metric's pathspec rots so that it matches no files, prints a clean 0, and both gates greet the largest possible regression in measurement quality as the largest improvement in the project's history"
-    severity: P0
+    if_fails: "P0 — this contract's guarantee does not hold"
+  - id: f_15
+    rule: "a metric's pathspec rots so that it matches no files, prints a clean 0, and both gates greet the largest possible regression in measurement quality as the largest improvement in the project's history"
+    prediction: "the named test fails when this condition holds"
     test: src/services/metrics_ratchet/drive_tests.rs::a_zero_against_a_nonzero_baseline_is_a_hole_not_the_best_day_in_project_history
-  - condition: "the control: the zero guard rejects every zero, so a metric can never reach the one number every ratchet is trying to get to"
-    severity: P0
+    if_fails: "P0 — this contract's guarantee does not hold"
+  - id: f_control_2
+    rule: "the control: the zero guard rejects every zero, so a metric can never reach the one number every ratchet is trying to get to"
+    prediction: "the named test fails when this condition holds"
     test: src/services/metrics_ratchet/drive_tests.rs::zero_is_still_reachable_when_it_is_declared_or_already_the_baseline
-  - condition: "this repository's own committed ratchet is red, or was captured from a number rather than from its command"
-    severity: P0
+    if_fails: "P0 — this contract's guarantee does not hold"
+  - id: f_16
+    rule: "this repository's own committed ratchet is red, or was captured from a number rather than from its command"
+    prediction: "the named test fails when this condition holds"
     test: src/services/metrics_ratchet/drive_tests.rs::the_committed_ratchet_holds_at_head
-  - condition: "a committed metric's command no longer runs, so its baseline has rotted while the number still looks plausible"
-    severity: P0
+    if_fails: "P0 — this contract's guarantee does not hold"
+  - id: f_17
+    rule: "a committed metric's command no longer runs, so its baseline has rotted while the number still looks plausible"
+    prediction: "the named test fails when this condition holds"
     test: src/services/metrics_ratchet/drive_tests.rs::every_committed_metric_command_still_measures
-  - condition: "the committed baselines carry slack the tree has already beaten, so a regression can hide inside the gap"
-    severity: P1
+    if_fails: "P0 — this contract's guarantee does not hold"
+  - id: f_18
+    rule: "the committed baselines carry slack the tree has already beaten, so a regression can hide inside the gap"
+    prediction: "the named test fails when this condition holds"
     test: src/services/metrics_ratchet/drive_tests.rs::the_committed_baselines_have_no_slack_left_in_them
-  - condition: "two metrics share a command, so a scope that was supposed to be pinned twice is pinned once — the 9,324-wide question of which files count is answered once and copied"
-    severity: P1
+    if_fails: "P1 — this contract's guarantee does not hold"
+  - id: f_19
+    rule: "two metrics share a command, so a scope that was supposed to be pinned twice is pinned once — the 9,324-wide question of which files count is answered once and copied"
+    prediction: "the named test fails when this condition holds"
     test: src/services/metrics_ratchet/drive_tests.rs::no_two_metrics_share_a_command
-  - condition: "the contract names kani harnesses that do not exist, or that were renamed out from under it — `#[cfg(kani)]` code is never compiled by `cargo test`, so nothing would notice"
-    severity: P1
+    if_fails: "P1 — this contract's guarantee does not hold"
+  - id: f_20
+    rule: "the contract names kani harnesses that do not exist, or that were renamed out from under it — `#[cfg(kani)]` code is never compiled by `cargo test`, so nothing would notice"
+    prediction: "the named test fails when this condition holds"
     test: src/services/metrics_ratchet/drive_tests.rs::every_kani_harness_the_contract_names_exists
-  - condition: "`kind: kernel` plus a `kani_harness` per equation is read as a discharged proof, though nothing in this repository can run one"
-    severity: P0
+    if_fails: "P1 — this contract's guarantee does not hold"
+  - id: f_21
+    rule: "`kind: kernel` plus a `kani_harness` per equation is read as a discharged proof, though nothing in this repository can run one"
+    prediction: "the named test fails when this condition holds"
     test: src/services/metrics_ratchet/drive_tests.rs::the_contract_states_whether_its_kani_harnesses_discharge
-  - condition: "the not_discharged note rots into a false claim: a kani runner is added and the note is left stale"
-    severity: P0
+    if_fails: "P0 — this contract's guarantee does not hold"
+  - id: f_22
+    rule: "the not_discharged note rots into a false claim: a kani runner is added and the note is left stale"
+    prediction: "the named test fails when this condition holds"
     test: src/services/metrics_ratchet/drive_tests.rs::a_discharged_claim_requires_something_that_actually_runs_kani
-  - condition: "CB-2102 is registered with no declared severity, so it defaults to Warning, does not fail a non-strict comply run, and falls outside the severity=error roster CB-2100 checks reachability for"
-    severity: P0
+    if_fails: "P0 — this contract's guarantee does not hold"
+  - id: f_23
+    rule: "CB-2102 is registered with no declared severity, so it defaults to Warning, does not fail a non-strict comply run, and falls outside the severity=error roster CB-2100 checks reachability for"
+    prediction: "the named test fails when this condition holds"
     test: src/services/metrics_ratchet/drive_tests.rs::cb_2102_is_declared_error_not_left_at_the_warning_default
-  - condition: "CB-2102 is registered under an id .pmat.yaml cannot address, so it can be neither configured nor found in CB-2100's enforcement ledger"
-    severity: P1
+    if_fails: "P0 — this contract's guarantee does not hold"
+  - id: f_24
+    rule: "CB-2102 is registered under an id .pmat.yaml cannot address, so it can be neither configured nor found in CB-2100's enforcement ledger"
+    prediction: "the named test fails when this condition holds"
     test: src/services/metrics_ratchet/drive_tests.rs::cb_2102_is_in_the_comply_rule_registry
-  - condition: "the rule is orphaned again: the engine exists and no comply check drives it, which is the state this contract was written to end"
-    severity: P0
+    if_fails: "P1 — this contract's guarantee does not hold"
+  - id: f_25
+    rule: "the rule is orphaned again: the engine exists and no comply check drives it, which is the state this contract was written to end"
+    prediction: "the named test fails when this condition holds"
     test: src/services/metrics_ratchet/drive_tests.rs::cb_2102_is_in_the_comply_rule_registry
+    if_fails: "P0 — this contract's guarantee does not hold"

--- a/contracts/comply-threshold-coherence-v1.yaml
+++ b/contracts/comply-threshold-coherence-v1.yaml
@@ -141,79 +141,129 @@ postconditions:
   - "CB-2101 reports Fail with severity=error whenever any invariant above is violated"
   - "every classified threshold appears as `<key>=<CLASS>` in the check's message, uncapped, so `pmat comply check --format json` carries the whole classification"
 
-falsification:
-  - condition: "F-1: max_unwrap_calls = 100 against ~11,002 measured does not classify VIOLATED, or classifies VIOLATED and does not Fail"
-    severity: P0
+falsification_tests:
+  - id: f_1
+    rule: "F-1: max_unwrap_calls = 100 against ~11,002 measured does not classify VIOLATED, or classifies VIOLATED and does not Fail"
+    prediction: "the named test fails when this condition holds"
     test: src/services/metrics_ratchet/config_tests.rs::arm_a_violated_threshold_on_a_green_build_fails
-  - condition: "F-1 on real data: this repository's own committed max_unwrap_calls is judged against a remembered number rather than a live measurement, or its class disagrees with the bound"
-    severity: P0
+    if_fails: "P0 — this contract's guarantee does not hold"
+  - id: f_1_2
+    rule: "F-1 on real data: this repository's own committed max_unwrap_calls is judged against a remembered number rather than a live measurement, or its class disagrees with the bound"
+    prediction: "the named test fails when this condition holds"
     test: src/services/metrics_ratchet/coherence_drive_tests.rs::arm_a_max_unwrap_calls_is_judged_against_a_live_measurement
-  - condition: "F-2: max_unwrap_calls = 100000 against ~11,002 measured does not classify VACUOUS"
-    severity: P0
+    if_fails: "P0 — this contract's guarantee does not hold"
+  - id: f_2
+    rule: "F-2: max_unwrap_calls = 100000 against ~11,002 measured does not classify VACUOUS"
+    prediction: "the named test fails when this condition holds"
     test: src/services/metrics_ratchet/config_tests.rs::mutation_max_unwrap_calls_100000_classifies_vacuous
-  - condition: "F-2 second half: a vacuous threshold with no justification passes"
-    severity: P0
+    if_fails: "P0 — this contract's guarantee does not hold"
+  - id: f_2_2
+    rule: "F-2 second half: a vacuous threshold with no justification passes"
+    prediction: "the named test fails when this condition holds"
     test: src/services/metrics_ratchet/config_tests.rs::arm_b_vacuous_threshold_warns_with_justification_and_fails_without
-  - condition: "F-3: a metric with no measurement available passes, or warns instead of failing, or is bought a pass by a justification"
-    severity: P0
+    if_fails: "P0 — this contract's guarantee does not hold"
+  - id: f_3
+    rule: "F-3: a metric with no measurement available passes, or warns instead of failing, or is bought a pass by a justification"
+    prediction: "the named test fails when this condition holds"
     test: src/services/metrics_ratchet/config_tests.rs::falsify_2101_3_unmeasurable_metric_fails
-  - condition: "INV-2101-3: some (limit, measured, band, dir) lands in zero classes or in two"
-    severity: P0
+    if_fails: "P0 — this contract's guarantee does not hold"
+  - id: f
+    rule: "INV-2101-3: some (limit, measured, band, dir) lands in zero classes or in two"
+    prediction: "the named test fails when this condition holds"
     test: src/services/metrics_ratchet/kernel_tests.rs::inv_2101_3_classification_is_total_and_disjoint
-  - condition: "INV-2101-2: VIOLATED is reported for something other than a breached bound"
-    severity: P0
+    if_fails: "P0 — this contract's guarantee does not hold"
+  - id: f_4
+    rule: "INV-2101-2: VIOLATED is reported for something other than a breached bound"
+    prediction: "the named test fails when this condition holds"
     test: src/services/metrics_ratchet/kernel_tests.rs::inv_2101_2_violated_iff_bound_breached
-  - condition: "INV-2101-1: the FIRING band is not exactly the reachable one — an off-by-one at slack = 0 or slack = band"
-    severity: P0
+    if_fails: "P0 — this contract's guarantee does not hold"
+  - id: f_5
+    rule: "INV-2101-1: the FIRING band is not exactly the reachable one — an off-by-one at slack = 0 or slack = band"
+    prediction: "the named test fails when this condition holds"
     test: src/services/metrics_ratchet/kernel_tests.rs::inv_2101_1_firing_is_exactly_the_reachable_band
-  - condition: "KANI-2101-2 in test form: loosening a FIRING threshold yields VIOLATED"
-    severity: P1
+    if_fails: "P0 — this contract's guarantee does not hold"
+  - id: f_6
+    rule: "KANI-2101-2 in test form: loosening a FIRING threshold yields VIOLATED"
+    prediction: "the named test fails when this condition holds"
     test: src/services/metrics_ratchet/kernel_tests.rs::classify_is_monotone_in_limit
-  - condition: "a threshold in a declared threshold section is skipped rather than classified, so totality is claimed and not held"
-    severity: P0
+    if_fails: "P1 — this contract's guarantee does not hold"
+  - id: f_7
+    rule: "a threshold in a declared threshold section is skipped rather than classified, so totality is claimed and not held"
+    prediction: "the named test fails when this condition holds"
     test: src/services/metrics_ratchet/config_tests.rs::inv_2101_3_every_threshold_gets_exactly_one_classification
-  - condition: "the fixed state is unreachable: a threshold sitting exactly at the measurement cannot be FIRING, so there is no value the config could take that this rule would accept"
-    severity: P0
+    if_fails: "P0 — this contract's guarantee does not hold"
+  - id: f_8
+    rule: "the fixed state is unreachable: a threshold sitting exactly at the measurement cannot be FIRING, so there is no value the config could take that this rule would accept"
+    prediction: "the named test fails when this condition holds"
     test: src/services/metrics_ratchet/config_tests.rs::firing_threshold_absorbs_one_unwrap_so_only_the_ratchet_moves
-  - condition: "kind = external names an enforcing file that does not exist, and the audit reports it as enforced — the doc comment claimed the gate verified this for a whole release while nothing did"
-    severity: P0
+    if_fails: "P0 — this contract's guarantee does not hold"
+  - id: f_9
+    rule: "kind = external names an enforcing file that does not exist, and the audit reports it as enforced — the doc comment claimed the gate verified this for a whole release while nothing did"
+    prediction: "the named test fails when this condition holds"
     test: src/services/metrics_ratchet/config_tests.rs::external_enforcement_must_name_a_file_that_exists
-  - condition: "the control for the above: a real enforcing path is rejected, so the existence check has broken every external binding"
-    severity: P0
+    if_fails: "P0 — this contract's guarantee does not hold"
+  - id: f_control
+    rule: "the control for the above: a real enforcing path is rejected, so the existence check has broken every external binding"
+    prediction: "the named test fails when this condition holds"
     test: src/services/metrics_ratchet/config_tests.rs::external_enforcement_accepts_a_path_that_exists
-  - condition: "F-3's upstream hole: a gate's metric stops matching anything, measures a clean 0, and classifies FIRING instead of failing — found by running this rule's own F-3 against the shipped binary"
-    severity: P0
+    if_fails: "P0 — this contract's guarantee does not hold"
+  - id: f_3_2
+    rule: "F-3's upstream hole: a gate's metric stops matching anything, measures a clean 0, and classifies FIRING instead of failing — found by running this rule's own F-3 against the shipped binary"
+    prediction: "the named test fails when this condition holds"
     test: src/services/metrics_ratchet/drive_tests.rs::a_zero_against_a_nonzero_baseline_is_a_hole_not_the_best_day_in_project_history
-  - condition: "this repository's own .pmat-metrics.toml has a threshold that no binding declares, or a section in neither list"
-    severity: P0
+    if_fails: "P0 — this contract's guarantee does not hold"
+  - id: f_10
+    rule: "this repository's own .pmat-metrics.toml has a threshold that no binding declares, or a section in neither list"
+    prediction: "the named test fails when this condition holds"
     test: src/services/metrics_ratchet/coherence_drive_tests.rs::every_committed_threshold_is_classified
-  - condition: "a binding names an enforced_by path or a metric id that does not exist in this repository"
-    severity: P0
+    if_fails: "P0 — this contract's guarantee does not hold"
+  - id: f_11
+    rule: "a binding names an enforced_by path or a metric id that does not exist in this repository"
+    prediction: "the named test fails when this condition holds"
     test: src/services/metrics_ratchet/coherence_drive_tests.rs::every_committed_binding_names_something_real
-  - condition: "an audit that classified nothing folds to Ok and passes every run forever — the exact live bug CB-2102's evaluator carried while it was orphaned"
-    severity: P0
+    if_fails: "P0 — this contract's guarantee does not hold"
+  - id: f_12
+    rule: "an audit that classified nothing folds to Ok and passes every run forever — the exact live bug CB-2102's evaluator carried while it was orphaned"
+    prediction: "the named test fails when this condition holds"
     test: src/services/metrics_ratchet/coherence_drive_tests.rs::an_empty_audit_is_a_failure_not_a_clean_sheet
-  - condition: "the check's message drops thresholds when there are many, so `pmat comply check --format json` no longer classifies all of them"
-    severity: P1
+    if_fails: "P0 — this contract's guarantee does not hold"
+  - id: f_13
+    rule: "the check's message drops thresholds when there are many, so `pmat comply check --format json` no longer classifies all of them"
+    prediction: "the named test fails when this condition holds"
     test: src/services/metrics_ratchet/coherence_drive_tests.rs::the_json_output_classifies_every_threshold
-  - condition: "the contract names kani harnesses that do not exist, or that were renamed out from under it — `#[cfg(kani)]` code is never compiled by `cargo test`, so nothing would notice"
-    severity: P1
+    if_fails: "P1 — this contract's guarantee does not hold"
+  - id: f_14
+    rule: "the contract names kani harnesses that do not exist, or that were renamed out from under it — `#[cfg(kani)]` code is never compiled by `cargo test`, so nothing would notice"
+    prediction: "the named test fails when this condition holds"
     test: src/services/metrics_ratchet/coherence_drive_tests.rs::every_kani_harness_the_contract_names_exists
-  - condition: "`kind: kernel` plus a `kani_harness` per equation is read as a discharged proof, though nothing in this repository can run one"
-    severity: P0
+    if_fails: "P1 — this contract's guarantee does not hold"
+  - id: f_15
+    rule: "`kind: kernel` plus a `kani_harness` per equation is read as a discharged proof, though nothing in this repository can run one"
+    prediction: "the named test fails when this condition holds"
     test: src/services/metrics_ratchet/coherence_drive_tests.rs::the_contract_states_whether_its_kani_harnesses_discharge
-  - condition: "the not_discharged note rots into a false claim: a kani runner is added and the note is left stale"
-    severity: P0
+    if_fails: "P0 — this contract's guarantee does not hold"
+  - id: f_16
+    rule: "the not_discharged note rots into a false claim: a kani runner is added and the note is left stale"
+    prediction: "the named test fails when this condition holds"
     test: src/services/metrics_ratchet/coherence_drive_tests.rs::a_discharged_claim_requires_something_that_actually_runs_kani
-  - condition: "CB-2101 is registered with no declared severity, so it defaults to Warning and cannot fail a non-strict comply run"
-    severity: P0
+    if_fails: "P0 — this contract's guarantee does not hold"
+  - id: f_17
+    rule: "CB-2101 is registered with no declared severity, so it defaults to Warning and cannot fail a non-strict comply run"
+    prediction: "the named test fails when this condition holds"
     test: src/services/metrics_ratchet/coherence_drive_tests.rs::cb_2101_is_declared_error_not_left_at_the_warning_default
-  - condition: "CB-2101 is registered under an id .pmat.yaml cannot address, so it can be neither configured nor found in CB-2100's enforcement ledger"
-    severity: P1
+    if_fails: "P0 — this contract's guarantee does not hold"
+  - id: f_18
+    rule: "CB-2101 is registered under an id .pmat.yaml cannot address, so it can be neither configured nor found in CB-2100's enforcement ledger"
+    prediction: "the named test fails when this condition holds"
     test: src/services/metrics_ratchet/coherence_drive_tests.rs::cb_2101_is_in_the_comply_rule_registry
-  - condition: "the rule is orphaned again: the evaluator exists and no comply check drives it, which is the state this contract was written to end"
-    severity: P0
+    if_fails: "P1 — this contract's guarantee does not hold"
+  - id: f_19
+    rule: "the rule is orphaned again: the evaluator exists and no comply check drives it, which is the state this contract was written to end"
+    prediction: "the named test fails when this condition holds"
     test: src/services/metrics_ratchet/coherence_drive_tests.rs::cb_2101_is_in_the_comply_rule_registry
-  - condition: "this contract is named by the module headers and does not exist on disk, as it did not for an entire release"
-    severity: P0
+    if_fails: "P0 — this contract's guarantee does not hold"
+  - id: f_20
+    rule: "this contract is named by the module headers and does not exist on disk, as it did not for an entire release"
+    prediction: "the named test fails when this condition holds"
     test: src/services/metrics_ratchet/coherence_drive_tests.rs::the_coherence_contract_is_committed
+    if_fails: "P0 — this contract's guarantee does not hold"

--- a/contracts/tdg-grade-order-v1.yaml
+++ b/contracts/tdg-grade-order-v1.yaml
@@ -4,6 +4,14 @@ metadata:
   created: "2026-08-20"
   author: PAIML Engineering
   registry: true
+  # The type these obligations are proved ABOUT. `scripts/pv-obligation-gate.py`
+  # requires that every function named by an `applies_to` actually mentions it,
+  # so a contract cannot be green while the code it names ignores the proof.
+  # This is not hypothetical: thirteen theorems below proved the grade order
+  # while `check_tdg_grade_gate` still carried its own ["A","B","C","D","F"]
+  # table and never referenced `Grade`, and every gate in the repository was
+  # green throughout.
+  proved_type: Grade
   contract: tdg-grade-order-v1
   status: active
   description: >

--- a/docs/status/unrun-tests-ledger.md
+++ b/docs/status/unrun-tests-ledger.md
@@ -14,7 +14,7 @@ Legs consulted (3):
 - `feature-matrix.yml:feature-tests[mcp-integration]`
 - `feature-matrix.yml:feature-tests[unified-protocol]`
 
-22964 of 26085 lib tests are executed; 3121 are compiled by no leg.
+22969 of 26090 lib tests are executed; 3121 are compiled by no leg.
 
 ## `<unsatisfiable>` — 18 test(s)
 

--- a/docs/status/unrun-tests-ledger.md
+++ b/docs/status/unrun-tests-ledger.md
@@ -14,7 +14,7 @@ Legs consulted (3):
 - `feature-matrix.yml:feature-tests[mcp-integration]`
 - `feature-matrix.yml:feature-tests[unified-protocol]`
 
-22951 of 26072 lib tests are executed; 3121 are compiled by no leg.
+22956 of 26077 lib tests are executed; 3121 are compiled by no leg.
 
 ## `<unsatisfiable>` — 18 test(s)
 

--- a/docs/status/unrun-tests-ledger.md
+++ b/docs/status/unrun-tests-ledger.md
@@ -14,7 +14,7 @@ Legs consulted (3):
 - `feature-matrix.yml:feature-tests[mcp-integration]`
 - `feature-matrix.yml:feature-tests[unified-protocol]`
 
-22947 of 26068 lib tests are executed; 3121 are compiled by no leg.
+22951 of 26072 lib tests are executed; 3121 are compiled by no leg.
 
 ## `<unsatisfiable>` — 18 test(s)
 

--- a/docs/status/unrun-tests-ledger.md
+++ b/docs/status/unrun-tests-ledger.md
@@ -14,7 +14,7 @@ Legs consulted (3):
 - `feature-matrix.yml:feature-tests[mcp-integration]`
 - `feature-matrix.yml:feature-tests[unified-protocol]`
 
-22936 of 26057 lib tests are executed; 3121 are compiled by no leg.
+22947 of 26068 lib tests are executed; 3121 are compiled by no leg.
 
 ## `<unsatisfiable>` — 18 test(s)
 

--- a/docs/status/unrun-tests-ledger.md
+++ b/docs/status/unrun-tests-ledger.md
@@ -14,7 +14,7 @@ Legs consulted (3):
 - `feature-matrix.yml:feature-tests[mcp-integration]`
 - `feature-matrix.yml:feature-tests[unified-protocol]`
 
-22956 of 26077 lib tests are executed; 3121 are compiled by no leg.
+22958 of 26079 lib tests are executed; 3121 are compiled by no leg.
 
 ## `<unsatisfiable>` — 18 test(s)
 

--- a/docs/status/unrun-tests-ledger.md
+++ b/docs/status/unrun-tests-ledger.md
@@ -14,7 +14,7 @@ Legs consulted (3):
 - `feature-matrix.yml:feature-tests[mcp-integration]`
 - `feature-matrix.yml:feature-tests[unified-protocol]`
 
-22969 of 26090 lib tests are executed; 3121 are compiled by no leg.
+22975 of 26096 lib tests are executed; 3121 are compiled by no leg.
 
 ## `<unsatisfiable>` — 18 test(s)
 

--- a/docs/status/unrun-tests-ledger.md
+++ b/docs/status/unrun-tests-ledger.md
@@ -14,7 +14,7 @@ Legs consulted (3):
 - `feature-matrix.yml:feature-tests[mcp-integration]`
 - `feature-matrix.yml:feature-tests[unified-protocol]`
 
-22958 of 26079 lib tests are executed; 3121 are compiled by no leg.
+22962 of 26083 lib tests are executed; 3121 are compiled by no leg.
 
 ## `<unsatisfiable>` — 18 test(s)
 

--- a/docs/status/unrun-tests-ledger.md
+++ b/docs/status/unrun-tests-ledger.md
@@ -14,7 +14,7 @@ Legs consulted (3):
 - `feature-matrix.yml:feature-tests[mcp-integration]`
 - `feature-matrix.yml:feature-tests[unified-protocol]`
 
-22962 of 26083 lib tests are executed; 3121 are compiled by no leg.
+22964 of 26085 lib tests are executed; 3121 are compiled by no leg.
 
 ## `<unsatisfiable>` — 18 test(s)
 

--- a/examples/quality_gate_violations.rs
+++ b/examples/quality_gate_violations.rs
@@ -24,6 +24,8 @@ fn main() {
 
     // Create sample results with violations
     let results = QualityGateResults {
+        files_examined: 0,
+        checks_run: Vec::new(),
         passed: false,
         total_violations: 5,
         // Of the 5 findings, 4 are verdict-bearing (warning/error) and one is

--- a/scripts/pv-obligation-gate.py
+++ b/scripts/pv-obligation-gate.py
@@ -1,21 +1,101 @@
-import glob, subprocess, sys, yaml
+#!/usr/bin/env python3
+"""Every contract must be readable by pv, and its obligations must bind to code.
 
-bad = []
-for f in sorted(glob.glob("contracts/*.yaml")):
-    if f.endswith("binding.yaml"):
-        continue
-    if subprocess.run(["pv", "validate", f], capture_output=True).returncode != 0:
-        bad.append(f"{f}: pv validate failed")
-    doc = yaml.safe_load(open(f)) or {}
-    # An obligation that names a TEST belongs under `falsification_tests`, which
-    # is the key pv reads. Under `falsification` pv reports zero and the audit
-    # it is supposed to perform silently covers nothing.
+Three checks, all blocking, all inside the required `provable ladder` job.
+
+1. `pv validate` passes on every contract.
+
+2. No test-bearing obligation hides under `falsification:`. pv reads
+   `falsification_tests:`; under the other key it reports zero, so the audit it
+   is supposed to perform silently covers nothing. Thirteen contracts did this,
+   hiding 135 of 179 obligations. Entries carrying `action:` and no `test:` are
+   left alone — those are alert thresholds, not falsification tests, and forcing
+   them into the schema would fabricate tests that do not exist.
+
+3. Every `applies_to` RESOLVES, and where it names a function in a contract that
+   declares a `proved_type`, that function's file must reference the type.
+
+   Check 3 is the one that closes the gap this whole exercise is about. Thirteen
+   Lean theorems proved the TDG grade order while `check_tdg_grade_gate` — named
+   by two obligations in that very contract — still carried its own
+   `["A","B","C","D","F"]` table and never mentioned `Grade`. The contract was
+   green, the proofs were sound, and the gate was blind to 1,719 violations.
+   A proof that the code ignores is decoration.
+
+   `applies_to` may name an equation of the same contract instead of a function;
+   `macs-ladder-kernel-v1.yaml` does exactly that with `ord_monotone`, which is
+   legitimate and must not be reported.
+"""
+
+import glob
+import re
+import subprocess
+import sys
+
+import yaml
+
+CONTRACTS = sorted(f for f in glob.glob("contracts/*.yaml") if not f.endswith("binding.yaml"))
+
+
+def _fn_files(name: str) -> list[str]:
+    out = subprocess.run(
+        ["git", "grep", "-l", "-E", rf"fn {re.escape(name)}\b", "--", "src/"],
+        capture_output=True, text=True,
+    )
+    return [p for p in out.stdout.split() if p]
+
+
+def check_validate(path: str) -> list[str]:
+    if subprocess.run(["pv", "validate", path], capture_output=True).returncode != 0:
+        return [f"{path}: pv validate failed"]
+    return []
+
+
+def check_visible(path: str, doc: dict) -> list[str]:
     hidden = [e for e in (doc.get("falsification") or [])
               if isinstance(e, dict) and "test" in e]
-    if hidden:
-        bad.append(f"{f}: {len(hidden)} test-bearing obligation(s) under "
-                   f"`falsification:`, which pv cannot read — use `falsification_tests:`")
-for b in bad:
-    print(f"::error::{b}")
-print(f"pv obligation gate: {len(bad)} problem(s)")
-sys.exit(1 if bad else 0)
+    if not hidden:
+        return []
+    return [f"{path}: {len(hidden)} test-bearing obligation(s) under `falsification:`, "
+            f"which pv cannot read — use `falsification_tests:`"]
+
+
+def check_bindings(path: str, doc: dict) -> list[str]:
+    equations = set((doc.get("equations") or {}).keys())
+    proved = (doc.get("metadata") or {}).get("proved_type")
+    problems = []
+    for ob in doc.get("proof_obligations") or []:
+        target = ob.get("applies_to")
+        if not target or target == "all" or target in equations:
+            continue
+        files = _fn_files(target)
+        if not files:
+            problems.append(f"{path}: applies_to {target!r} names neither an equation "
+                            f"of this contract nor any `fn` under src/")
+            continue
+        if proved and not any(
+            re.search(rf"\b{re.escape(proved)}\b", open(f, encoding="utf-8", errors="replace").read())
+            for f in files
+        ):
+            problems.append(
+                f"{path}: applies_to {target!r} is proved against {proved!r}, but none of "
+                f"{files} mentions it — the proof does not reach the code it names"
+            )
+    return problems
+
+
+def main() -> int:
+    problems = []
+    for path in CONTRACTS:
+        doc = yaml.safe_load(open(path, encoding="utf-8")) or {}
+        problems += check_validate(path)
+        problems += check_visible(path, doc)
+        problems += check_bindings(path, doc)
+    for p in problems:
+        print(f"::error::{p}")
+    print(f"pv obligation gate: {len(problems)} problem(s) over {len(CONTRACTS)} contracts")
+    return 1 if problems else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/pv-obligation-gate.py
+++ b/scripts/pv-obligation-gate.py
@@ -1,0 +1,21 @@
+import glob, subprocess, sys, yaml
+
+bad = []
+for f in sorted(glob.glob("contracts/*.yaml")):
+    if f.endswith("binding.yaml"):
+        continue
+    if subprocess.run(["pv", "validate", f], capture_output=True).returncode != 0:
+        bad.append(f"{f}: pv validate failed")
+    doc = yaml.safe_load(open(f)) or {}
+    # An obligation that names a TEST belongs under `falsification_tests`, which
+    # is the key pv reads. Under `falsification` pv reports zero and the audit
+    # it is supposed to perform silently covers nothing.
+    hidden = [e for e in (doc.get("falsification") or [])
+              if isinstance(e, dict) and "test" in e]
+    if hidden:
+        bad.append(f"{f}: {len(hidden)} test-bearing obligation(s) under "
+                   f"`falsification:`, which pv cannot read — use `falsification_tests:`")
+for b in bad:
+    print(f"::error::{b}")
+print(f"pv obligation gate: {len(bad)} problem(s)")
+sys.exit(1 if bad else 0)

--- a/src/bin/pmat.rs
+++ b/src/bin/pmat.rs
@@ -17,6 +17,7 @@ fn main() {
 #[cfg(feature = "standard-deps")]
 mod full {
     use anyhow::Result;
+    use pmat::cli_exit::ExitCode;
     use pmat::{cli, stateless_server::StatelessTemplateServer};
     use std::io::IsTerminal;
     use std::process;
@@ -31,36 +32,6 @@ mod full {
         /// MCP opt-in. Print help and exit non-zero instead of blocking on stdin
         /// (see GH-285).
         HelpAndExit,
-    }
-
-    /// POSIX-compliant exit codes for CLI interface
-    /// Per SPECIFICATION.md Section 23: CLI Interface
-    #[derive(Debug, Clone, Copy)]
-    pub enum ExitCode {
-        /// Success
-        Success = 0,
-        /// General error
-        GeneralError = 1,
-        /// Misuse of shell command
-        MisuseError = 2,
-        /// Permission denied
-        PermissionDenied = 126,
-        /// Command not found
-        CommandNotFound = 127,
-        /// Invalid argument to exit
-        InvalidExitArg = 128,
-        /// Quality gate failure (custom)
-        QualityGateFailure = 3,
-        /// Configuration error (custom)
-        ConfigurationError = 4,
-        /// Analysis error (custom)
-        AnalysisError = 5,
-    }
-
-    impl From<ExitCode> for i32 {
-        fn from(code: ExitCode) -> Self {
-            code as i32
-        }
     }
 
     fn detect_execution_mode() -> ExecutionMode {
@@ -203,32 +174,12 @@ mod full {
         }
     }
 
+    /// The process exit code, taken from the error itself.
+    ///
+    /// Delegates to [`pmat::cli_exit::code_for`], which reads a code DECLARED by
+    /// the raise site. See that module for what this replaced and why.
     fn categorize_error(error: &anyhow::Error) -> ExitCode {
-        let error_str = error.to_string().to_lowercase();
-
-        match () {
-            _ if is_quality_gate_error(&error_str) => ExitCode::QualityGateFailure,
-            _ if is_configuration_error(&error_str) => ExitCode::ConfigurationError,
-            _ if is_analysis_error(&error_str) => ExitCode::AnalysisError,
-            _ if is_permission_error(&error_str) => ExitCode::PermissionDenied,
-            _ => ExitCode::GeneralError,
-        }
-    }
-
-    fn is_quality_gate_error(error_str: &str) -> bool {
-        error_str.contains("quality gate") || error_str.contains("violation")
-    }
-
-    fn is_configuration_error(error_str: &str) -> bool {
-        error_str.contains("config") || error_str.contains("parse")
-    }
-
-    fn is_analysis_error(error_str: &str) -> bool {
-        error_str.contains("analysis") || error_str.contains("complexity")
-    }
-
-    fn is_permission_error(error_str: &str) -> bool {
-        error_str.contains("permission") || error_str.contains("access")
+        pmat::cli_exit::code_for(error)
     }
 
     async fn run_main() -> Result<()> {

--- a/src/cli/analysis_utilities/color_never_printer_tests.rs
+++ b/src/cli/analysis_utilities/color_never_printer_tests.rs
@@ -198,6 +198,8 @@ fn complexity_summary_is_plain_with_colour_off() {
 
 fn qg_results(passed: bool) -> super::QualityGateResults {
     super::QualityGateResults {
+        files_examined: 0,
+        checks_run: Vec::new(),
         passed,
         total_violations: 2,
         blocking_violations: if passed { 0 } else { 1 },

--- a/src/cli/analysis_utilities/comprehensive_types.rs
+++ b/src/cli/analysis_utilities/comprehensive_types.rs
@@ -21,6 +21,21 @@ pub struct QualityGateResults {
     pub section_violations: usize,
     pub provability_violations: usize,
     pub provability_score: Option<f64>,
+    /// Source files the gate actually looked at.
+    ///
+    /// Without it, a gate over an EMPTY DIRECTORY and a gate over a clean
+    /// project were byte-identical: same JSON, same stderr, both `passed:true`,
+    /// both exit 0. "Nothing was wrong" and "nothing was examined" are not the
+    /// same claim, and a consumer could not tell them apart.
+    pub files_examined: usize,
+    /// The checks that were selected and ran.
+    ///
+    /// The nine `*_violations` counters below always serialize, so
+    /// `--checks complexity` still reported `security_violations: 0` for a
+    /// check that never executed — eight zeros that mean "not run" rendered
+    /// identically to zeros that mean "clean". This names what ran, so the
+    /// difference is recoverable.
+    pub checks_run: Vec<String>,
     /// One line per violation, in the same order as the full `violations` array
     /// emitted alongside these results.
     ///
@@ -67,6 +82,8 @@ impl Default for QualityGateResults {
     fn default() -> Self {
         Self {
             passed: true, // Default to passed when no violations
+            files_examined: 0,
+            checks_run: Vec::new(),
             total_violations: 0,
             blocking_violations: 0,
             complexity_violations: 0,

--- a/src/cli/analysis_utilities/quality_checks_part3_tests.rs
+++ b/src/cli/analysis_utilities/quality_checks_part3_tests.rs
@@ -6,6 +6,8 @@ mod quality_checks_part3_tests {
 
     fn create_test_results(passed: bool, total: usize) -> QualityGateResults {
         QualityGateResults {
+            files_examined: 0,
+            checks_run: Vec::new(),
             passed,
             total_violations: total,
             blocking_violations: total,

--- a/src/cli/analysis_utilities/quality_gate_project.rs
+++ b/src/cli/analysis_utilities/quality_gate_project.rs
@@ -1,3 +1,22 @@
+/// Source files the gate could have examined, counted the way the analyzers walk.
+///
+/// Deliberately the same `ignore` walk the rest of the tool uses (gitignore
+/// honoured, hidden skipped) so this number cannot disagree with what the checks
+/// actually saw. It counts FILES WITH AN EXTENSION rather than a language list:
+/// the question here is "was there anything to look at", and answering it from a
+/// list of supported languages would add another copy of a set this repository
+/// already keeps in several places that disagree.
+fn count_examined_sources(project_path: &std::path::Path) -> usize {
+    ignore::WalkBuilder::new(project_path)
+        .hidden(true)
+        .git_ignore(true)
+        .build()
+        .filter_map(std::result::Result::ok)
+        .filter(|e| e.file_type().is_some_and(|t| t.is_file()))
+        .filter(|e| e.path().extension().is_some())
+        .count()
+}
+
 /// Handles project-wide quality gate checks
 #[allow(clippy::too_many_arguments)]
 async fn handle_project_quality_gate(
@@ -67,6 +86,32 @@ async fn handle_project_quality_gate(
     // the gate, while the MCP `quality_gate` tool over the SAME producer
     // (`check_satd`) ignored `severity:"info"`. One `// TODO` in one file was
     // `passed:false` here and `passed:true` there, with byte-identical findings.
+    // A gate that examined NOTHING is not a gate that passed.
+    //
+    // Measured before this: `quality-gate --checks complexity` over an empty
+    // directory and over a clean two-function project produced byte-identical
+    // JSON, byte-identical stderr, and exit 0 from both. `violations_pass` over
+    // an empty list is `true` whether the list is empty because the code is
+    // clean or because no code was read.
+    //
+    // The precedent is already in this repository: an unmeasured COVERAGE gate
+    // blocks rather than passing. This applies the same rule to the population.
+    results.files_examined = count_examined_sources(&project_path);
+    results.checks_run = checks.iter().map(|c| format!("{c:?}")).collect();
+    if results.files_examined == 0 {
+        violations.push(QualityViolation {
+            check_type: "population".to_string(),
+            severity: "error".to_string(),
+            file: project_path.display().to_string(),
+            line: None,
+            message: format!(
+                "no source files were examined under {}, so no check could have found \
+                 anything — this is an unmeasured gate, not a clean one",
+                project_path.display()
+            ),
+            details: None,
+        });
+    }
     results.passed = violations_pass(&violations);
     results.total_violations = violations.len();
     results.blocking_violations = blocking_violation_count(&violations);
@@ -190,5 +235,64 @@ fn get_check_display_name(check: &QualityCheckType) -> &'static str {
         QualityCheckType::Sections => "Sections",
         QualityCheckType::Provability => "Provability",
         QualityCheckType::All => "All",
+    }
+}
+
+#[cfg(test)]
+mod population_tests {
+    use super::count_examined_sources;
+
+    /// An empty tree has no population, and that is the fact the gate turns
+    /// into a verdict.
+    ///
+    /// Before this, `quality-gate --checks complexity` over an empty directory
+    /// and over a clean two-function project produced byte-identical JSON,
+    /// byte-identical stderr, and exit 0 from both. `violations_pass` over an
+    /// empty violation list is `true` whether the list is empty because the
+    /// code is clean or because no code was read.
+    #[test]
+    fn an_empty_tree_examines_nothing() {
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        assert_eq!(count_examined_sources(dir.path()), 0);
+    }
+
+    /// The counter-test, and the more important half. A tree WITH sources must
+    /// report a non-zero population, or the fix converts every clean run into a
+    /// failure and the gate becomes one people disable.
+    #[test]
+    fn a_populated_tree_is_counted() {
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        std::fs::write(dir.path().join("lib.rs"), "pub fn f() {}\n").expect("write");
+        std::fs::write(dir.path().join("notes.md"), "# hi\n").expect("write");
+        assert_eq!(count_examined_sources(dir.path()), 2);
+    }
+
+    /// Gitignored files are not population. The walk must agree with the one
+    /// the checks use, or the denominator would count files no check could see.
+    ///
+    /// `git init` is load-bearing: `ignore::WalkBuilder` only applies
+    /// `.gitignore` inside a repository, so without it this test passes for the
+    /// wrong reason — it would count 2 and prove nothing about the rule.
+    #[test]
+    fn gitignored_files_are_not_population() {
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        assert!(
+            std::process::Command::new("git")
+                .arg("-C")
+                .arg(dir.path())
+                .args(["init", "-q"])
+                .status()
+                .expect("git must be runnable")
+                .success(),
+            "git init"
+        );
+        std::fs::write(dir.path().join(".gitignore"), "skipme.rs\n").expect("write");
+        std::fs::write(dir.path().join("skipme.rs"), "pub fn s() {}\n").expect("write");
+        std::fs::write(dir.path().join("keep.rs"), "pub fn k() {}\n").expect("write");
+        assert_eq!(
+            count_examined_sources(dir.path()),
+            1,
+            "only keep.rs is population; .gitignore itself has no extension"
+        );
     }
 }

--- a/src/cli/analysis_utilities/tests_core_part4.rs
+++ b/src/cli/analysis_utilities/tests_core_part4.rs
@@ -28,6 +28,8 @@
     #[test]
     fn test_format_quality_gate_output_json() {
         let results = QualityGateResults {
+            files_examined: 0,
+            checks_run: Vec::new(),
             passed: false,
             total_violations: 10,
             complexity_violations: 3,
@@ -74,6 +76,8 @@
     #[test]
     fn test_format_quality_gate_output_human() {
         let results = QualityGateResults {
+            files_examined: 0,
+            checks_run: Vec::new(),
             passed: true,
             total_violations: 0,
             complexity_violations: 0,
@@ -104,6 +108,8 @@
     #[test]
     fn test_format_quality_gate_output_junit() {
         let results = QualityGateResults {
+            files_examined: 0,
+            checks_run: Vec::new(),
             passed: false,
             total_violations: 2,
             complexity_violations: 1,
@@ -143,6 +149,8 @@
     #[test]
     fn test_format_quality_gate_output_summary() {
         let results = QualityGateResults {
+            files_examined: 0,
+            checks_run: Vec::new(),
             passed: true,
             total_violations: 0,
             complexity_violations: 0,
@@ -173,6 +181,8 @@
     #[test]
     fn test_format_quality_gate_output_detailed() {
         let results = QualityGateResults {
+            files_examined: 0,
+            checks_run: Vec::new(),
             passed: false,
             total_violations: 5,
             complexity_violations: 1,
@@ -212,6 +222,8 @@
     #[test]
     fn test_format_quality_gate_output_all_violation_types() {
         let results = QualityGateResults {
+            files_examined: 0,
+            checks_run: Vec::new(),
             passed: false,
             total_violations: 9,
             complexity_violations: 1,

--- a/src/cli/analysis_utilities/tests_extreme_tdd.rs
+++ b/src/cli/analysis_utilities/tests_extreme_tdd.rs
@@ -480,6 +480,8 @@ mod extreme_tdd_coverage_tests {
     #[test]
     fn test_format_quality_gate_output_json() {
         let results = QualityGateResults {
+            files_examined: 0,
+            checks_run: Vec::new(),
             passed: false,
             total_violations: 5,
             complexity_violations: 2,
@@ -513,6 +515,8 @@ mod extreme_tdd_coverage_tests {
     #[test]
     fn test_format_quality_gate_output_human() {
         let results = QualityGateResults {
+            files_examined: 0,
+            checks_run: Vec::new(),
             passed: true,
             total_violations: 0,
             complexity_violations: 0,
@@ -537,6 +541,8 @@ mod extreme_tdd_coverage_tests {
     #[test]
     fn test_format_quality_gate_output_summary() {
         let results = QualityGateResults {
+            files_examined: 0,
+            checks_run: Vec::new(),
             passed: false,
             total_violations: 10,
             complexity_violations: 5,

--- a/src/cli/analysis_utilities/tests_markdown.rs
+++ b/src/cli/analysis_utilities/tests_markdown.rs
@@ -7,6 +7,8 @@ mod markdown_formatting_tests {
     /// Create test quality gate results for testing
     fn create_test_quality_results(passed: bool, violations: u64) -> QualityGateResults {
         QualityGateResults {
+            files_examined: 0,
+            checks_run: Vec::new(),
             passed,
             total_violations: violations as usize,
             complexity_violations: (violations / 3) as usize,

--- a/src/cli/cli_run_command.rs
+++ b/src/cli/cli_run_command.rs
@@ -84,7 +84,6 @@ fn apply_ux_settings(cli: &commands::Cli) {
 /// Parse CLI with command suggestions on failure
 #[cfg_attr(coverage_nightly, coverage(off))]
 fn parse_with_suggestions() -> Result<Cli, String> {
-    use crate::utils::command_suggestions::CommandSuggester;
     use clap::Parser;
 
     // Try to parse normally first
@@ -104,24 +103,25 @@ fn parse_with_suggestions() -> Result<Cli, String> {
                     print!("{clap_error}");
                     std::process::exit(0);
                 }
-                _ => {
-                    // For other errors, provide suggestions
-                    let args: Vec<String> = std::env::args().skip(1).collect();
-                    let suggester = CommandSuggester::new();
-
-                    // Get suggestion based on the failed arguments
-                    if let Some(suggestion) = suggester.suggest_command(&args) {
-                        let error_msg = format!(
-                            "error: unrecognized subcommand\n\n{suggestion}\n\nFor more information, try 'pmat --help'"
-                        );
-                        Err(error_msg)
-                    } else {
-                        // If no suggestion, show the original clap error with examples
-                        let examples = CommandSuggester::get_help_examples();
-                        let error_msg = format!("{clap_error}{examples}");
-                        Err(error_msg)
-                    }
-                }
+                // Clap's own error, verbatim.
+                //
+                // This used to hand the argv to `CommandSuggester` and, whenever
+                // it returned anything at all, REPLACE clap's error with
+                // "error: unrecognized subcommand" plus a guess. The diagnosis
+                // was wrong for every failure that is not an unknown
+                // subcommand, and the most common one is a bad flag:
+                //
+                //     $ pmat analyze complexity --bogus-flag
+                //     error: unrecognized subcommand
+                //     Did you mean 'pmat analyze complexity'?
+                //
+                // The subcommand IS recognized, the suggestion is the command
+                // the user already typed, and `--bogus-flag` — the actual
+                // problem — is never named. Clap says
+                // "unexpected argument '--bogus-flag' found" and offers a real
+                // suggestion, and it knows which of the ~40 error kinds it
+                // raised; a Levenshtein pass over argv does not.
+                _ => Err(format!("{clap_error}")),
             }
         }
     }

--- a/src/cli/handlers/analysis_handlers/entropy_semantic.rs
+++ b/src/cli/handlers/analysis_handlers/entropy_semantic.rs
@@ -38,6 +38,23 @@ pub(super) async fn route_entropy_analysis(cmd: AnalyzeCommands) -> Result<()> {
 
         output_entropy_results(output, &output_content)?;
 
+        // Report first, then REFUSE. GH-681 closed the "the path is not there"
+        // hole above; this closes the one behind it — the path IS there and
+        // holds nothing this analyzer can read. Over an empty directory the
+        // report printed "Files Analyzed: 0 / Source Lines Analyzed: 0 /
+        // Pattern Diversity: not measured" and exited 0, so the document said
+        // "not measured" and the exit code said "measured, and fine".
+        //
+        // The guard keys on FILES, not on the diversity metric: a tree where
+        // files were read and no pattern repeated is a real measurement of a
+        // real absence, and must keep exiting 0. Only zero files is the
+        // undefined case.
+        crate::cli::ensure_source_files_were_analyzed(
+            "entropy",
+            &analysis_path,
+            report.total_files_analyzed,
+        )?;
+
         Ok(())
     } else {
         unreachable!("Expected Entropy command")
@@ -990,5 +1007,68 @@ mod top_violations_reaches_every_format_tests {
                 "--format {format:?} ignores --top-violations"
             );
         }
+    }
+}
+
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg(test)]
+mod empty_population_tests {
+    use super::*;
+    use crate::cli::{EntropyOutputFormat, EntropySeverity};
+
+    fn entropy_over(path: &std::path::Path) -> AnalyzeCommands {
+        AnalyzeCommands::Entropy {
+            path: path.to_path_buf(),
+            project_path: None,
+            format: EntropyOutputFormat::Summary,
+            output: None,
+            min_severity: EntropySeverity::Low,
+            top_violations: 5,
+            file: None,
+            include_tests: false,
+        }
+    }
+
+    /// A tree it read no file of must not exit 0.
+    ///
+    /// GH-681 closed the "the path is not there" hole. This is the one behind
+    /// it: the path IS there and holds nothing readable. The report printed
+    /// "Files Analyzed: 0 / Source Lines Analyzed: 0 / Pattern Diversity: not
+    /// measured" and exited 0 — the document said "not measured" and the exit
+    /// code said "measured, and fine". CI reads the exit code.
+    #[tokio::test]
+    async fn a_tree_with_no_readable_file_does_not_exit_zero() {
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        std::fs::write(dir.path().join("legacy.cbl"), "IDENTIFICATION DIVISION.\n")
+            .expect("write cobol");
+
+        let err = route_entropy_analysis(entropy_over(dir.path()))
+            .await
+            .expect_err("zero files analysed must not report success");
+        assert!(
+            err.to_string().to_lowercase().contains("entropy"),
+            "the refusal must name the measurement: {err}"
+        );
+    }
+
+    /// The counter-test, and the reason the guard keys on FILES not on the
+    /// diversity metric.
+    ///
+    /// A tree where files WERE read and no pattern repeated reports "Pattern
+    /// Diversity: not measured" too — but that is a real measurement of a real
+    /// absence, and must keep exiting 0. Guarding on the metric instead of on
+    /// the file count would fail every small clean project.
+    #[tokio::test]
+    async fn a_readable_tree_with_no_repetition_still_succeeds() {
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        std::fs::write(
+            dir.path().join("ok.rs"),
+            "//! Tiny.\n\n/// Adds.\npub fn add(a: i32, b: i32) -> i32 {\n    a + b\n}\n",
+        )
+        .expect("write rs");
+
+        route_entropy_analysis(entropy_over(dir.path()))
+            .await
+            .expect("a readable tree must still succeed");
     }
 }

--- a/src/cli/handlers/complexity_handlers/analysis.rs
+++ b/src/cli/handlers/complexity_handlers/analysis.rs
@@ -476,13 +476,27 @@ pub(super) async fn analyze_files_by_mode(
     // Provide feedback on analysis results
     match &result {
         Ok(metrics) if metrics.is_empty() => {
-            eprintln!("\n⚠️  Warning: No files were found or analyzed");
-            eprintln!("   Possible reasons:");
-            eprintln!("   - Directory is empty or contains no supported file types");
-            eprintln!("   - Files are excluded by .gitignore patterns");
-            eprintln!("   - Include patterns don't match any files");
+            // What the walk SAW, not a list of things it might have been.
+            //
+            // This printed three guesses — "Directory is empty or contains no
+            // supported file types", ".gitignore patterns", "Include patterns
+            // don't match" — above the error that actually names the cause. The
+            // reader hits the speculation first, and on a directory of COBOL it
+            // sends them to check their .gitignore.
+            //
+            // Every one of those guesses is answerable. The walk knows how many
+            // files it saw and with which extensions, so it says that, and the
+            // include patterns are only mentioned when some were supplied.
+            eprintln!(
+                "\n⚠️  No files were analyzed under {}",
+                config.project_path.display()
+            );
+            match unanalyzed_summary(metrics, config) {
+                Some(note) => eprintln!("{note}"),
+                None => eprintln!("   the walk found no files with a file extension"),
+            }
             if !config.include.is_empty() {
-                eprintln!("   - Current include patterns: {:?}", config.include);
+                eprintln!("   include patterns in effect: {:?}", config.include);
             }
             eprintln!();
         }
@@ -523,18 +537,38 @@ fn unanalyzed_summary(
     metrics: &[FileComplexityMetrics],
     config: &ComplexityConfig,
 ) -> Option<String> {
+    use crate::services::ast::strategy::StrategySelector;
     use std::collections::{BTreeMap, HashSet};
 
     // Single-file and explicit-file modes have no population to compare against.
     if !config.project_path.is_dir() {
         return None;
     }
+
+    // `m.path` is relative to the PROCESS CWD, not to `project_path`. Joining it
+    // onto `project_path` built `src/tdg/src/tdg/foo.rs` — which canonicalizes to
+    // nothing — so `analyzed` came back EMPTY and every file in the walk was
+    // counted as unanalyzed. Try the path as given first, then as a child of the
+    // scanned root, and keep whichever actually resolves.
+    let resolve = |p: &Path| -> Option<PathBuf> {
+        std::fs::canonicalize(p)
+            .or_else(|_| std::fs::canonicalize(config.project_path.join(p)))
+            .ok()
+    };
     let analyzed: HashSet<PathBuf> = metrics
         .iter()
-        .map(|m| config.project_path.join(&m.path))
-        .filter_map(|p| std::fs::canonicalize(p).ok())
+        .filter_map(|m| resolve(Path::new(&m.path)))
         .collect();
 
+    // Which extensions pmat can analyse is not a guess: `supported_extensions`
+    // is compiled under the same feature flags as this binary, so it cannot
+    // drift from what the build can actually parse.
+    let supported: HashSet<String> = StrategySelector::supported_extensions()
+        .into_iter()
+        .map(str::to_ascii_lowercase)
+        .collect();
+
+    let mut no_analyzer: BTreeMap<String, usize> = BTreeMap::new();
     let mut skipped: BTreeMap<String, usize> = BTreeMap::new();
     let mut total = 0usize;
     for entry in ignore::WalkBuilder::new(&config.project_path)
@@ -549,27 +583,54 @@ fn unanalyzed_summary(
         let Some(ext) = entry.path().extension().and_then(|e| e.to_str()) else {
             continue;
         };
+        let ext = ext.to_ascii_lowercase();
         total += 1;
-        let canonical = std::fs::canonicalize(entry.path()).ok();
-        if canonical.is_some_and(|c| analyzed.contains(&c)) {
+        if resolve(entry.path()).is_some_and(|c| analyzed.contains(&c)) {
             continue;
         }
-        *skipped.entry(ext.to_ascii_lowercase()).or_default() += 1;
+        if supported.contains(&ext) {
+            *skipped.entry(ext).or_default() += 1;
+        } else {
+            *no_analyzer.entry(ext).or_default() += 1;
+        }
     }
 
-    if skipped.is_empty() {
+    // ONE derivation of the count. It used to be `total - metrics.len()` while
+    // the census was built separately from the walk, so when the path match
+    // broke the two contradicted each other inside a single sentence:
+    //   "0 of 220 file(s) were not analyzed — pmat has no complexity analyzer
+    //    for: .rs (220)"
+    // Both halves now come from the same tally, which cannot disagree with
+    // itself, and a wrong tally shows up as a wrong number instead of hiding
+    // behind a plausible zero.
+    let missing: usize = no_analyzer.values().chain(skipped.values()).sum();
+    if missing == 0 {
         return None;
     }
-    let listed: Vec<String> = skipped
-        .iter()
-        .map(|(ext, n)| format!(".{ext} ({n})"))
-        .collect();
-    Some(format!(
-        "   {} of {} file(s) were not analyzed — pmat has no complexity analyzer for: {}",
-        total.saturating_sub(metrics.len()),
-        total,
-        listed.join(", ")
-    ))
+
+    let census = |m: &BTreeMap<String, usize>| -> String {
+        m.iter()
+            .map(|(e, n)| format!(".{e} ({n})"))
+            .collect::<Vec<_>>()
+            .join(", ")
+    };
+    let mut out = format!("   {missing} of {total} file(s) were not analyzed");
+    if !no_analyzer.is_empty() {
+        out.push_str(&format!(
+            "\n   no complexity analyzer for: {}",
+            census(&no_analyzer)
+        ));
+    }
+    // A supported extension that still produced no metrics is a DIFFERENT fact
+    // from an unsupported one — reporting it as "no analyzer" told users to stop
+    // expecting Rust support because three files failed to parse.
+    if !skipped.is_empty() {
+        out.push_str(&format!(
+            "\n   supported, but no metrics were produced: {}",
+            census(&skipped)
+        ));
+    }
+    Some(out)
 }
 
 async fn analyze_by_mode(
@@ -937,6 +998,90 @@ mod unanalyzed_tests {
             functions: Vec::new(),
             classes: Vec::new(),
         }
+    }
+
+    /// The count and the census are one tally, on the path shape PRODUCTION uses.
+    ///
+    /// `m.path` is relative to the process CWD, not to the scanned root. The
+    /// first version of this function joined it onto `project_path` — building
+    /// `src/tdg/src/tdg/foo.rs`, which resolves to nothing — so the analyzed set
+    /// came back empty and every file was counted as skipped. It went unseen
+    /// because the count was derived a SECOND way (`total - metrics.len()`),
+    /// which still read 0, so `pmat analyze complexity --path src/tdg` printed
+    /// one self-contradicting sentence:
+    ///
+    ///     0 of 220 file(s) were not analyzed — pmat has no complexity analyzer
+    ///     for: .rs (220)
+    ///
+    /// The tests above missed it entirely by passing `"ok.rs"` — relative to the
+    /// temp dir, a shape the walker never emits. The fixture agreed with the
+    /// author instead of with production. This one builds the root under the CWD
+    /// and names the file the way the walker really does.
+    #[test]
+    fn the_count_and_the_census_are_one_tally() {
+        let dir = tempfile::TempDir::with_prefix_in("pmat-unanalyzed-", ".").expect("temp dir");
+        // RELATIVE, like `--path src/tdg`. `dir.path()` is absolute, and
+        // `Path::join(absolute)` returns the absolute unchanged — which silently
+        // repairs the very bug under test, so an absolute fixture proves nothing.
+        let root = std::path::PathBuf::from(".").join(dir.path().file_name().expect("dir name"));
+        std::fs::write(root.join("ok.rs"), "fn main(){}\n").expect("write rs");
+        for ext in ["cbl", "f90", "vhd"] {
+            std::fs::write(root.join(format!("thing.{ext}")), "x\n").expect("write");
+        }
+
+        // Exactly what the walker hands back: the root as given, plus the child.
+        let as_walked = format!("{}/ok.rs", root.display());
+        let note = unanalyzed_summary(&[metric(&as_walked)], &cfg(&root))
+            .expect("three unanalyzable files must be reported");
+
+        let stated: usize = note
+            .split_whitespace()
+            .next()
+            .and_then(|n| n.parse().ok())
+            .unwrap_or_default();
+        assert!(stated > 0, "no leading count in: {note}");
+        let counted: usize = note
+            .match_indices('(')
+            .filter_map(|(i, _)| note[i + 1..].split(')').next())
+            .filter_map(|n| n.parse::<usize>().ok())
+            .sum();
+        assert_eq!(
+            stated, counted,
+            "the number and the per-extension census disagree: {note}"
+        );
+        assert_eq!(
+            stated, 3,
+            "one .rs was analyzed, three files were not: {note}"
+        );
+    }
+
+    /// A supported extension is never reported as unsupported.
+    ///
+    /// The broken path match put all 220 analyzed `.rs` files into the skipped
+    /// census, so pmat told a Rust project it had "no complexity analyzer for
+    /// .rs" — while printing the metrics it had just computed for them.
+    #[test]
+    fn a_supported_extension_is_never_called_unsupported() {
+        let dir = tempfile::TempDir::with_prefix_in("pmat-supported-", ".").expect("temp dir");
+        // Relative for the same reason as above.
+        let root = std::path::PathBuf::from(".").join(dir.path().file_name().expect("dir name"));
+        std::fs::write(root.join("ok.rs"), "fn main(){}\n").expect("write rs");
+        std::fs::write(root.join("thing.cbl"), "x\n").expect("write cbl");
+
+        let as_walked = format!("{}/ok.rs", root.display());
+        let note = unanalyzed_summary(&[metric(&as_walked)], &cfg(&root))
+            .expect("the .cbl must be reported");
+
+        let claim = note
+            .lines()
+            .find(|l| l.contains("no complexity analyzer for"))
+            .unwrap_or_default();
+        assert!(!claim.is_empty(), "expected an unsupported line in: {note}");
+        assert!(
+            !claim.contains(".rs"),
+            "pmat analyzed the .rs and still called it unsupported: {note}"
+        );
+        assert!(claim.contains(".cbl"), "the .cbl must be named: {note}");
     }
 
     /// A file type pmat cannot analyze must be NAMED, not silently dropped.

--- a/src/cli/handlers/complexity_handlers/analysis.rs
+++ b/src/cli/handlers/complexity_handlers/analysis.rs
@@ -488,6 +488,9 @@ pub(super) async fn analyze_files_by_mode(
         }
         Ok(metrics) => {
             crate::status_eprintln!("✅ Successfully analyzed {} file(s)", metrics.len());
+            if let Some(note) = unanalyzed_summary(metrics, config) {
+                crate::status_eprintln!("{}", note);
+            }
         }
         Err(_) => {
             // Error will be returned and handled by caller
@@ -499,6 +502,76 @@ pub(super) async fn analyze_files_by_mode(
 
 /// Pick the analysis the flags asked for. Split out of `analyze_files_by_mode`
 /// so the whole of it — mode selection included — sits inside the budget.
+/// Name the files the walk saw and did not analyze.
+///
+/// `✅ Successfully analyzed 1 file(s)` is a count with no denominator. Point
+/// pmat at a directory holding one `.rs` and eight `.cbl`, and that is exactly
+/// what it printed — a confident green, with no hint that eight of nine files
+/// were never read. A COBOL codebase with one stray Rust file gets a clean bill
+/// of health for the Rust file alone.
+///
+/// The comment on `analyze_project` already records this defect for a different
+/// cause: toolchain auto-detection used to restrict the walk, so "a directory
+/// holding a.go, app.ts and main.py therefore reported Files analyzed: 1". That
+/// was fixed. The same silence for a file type pmat has no analyzer for was not.
+///
+/// UNSUPPORTED IS DERIVED, NOT LISTED. The set is "present in the walk, absent
+/// from the results" — so this cannot drift from whatever the analyzers actually
+/// handle, and it adds no fourth copy of a language list to a repository that
+/// already has several that disagree.
+fn unanalyzed_summary(
+    metrics: &[FileComplexityMetrics],
+    config: &ComplexityConfig,
+) -> Option<String> {
+    use std::collections::{BTreeMap, HashSet};
+
+    // Single-file and explicit-file modes have no population to compare against.
+    if !config.project_path.is_dir() {
+        return None;
+    }
+    let analyzed: HashSet<PathBuf> = metrics
+        .iter()
+        .map(|m| config.project_path.join(&m.path))
+        .filter_map(|p| std::fs::canonicalize(p).ok())
+        .collect();
+
+    let mut skipped: BTreeMap<String, usize> = BTreeMap::new();
+    let mut total = 0usize;
+    for entry in ignore::WalkBuilder::new(&config.project_path)
+        .hidden(true)
+        .git_ignore(true)
+        .build()
+        .filter_map(std::result::Result::ok)
+    {
+        if !entry.file_type().is_some_and(|t| t.is_file()) {
+            continue;
+        }
+        let Some(ext) = entry.path().extension().and_then(|e| e.to_str()) else {
+            continue;
+        };
+        total += 1;
+        let canonical = std::fs::canonicalize(entry.path()).ok();
+        if canonical.is_some_and(|c| analyzed.contains(&c)) {
+            continue;
+        }
+        *skipped.entry(ext.to_ascii_lowercase()).or_default() += 1;
+    }
+
+    if skipped.is_empty() {
+        return None;
+    }
+    let listed: Vec<String> = skipped
+        .iter()
+        .map(|(ext, n)| format!(".{ext} ({n})"))
+        .collect();
+    Some(format!(
+        "   {} of {} file(s) were not analyzed — pmat has no complexity analyzer for: {}",
+        total.saturating_sub(metrics.len()),
+        total,
+        listed.join(", ")
+    ))
+}
+
 async fn analyze_by_mode(
     file: Option<PathBuf>,
     files: Vec<PathBuf>,
@@ -845,5 +918,75 @@ mod timeout_is_a_bound_tests {
             .await
             .expect("one small file cannot exhaust a 300s budget");
         assert_eq!(metrics.len(), 1, "the one file must still be analyzed");
+    }
+}
+
+#[cfg(test)]
+mod unanalyzed_tests {
+    use super::*;
+    use crate::services::complexity::types::ComplexityMetrics;
+
+    fn cfg(dir: &std::path::Path) -> ComplexityConfig {
+        ComplexityConfig::from_args(dir.to_path_buf(), None, None, None, vec![], 300, 10)
+    }
+
+    fn metric(path: &str) -> FileComplexityMetrics {
+        FileComplexityMetrics {
+            path: path.to_string(),
+            total_complexity: ComplexityMetrics::default(),
+            functions: Vec::new(),
+            classes: Vec::new(),
+        }
+    }
+
+    /// A file type pmat cannot analyze must be NAMED, not silently dropped.
+    ///
+    /// `✅ Successfully analyzed 1 file(s)` is a count with no denominator: one
+    /// `.rs` beside eight `.cbl` printed exactly that, and a COBOL codebase with
+    /// one stray Rust file got a clean bill of health for the Rust file alone.
+    #[test]
+    fn unanalyzed_file_types_are_named_with_a_denominator() {
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        std::fs::write(dir.path().join("ok.rs"), "fn main(){}\n").expect("write rs");
+        for ext in ["cbl", "f90", "vhd"] {
+            std::fs::write(dir.path().join(format!("thing.{ext}")), "x\n").expect("write");
+        }
+
+        let note = unanalyzed_summary(&[metric("ok.rs")], &cfg(dir.path()))
+            .expect("skipped files must be reported");
+
+        assert!(note.contains("3 of 4"), "needs a denominator, got: {note}");
+        for ext in [".cbl", ".f90", ".vhd"] {
+            assert!(note.contains(ext), "{ext} must be named, got: {note}");
+        }
+    }
+
+    /// The counter-test. A tree pmat fully analyzed must produce NO note —
+    /// otherwise the fix is a nag on every clean run, and a warning everyone
+    /// learns to ignore is worse than the silence it replaced.
+    #[test]
+    fn a_fully_analyzed_tree_is_not_nagged() {
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        std::fs::write(dir.path().join("a.rs"), "fn a(){}\n").expect("write a");
+        std::fs::write(dir.path().join("b.rs"), "fn b(){}\n").expect("write b");
+
+        assert_eq!(
+            unanalyzed_summary(&[metric("a.rs"), metric("b.rs")], &cfg(dir.path())),
+            None,
+            "a fully analyzed tree must produce no note"
+        );
+    }
+
+    /// Single-file mode has no population to compare against, so it must not
+    /// invent one from the file's parent directory.
+    #[test]
+    fn single_file_mode_reports_nothing() {
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        let file = dir.path().join("only.rs");
+        std::fs::write(&file, "fn f(){}\n").expect("write");
+        std::fs::write(dir.path().join("other.cbl"), "x\n").expect("write");
+
+        let c = ComplexityConfig::from_args(file, None, None, None, vec![], 300, 10);
+        assert_eq!(unanalyzed_summary(&[metric("only.rs")], &c), None);
     }
 }

--- a/src/cli/handlers/comply_handlers/check_handlers/check.rs
+++ b/src/cli/handlers/comply_handlers/check_handlers/check.rs
@@ -51,7 +51,10 @@ pub(crate) async fn handle_check(
     failures_only: bool,
     format: ComplyOutputFormat,
 ) -> Result<()> {
-    let report = compute_compliance_report(project_path, failures_only)?;
+    let mut report = compute_compliance_report(project_path)?;
+    if failures_only {
+        retain_blocking_checks(&mut report, strict);
+    }
 
     output_compliance_report(&report, format, project_path)?;
 
@@ -99,10 +102,7 @@ fn guard_analysable_project(project_path: &Path) -> Result<()> {
 /// and report's JSON was byte-identical for an empty project and a 121-file
 /// defect-ridden one bar the timestamp. Both commands now share this function,
 /// so there is exactly one answer to give.
-pub(crate) fn compute_compliance_report(
-    project_path: &Path,
-    failures_only: bool,
-) -> Result<ComplianceReport> {
+pub(crate) fn compute_compliance_report(project_path: &Path) -> Result<ComplianceReport> {
     guard_analysable_project(project_path)?;
 
     crate::status_eprintln!("Checking PMAT compliance for {}", project_path.display());
@@ -124,7 +124,6 @@ pub(crate) fn compute_compliance_report(
         checks,
         project_version,
         version_source,
-        failures_only,
     ))
 }
 
@@ -254,6 +253,26 @@ pub(crate) fn exit_policy(report: &ComplianceReport, strict: bool) -> ExitPolicy
         code: 0,
         reason: None,
     }
+}
+
+/// Narrow the report to the checks that BLOCK, for `--failures-only`.
+///
+/// This used to keep `Fail` and nothing else, wherever `--strict` was set. But
+/// `--strict` is the flag that makes a warning fail the run, so on a tree with
+/// 12 warnings and 0 failures, `comply check --failures-only --strict` printed
+/// an empty check list and exited 2 — the report showed nothing at all, and the
+/// twelve things that caused the exit were the twelve it had just dropped.
+///
+/// The rule is that `--failures-only` shows everything that contributed to the
+/// exit code, which is what `--strict` changes. `summary` is deliberately left
+/// alone: it is tallied over every check before this runs, so the counts stay
+/// honest about what was measured even when the list is narrowed.
+fn retain_blocking_checks(report: &mut ComplianceReport, strict: bool) {
+    report.checks.retain(|c| match c.status {
+        CheckStatus::Fail => true,
+        CheckStatus::Warn => strict,
+        CheckStatus::Pass | CheckStatus::Skip => false,
+    });
 }
 
 /// Apply the report's exit policy, explaining any non-zero code on stderr.
@@ -515,7 +534,6 @@ fn build_compliance_report(
     checks: Vec<ComplianceCheck>,
     project_version: &str,
     version_source: VersionSource,
-    failures_only: bool,
 ) -> ComplianceReport {
     debug_assert!(
         !project_version.is_empty(),
@@ -546,14 +564,7 @@ fn build_compliance_report(
         is_compliant: failures == 0,
         versions_behind,
         summary: CheckSummary::tally(&checks),
-        checks: if failures_only {
-            checks
-                .into_iter()
-                .filter(|c| c.status == CheckStatus::Fail)
-                .collect()
-        } else {
-            checks
-        },
+        checks,
         breaking_changes,
         recommendations,
         timestamp: Utc::now(),
@@ -625,23 +636,49 @@ fn sarif_rule_id(name: &str) -> String {
     format!("pmat/{}", slug.trim_matches('-'))
 }
 
-/// SARIF level for a check result. Skipped and passing checks produce no
-/// result at all — a SARIF run reports findings, not a roll call.
-fn sarif_level(check: &ComplianceCheck) -> Option<&'static str> {
+/// The SARIF `(level, kind)` for a check result, or `None` when the check
+/// should produce no result at all.
+///
+/// Only PASSING checks produce nothing. A skipped check used to be dropped
+/// alongside them, on the reasoning that "a SARIF run reports findings, not a
+/// roll call" — but a skip is not the absence of a finding, it is the absence
+/// of a MEASUREMENT, and the two are opposite claims. `rules[]` declares every
+/// check including the skipped ones, so a consumer that saw a declared rule
+/// with no result concluded the check had run and was clean. On a machine where
+/// 40 of 155 checks skip for want of gitignored `.pmat/` state, that is 40
+/// unmeasured checks rendered as 40 green ones.
+///
+/// SARIF 2.1.0 has the vocabulary for this: `kind: "notApplicable"` says the
+/// rule did not apply, and `level: "none"` keeps it out of the failure counts.
+/// With skips carried explicitly, the mapping is total and absence now means
+/// exactly one thing — the check ran and passed.
+fn sarif_result_shape(check: &ComplianceCheck) -> Option<(&'static str, &'static str)> {
     match check.status {
-        CheckStatus::Fail => Some(match check.severity {
-            Severity::Critical | Severity::Error => "error",
-            Severity::Warning => "warning",
-            Severity::Info => "note",
-        }),
-        CheckStatus::Warn => Some("warning"),
-        CheckStatus::Pass | CheckStatus::Skip => None,
+        CheckStatus::Fail => Some((
+            match check.severity {
+                Severity::Critical | Severity::Error => "error",
+                Severity::Warning => "warning",
+                Severity::Info => "note",
+            },
+            "fail",
+        )),
+        CheckStatus::Warn => Some(("warning", "fail")),
+        CheckStatus::Skip => Some(("none", "notApplicable")),
+        CheckStatus::Pass => None,
     }
 }
 
 /// A SARIF 2.1.0 document for pmat's own compliance report.
 fn build_sarif(report: &ComplianceReport, project_path: &Path) -> serde_json::Value {
-    let uri = project_path.display().to_string();
+    // Every result is about the project as a whole: `ComplianceCheck` carries a
+    // name, status, message and severity, and no file. This used to be encoded
+    // as `project_path` verbatim, which put the ABSOLUTE path of whoever ran it
+    // into the document — "/home/noah/src/paiml-mcp-agent-toolkit". That output
+    // is uploaded to code scanning, so it published a developer's home
+    // directory, and it made the document differ between two checkouts of the
+    // same commit. `%SRCROOT%` is the standard base id for repository-relative
+    // locations, and "." under it is the root without naming anyone's disk.
+    let _ = project_path;
 
     let rules: Vec<serde_json::Value> = report
         .checks
@@ -659,14 +696,15 @@ fn build_sarif(report: &ComplianceReport, project_path: &Path) -> serde_json::Va
         .checks
         .iter()
         .filter_map(|check| {
-            let level = sarif_level(check)?;
+            let (level, kind) = sarif_result_shape(check)?;
             Some(serde_json::json!({
                 "ruleId": sarif_rule_id(&check.name),
                 "level": level,
+                "kind": kind,
                 "message": { "text": format!("{}: {}", check.name, check.message) },
                 "locations": [{
                     "physicalLocation": {
-                        "artifactLocation": { "uri": uri }
+                        "artifactLocation": { "uri": ".", "uriBaseId": "%SRCROOT%" }
                     }
                 }],
             }))
@@ -743,11 +781,27 @@ mod build_compliance_report_tests {
         }
     }
 
+    /// A minimal report carrying just the checks under test.
+    fn report_of(checks: Vec<ComplianceCheck>) -> ComplianceReport {
+        ComplianceReport {
+            project_version: "1.0".into(),
+            project_version_source: VersionSource::PinnedByProject,
+            summary: CheckSummary::tally(&checks),
+            current_version: "1.0".into(),
+            is_compliant: checks.iter().all(|c| c.status != CheckStatus::Fail),
+            versions_behind: 0,
+            checks,
+            breaking_changes: vec![],
+            recommendations: vec![],
+            timestamp: Utc::now(),
+            history: None,
+        }
+    }
+
     #[test]
     fn test_compliant_when_no_failures() {
         let checks = vec![check("a", CheckStatus::Pass), check("b", CheckStatus::Warn)];
-        let report =
-            build_compliance_report(checks, "1.0.0", VersionSource::PinnedByProject, false);
+        let report = build_compliance_report(checks, "1.0.0", VersionSource::PinnedByProject);
         assert!(report.is_compliant);
         assert_eq!(report.checks.len(), 2);
     }
@@ -755,22 +809,75 @@ mod build_compliance_report_tests {
     #[test]
     fn test_non_compliant_when_any_fail() {
         let checks = vec![check("a", CheckStatus::Pass), check("b", CheckStatus::Fail)];
-        let report =
-            build_compliance_report(checks, "1.0.0", VersionSource::PinnedByProject, false);
+        let report = build_compliance_report(checks, "1.0.0", VersionSource::PinnedByProject);
         assert!(!report.is_compliant);
     }
 
     #[test]
-    fn test_failures_only_filter_drops_non_fail_checks() {
-        let checks = vec![
+    fn failures_only_keeps_just_the_failures() {
+        let mut report = report_of(vec![
             check("p", CheckStatus::Pass),
             check("w", CheckStatus::Warn),
             check("s", CheckStatus::Skip),
             check("f", CheckStatus::Fail),
-        ];
-        let report = build_compliance_report(checks, "1.0.0", VersionSource::PinnedByProject, true);
+        ]);
+        retain_blocking_checks(&mut report, false);
         assert_eq!(report.checks.len(), 1);
         assert_eq!(report.checks[0].name, "f");
+    }
+
+    /// `--failures-only --strict` must not hide what made the run exit non-zero.
+    ///
+    /// `--strict` is defined as "warnings are errors", and the filter kept
+    /// `Fail` only regardless. So a tree with 12 warnings and 0 failures printed
+    /// an EMPTY check list and exited 2: every one of the twelve reasons had
+    /// just been dropped from the report that was supposed to explain them.
+    #[test]
+    fn failures_only_under_strict_shows_the_warnings_that_caused_the_exit() {
+        let mut report = report_of(vec![
+            check("p", CheckStatus::Pass),
+            check("s", CheckStatus::Skip),
+            check("w", CheckStatus::Warn),
+        ]);
+        assert_eq!(
+            exit_policy(&report, true).code,
+            2,
+            "precondition: --strict must fail this report"
+        );
+
+        retain_blocking_checks(&mut report, true);
+
+        let names: Vec<&str> = report.checks.iter().map(|c| c.name.as_str()).collect();
+        assert_eq!(
+            names,
+            vec!["w"],
+            "the warning that caused exit 2 must survive the filter"
+        );
+    }
+
+    /// Narrowing the LIST must not rewrite the COUNTS.
+    ///
+    /// The summary is what tells a reader how much was measured. If filtering
+    /// the displayed checks also re-tallied it, `--failures-only` would report
+    /// "1 check, 1 failure" on a run that examined 154 — an absence of output
+    /// reading as an absence of work.
+    #[test]
+    fn narrowing_the_list_leaves_the_summary_alone() {
+        let mut report = report_of(vec![
+            check("p", CheckStatus::Pass),
+            check("s", CheckStatus::Skip),
+            check("w", CheckStatus::Warn),
+            check("f", CheckStatus::Fail),
+        ]);
+        let before = report.summary;
+
+        retain_blocking_checks(&mut report, false);
+
+        assert_eq!(report.checks.len(), 1);
+        assert_eq!(report.summary.total, before.total, "total was rewritten");
+        assert_eq!(report.summary.pass, before.pass, "pass was rewritten");
+        assert_eq!(report.summary.skip, before.skip, "skip was rewritten");
+        assert_eq!(report.summary.warn, before.warn, "warn was rewritten");
     }
 
     #[test]
@@ -780,15 +887,13 @@ mod build_compliance_report_tests {
             check("w", CheckStatus::Warn),
             check("f", CheckStatus::Fail),
         ];
-        let report =
-            build_compliance_report(checks, "1.0.0", VersionSource::PinnedByProject, false);
+        let report = build_compliance_report(checks, "1.0.0", VersionSource::PinnedByProject);
         assert_eq!(report.checks.len(), 3);
     }
 
     #[test]
     fn test_project_version_propagates() {
-        let report =
-            build_compliance_report(vec![], "2.5.0", VersionSource::PinnedByProject, false);
+        let report = build_compliance_report(vec![], "2.5.0", VersionSource::PinnedByProject);
         assert_eq!(report.project_version, "2.5.0");
         assert!(!report.current_version.is_empty());
     }
@@ -796,8 +901,7 @@ mod build_compliance_report_tests {
     #[test]
     fn test_empty_checks_compliant() {
         // No failures = compliant by definition
-        let report =
-            build_compliance_report(vec![], "1.0.0", VersionSource::PinnedByProject, false);
+        let report = build_compliance_report(vec![], "1.0.0", VersionSource::PinnedByProject);
         assert!(report.is_compliant);
         assert_eq!(report.checks.len(), 0);
     }
@@ -905,7 +1009,10 @@ mod build_compliance_report_tests {
             fail: 0,
             skip: 115,
         };
-        // What `--failures-only` leaves behind: no failures, so no checks.
+        // What `--failures-only` leaves behind WITHOUT --strict: no failures,
+        // so no checks. (With --strict the warnings are now kept — see
+        // `failures_only_under_strict_shows_the_warnings_that_caused_the_exit`.
+        // The point here is that the exit code does not move either way.)
         let filtered = report_with(summary, vec![]);
         let unfiltered = report_with(summary, vec![check("w", CheckStatus::Warn)]);
 
@@ -975,21 +1082,115 @@ mod build_compliance_report_tests {
         assert_eq!(runs.len(), 1);
         assert_eq!(runs[0]["tool"]["driver"]["name"], "pmat");
 
-        // One result per Fail/Warn, none for Pass/Skip.
+        // One result per Fail/Warn/Skip. Only a PASS produces nothing, so
+        // absence in results[] means exactly one thing.
         let results = runs[0]["results"].as_array().expect("results[]");
-        assert_eq!(results.len(), 2, "{results:#?}");
+        assert_eq!(results.len(), 3, "{results:#?}");
         assert_eq!(results[0]["ruleId"], "CB-030");
         assert_eq!(results[0]["level"], "error");
+        assert_eq!(results[0]["kind"], "fail");
         assert!(results[0]["message"]["text"]
             .as_str()
             .expect("message")
             .contains("hook missing"));
         assert_eq!(results[1]["ruleId"], "pmat/quality-thresholds");
         assert_eq!(results[1]["level"], "warning");
+        assert_eq!(results[2]["ruleId"], "pmat/disabled-check");
+        assert_eq!(results[2]["kind"], "notApplicable");
 
         // The document must NOT be the plain compliance report.
         assert!(sarif.get("checks").is_none());
         assert!(sarif.get("is_compliant").is_none());
+    }
+
+    /// A check that did not RUN must not be indistinguishable from one that ran
+    /// clean.
+    ///
+    /// `sarif_level` returned `None` for `Skip` as well as `Pass`, so a skipped
+    /// check vanished from `results[]` — while `rules[]` still declared it. A
+    /// consumer reading that document sees a rule it was told about, finds no
+    /// result against it, and concludes the check ran and passed. On a machine
+    /// where 40 of 155 checks skip for want of gitignored `.pmat/` state, the
+    /// upload showed 40 green checks nobody had measured.
+    #[test]
+    fn a_skipped_check_is_not_erased_from_the_sarif() {
+        let report = report_of(vec![
+            check("Ran And Passed", CheckStatus::Pass),
+            check("Never Ran", CheckStatus::Skip),
+        ]);
+
+        let sarif = build_sarif(&report, Path::new("."));
+        let results = sarif["runs"][0]["results"]
+            .as_array()
+            .expect("results[]")
+            .clone();
+
+        let skipped: Vec<_> = results
+            .iter()
+            .filter(|r| r["ruleId"] == "pmat/never-ran")
+            .collect();
+        assert_eq!(
+            skipped.len(),
+            1,
+            "the skipped check must be carried, not dropped: {results:#?}"
+        );
+        assert_eq!(
+            skipped[0]["kind"], "notApplicable",
+            "a skip is an absent measurement, not an absent finding: {skipped:#?}"
+        );
+        assert_eq!(
+            skipped[0]["level"], "none",
+            "an unmeasured check must not count as a failure: {skipped:#?}"
+        );
+
+        // The counter-test: a PASS still produces nothing, so absence in
+        // results[] now means "ran and passed" and nothing else.
+        assert!(
+            !results.iter().any(|r| r["ruleId"] == "pmat/ran-and-passed"),
+            "a passing check should not be rolled call: {results:#?}"
+        );
+    }
+
+    /// The document must not carry the absolute path of whoever produced it.
+    ///
+    /// Every result's `artifactLocation.uri` was `project_path` verbatim, so
+    /// `comply check -f sarif` emitted "/home/<user>/src/<repo>" once per
+    /// finding. That output is uploaded to code scanning, publishing a home
+    /// directory, and it makes the same commit produce different SARIF on two
+    /// machines.
+    #[test]
+    fn the_sarif_carries_no_absolute_machine_path() {
+        let report = report_of(vec![check("Some Rule", CheckStatus::Fail)]);
+        let sarif = build_sarif(&report, Path::new("/home/someone/src/their-repo"));
+        let text = serde_json::to_string(&sarif).expect("serialize");
+
+        assert!(
+            !text.contains("/home/someone"),
+            "the producer's absolute path leaked into the SARIF: {text}"
+        );
+        assert!(
+            !text.contains("their-repo"),
+            "the producer's checkout name leaked into the SARIF: {text}"
+        );
+    }
+
+    /// Two checkouts of one commit must produce one document.
+    ///
+    /// Embedding `project_path` made the SARIF depend on where the repository
+    /// happened to be cloned, so a diff between a developer's run and CI's was
+    /// noise on every result.
+    #[test]
+    fn the_sarif_is_identical_from_two_checkout_paths() {
+        let checks = vec![
+            check("Some Rule", CheckStatus::Fail),
+            check("Never Ran", CheckStatus::Skip),
+        ];
+        let a = build_sarif(&report_of(checks.clone()), Path::new("/build/one"));
+        let b = build_sarif(&report_of(checks), Path::new("/somewhere/else/two"));
+        assert_eq!(
+            a["runs"][0]["results"], b["runs"][0]["results"],
+            "the same checks produced different SARIF from two checkout paths"
+        );
     }
 
     /// #939: resolving the project's pinned version CREATED
@@ -1030,8 +1231,8 @@ mod build_compliance_report_tests {
         .expect("write manifest");
         std::fs::write(dir.path().join("src/lib.rs"), "//! x\n").expect("write lib");
 
-        let first = compute_compliance_report(dir.path(), false).expect("run 1");
-        let second = compute_compliance_report(dir.path(), false).expect("run 2");
+        let first = compute_compliance_report(dir.path()).expect("run 1");
+        let second = compute_compliance_report(dir.path()).expect("run 2");
 
         assert_eq!(first.summary, second.summary, "verdict moved on its own");
         assert_eq!(first.is_compliant, second.is_compliant);

--- a/src/cli/handlers/comply_handlers/check_handlers/check_tdg_grade.rs
+++ b/src/cli/handlers/comply_handlers/check_handlers/check_tdg_grade.rs
@@ -478,16 +478,30 @@ mod tests_tdg_grade {
     /// the bug.
     #[test]
     fn passing_set_is_the_up_set_of_the_floor() {
-        assert_eq!(passing_spellings("A+").unwrap(), vec!["A+"]);
-        assert_eq!(passing_spellings("A").unwrap(), vec!["A+", "A"]);
-        // The spelling that used to produce an EMPTY failing set and a Pass.
-        assert_eq!(passing_spellings("A-").unwrap(), vec!["A+", "A", "A-"]);
         assert_eq!(
-            passing_spellings("B").unwrap(),
+            passing_spellings("A+").expect("A+ is a canonical grade spelling"),
+            vec!["A+"]
+        );
+        assert_eq!(
+            passing_spellings("A").expect("A is a canonical grade spelling"),
+            vec!["A+", "A"]
+        );
+        // The spelling that used to produce an EMPTY failing set and a Pass.
+        assert_eq!(
+            passing_spellings("A-").expect("A- is a canonical grade spelling"),
+            vec!["A+", "A", "A-"]
+        );
+        assert_eq!(
+            passing_spellings("B").expect("B is a canonical grade spelling"),
             vec!["A+", "A", "A-", "B+", "B"]
         );
         // Only F admits everything, and that is the one honest vacuous floor.
-        assert_eq!(passing_spellings("F").unwrap().len(), GRADE_VARIANTS.len());
+        assert_eq!(
+            passing_spellings("F")
+                .expect("F is a canonical grade spelling")
+                .len(),
+            GRADE_VARIANTS.len()
+        );
     }
 
     /// Passing and failing partition the scale at every floor — the property

--- a/src/cli/handlers/comply_handlers/check_handlers/check_tdg_grade.rs
+++ b/src/cli/handlers/comply_handlers/check_handlers/check_tdg_grade.rs
@@ -4,29 +4,38 @@
 // a configurable minimum TDG grade (default A).
 
 use crate::models::comply_config::ComplyConfig;
+use crate::tdg::grade::GRADE_VARIANTS;
+use crate::tdg::Grade;
 use std::path::Path;
 
 use super::types::*;
 
 /// Convert a TDG grade letter to a numeric ordinal for comparison.
-fn grade_ordinal(grade: &str) -> u8 {
-    match grade.trim() {
-        "A" => 0,
-        "B" => 1,
-        "C" => 2,
-        "D" => 3,
-        "F" => 4,
-        _ => 5,
-    }
-}
-
-/// Return all grade letters that are strictly below (worse than) the given minimum.
-fn grades_below(min_grade: &str) -> Vec<&'static str> {
-    let threshold = grade_ordinal(min_grade);
-    ["A", "B", "C", "D", "F"]
-        .into_iter()
-        .filter(|g| grade_ordinal(g) > threshold)
-        .collect()
+/// The spellings a floor ADMITS, computed from the proved order.
+///
+/// Returns `None` when the threshold is not a grade this codebase produces, so
+/// an unreadable threshold fails the rule instead of yielding an empty set that
+/// reads as "nothing violates".
+///
+/// This replaces a private `grade_ordinal` over `["A","B","C","D","F"]` with a
+/// `_ => 5` catch-all. Both halves were wrong. The five-letter list could never
+/// match a MODIFIED grade against `WHERE tdg_grade IN (...)`, so at a floor of
+/// "A" the gate saw 247 violations and could not see 1,719. And the catch-all
+/// ranked every modified grade WORSE THAN F, so `grades_below("A-")` was empty
+/// and the caller returned Pass — `.pmat-metrics.toml:44` declares exactly that
+/// spelling.
+///
+/// The order is `Grade`'s, anchored to the score bands in
+/// `contracts/lean/Theorems/Tdg/Grade.lean::Grade_Rank_Anchored_To_Score`.
+fn passing_spellings(min_grade: &str) -> Option<Vec<&'static str>> {
+    let floor = Grade::from_variant_name(min_grade.trim())?;
+    Some(
+        GRADE_VARIANTS
+            .iter()
+            .copied()
+            .filter(|g| Grade::from_variant_name(g).is_some_and(|x| x.meets_threshold(floor)))
+            .collect(),
+    )
 }
 
 struct TdgViolation {
@@ -152,7 +161,7 @@ fn is_source_file(path: &Path) -> bool {
 /// Query violations from the context database for grades below threshold
 fn query_tdg_violations(
     db_path: &Path,
-    failing_grades: &[&str],
+    passing_grades: &[&str],
 ) -> Result<Vec<TdgViolation>, ComplianceCheck> {
     let conn = rusqlite::Connection::open_with_flags(
         db_path,
@@ -164,19 +173,24 @@ fn query_tdg_violations(
         message: format!("Failed to open context.db: {e}"),
         severity: Severity::Info,
     })?;
-    let placeholders: Vec<String> = failing_grades
+    let placeholders: Vec<String> = passing_grades
         .iter()
         .enumerate()
         .map(|(i, _)| format!("?{}", i + 1))
         .collect();
-    let sql = format!("SELECT file_path, function_name, tdg_grade, complexity, start_line FROM functions WHERE tdg_grade IN ({})", placeholders.join(", "));
+    // NOT IN the PASSING set, never IN a failing list. `IN` answers "no row"
+    // for a value it does not list and never an error, so an eleven-letter
+    // writer and a five-letter reader coexisted silently for a release.
+    // Enumerating what passes makes any future alphabet drift return a row that
+    // must be classified, instead of a smaller number nobody can see.
+    let sql = format!("SELECT file_path, function_name, tdg_grade, complexity, start_line FROM functions WHERE tdg_grade NOT IN ({})", placeholders.join(", "));
     let mut stmt = conn.prepare(&sql).map_err(|e| ComplianceCheck {
         name: "CB-200: TDG Grade Gate".into(),
         status: CheckStatus::Skip,
         message: format!("Failed to query context.db: {e}"),
         severity: Severity::Info,
     })?;
-    let params: Vec<&dyn rusqlite::types::ToSql> = failing_grades
+    let params: Vec<&dyn rusqlite::types::ToSql> = passing_grades
         .iter()
         .map(|g| g as &dyn rusqlite::types::ToSql)
         .collect();
@@ -252,8 +266,19 @@ pub(crate) fn check_tdg_grade_gate(
         .min_grade
         .as_deref()
         .unwrap_or(&comply_config.thresholds.min_tdg_grade);
-    let failing_grades = grades_below(min_grade);
-    if failing_grades.is_empty() {
+    let Some(passing_grades) = passing_spellings(min_grade) else {
+        return ComplianceCheck {
+            name: "CB-200: TDG Grade Gate".into(),
+            status: CheckStatus::Fail,
+            message: format!(
+                "minimum grade {min_grade:?} is not a grade this codebase produces (known: {}). \
+                 A threshold that cannot be parsed must not be read as a threshold nothing violates.",
+                GRADE_VARIANTS.join(", ")
+            ),
+            severity: Severity::Error,
+        };
+    };
+    if passing_grades.len() == GRADE_VARIANTS.len() {
         return ComplianceCheck {
             name: "CB-200: TDG Grade Gate".into(),
             status: CheckStatus::Pass,
@@ -263,7 +288,7 @@ pub(crate) fn check_tdg_grade_gate(
             severity: Severity::Info,
         };
     }
-    let violations = match query_tdg_violations(&db_path, &failing_grades) {
+    let violations = match query_tdg_violations(&db_path, &passing_grades) {
         Ok(v) => v,
         Err(check) => return check,
     };
@@ -443,23 +468,62 @@ mod tests_tdg_grade {
     use crate::models::comply_config::ComplyConfig;
     use std::path::PathBuf;
 
+    /// The floor admits exactly the grades at least as good as it.
+    ///
+    /// Replaces `test_grade_ordinal` and `test_grades_below`, which pinned the
+    /// defect rather than the rule: they asserted `grade_ordinal("X") == 5`
+    /// (the catch-all that ranked every unknown, and every MODIFIED, grade
+    /// worse than F) and `grades_below("A") == ["B","C","D","F"]` (the
+    /// five-letter blindness). Both were true of the old code and both were
+    /// the bug.
     #[test]
-    fn test_grade_ordinal() {
-        assert_eq!(grade_ordinal("A"), 0);
-        assert_eq!(grade_ordinal("B"), 1);
-        assert_eq!(grade_ordinal("C"), 2);
-        assert_eq!(grade_ordinal("D"), 3);
-        assert_eq!(grade_ordinal("F"), 4);
-        assert_eq!(grade_ordinal("X"), 5);
+    fn passing_set_is_the_up_set_of_the_floor() {
+        assert_eq!(passing_spellings("A+").unwrap(), vec!["A+"]);
+        assert_eq!(passing_spellings("A").unwrap(), vec!["A+", "A"]);
+        // The spelling that used to produce an EMPTY failing set and a Pass.
+        assert_eq!(passing_spellings("A-").unwrap(), vec!["A+", "A", "A-"]);
+        assert_eq!(
+            passing_spellings("B").unwrap(),
+            vec!["A+", "A", "A-", "B+", "B"]
+        );
+        // Only F admits everything, and that is the one honest vacuous floor.
+        assert_eq!(passing_spellings("F").unwrap().len(), GRADE_VARIANTS.len());
     }
 
+    /// Passing and failing partition the scale at every floor — the property
+    /// the five-letter table did not have, proved for all eleven floors in
+    /// `contracts/lean/Theorems/Tdg/Grade.lean::Grade_Partition`.
     #[test]
-    fn test_grades_below() {
-        assert_eq!(grades_below("A"), vec!["B", "C", "D", "F"]);
-        assert_eq!(grades_below("B"), vec!["C", "D", "F"]);
-        assert_eq!(grades_below("C"), vec!["D", "F"]);
-        assert_eq!(grades_below("D"), vec!["F"]);
-        assert!(grades_below("F").is_empty());
+    fn passing_and_failing_partition_the_scale() {
+        for floor in GRADE_VARIANTS {
+            let passing = passing_spellings(floor).expect("canonical spelling parses");
+            let failing: Vec<_> = GRADE_VARIANTS
+                .iter()
+                .filter(|g| !passing.contains(g))
+                .collect();
+            assert_eq!(
+                passing.len() + failing.len(),
+                GRADE_VARIANTS.len(),
+                "floor {floor} does not partition the scale"
+            );
+        }
+    }
+
+    /// An unreadable threshold yields `None`, never an empty set. An empty set
+    /// is what the caller reads as "nothing violates".
+    #[test]
+    fn an_unparseable_floor_is_none_not_empty() {
+        for bad in ["X", "", " ", "A--", "Q", "E"] {
+            assert!(
+                passing_spellings(bad).is_none(),
+                "{bad:?} must not parse as a grade floor"
+            );
+        }
+        // Counter-test: every canonical spelling still parses, so the guard did
+        // not become a spelling police.
+        for good in GRADE_VARIANTS {
+            assert!(passing_spellings(good).is_some(), "{good} must parse");
+        }
     }
 
     #[test]

--- a/src/cli/handlers/comply_handlers/migrate_handlers_enforce.rs
+++ b/src/cli/handlers/comply_handlers/migrate_handlers_enforce.rs
@@ -16,7 +16,12 @@ fn remove_pmat_hook(hook_path: &Path, markers: &[&str], hook_name: &str) -> Resu
         fs::remove_file(hook_path)?;
         crate::status_println!("{}", c::pass(&format!("Removed PMAT {hook_name} hook")));
     } else {
-        println!("{}", c::warn(&format!("{hook_name} hook exists but is not PMAT - not removed")));
+        println!(
+            "{}",
+            c::warn(&format!(
+                "{hook_name} hook exists but is not PMAT - not removed"
+            ))
+        );
     }
     Ok(())
 }
@@ -37,11 +42,22 @@ fn print_enforce_result(format: &ComplyOutputFormat, hooks_dir: &Path) -> Result
     match format {
         ComplyOutputFormat::Text => {
             println!("\n{}", c::pass("PMAT enforcement hooks installed!"));
-            println!("   {} {}", c::label("Pre-commit hook:"), c::path(&hooks_dir.join("pre-commit").display().to_string()));
-            println!("   {} {}", c::label("Pre-push hook:  "), c::path(&hooks_dir.join("pre-push").display().to_string()));
+            println!(
+                "   {} {}",
+                c::label("Pre-commit hook:"),
+                c::path(&hooks_dir.join("pre-commit").display().to_string())
+            );
+            println!(
+                "   {} {}",
+                c::label("Pre-push hook:  "),
+                c::path(&hooks_dir.join("pre-push").display().to_string())
+            );
             println!("\nCommits will now require an active work ticket.");
             println!("Pushes will validate ComputeBrick compliance.");
-            println!("Use '{}' to remove hooks.", c::label("pmat comply enforce --disable"));
+            println!(
+                "Use '{}' to remove hooks.",
+                c::label("pmat comply enforce --disable")
+            );
         }
         ComplyOutputFormat::Json | ComplyOutputFormat::Sarif => {
             let result = serde_json::json!({
@@ -76,17 +92,30 @@ async fn handle_enforce(
 
     if disable {
         remove_pmat_hook(&hooks_dir.join("pre-commit"), &["PMAT"], "pre-commit")?;
-        remove_pmat_hook(&hooks_dir.join("pre-push"), &["PMAT", "ComputeBrick"], "pre-push")?;
+        remove_pmat_hook(
+            &hooks_dir.join("pre-push"),
+            &["PMAT", "ComputeBrick"],
+            "pre-push",
+        )?;
         return Ok(());
     }
 
     if !yes {
         use crate::cli::colors as c;
         crate::status_println!("{}", c::label("This will install PMAT enforcement hooks:"));
-        crate::status_println!("  - {}: Block commits without active work ticket", c::label("pre-commit"));
-        crate::status_println!("  - {}: Validate spec compliance before push", c::label("pre-push"));
+        crate::status_println!(
+            "  - {}: Block commits without active work ticket",
+            c::label("pre-commit")
+        );
+        crate::status_println!(
+            "  - {}: Validate spec compliance before push",
+            c::label("pre-push")
+        );
         crate::status_println!("\nProceed? [y/N] ");
-        crate::status_println!("{}", c::dim("(Auto-proceeding due to non-interactive mode)"));
+        crate::status_println!(
+            "{}",
+            c::dim("(Auto-proceeding due to non-interactive mode)")
+        );
     }
 
     let pre_commit_content = include_str!("../../templates/pre_commit_hook.sh");
@@ -174,7 +203,10 @@ fn ticket_history_line(entry: &TicketHistoryEntry) -> String {
     let id = entry.ticket_id.as_deref().unwrap_or(&entry.file);
     let status = entry.status.as_deref().unwrap_or("status not recorded");
     let category = entry.category.as_deref().unwrap_or("category not recorded");
-    let created = entry.created_at.as_deref().unwrap_or("created_at not recorded");
+    let created = entry
+        .created_at
+        .as_deref()
+        .unwrap_or("created_at not recorded");
     format!("{id} [{status}] {category} — {created}")
 }
 
@@ -200,7 +232,7 @@ async fn handle_report(
     format: ComplyOutputFormat,
     output: Option<&Path>,
 ) -> Result<()> {
-    let mut report = compute_compliance_report(project_path, false)?;
+    let mut report = compute_compliance_report(project_path)?;
     // ONE FLAG, EVERY FORMAT. `--include-history` used to be read inside
     // the Text arm alone — and there it only printed "(Work history not yet
     // implemented)". The DEFAULT format is markdown, and json/sarif never
@@ -222,7 +254,13 @@ async fn handle_report(
     if let Some(output_path) = output {
         use crate::cli::colors as c;
         fs::write(output_path, &output_text)?;
-        crate::status_println!("{}", c::pass(&format!("Compliance report written to {}", c::path(&output_path.display().to_string()))));
+        crate::status_println!(
+            "{}",
+            c::pass(&format!(
+                "Compliance report written to {}",
+                c::path(&output_path.display().to_string())
+            ))
+        );
     } else {
         println!("{}", output_text);
     }
@@ -234,150 +272,166 @@ async fn handle_report(
 /// match arm this size put the whole function over the complexity gate, and a
 /// renderer is not a control-flow decision.
 fn render_report_text(report: &ComplianceReport) -> String {
-        use crate::cli::colors as c;
-        let mut out = String::new();
-        out.push_str(&format!("\n{}\n", c::rule()));
-        out.push_str(&format!("{}\n", c::header("PMAT Compliance Report")));
-        out.push_str(&format!("{}\n", c::rule()));
-        out.push_str(&format!("\n{} {}\n", c::label("Generated:"), report.timestamp));
-        out.push_str(&format!("{} {}\n", c::label("Project Version:"), report.project_version));
-        if let Some(note) = report.project_version_source.note() {
-            out.push_str(&format!("  {}\n", c::dim(&format!("({note})"))));
-        }
-        out.push_str(&format!("{} {}\n", c::label("Current PMAT:"), report.current_version));
-        out.push_str(&format!("{} {}\n", c::label("Versions Behind:"), report.versions_behind));
-        let status_str = if report.is_compliant {
-            format!("{}COMPLIANT{}", c::BOLD_GREEN, c::RESET)
-        } else {
-            format!("{}NON-COMPLIANT{}", c::BOLD_RED, c::RESET)
+    use crate::cli::colors as c;
+    let mut out = String::new();
+    out.push_str(&format!("\n{}\n", c::rule()));
+    out.push_str(&format!("{}\n", c::header("PMAT Compliance Report")));
+    out.push_str(&format!("{}\n", c::rule()));
+    out.push_str(&format!(
+        "\n{} {}\n",
+        c::label("Generated:"),
+        report.timestamp
+    ));
+    out.push_str(&format!(
+        "{} {}\n",
+        c::label("Project Version:"),
+        report.project_version
+    ));
+    if let Some(note) = report.project_version_source.note() {
+        out.push_str(&format!("  {}\n", c::dim(&format!("({note})"))));
+    }
+    out.push_str(&format!(
+        "{} {}\n",
+        c::label("Current PMAT:"),
+        report.current_version
+    ));
+    out.push_str(&format!(
+        "{} {}\n",
+        c::label("Versions Behind:"),
+        report.versions_behind
+    ));
+    let status_str = if report.is_compliant {
+        format!("{}COMPLIANT{}", c::BOLD_GREEN, c::RESET)
+    } else {
+        format!("{}NON-COMPLIANT{}", c::BOLD_RED, c::RESET)
+    };
+    out.push_str(&format!("{} {}\n", c::label("Status:"), status_str));
+    out.push_str(&format!(
+        "{} {} total \u{b7} {} pass \u{b7} {} warn \u{b7} {} fail \u{b7} {} skip\n\n",
+        c::label("Checks:"),
+        report.summary.total,
+        report.summary.pass,
+        report.summary.warn,
+        report.summary.fail,
+        report.summary.skip
+    ));
+
+    out.push_str(&format!("{}:\n", c::label("Checks")));
+    for check in &report.checks {
+        let line = format!("{}: {}", check.name, check.message);
+        let formatted = match check.status {
+            CheckStatus::Pass => c::pass(&line),
+            CheckStatus::Warn => c::warn(&line),
+            CheckStatus::Fail => c::fail(&line),
+            CheckStatus::Skip => c::skip(&line),
         };
-        out.push_str(&format!("{} {}\n", c::label("Status:"), status_str));
-        out.push_str(&format!(
-            "{} {} total \u{b7} {} pass \u{b7} {} warn \u{b7} {} fail \u{b7} {} skip\n\n",
-            c::label("Checks:"),
-            report.summary.total,
-            report.summary.pass,
-            report.summary.warn,
-            report.summary.fail,
-            report.summary.skip
-        ));
+        out.push_str(&format!("  {}\n", formatted));
+    }
 
-        out.push_str(&format!("{}:\n", c::label("Checks")));
-        for check in &report.checks {
-            let line = format!("{}: {}", check.name, check.message);
-            let formatted = match check.status {
-                CheckStatus::Pass => c::pass(&line),
-                CheckStatus::Warn => c::warn(&line),
-                CheckStatus::Fail => c::fail(&line),
-                CheckStatus::Skip => c::skip(&line),
-            };
-            out.push_str(&format!("  {}\n", formatted));
+    // Computed by the shared builder, and therefore printed. They used
+    // to be a hardcoded empty vec and were rendered nowhere.
+    if !report.breaking_changes.is_empty() {
+        out.push_str(&format!("\n{}:\n", c::label("Breaking Changes")));
+        for bc in &report.breaking_changes {
+            out.push_str(&format!("  v{}: {}\n", bc.version, bc.description));
         }
+    }
+    if !report.recommendations.is_empty() {
+        out.push_str(&format!("\n{}:\n", c::label("Recommendations")));
+        for rec in &report.recommendations {
+            out.push_str(&format!("  \u{2022} {}\n", rec));
+        }
+    }
 
-        // Computed by the shared builder, and therefore printed. They used
-        // to be a hardcoded empty vec and were rendered nowhere.
-        if !report.breaking_changes.is_empty() {
-            out.push_str(&format!("\n{}:\n", c::label("Breaking Changes")));
-            for bc in &report.breaking_changes {
-                out.push_str(&format!("  v{}: {}\n", bc.version, bc.description));
+    if let Some(history) = &report.history {
+        out.push_str(&format!("\n{}:\n", c::label("Ticket History")));
+        if history.is_empty() {
+            out.push_str(&format!("  {}\n", c::dim("no tickets in .pmat-tickets/")));
+        } else {
+            for entry in history {
+                out.push_str(&format!("  {}\n", ticket_history_line(entry)));
             }
         }
-        if !report.recommendations.is_empty() {
-            out.push_str(&format!("\n{}:\n", c::label("Recommendations")));
-            for rec in &report.recommendations {
-                out.push_str(&format!("  \u{2022} {}\n", rec));
-            }
-        }
+    }
 
-        if let Some(history) = &report.history {
-            out.push_str(&format!("\n{}:\n", c::label("Ticket History")));
-            if history.is_empty() {
-                out.push_str(&format!("  {}\n", c::dim("no tickets in .pmat-tickets/")));
-            } else {
-                for entry in history {
-                    out.push_str(&format!("  {}\n", ticket_history_line(entry)));
-                }
-            }
-        }
-
-        out
+    out
 }
 
 /// The `-f markdown` rendering (the default format).
 fn render_report_markdown(report: &ComplianceReport) -> String {
-        let mut out = String::new();
-        out.push_str("# PMAT Compliance Report\n\n");
-        out.push_str(&format!("**Generated:** {}\n\n", report.timestamp));
-        out.push_str("| Property | Value |\n");
-        out.push_str("|----------|-------|\n");
-        out.push_str(&format!(
-            "| Project Version | {} |\n",
-            report.project_version
-        ));
-        if let Some(note) = report.project_version_source.note() {
-            out.push_str(&format!("| Project Version caveat | {} |\n", note));
+    let mut out = String::new();
+    out.push_str("# PMAT Compliance Report\n\n");
+    out.push_str(&format!("**Generated:** {}\n\n", report.timestamp));
+    out.push_str("| Property | Value |\n");
+    out.push_str("|----------|-------|\n");
+    out.push_str(&format!(
+        "| Project Version | {} |\n",
+        report.project_version
+    ));
+    if let Some(note) = report.project_version_source.note() {
+        out.push_str(&format!("| Project Version caveat | {} |\n", note));
+    }
+    out.push_str(&format!("| Current PMAT | {} |\n", report.current_version));
+    out.push_str(&format!(
+        "| Versions Behind | {} |\n",
+        report.versions_behind
+    ));
+    out.push_str(&format!(
+        "| Status | {} |\n",
+        if report.is_compliant {
+            "\u{2705} COMPLIANT"
+        } else {
+            "\u{274c} NON-COMPLIANT"
         }
-        out.push_str(&format!("| Current PMAT | {} |\n", report.current_version));
-        out.push_str(&format!(
-            "| Versions Behind | {} |\n",
-            report.versions_behind
-        ));
-        out.push_str(&format!(
-            "| Status | {} |\n",
-            if report.is_compliant {
-                "\u{2705} COMPLIANT"
-            } else {
-                "\u{274c} NON-COMPLIANT"
-            }
-        ));
-        out.push_str(&format!(
-            "| Checks | {} total, {} pass, {} warn, {} fail, {} skip |\n\n",
-            report.summary.total,
-            report.summary.pass,
-            report.summary.warn,
-            report.summary.fail,
-            report.summary.skip
-        ));
+    ));
+    out.push_str(&format!(
+        "| Checks | {} total, {} pass, {} warn, {} fail, {} skip |\n\n",
+        report.summary.total,
+        report.summary.pass,
+        report.summary.warn,
+        report.summary.fail,
+        report.summary.skip
+    ));
 
-        out.push_str("## Checks\n\n");
-        for check in &report.checks {
-            let icon = match check.status {
-                CheckStatus::Pass => "\u{2705}",
-                CheckStatus::Warn => "\u{26a0}\u{fe0f}",
-                CheckStatus::Fail => "\u{274c}",
-                CheckStatus::Skip => "\u{23ed}\u{fe0f}",
-            };
-            out.push_str(&format!(
-                "- {} **{}**: {}\n",
-                icon, check.name, check.message
-            ));
-        }
+    out.push_str("## Checks\n\n");
+    for check in &report.checks {
+        let icon = match check.status {
+            CheckStatus::Pass => "\u{2705}",
+            CheckStatus::Warn => "\u{26a0}\u{fe0f}",
+            CheckStatus::Fail => "\u{274c}",
+            CheckStatus::Skip => "\u{23ed}\u{fe0f}",
+        };
+        out.push_str(&format!(
+            "- {} **{}**: {}\n",
+            icon, check.name, check.message
+        ));
+    }
 
-        if !report.breaking_changes.is_empty() {
-            out.push_str("\n## Breaking Changes\n\n");
-            for bc in &report.breaking_changes {
-                out.push_str(&format!("- **v{}**: {}\n", bc.version, bc.description));
+    if !report.breaking_changes.is_empty() {
+        out.push_str("\n## Breaking Changes\n\n");
+        for bc in &report.breaking_changes {
+            out.push_str(&format!("- **v{}**: {}\n", bc.version, bc.description));
+        }
+    }
+    if !report.recommendations.is_empty() {
+        out.push_str("\n## Recommendations\n\n");
+        for rec in &report.recommendations {
+            out.push_str(&format!("- {}\n", rec));
+        }
+    }
+
+    if let Some(history) = &report.history {
+        out.push_str("\n## Ticket History\n\n");
+        if history.is_empty() {
+            out.push_str("_No tickets in `.pmat-tickets/`._\n");
+        } else {
+            for entry in history {
+                out.push_str(&format!("- {}\n", ticket_history_line(entry)));
             }
         }
-        if !report.recommendations.is_empty() {
-            out.push_str("\n## Recommendations\n\n");
-            for rec in &report.recommendations {
-                out.push_str(&format!("- {}\n", rec));
-            }
-        }
+    }
 
-        if let Some(history) = &report.history {
-            out.push_str("\n## Ticket History\n\n");
-            if history.is_empty() {
-                out.push_str("_No tickets in `.pmat-tickets/`._\n");
-            } else {
-                for entry in history {
-                    out.push_str(&format!("- {}\n", ticket_history_line(entry)));
-                }
-            }
-        }
-
-        out
+    out
 }
 
 /// `comply report` and `comply check` are one rule with two renderings.
@@ -459,7 +513,7 @@ mod report_shares_check_computation_tests {
             "a project pinned to 2.0.0 is behind: {got:?}"
         );
         let shared =
-            compute_compliance_report(twin.path(), false).expect("shared computation must succeed");
+            compute_compliance_report(twin.path()).expect("shared computation must succeed");
         assert_eq!(
             got, shared.recommendations,
             "report must publish the SAME recommendations the shared computation produced"
@@ -476,7 +530,7 @@ mod report_shares_check_computation_tests {
         let twin = project(None);
         let json = report_json(dir.path()).await;
         let shared =
-            compute_compliance_report(twin.path(), false).expect("shared computation must succeed");
+            compute_compliance_report(twin.path()).expect("shared computation must succeed");
 
         assert!(
             shared.checks.len() > 5,
@@ -515,8 +569,8 @@ mod report_shares_check_computation_tests {
         )
         .expect("write bad.rs");
 
-        let a = compute_compliance_report(clean.path(), false).expect("clean");
-        let b = compute_compliance_report(dirty.path(), false).expect("dirty");
+        let a = compute_compliance_report(clean.path()).expect("clean");
+        let b = compute_compliance_report(dirty.path()).expect("dirty");
 
         assert_ne!(
             (a.summary.pass, a.summary.warn, a.summary.fail),
@@ -572,7 +626,9 @@ mod report_shares_check_computation_tests {
         let json = report_json(project(None).path()).await;
         assert_eq!(
             json["project_version_source"],
-            serde_json::json!("not pinned by this project - defaulted to the installed pmat's own version"),
+            serde_json::json!(
+                "not pinned by this project - defaulted to the installed pmat's own version"
+            ),
             "the JSON must not present pmat's own version as an unqualified project verdict"
         );
 

--- a/src/cli/handlers/deep_wasm_handlers.rs
+++ b/src/cli/handlers/deep_wasm_handlers.rs
@@ -9,7 +9,7 @@ use crate::services::deep_wasm::{
     AnalysisFocus, DeepWasmAnalysisRequest, DeepWasmService, SourceLanguage,
 };
 use anyhow::Result;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// Options for deep WASM analysis
 #[cfg(feature = "deep-wasm")]
@@ -48,6 +48,9 @@ pub async fn handle_deep_wasm(options: DeepWasmOptions) -> Result<()> {
         _track_memory,
         _detect_deadlocks,
     } = options;
+
+    // Say what input was needed, before the service says "os error 21".
+    guard_source_file(&source_path, language.clone())?;
 
     // Convert CLI options to service request
     let request = create_analysis_request(
@@ -94,6 +97,49 @@ fn create_analysis_request(
         source_map_path: source_map,
         language: source_language,
         analysis_focus,
+    }
+}
+
+/// `--source-path` names one source FILE, and this says so when it does not.
+///
+/// A directory reached the service and surfaced as
+/// `Error: IO error: Is a directory (os error 21)` — an errno where a sentence
+/// belonged, naming neither the flag nor what it wanted.
+///
+/// The unknown-extension arm is the same defect one level down:
+/// `auto_detect_language` falls back to `SourceLanguage::Rust` for ANY
+/// unrecognised extension, so `--source-path app.py` was analysed as Rust and
+/// reported as a finding about Rust. A guess is only honest when it is
+/// declared, so an extension pmat does not recognise is refused unless
+/// `--language` says what to treat it as.
+#[cfg(feature = "deep-wasm")]
+fn guard_source_file(path: &Path, language: Option<DeepWasmLanguage>) -> Result<()> {
+    if !path.exists() {
+        anyhow::bail!("--source-path {} does not exist", path.display());
+    }
+    if path.is_dir() {
+        anyhow::bail!(
+            "--source-path {} is a directory. deep-wasm inspects ONE source file through its \
+             compiled WASM, so point it at the .rs or .ruchy file itself.",
+            path.display()
+        );
+    }
+    if language.is_some() {
+        return Ok(());
+    }
+    match path.extension().and_then(|e| e.to_str()) {
+        Some("rs" | "rch" | "ruchy") => Ok(()),
+        Some(other) => anyhow::bail!(
+            "--source-path {} has extension .{other}, which deep-wasm has no source reader for \
+             (it reads .rs, .rch and .ruchy). Pass --language rust|ruchy to analyse it as one of \
+             those anyway.",
+            path.display()
+        ),
+        None => anyhow::bail!(
+            "--source-path {} has no file extension, so deep-wasm cannot tell which language to \
+             read it as. Pass --language rust|ruchy.",
+            path.display()
+        ),
     }
 }
 
@@ -261,4 +307,75 @@ pub async fn handle_deep_wasm(
 
 #[cfg_attr(coverage_nightly, coverage(off))]
 #[cfg(test)]
-mod tests {}
+#[cfg(feature = "deep-wasm")]
+mod source_path_tests {
+    use super::*;
+
+    /// A directory must be named as such, not surfaced as an errno.
+    ///
+    /// `analyze deep-wasm --source-path <dir>` reached the service and failed
+    /// with `Error: IO error: Is a directory (os error 21)` — which names
+    /// neither the flag nor what it wanted.
+    #[test]
+    fn a_directory_is_refused_by_name() {
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        let err =
+            guard_source_file(dir.path(), None).expect_err("a directory is not a source file");
+        let msg = err.to_string();
+        assert!(msg.contains("--source-path"), "must name the flag: {msg}");
+        assert!(msg.contains("directory"), "must say what was wrong: {msg}");
+        assert!(
+            !msg.contains("os error"),
+            "an errno is not an explanation: {msg}"
+        );
+    }
+
+    /// An extension pmat has no reader for must not be silently read as Rust.
+    ///
+    /// `auto_detect_language` falls back to `SourceLanguage::Rust` for any
+    /// unrecognised extension, so `--source-path app.py` produced a report
+    /// about Rust.
+    #[test]
+    fn an_unreadable_extension_is_not_silently_treated_as_rust() {
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        let file = dir.path().join("app.py");
+        std::fs::write(&file, "print('hi')\n").expect("write py");
+
+        let err = guard_source_file(&file, None).expect_err("a .py is not a deep-wasm source");
+        let msg = err.to_string();
+        assert!(msg.contains(".py"), "must name the extension it got: {msg}");
+        assert!(
+            msg.contains("--language"),
+            "must say how to override: {msg}"
+        );
+    }
+
+    /// ...but an explicit --language is the user declaring the guess, so it is
+    /// honoured. Without this, the guard would block a deliberate override.
+    #[test]
+    fn an_explicit_language_overrides_the_extension() {
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        let file = dir.path().join("app.py");
+        std::fs::write(&file, "print('hi')\n").expect("write py");
+
+        guard_source_file(&file, Some(DeepWasmLanguage::Rust))
+            .expect("an explicit --language must be honoured");
+    }
+
+    /// The counter-test: a real .rs file still passes.
+    #[test]
+    fn a_rust_source_file_still_passes() {
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        let file = dir.path().join("lib.rs");
+        std::fs::write(&file, "pub fn f() {}\n").expect("write rs");
+
+        guard_source_file(&file, None).expect("a .rs file is exactly what this reads");
+    }
+
+    #[test]
+    fn a_missing_path_says_it_is_missing() {
+        let err = guard_source_file(Path::new("/definitely/not/here.rs"), None)
+            .expect_err("a nonexistent path must be refused");
+        assert!(err.to_string().contains("does not exist"), "{err}");
+    }
+}

--- a/src/cli/handlers/defect_prediction_handler.rs
+++ b/src/cli/handlers/defect_prediction_handler.rs
@@ -64,9 +64,23 @@ pub async fn handle_analyze_defect_prediction(config: DefectPredictionConfig) ->
 
     // Perform analysis using facade
     let result = facade.analyze_project(request).await?;
+    let files_analyzed = result.total_files_analyzed;
+    let project_path = config.project_path.clone();
 
     // Format and output results
     output_results(result, config.format, config.output).await?;
+
+    // Report first, then REFUSE. Over an empty directory this printed
+    // "Analyzed 0 of 0 discovered files: 0 high risk, 0 medium risk, 0 low
+    // risk" and exited 0 — a risk distribution over an empty population, which
+    // is not a measurement, handed to CI as a pass. The eleven analyzers that
+    // already call this helper refuse the same case; this one was written
+    // before it existed.
+    crate::cli::ensure_source_files_were_analyzed(
+        "defect-prediction",
+        &project_path,
+        files_analyzed,
+    )?;
 
     {
         use crate::cli::colors as c;
@@ -590,5 +604,66 @@ mod tests {
             data_line.ends_with("not measured"),
             "csv duplication column must be 'not measured', got: {data_line}"
         );
+    }
+}
+
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg(test)]
+mod empty_population_tests {
+    use super::*;
+
+    fn predict_over(path: &std::path::Path) -> DefectPredictionConfig {
+        DefectPredictionConfig {
+            project_path: path.to_path_buf(),
+            confidence_threshold: 0.5,
+            min_lines: 1,
+            include_low_confidence: true,
+            format: DefectPredictionOutputFormat::Summary,
+            high_risk_only: false,
+            include_recommendations: false,
+            include: None,
+            exclude: None,
+            output: None,
+            perf: false,
+            top_files: 10,
+        }
+    }
+
+    /// A risk distribution over an empty population is not a measurement.
+    ///
+    /// Over a directory with nothing it can read, this printed "Analyzed 0 of 0
+    /// discovered files: 0 high risk, 0 medium risk, 0 low risk" and exited 0 —
+    /// handed to CI as a pass. Eleven analyzers already refuse this case
+    /// through `ensure_source_files_were_analyzed`; this one predates it.
+    #[tokio::test]
+    async fn a_prediction_over_zero_files_does_not_exit_zero() {
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        std::fs::write(dir.path().join("legacy.cbl"), "IDENTIFICATION DIVISION.\n")
+            .expect("write cobol");
+
+        let err = handle_analyze_defect_prediction(predict_over(dir.path()))
+            .await
+            .expect_err("zero files analysed must not report success");
+        assert!(
+            err.to_string().to_lowercase().contains("defect-prediction"),
+            "the refusal must name the measurement: {err}"
+        );
+    }
+
+    /// The counter-test: a tree it CAN read still succeeds, so refusing
+    /// unconditionally cannot pass the test above.
+    #[tokio::test]
+    async fn a_prediction_over_real_files_still_succeeds() {
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        std::fs::create_dir_all(dir.path().join("src")).expect("mkdir");
+        std::fs::write(
+            dir.path().join("src/lib.rs"),
+            "//! Tiny.\n\n/// Adds.\npub fn add(a: i32, b: i32) -> i32 {\n    a + b\n}\n",
+        )
+        .expect("write rs");
+
+        handle_analyze_defect_prediction(predict_over(dir.path()))
+            .await
+            .expect("a readable tree must still succeed");
     }
 }

--- a/src/cli/handlers/new_tdg_handler.rs
+++ b/src/cli/handlers/new_tdg_handler.rs
@@ -232,6 +232,30 @@ async fn run_tdg_analysis(config: TdgAnalysisConfig, enforce_threshold: bool) ->
 
     write_or_print_result(&result, config.output).await?;
 
+    // Report first, then REFUSE. `analyze tdg` over a directory holding nothing
+    // it can grade printed
+    //
+    //     Average Score: not measured (no files analysed)
+    //     Total Files: 0
+    //
+    // and exited 0. The sentence and the exit code said opposite things, and CI
+    // reads the exit code. The honest verdict was already computed —
+    // `measured_score` is `None` precisely here, and `enforce_tdg_threshold`
+    // has long refused it on the grounds that "a gate that could not measure
+    // must not report a pass" — but only `analyze build-tdg` ever consulted it.
+    // `pmat tdg` refuses the same tree at exit 5; three commands over one
+    // directory must not disagree about whether it was measured.
+    //
+    // Gated runs are left alone: `build-tdg` already fails below, with a
+    // message about the threshold it could not check.
+    if !enforce_threshold && measured_score.is_none() {
+        return Err(crate::cli_exit::analysis_error(anyhow::anyhow!(
+            "no file under {} could be graded, so no TDG measurement was taken. \
+             This is not a clean result.",
+            config.path.display()
+        )));
+    }
+
     // KNOWN DEFECTS v2.1: Check for critical defects. Auto-fail is the gated
     // (`analyze build-tdg`) command's job only — see #705.
     check_for_critical_defects(&config.path, enforce_threshold).await?;
@@ -812,6 +836,64 @@ mod tests {
     use super::*;
     use std::io::Write;
     use tempfile::NamedTempFile;
+
+    /// A tree with nothing gradable in it must not exit 0.
+    ///
+    /// `analyze tdg` printed "Average Score: not measured (no files analysed)"
+    /// and exited 0 — the sentence and the exit code said opposite things, and
+    /// CI reads the exit code. `pmat tdg` and `analyze complexity` both exit 5
+    /// over the same directory, and `analyze build-tdg` already failed here;
+    /// only this path disagreed.
+    #[tokio::test]
+    async fn an_ungradable_tree_does_not_exit_zero() {
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        std::fs::write(dir.path().join("legacy.cbl"), "IDENTIFICATION DIVISION.\n")
+            .expect("write cobol");
+
+        let err = handle_analyze_tdg(TdgAnalysisConfig {
+            path: dir.path().to_path_buf(),
+            threshold: None,
+            top_files: None,
+            format: TdgOutputFormat::Table,
+            include_components: false,
+            output: Some(dir.path().join("out.txt")),
+            critical_only: false,
+            verbose: false,
+        })
+        .await
+        .expect_err("a tree with no gradable file must not report success");
+
+        assert!(
+            err.to_string().contains("not a clean result"),
+            "the refusal must say why: {err}"
+        );
+    }
+
+    /// The counter-test: a tree it CAN grade still succeeds.
+    ///
+    /// Without this, refusing unconditionally would pass the test above.
+    #[tokio::test]
+    async fn a_gradable_tree_still_succeeds() {
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        std::fs::write(
+            dir.path().join("ok.rs"),
+            "//! A tiny module.\n\n/// Adds.\npub fn add(a: i32, b: i32) -> i32 {\n    a + b\n}\n",
+        )
+        .expect("write rs");
+
+        handle_analyze_tdg(TdgAnalysisConfig {
+            path: dir.path().to_path_buf(),
+            threshold: None,
+            top_files: None,
+            format: TdgOutputFormat::Table,
+            include_components: false,
+            output: Some(dir.path().join("out.txt")),
+            critical_only: false,
+            verbose: false,
+        })
+        .await
+        .expect("a gradable tree must still succeed");
+    }
 
     #[tokio::test]
     async fn test_handle_analyze_tdg_file() -> Result<()> {

--- a/src/cli/handlers/quality_gate_formatter_tests.rs
+++ b/src/cli/handlers/quality_gate_formatter_tests.rs
@@ -7,6 +7,8 @@ mod tests {
     // Helper function to create test quality gate results
     fn create_test_results(passed: bool, total: usize) -> QualityGateResults {
         QualityGateResults {
+            files_examined: 0,
+            checks_run: Vec::new(),
             passed,
             total_violations: total,
             blocking_violations: total,

--- a/src/cli/handlers/tdg_handlers/formatting.rs
+++ b/src/cli/handlers/tdg_handlers/formatting.rs
@@ -203,14 +203,24 @@ fn format_tdg_score_table(
     // next row says so: an unexplained `99.8/100 (B)` next to a `96.7/100 (A+)`
     // from the same command is not a report, it is a contradiction. The note
     // gets its own row because `box_row` clips at the frame width.
-    let grade_str = format_grade(score.grade);
-    line(box_row(&format!(
-        "Overall Score: {}/100 ({})",
-        c::number(&format!("{:.1}", score.total)),
-        c::grade(&grade_str)
-    )));
-    if let Some(note) = cap_note(project) {
-        line(box_row(&format!("⚠ Grade {note}")));
+    if nothing_was_measured(project) {
+        // An empty population supports no grade. This printed
+        // `Overall Score: 0.0/100 (F)` over a directory pmat could not read one
+        // file of — an F is a claim about a codebase's quality, and zero files
+        // is the absence of evidence for any claim at all. The same run already
+        // suppressed the component breakdown for exactly this reason; the
+        // headline just never asked.
+        line(box_row("Overall Score: not measured (0 files analyzed)"));
+    } else {
+        let grade_str = format_grade(score.grade);
+        line(box_row(&format!(
+            "Overall Score: {}/100 ({})",
+            c::number(&format!("{:.1}", score.total)),
+            c::grade(&grade_str)
+        )));
+        if let Some(note) = cap_note(project) {
+            line(box_row(&format!("⚠ Grade {note}")));
+        }
     }
     // A file that was walked but REFUSED is disclosed beside the score it is
     // missing from. `pmat tdg <dir>` on a crate whose only Rust file fails to
@@ -324,9 +334,23 @@ fn format_tdg_score_json(
             .and_then(crate::tdg::ProjectScore::uncapped_grade)
             .map(format_grade),
         "f_grade_count": project.map(|p| p.f_grade_count),
+        "not_measured": nothing_was_measured(project),
         "score": {
-            "total": score.total,
-            "grade": format_grade(score.grade),
+            // Null, not 0.0/"F". A machine consumer averaging `total` over a
+            // tree folded an unreadable directory in as a genuine zero, and one
+            // testing `grade == "F"` could not tell "graded badly" from "never
+            // graded". `grade_uncapped` is already nullable here, so a null
+            // grade is a shape this document could always produce.
+            "total": if nothing_was_measured(project) {
+                serde_json::Value::Null
+            } else {
+                serde_json::json!(score.total)
+            },
+            "grade": if nothing_was_measured(project) {
+                serde_json::Value::Null
+            } else {
+                serde_json::json!(format_grade(score.grade))
+            },
             "breakdown": if include_components && !nothing_was_measured(project) {
                 Some(serde_json::json!({
                     "structural_complexity": score.structural_complexity,
@@ -370,11 +394,15 @@ fn format_tdg_score_markdown(
         output.push_str(&format!("**File**: `{}`\n\n", file_path.display()));
     }
 
-    output.push_str(&format!(
-        "**Overall Score**: {:.1}/100 ({})\n",
-        score.total,
-        grade_headline(score, project)
-    ));
+    if nothing_was_measured(project) {
+        output.push_str("**Overall Score**: not measured — 0 files analyzed\n");
+    } else {
+        output.push_str(&format!(
+            "**Overall Score**: {:.1}/100 ({})\n",
+            score.total,
+            grade_headline(score, project)
+        ));
+    }
     output.push_str(&format!(
         "**Language**: {:?} (confidence: {:.0}%)\n\n",
         score.language,
@@ -643,7 +671,21 @@ mod cap_disclosure_tests {
 
         let json = format_tdg_score_json(&score, None, true, Some(&project)).expect("render");
         let value: serde_json::Value = serde_json::from_str(&json).expect("valid json");
-        assert_eq!(value["score"]["total"], 0.0);
+        // NOT 0.0, and NOT "F". This asserted `total == 0.0`, which pinned the
+        // headline defect in place: a consumer averaging `total` across a tree
+        // folded an unreadable directory in as a genuine zero, and one testing
+        // `grade == "F"` could not tell "graded badly" from "never graded".
+        assert!(
+            value["score"]["total"].is_null(),
+            "total must be null when no file was analyzed, got {}",
+            value["score"]["total"]
+        );
+        assert!(
+            value["score"]["grade"].is_null(),
+            "grade must be null when no file was analyzed, got {}",
+            value["score"]["grade"]
+        );
+        assert_eq!(value["not_measured"], true);
         assert!(
             value["score"]["breakdown"].is_null(),
             "breakdown must be null when no file was analyzed, got {}",
@@ -654,9 +696,19 @@ mod cap_disclosure_tests {
         let table = format_tdg_score_table(&score, None, true, Some(&project)).expect("render");
         assert!(table.contains("not measured"), "got:\n{table}");
         assert!(!table.contains("25.0"), "got:\n{table}");
+        // The HEADLINE, not just the breakdown: `Overall Score: 0.0/100 (F)`
+        // was printed over a directory pmat could not read one file of.
+        assert!(
+            !table.contains("(F)"),
+            "an empty population must not be graded F: {table}"
+        );
 
         let md = format_tdg_score_markdown(&score, None, true, Some(&project)).expect("render");
         assert!(md.contains("Not measured"), "got:\n{md}");
+        assert!(
+            !md.contains("0.0/100"),
+            "an empty population must not be scored 0.0/100: {md}"
+        );
     }
 
     /// A single-file run has no project aggregate; nothing may be suppressed or

--- a/src/cli/handlers/tdg_handlers/mod.rs
+++ b/src/cli/handlers/tdg_handlers/mod.rs
@@ -310,6 +310,26 @@ pub async fn handle_tdg_command(config: TdgCommandConfig) -> Result<()> {
     let output_str = formatting::format_tdg_analysis(&analysis, git_context, &config)?;
     formatting::write_tdg_output(&output_str, &config)?;
 
+    // The report is written first, then the run REFUSES. `pmat tdg <dir>` on a
+    // directory holding nothing pmat can parse — an empty one, or one of COBOL
+    // — printed `Overall Score: 0.0/100 (F)` and exited 0. Both halves were
+    // wrong in the same direction: an F is a claim about a codebase's quality,
+    // zero files is the absence of evidence for any claim, and a zero exit told
+    // CI the measurement had been taken. `analyze complexity` on that same
+    // directory already exits 5 saying "This is not a clean result"; two
+    // commands over one tree must not disagree about whether it was measured.
+    if analysis
+        .project
+        .as_ref()
+        .is_some_and(|p| p.total_files == 0)
+    {
+        return Err(crate::cli_exit::analysis_error(anyhow::anyhow!(
+            "no gradable source files were found under {}, so no TDG measurement was taken. \
+             This is not a clean result.",
+            analysis.root.display()
+        )));
+    }
+
     Ok(())
 }
 

--- a/src/cli/handlers/tdg_handlers_tests.rs
+++ b/src/cli/handlers/tdg_handlers_tests.rs
@@ -1198,6 +1198,29 @@ mod sarif_format_fidelity {
         std::fs::read_to_string(&out).unwrap()
     }
 
+    /// As `render`, for a tree pmat cannot measure at all.
+    ///
+    /// The document is written and THEN the run refuses, so the rendering is
+    /// still available to compare while the exit stays non-zero. `pmat tdg` on
+    /// a directory holding nothing it can parse used to print
+    /// `Overall Score: 0.0/100 (F)` and exit 0 — a quality verdict over zero
+    /// evidence, and a green exit for a measurement never taken.
+    async fn render_unmeasured(
+        path: &std::path::Path,
+        format: TdgOutputFormat,
+        tag: &str,
+    ) -> String {
+        let out = path.join(format!("out-{tag}.txt"));
+        let err = handle_tdg_command(config_with_format(path.to_path_buf(), out.clone(), format))
+            .await
+            .expect_err("a tree with no gradable file must not exit 0");
+        assert!(
+            err.to_string().contains("not a clean result"),
+            "the refusal must say why: {err}"
+        );
+        std::fs::read_to_string(&out).expect("the document is written before the refusal")
+    }
+
     /// Write a small tree that scores well, so the top of the grade scale is
     /// actually exercised.
     fn clean_fixture() -> TempDir {
@@ -1276,7 +1299,11 @@ mod sarif_format_fidelity {
             (clean.path(), "clean"),
             (awful.path(), "awful"),
         ] {
-            let raw = render(dir, TdgOutputFormat::Sarif, tag).await;
+            let raw = if tag == "empty" {
+                render_unmeasured(dir, TdgOutputFormat::Sarif, tag).await
+            } else {
+                render(dir, TdgOutputFormat::Sarif, tag).await
+            };
             let doc: serde_json::Value = serde_json::from_str(&raw).unwrap();
             let results = doc["runs"][0]["results"].as_array().unwrap();
             assert!(

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -478,11 +478,17 @@ pub fn ensure_files_were_analyzed(
     if files_analyzed > 0 {
         return Ok(());
     }
-    anyhow::bail!(
+    // Exit 5 DECLARED, not inferred. This refusal reached
+    // `ExitCode::AnalysisError` only because the interpolated `measurement` was
+    // sometimes the word "complexity", which the old substring classifier
+    // matched. The same refusal for a different analysis — where `measurement`
+    // is "dead-code" or "churn" — matched nothing and exited 1, so one class of
+    // failure had two exit codes decided by an interpolation.
+    Err(crate::cli_exit::analysis_error(anyhow::anyhow!(
         "no {population} were found under {}, so no {measurement} measurement was taken. \
          This is not a clean result.",
         path.display()
-    )
+    )))
 }
 
 /// The single implementation of `--top-files N`.

--- a/src/cli_exit.rs
+++ b/src/cli_exit.rs
@@ -58,19 +58,33 @@ impl From<ExitCode> for i32 {
 /// one byte of what the user reads. That separation is the point: the message
 /// and the exit code stop being the same channel.
 #[derive(Debug, thiserror::Error)]
-#[error("{source}")]
+#[error("{inner:#}")]
 pub struct ExitCoded {
     /// The code this failure exits with.
     pub code: ExitCode,
-    /// The underlying error, whose `Display` is preserved verbatim.
-    #[source]
-    pub source: anyhow::Error,
+    /// The underlying error, rendered verbatim.
+    ///
+    /// Named `inner`, not `source`, and that is load-bearing. `write_fatal_error`
+    /// prints `{error:#}` — the alternate form that walks the whole anyhow chain
+    /// joining entries with ": ". While this field was called `source`, thiserror
+    /// linked it as the error source (it does that from the NAME, with or without
+    /// the `#[source]` attribute), so the chain held both `ExitCoded` and the
+    /// error it wraps — whose `Display` is identical. Every coded failure printed
+    /// its own message twice:
+    ///
+    ///     Error: no source files were found under X ...: no source files were
+    ///     found under X ...
+    ///
+    /// Dropping the attribute alone did NOT fix it; only the rename did.
+    /// `{inner:#}` then renders the inner chain in full from a single entry, so
+    /// no `.context()` layer is lost and nothing repeats.
+    pub inner: anyhow::Error,
 }
 
 /// Attach an exit code to an error at the site that raises it.
 #[must_use]
-pub fn with_code(code: ExitCode, source: anyhow::Error) -> anyhow::Error {
-    anyhow::Error::new(ExitCoded { code, source })
+pub fn with_code(code: ExitCode, inner: anyhow::Error) -> anyhow::Error {
+    anyhow::Error::new(ExitCoded { code, inner })
 }
 
 /// Configuration is missing or unusable — exit 4.
@@ -127,6 +141,58 @@ mod tests {
 
     /// The counter-test. An undeclared error must NOT pick up a code from words
     /// that used to trigger the classifier — otherwise the substring behaviour
+    /// A coded failure renders its message exactly once.
+    ///
+    /// `write_fatal_error` prints `{error:#}`, and the alternate form walks the
+    /// whole chain joining entries with ": ". While the field was NAMED
+    /// `source`, the chain held `ExitCoded` AND the error it wraps, whose
+    /// `Display` is identical — so every coded failure printed itself twice:
+    /// "no source files were found under X ...: no source files were found
+    /// under X ...". Three tests already covered this type and none of them
+    /// rendered `{:#}`, so the repetition shipped unseen.
+    #[test]
+    fn the_message_is_not_printed_twice() {
+        let text = "no source files were found under /nope";
+        let e = anyhow::Error::from(ExitCoded {
+            code: ExitCode::AnalysisError,
+            inner: anyhow::anyhow!(text),
+        });
+        let rendered = format!("{e:#}");
+        assert_eq!(
+            rendered.matches(text).count(),
+            1,
+            "message repeated in the chain-rendered form: {rendered}"
+        );
+        assert_eq!(rendered, text);
+    }
+
+    /// ...and the inner chain is not lost to that fix.
+    ///
+    /// The cheap way to stop the duplication is to drop the field as a source,
+    /// which also drops every `.context()` layer beneath it from the rendered
+    /// output. `{inner:#}` keeps them.
+    #[test]
+    fn the_inner_context_chain_still_renders() {
+        let inner = anyhow::anyhow!("permission denied")
+            .context("could not open .pmat/index.db")
+            .context("cache load failed");
+        let e = anyhow::Error::from(ExitCoded {
+            code: ExitCode::GeneralError,
+            inner,
+        });
+        let rendered = format!("{e:#}");
+        for part in [
+            "cache load failed",
+            "could not open .pmat/index.db",
+            "permission denied",
+        ] {
+            assert!(
+                rendered.contains(part),
+                "context layer {part:?} lost from: {rendered}"
+            );
+        }
+    }
+
     /// survives under a new name.
     #[test]
     fn undeclared_errors_are_general_whatever_they_say() {

--- a/src/cli_exit.rs
+++ b/src/cli_exit.rs
@@ -1,0 +1,154 @@
+//! Process exit codes, declared by the site that raises the error.
+//!
+//! This module exists because the exit code used to be a property of the
+//! WORDING of a user-facing sentence. `src/bin/pmat.rs` lowercased
+//! `error.to_string()` and grepped it: "quality gate" or "violation" gave 3,
+//! "config" or "parse" gave 4, "analysis" or "complexity" gave 5, "permission"
+//! or "access" gave 126. Rewording a message changed the exit code, and CI
+//! branches on exit codes.
+//!
+//! Two measured instances, both live before this module:
+//!
+//! * `pmat serve --transport http` with no token exits 4, and the help text at
+//!   `commands_enum/definition.rs:933` documents that as a contract. The 4 came
+//!   from the word "configured" inside a subordinate clause explaining pmcp's
+//!   behaviour — "pmcp serves every request when no auth provider is
+//!   configured" — in a message whose subject is a MISSING TOKEN. Nothing in
+//!   that sentence was written to select an exit code.
+//!
+//! * `analyze complexity` over a directory of unanalyzable files exits 5,
+//!   because its refusal contains "no complexity measurement was taken". Point
+//!   it at an absent path and the refusal reads "Path not found", matching no
+//!   keyword, so the same class of failure exits 1.
+//!
+//! A code is now stated where the error is raised, or it is `GeneralError`.
+
+/// Process exit codes.
+///
+/// `CommandNotFound = 127` and `InvalidExitArg = 128` were removed along with
+/// the substring classifier: no error text could reach them, and the
+/// `SPECIFICATION.md Section 23` they cited does not exist in this tree.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExitCode {
+    /// Success.
+    Success = 0,
+    /// Any failure that does not declare a more specific code.
+    GeneralError = 1,
+    /// Command-line misuse. Clap owns this one.
+    MisuseError = 2,
+    /// A quality gate found blocking violations.
+    QualityGateFailure = 3,
+    /// Configuration is missing or unusable.
+    ConfigurationError = 4,
+    /// An analysis could not produce a measurement.
+    AnalysisError = 5,
+    /// Permission denied.
+    PermissionDenied = 126,
+}
+
+impl From<ExitCode> for i32 {
+    fn from(code: ExitCode) -> Self {
+        code as i32
+    }
+}
+
+/// An error that DECLARES its process exit code.
+///
+/// `Display` delegates to the wrapped error, so attaching a code changes not
+/// one byte of what the user reads. That separation is the point: the message
+/// and the exit code stop being the same channel.
+#[derive(Debug, thiserror::Error)]
+#[error("{source}")]
+pub struct ExitCoded {
+    /// The code this failure exits with.
+    pub code: ExitCode,
+    /// The underlying error, whose `Display` is preserved verbatim.
+    #[source]
+    pub source: anyhow::Error,
+}
+
+/// Attach an exit code to an error at the site that raises it.
+#[must_use]
+pub fn with_code(code: ExitCode, source: anyhow::Error) -> anyhow::Error {
+    anyhow::Error::new(ExitCoded { code, source })
+}
+
+/// Configuration is missing or unusable — exit 4.
+#[must_use]
+pub fn configuration_error(source: anyhow::Error) -> anyhow::Error {
+    with_code(ExitCode::ConfigurationError, source)
+}
+
+/// An analysis could not produce a measurement — exit 5.
+#[must_use]
+pub fn analysis_error(source: anyhow::Error) -> anyhow::Error {
+    with_code(ExitCode::AnalysisError, source)
+}
+
+/// A quality gate found blocking violations — exit 3.
+#[must_use]
+pub fn quality_gate_failure(source: anyhow::Error) -> anyhow::Error {
+    with_code(ExitCode::QualityGateFailure, source)
+}
+
+/// The declared code for an error, or `GeneralError` when none was declared.
+///
+/// Walks the whole cause chain, so a declaring error keeps its code after
+/// `.context(...)` wraps it.
+#[must_use]
+pub fn code_for(error: &anyhow::Error) -> ExitCode {
+    error
+        .chain()
+        .find_map(|cause| cause.downcast_ref::<ExitCoded>())
+        .map_or(ExitCode::GeneralError, |coded| coded.code)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The whole point: the code does not move when the words do.
+    #[test]
+    fn the_exit_code_is_independent_of_the_message() {
+        for text in [
+            "PMAT_MCP_HTTP_TOKEN is not set, no auth provider is configured",
+            "the token is absent",
+            "quality gate violation complexity permission access parse",
+        ] {
+            let e = configuration_error(anyhow::anyhow!("{text}"));
+            assert_eq!(
+                code_for(&e),
+                ExitCode::ConfigurationError,
+                "wording must not change the code: {text}"
+            );
+            assert_eq!(e.to_string(), text, "the user's message must be unchanged");
+        }
+    }
+
+    /// The counter-test. An undeclared error must NOT pick up a code from words
+    /// that used to trigger the classifier — otherwise the substring behaviour
+    /// survives under a new name.
+    #[test]
+    fn undeclared_errors_are_general_whatever_they_say() {
+        for text in [
+            "quality gate failed with 3 violations",
+            "failed to parse config",
+            "analysis of complexity aborted",
+            "permission denied: access refused",
+        ] {
+            assert_eq!(
+                code_for(&anyhow::anyhow!("{text}")),
+                ExitCode::GeneralError,
+                "an undeclared error must be GeneralError: {text}"
+            );
+        }
+    }
+
+    /// A declared code survives being wrapped in context.
+    #[test]
+    fn context_does_not_lose_the_declared_code() {
+        let inner = analysis_error(anyhow::anyhow!("no measurement was taken"));
+        let wrapped = inner.context("while analysing the project");
+        assert_eq!(code_for(&wrapped), ExitCode::AnalysisError);
+    }
+}

--- a/src/handlers/tools_advanced_part1.rs
+++ b/src/handlers/tools_advanced_part1.rs
@@ -197,7 +197,7 @@ pub(crate) async fn handle_analyze_defect_probability(
     let file_metrics =
         match discover_and_analyze_files(&project_path, churn_map, request_id.clone()).await {
             Ok(metrics) => metrics,
-            Err(response) => return response,
+            Err(response) => return *response,
         };
 
     // Calculate defect probabilities and create response
@@ -241,7 +241,7 @@ async fn discover_and_analyze_files(
     project_path: &Path,
     churn_map: std::collections::HashMap<String, f32>,
     request_id: serde_json::Value,
-) -> Result<Vec<crate::services::defect_probability::FileMetrics>, McpResponse> {
+) -> Result<Vec<crate::services::defect_probability::FileMetrics>, Box<McpResponse>> {
     use crate::services::file_discovery::ProjectFileDiscovery;
     use futures::stream::{self, StreamExt};
 
@@ -251,11 +251,14 @@ async fn discover_and_analyze_files(
         Ok(files) => files,
         Err(e) => {
             error!("Failed to discover files: {}", e);
-            return Err(McpResponse::error(
+            // Boxed: `McpResponse` is 272 bytes, so an unboxed `Err` made every
+            // Ok-path return of this function carry the error's footprint
+            // (clippy::result_large_err, enforced since the 1.98 toolchain).
+            return Err(Box::new(McpResponse::error(
                 request_id,
                 -32603,
                 format!("Failed to discover files: {e}"),
-            ));
+            )));
         }
     };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,6 +129,7 @@ pub mod agents_md; // AGENTS.md integration for AI agent guidance
 pub mod ast; // Unified AST module for all language parsing
 #[cfg(feature = "standard-deps")]
 pub mod cli;
+pub mod cli_exit;
 #[cfg(feature = "standard-deps")]
 pub mod contracts; // Uniform contracts across ALL interfaces (CLI, MCP, HTTP)
                    // Feature-gated: Demo/showcase functionality (opt-in, ~13,400 lines)

--- a/src/mcp_pmcp/http_server.rs
+++ b/src/mcp_pmcp/http_server.rs
@@ -69,12 +69,19 @@ impl BearerToken {
     pub fn from_env() -> Result<Self> {
         match std::env::var(TOKEN_ENV) {
             Ok(t) => Self::new(t),
-            Err(_) => bail!(
+            // Exit code DECLARED, not inferred. This message used to reach
+            // `ExitCode::ConfigurationError` (4) because the substring "config"
+            // appears in "no auth provider is configured" — a clause about
+            // pmcp's behaviour, in a message about a missing token. The help at
+            // commands_enum/definition.rs:933 documents exit 4 as a contract,
+            // so the code is kept and now stated here, where it cannot be
+            // changed by editing prose.
+            Err(_) => Err(crate::cli_exit::configuration_error(anyhow::anyhow!(
                 "{TOKEN_ENV} is not set. `pmat serve` will not start an unauthenticated MCP \
                  endpoint: pmcp serves every request when no auth provider is configured, so \
                  starting without a token would publish the full tool surface to anyone who \
                  can reach the port."
-            ),
+            ))),
         }
     }
 

--- a/src/mcp_pmcp/tools/auto_clippy_fix.rs
+++ b/src/mcp_pmcp/tools/auto_clippy_fix.rs
@@ -25,9 +25,31 @@ pub async fn auto_clippy_fix(
     // Run clippy and get diagnostics
     let diagnostics = run_clippy_analysis(&path).await?;
 
+    // How many clippy actually REPORTED, before any of ours filtering.
+    //
+    // Everything downstream counts the FILTERED list, so on a crate where
+    // `cargo clippy` emits 76 warnings this reported
+    //
+    //     "total_diagnostics": 0, "action": "applied",
+    //     "message": "🔧 Clippy fixes applied successfully"
+    //
+    // and exited 0. The default is `--confidence high`, and `default_confidence`
+    // rates anything without an explicit rule as Medium (a suggestion exists) or
+    // Low (none) — so unless a lint is named in `confidence_rules`, every
+    // diagnostic is dropped here. All 76 were: 75 `clippy::collapsible_if` and
+    // one `dead_code`. "None were auto-fixable at this confidence" and "the
+    // crate is clippy-clean" are opposite claims, and only the second was
+    // reported.
+    let census = DiagnosticCensus {
+        found: diagnostics.len(),
+        eligible: 0,
+        min_confidence: format!("{min_confidence:?}"),
+    };
+
     // Filter by confidence level
     let engine = ClippyFixEngine::new();
     let filtered = filter_diagnostics(&engine, diagnostics, min_confidence, &fix_specific_codes);
+    let eligible = filtered.len();
 
     // Apply fixes or show what would be fixed
     let results = if is_dry_run {
@@ -36,7 +58,11 @@ pub async fn auto_clippy_fix(
         apply_fixes(&engine, filtered).await?
     };
 
-    Ok(create_fix_response(results, is_dry_run))
+    Ok(create_fix_response(
+        results,
+        is_dry_run,
+        &census.with_eligible(eligible),
+    ))
 }
 
 // Core helper functions: parsing, filtering, simulation, application, response creation

--- a/src/mcp_pmcp/tools/auto_clippy_fix_core.rs
+++ b/src/mcp_pmcp/tools/auto_clippy_fix_core.rs
@@ -145,14 +145,59 @@ async fn apply_fixes(
     }))
 }
 
+/// What clippy reported, beside what we were willing to act on.
+///
+/// These are different numbers and were reported as one. See the comment at the
+/// call site in `auto_clippy_fix`.
+struct DiagnosticCensus {
+    /// Diagnostics `cargo clippy` emitted, before any filtering of ours.
+    found: usize,
+    /// Of those, the ones that met `min_confidence` and the code filter.
+    eligible: usize,
+    /// The confidence bar that did the filtering, so the gap is explainable.
+    min_confidence: String,
+}
+
+impl DiagnosticCensus {
+    fn with_eligible(self, eligible: usize) -> Self {
+        Self { eligible, ..self }
+    }
+
+    /// A sentence that cannot say "successfully" about work not done.
+    fn message(&self, action: &str) -> String {
+        if self.found == 0 {
+            let _ = action;
+            return "\u{2705} clippy reported no diagnostics; nothing to fix".to_string();
+        }
+        let skipped = self.found.saturating_sub(self.eligible);
+        if self.eligible == 0 {
+            return format!(
+                "\u{26a0}\u{fe0f} clippy reported {} diagnostic(s), and none met the required \
+                 confidence ({}) — {} left untouched. This is NOT a clean result; \
+                 re-run with --confidence low to see them.",
+                self.found, self.min_confidence, skipped
+            );
+        }
+        format!(
+            "\u{1f527} clippy reported {} diagnostic(s); {} met confidence {} and were {}, \
+             {} left untouched",
+            self.found, self.eligible, self.min_confidence, action, skipped
+        )
+    }
+}
+
 /// Create MCP response (complexity: 2)
-fn create_fix_response(results: Value, is_dry_run: bool) -> ToolResult {
+fn create_fix_response(results: Value, is_dry_run: bool, census: &DiagnosticCensus) -> ToolResult {
     let action = if is_dry_run { "analyzed" } else { "applied" };
 
     let response = json!({
         "action": action,
+        "diagnostics_found": census.found,
+        "diagnostics_eligible": census.eligible,
+        "diagnostics_filtered_out": census.found.saturating_sub(census.eligible),
+        "min_confidence": census.min_confidence,
         "results": results,
-        "message": format!("\u{1f527} Clippy fixes {} successfully", action)
+        "message": census.message(action)
     });
 
     ToolResult::new(vec![pmcp::Content::Text {

--- a/src/mcp_pmcp/tools/auto_clippy_fix_tests_integration.rs
+++ b/src/mcp_pmcp/tools/auto_clippy_fix_tests_integration.rs
@@ -123,6 +123,66 @@ mod integration_tests {
     // Tests for create_fix_response
     // ========================================================================
 
+    fn census(found: usize, eligible: usize) -> DiagnosticCensus {
+        DiagnosticCensus {
+            found,
+            eligible,
+            min_confidence: "High".to_string(),
+        }
+    }
+
+    /// Diagnostics FOUND and diagnostics ELIGIBLE are different numbers.
+    ///
+    /// They were reported as one: everything downstream counted the filtered
+    /// list, so on a crate where `cargo clippy` emits 76 warnings this returned
+    /// `"total_diagnostics": 0` with `"message": "🔧 Clippy fixes applied
+    /// successfully"` and exit 0. The default is `--confidence high`, and any
+    /// lint without an explicit rule is rated Medium or Low, so every
+    /// diagnostic was dropped — 75 `clippy::collapsible_if` and one
+    /// `dead_code`. "None were auto-fixable at this confidence" and "the crate
+    /// is clippy-clean" are opposite claims, and only the second was reported.
+    #[test]
+    fn diagnostics_found_survives_the_confidence_filter() {
+        let response = create_fix_response(json!({}), false, &census(76, 0));
+        let pmcp::Content::Text { text } = &response.content[0] else {
+            unreachable!("Expected Text content")
+        };
+        let doc: serde_json::Value = serde_json::from_str(text).expect("valid json");
+
+        assert_eq!(doc["diagnostics_found"], 76, "{text}");
+        assert_eq!(doc["diagnostics_eligible"], 0, "{text}");
+        assert_eq!(doc["diagnostics_filtered_out"], 76, "{text}");
+
+        let message = doc["message"].as_str().expect("message");
+        assert!(
+            message.contains("76"),
+            "the message must carry the count clippy actually reported: {message}"
+        );
+        assert!(
+            !message.contains("successfully"),
+            "0 of 76 fixed is not success: {message}"
+        );
+    }
+
+    /// The counter-test: a genuinely clean crate must still read as clean.
+    ///
+    /// Without this, warning on every run would pass the test above.
+    #[test]
+    fn a_crate_with_no_diagnostics_still_reads_as_clean() {
+        let response = create_fix_response(json!({}), false, &census(0, 0));
+        let pmcp::Content::Text { text } = &response.content[0] else {
+            unreachable!("Expected Text content")
+        };
+        let doc: serde_json::Value = serde_json::from_str(text).expect("valid json");
+
+        assert_eq!(doc["diagnostics_found"], 0);
+        let message = doc["message"].as_str().expect("message");
+        assert!(
+            !message.contains("NOT a clean result"),
+            "a crate clippy had nothing to say about must not be flagged: {message}"
+        );
+    }
+
     #[test]
     fn test_create_fix_response_dry_run() {
         let results = json!({
@@ -131,14 +191,14 @@ mod integration_tests {
             "fixes": []
         });
 
-        let response = create_fix_response(results, true);
+        let response = create_fix_response(results, true, &census(5, 5));
 
         assert!(!response.is_error);
         assert_eq!(response.content.len(), 1);
 
         if let pmcp::Content::Text { text } = &response.content[0] {
             assert!(text.contains("analyzed"));
-            assert!(text.contains("Clippy fixes"));
+            assert!(text.contains("clippy reported"));
             assert!(text.contains("dry_run"));
         } else {
             panic!("Expected Text content");
@@ -155,14 +215,14 @@ mod integration_tests {
             }
         });
 
-        let response = create_fix_response(results, false);
+        let response = create_fix_response(results, false, &census(10, 8));
 
         assert!(!response.is_error);
         assert_eq!(response.content.len(), 1);
 
         if let pmcp::Content::Text { text } = &response.content[0] {
             assert!(text.contains("applied"));
-            assert!(text.contains("Clippy fixes"));
+            assert!(text.contains("clippy reported"));
         } else {
             panic!("Expected Text content");
         }
@@ -260,8 +320,8 @@ mod integration_tests {
 
     #[test]
     fn test_create_fix_response_message_formatting() {
-        let response_dry = create_fix_response(json!({}), true);
-        let response_apply = create_fix_response(json!({}), false);
+        let response_dry = create_fix_response(json!({}), true, &census(3, 3));
+        let response_apply = create_fix_response(json!({}), false, &census(3, 3));
 
         // Verify different messages for dry run vs apply
         if let (pmcp::Content::Text { text: text_dry }, pmcp::Content::Text { text: text_apply }) =

--- a/src/roadmap/commands/commands_init.rs
+++ b/src/roadmap/commands/commands_init.rs
@@ -36,9 +36,9 @@ async fn init_sprint(
             "Changelog updated".to_string(),
         ],
         quality_gates: vec![
-            format!("Complexity ≤ 20"),
-            format!("SATD = 0"),
-            format!("Coverage ≥ 80%"),
+            "Complexity ≤ 20".to_string(),
+            "SATD = 0".to_string(),
+            "Coverage ≥ 80%".to_string(),
         ],
     };
 

--- a/src/services/unrun_tests/mod.rs
+++ b/src/services/unrun_tests/mod.rs
@@ -145,6 +145,72 @@ fn env_for(graph: &features::FeatureGraph, leg: &legs::Leg) -> Env {
     }
 }
 
+/// Refuse only when the feature parser actually LOST something.
+///
+/// This was `if graph.len() < 40`, a threshold calibrated to pmat's own
+/// manifest and then asserted as a fact about the parser. Every other crate
+/// tripped it: a fixture declaring exactly four features was told
+///
+///     only 4 features parsed from [features] — the parser is broken, not the crate
+///
+/// and a crate with no `[features]` table at all was told the same thing about
+/// zero. Both statements were false — the parser had read the table correctly,
+/// and the crate simply had few features — and each was a hard exit 1, so
+/// `analyze unrun-tests` could not be run on an ordinary crate at all.
+///
+/// The honest test compares what the parser produced against what the table
+/// textually declares. Fewer parsed than declared means entries were dropped,
+/// which is the failure the guard was written for; a small table is not.
+fn parser_is_intact(manifest: &str, parsed: usize) -> Result<(), String> {
+    let declared = declared_feature_count(manifest);
+    if parsed < declared {
+        return Err(format!(
+            "the [features] table declares {declared} feature(s) but only {parsed} parsed — \
+             the parser is broken, not the crate"
+        ));
+    }
+    Ok(())
+}
+
+/// How many entries the `[features]` table declares, counted independently of
+/// [`features::parse`] so the two cannot agree by sharing a bug.
+///
+/// Counts the `name =` lines inside `[features]`, skipping the continuation
+/// lines of a multi-line value (which carry no `=` of their own).
+fn declared_feature_count(manifest: &str) -> usize {
+    let mut in_features = false;
+    let mut continuing = false;
+    let mut declared = 0usize;
+    for raw in manifest.lines() {
+        let line = match raw.find('#') {
+            Some(i) if !raw[..i].contains('"') => &raw[..i],
+            _ => raw,
+        };
+        let trimmed = line.trim();
+        if trimmed.starts_with('[') {
+            in_features = trimmed == "[features]";
+            continuing = false;
+            continue;
+        }
+        if !in_features || trimmed.is_empty() {
+            continue;
+        }
+        if continuing {
+            continuing = !trimmed.contains(']');
+            continue;
+        }
+        let Some((name, rest)) = trimmed.split_once('=') else {
+            continue;
+        };
+        if name.trim().trim_matches('"').is_empty() {
+            continue;
+        }
+        declared += 1;
+        continuing = rest.contains('[') && !rest.contains(']');
+    }
+    declared
+}
+
 /// Run the analysis.
 ///
 /// `extra_legs` are test-running invocations defined OUTSIDE this repository —
@@ -161,12 +227,7 @@ pub fn analyze(project_root: &Path, extra_legs: &[String]) -> Result<Report, Str
     let manifest = std::fs::read_to_string(project_root.join("Cargo.toml"))
         .map_err(|e| format!("Cargo.toml: {e}"))?;
     let graph = features::parse(&manifest);
-    if graph.len() < 40 {
-        return Err(format!(
-            "only {} features parsed from [features] — the parser is broken, not the crate",
-            graph.len()
-        ));
-    }
+    parser_is_intact(&manifest, graph.len())?;
 
     let mut legs: Vec<legs::Leg> = legs::from_workflows(&project_root.join(".github/workflows"))
         .into_iter()

--- a/src/services/unrun_tests/tests.rs
+++ b/src/services/unrun_tests/tests.rs
@@ -732,3 +732,108 @@ fn counter_write_proceeds_outside_a_git_repository() {
     ledger::write(d.path(), &report, false).expect("no git metadata must not block a write");
     assert!(d.path().join(ledger::LEDGER_PATH).is_file());
 }
+
+#[cfg(test)]
+mod parser_health_tests {
+    use super::super::{declared_feature_count, parser_is_intact};
+
+    const FOUR: &str = "\
+[package]
+name = \"corpus\"
+
+[features]
+default = [\"std\"]
+std = []
+simd = []
+tracing = []
+
+[[bench]]
+name = \"throughput\"
+";
+
+    /// A small crate is not a broken parser.
+    ///
+    /// The guard was `if graph.len() < 40`, a threshold calibrated to pmat's own
+    /// manifest and then stated as a fact about the parser. A fixture declaring
+    /// exactly four features was told "only 4 features parsed from [features] —
+    /// the parser is broken, not the crate", and a crate with no [features]
+    /// table was told the same about zero. Both were false, both were exit 1,
+    /// and between them they made `analyze unrun-tests` unusable on any crate
+    /// but this one.
+    #[test]
+    fn a_small_feature_table_is_not_a_broken_parser() {
+        assert_eq!(declared_feature_count(FOUR), 4);
+        parser_is_intact(FOUR, 4).expect("four declared and four parsed is intact");
+    }
+
+    #[test]
+    fn a_crate_with_no_features_table_is_not_a_broken_parser() {
+        let manifest = "[package]\nname = \"tiny\"\n";
+        assert_eq!(declared_feature_count(manifest), 0);
+        parser_is_intact(manifest, 0).expect("no table to lose entries from");
+    }
+
+    /// The guard must still catch what it was written for: entries dropped.
+    ///
+    /// Without this the fix would be "delete the check", which passes both
+    /// tests above and detects nothing.
+    #[test]
+    fn dropping_declared_features_is_still_refused() {
+        let err = parser_is_intact(FOUR, 1).expect_err("1 parsed of 4 declared is a broken parser");
+        assert!(err.contains("declares 4"), "{err}");
+        assert!(err.contains("only 1 parsed"), "{err}");
+    }
+
+    /// Continuation lines of a multi-line value are not extra features.
+    #[test]
+    fn a_multi_line_feature_value_counts_once() {
+        let manifest = "\
+[features]
+default = [
+    \"std\",
+    \"simd\",
+]
+std = []
+";
+        assert_eq!(declared_feature_count(manifest), 2);
+    }
+
+    /// End-to-end: `analyze` on a small crate must not blame its own parser.
+    ///
+    /// The tests above call the guard directly, so they do not cover the call
+    /// site where the threshold actually lived. This one does: a four-feature
+    /// crate reaches `analyze` and must get past the manifest check. It still
+    /// fails afterwards — no CI workflow means no test leg, which is a
+    /// different and legitimate refusal — so the assertion is on WHICH error.
+    #[test]
+    fn analyze_does_not_blame_the_parser_on_a_small_crate() {
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        std::fs::write(dir.path().join("Cargo.toml"), FOUR).expect("write manifest");
+
+        let err = super::super::analyze(dir.path(), &[])
+            .expect_err("no workflows means no leg, so this still fails");
+        assert!(
+            !err.contains("the parser is broken"),
+            "a four-feature crate is not a broken parser: {err}"
+        );
+        assert!(
+            err.contains("cargo test") || err.contains("leg"),
+            "expected the no-leg refusal, got: {err}"
+        );
+    }
+
+    /// The counter must agree with the parser on pmat's own manifest — the one
+    /// input where the old threshold happened to be right.
+    #[test]
+    fn the_two_counts_agree_on_this_crate() {
+        let manifest = std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/Cargo.toml"))
+            .expect("read our own Cargo.toml");
+        let parsed = super::super::features::parse(&manifest).len();
+        let declared = declared_feature_count(&manifest);
+        assert_eq!(
+            parsed, declared,
+            "the independent count and the parser disagree on our own manifest"
+        );
+        parser_is_intact(&manifest, parsed).expect("our own manifest must be intact");
+    }
+}

--- a/src/tdg/grade.rs
+++ b/src/tdg/grade.rs
@@ -36,7 +36,11 @@ pub enum Grade {
 }
 
 /// Grade spellings as `Serialize` emits them, for error messages.
-const GRADE_VARIANTS: &[&str] = &["A+", "A", "A-", "B+", "B", "B-", "C+", "C", "C-", "D", "F"];
+/// CANONICAL, and the only list of grade spellings anything may enumerate.
+/// Ordered worst-last, matching `Grade`'s own `Ord`. CB-200 kept a private
+/// `["A","B","C","D","F"]` and was blind to every modified grade for a release.
+pub(crate) const GRADE_VARIANTS: &[&str] =
+    &["A+", "A", "A-", "B+", "B", "B-", "C+", "C", "C-", "D", "F"];
 
 impl Serialize for Grade {
     /// Emits the symbolic form -- byte-identical to `Display`. See the note on
@@ -64,7 +68,7 @@ impl<'de> Deserialize<'de> for Grade {
 impl Grade {
     /// Parse a serialized variant name. Case-insensitive on purpose: see the
     /// note on `Grade::APlus`.
-    fn from_variant_name(name: &str) -> Option<Self> {
+    pub(crate) fn from_variant_name(name: &str) -> Option<Self> {
         // Accepts BOTH spellings. `Serialize` emits the variant name (what
         // every stored baseline contains), but symbolic forms reach this from
         // user input and from output written while the two round-3 fixes
@@ -470,3 +474,29 @@ mod tests {
         assert!(err.to_string().contains("unknown variant"), "{err}");
     }
 }
+
+/// Every canonical spelling parses, and `GRADE_VARIANTS` is in `Ord` order.
+///
+/// A TEST, not a `const` block: `from_variant_name` lowercases, and
+/// `str::to_ascii_lowercase` is not a `const fn`, so this cannot run in a const
+/// context. It runs under `cargo test --lib`, which is the rung this repository
+/// actually executes. The anchoring property — that rank tracks the score band
+/// — is proved in `contracts/lean/Theorems/Tdg/Grade.lean`, because no
+/// self-referential assertion can catch a scale reversed together with its own
+/// array.
+#[test]
+fn grade_order_is_parseable() {
+    let parsed: Vec<Grade> = GRADE_VARIANTS
+        .iter()
+        .map(|s| Grade::from_variant_name(s).expect("every canonical spelling must parse"))
+        .collect();
+    let mut sorted = parsed.clone();
+    sorted.sort();
+    assert_eq!(parsed, sorted, "GRADE_VARIANTS is not in Ord order");
+    assert_eq!(
+        parsed.len(),
+        Grade::all().len(),
+        "GRADE_VARIANTS and Grade::all() disagree"
+    );
+}
+const GRADE_ORDER_IS_PARSEABLE: () = ();

--- a/tests/modules/quality_harness/differential_corpus.rs
+++ b/tests/modules/quality_harness/differential_corpus.rs
@@ -123,6 +123,66 @@ const NON_MEASURING: &[(&str, &str)] = &[
 const ALLOWED_CONSTANTS: &[(&str, &str, &str)] = &[
     // (command path, json leaf path, why it is legitimately constant)
     (
+        "analyze dead-code",
+        "omitted.files",
+        "the default invocation lists every file it found (16 of 16 on the large corpus), so nothing is omitted. The family DOES respond, to the flags rather than to the corpus: `--top-files 2` reports omitted.files=14, dead_lines=399, dead_functions=72, dead_classes=13 and reasons ['below --min-dead-lines', 'beyond --top-files']. Verified 2026-08-21",
+    ),
+    (
+        "analyze dead-code",
+        "omitted.dead_lines",
+        "the default invocation lists every file it found (16 of 16 on the large corpus), so nothing is omitted. The family DOES respond, to the flags rather than to the corpus: `--top-files 2` reports omitted.files=14, dead_lines=399, dead_functions=72, dead_classes=13 and reasons ['below --min-dead-lines', 'beyond --top-files']. Verified 2026-08-21",
+    ),
+    (
+        "analyze dead-code",
+        "omitted.dead_functions",
+        "the default invocation lists every file it found (16 of 16 on the large corpus), so nothing is omitted. The family DOES respond, to the flags rather than to the corpus: `--top-files 2` reports omitted.files=14, dead_lines=399, dead_functions=72, dead_classes=13 and reasons ['below --min-dead-lines', 'beyond --top-files']. Verified 2026-08-21",
+    ),
+    (
+        "analyze dead-code",
+        "omitted.dead_classes",
+        "the default invocation lists every file it found (16 of 16 on the large corpus), so nothing is omitted. The family DOES respond, to the flags rather than to the corpus: `--top-files 2` reports omitted.files=14, dead_lines=399, dead_functions=72, dead_classes=13 and reasons ['below --min-dead-lines', 'beyond --top-files']. Verified 2026-08-21",
+    ),
+    (
+        "analyze dead-code",
+        "omitted.dead_modules",
+        "the default invocation lists every file it found (16 of 16 on the large corpus), so nothing is omitted. The family DOES respond, to the flags rather than to the corpus: `--top-files 2` reports omitted.files=14, dead_lines=399, dead_functions=72, dead_classes=13 and reasons ['below --min-dead-lines', 'beyond --top-files']. Verified 2026-08-21",
+    ),
+    (
+        "analyze dead-code",
+        "omitted.unreachable_blocks",
+        "the default invocation lists every file it found (16 of 16 on the large corpus), so nothing is omitted. The family DOES respond, to the flags rather than to the corpus: `--top-files 2` reports omitted.files=14, dead_lines=399, dead_functions=72, dead_classes=13 and reasons ['below --min-dead-lines', 'beyond --top-files']. Verified 2026-08-21",
+    ),
+    (
+        "analyze dead-code",
+        "omitted.reasons[].len",
+        "the default invocation lists every file it found (16 of 16 on the large corpus), so nothing is omitted. The family DOES respond, to the flags rather than to the corpus: `--top-files 2` reports omitted.files=14, dead_lines=399, dead_functions=72, dead_classes=13 and reasons ['below --min-dead-lines', 'beyond --top-files']. Verified 2026-08-21",
+    ),
+    (
+        "analyze satd",
+        "files_not_read.too_large",
+        "the `analyze` surface routes through `skip_reason_for_analysis`, which DELIBERATELY omits the >512KB rule that `skip_reason` applies — unifying them would make this path skip more files and find fewer defects, a behaviour change the code says deserves its own measurement (satd_detector/detection_analysis.rs). Zero files therefore go unread for size here, which is a true zero and not an unmeasured one; a 748,903-byte file is read, not skipped. Verified one file at a time, 2026-08-21",
+    ),
+    (
+        "analyze comprehensive",
+        "satd.skipped.too_large",
+        "the `analyze` surface routes through `skip_reason_for_analysis`, which DELIBERATELY omits the >512KB rule that `skip_reason` applies — unifying them would make this path skip more files and find fewer defects, a behaviour change the code says deserves its own measurement (satd_detector/detection_analysis.rs). Zero files therefore go unread for size here, which is a true zero and not an unmeasured one; a 748,903-byte file is read, not skipped. Verified one file at a time, 2026-08-21",
+    ),
+    (
+        "quality-gate",
+        "results.checks_run[].len",
+        "the sweep runs one fixed check selection, so the NUMBER of checks run is a property of the invocation, not of the tree. The leaf exists so that a run which selected checks and executed none is distinguishable from one that executed them; `files_examined` and the violation counts are what respond to the corpus",
+    ),
+    (
+        "comply check",
+        "is_compliant",
+        "both corpora are non-compliant, and legitimately so: an empty crate fails the same structural checks a defect-rich one does, so the boolean is false either way. What separates them is the breakdown — summary.pass/warn/fail respond across the corpora (see the `summary.total` entry above)",
+    ),
+    (
+        "comply report",
+        "is_compliant",
+        "both corpora are non-compliant, and legitimately so: an empty crate fails the same structural checks a defect-rich one does, so the boolean is false either way. What separates them is the breakdown — summary.pass/warn/fail respond across the corpora (see the `summary.total` entry above)",
+    ),
+    (
         "comply check",
         "checks[].len",
         "a fixed checklist; the count is structural, the verdicts are what vary",

--- a/tests/modules/quality_harness/mod.rs
+++ b/tests/modules/quality_harness/mod.rs
@@ -1133,6 +1133,46 @@ pub fn copy_prefix(src: &[u8], dst: &mut [u8]) {
     )
     .expect("write lib.rs");
 
+    // Two files that exist only to be DECLINED, each carrying debt so that
+    // declining them is observable.
+    //
+    // `analyze satd` reports `files_not_read` broken down by reason, and two of
+    // those buckets read 0 for every corpus — not because the counters are
+    // broken (both fire: an `examples/` file books `out_of_scope`, a `.min.`
+    // file books `minified_or_vendor`, verified one file at a time) but because
+    // no corpus contained anything for them to count. A bucket that is 0 on
+    // every input is indistinguishable from a bucket nothing can ever reach,
+    // which is the very thing this harness exists to catch.
+    //
+    // Neither is declared in `lib.rs`: `bundled.min.rs` is not a valid module
+    // name, and `examples/demo.rs` is cargo's own target layout. Both are still
+    // walked by the analysers, which is the point.
+    std::fs::write(
+        root.join("src/bundled.min.rs"),
+        "// TODO: vendored bundle, not ours to fix
+// FIXME: regenerate from upstream
+pub fn bundled_entry() -> u32 {
+    7
+}
+",
+    )
+    .expect("write bundled.min.rs");
+    std::fs::create_dir_all(root.join("examples")).expect("mkdir examples");
+    std::fs::write(
+        root.join("examples/demo.rs"),
+        "//! Example target: excluded from production scope, so it books
+//! `out_of_scope` rather than being read.
+
+// TODO: the example still uses the old API
+// HACK: hardcoded so the demo always succeeds
+
+fn main() {
+    println!(\"demo\");
+}
+",
+    )
+    .expect("write examples/demo.rs");
+
     // A test file, so test-aware analyses have something to find — carrying
     // debt of its own, because a flag whose job is to *include test files*
     // ("--include-tests") can only be observed when the test files contain


### PR DESCRIPTION
25 commits. One defect family, found by asking every gate and every report the
same question: **can this tell "measured, and clean" apart from "not measured"?**

## Gates that could not fail

- **CB-200 was blind to 1,719 of 1,966 violations.** A five-letter `IN` list plus
  a `_ => 5` catch-all meant most grades matched nothing. It now derives the
  passing spellings from the `Grade` type it claims to enforce.
- **`pv` could not read 135 of this repo's 179 obligations** — it reads
  `falsification_tests:`, and thirteen contracts wrote `falsification:`, so the
  audit reported a confident zero. Now a blocking CI step, so an unreadable
  obligation fails the merge instead of passing silently.
- **`quality-gate` on an empty directory was byte-identical to a clean project**,
  both exit 0. It now reports `files_examined` / `checks_run` and fails an empty
  population.
- **The process exit code was decided by the wording of the error message.**
  `serve` exited 4 because its text contained "configured". Replaced with a
  declared `ExitCoded`.

## Reports that called absence success

- **`pmat tdg` graded a directory it could not read one file of as F, at exit 0.**
  It already carried `files_analyzed: 0`; the headline never asked.
- **`analyze tdg` printed "not measured" and exited 0 in the same breath** — the
  honest verdict was already computed and only `build-tdg` consulted it.
- **`analyze clippy` reported 0 diagnostics on a crate `cargo clippy` gives 76
  warnings for.** Counts were taken after the confidence filter.
- **`analyze unrun-tests` refused every crate but this one**, blaming its own
  parser: `if graph.len() < 40`, a threshold calibrated to pmat's manifest.
- **comply's SARIF erased every skipped check** and shipped the author's home
  directory into a document meant for code scanning.
- Plus `entropy` / `defect-prediction` reporting on zero files at exit 0,
  `deep-wasm` answering a directory with `os error 21` and reading `app.py` as
  Rust, a false "no complexity analyzer for .rs", and every coded error printing
  its message twice.

## Provable contracts

TDG grade order proved at L5 (`contracts/lean/Theorems/Tdg/Grade.lean`, 13
theorems, hole-free). `applies_to` is now enforced, so a contract cannot be green
while the function it names ignores the type it proves.

## Verification

Every fix carries a RED-first proof: the defect is reapplied as a named mutation,
the test is shown to fail, and restored. Where a fix could over-reach, a
counter-test bounds it — "refuse everything" and "warn always" fail their pairs.

`make gate-differential` went from 16 constant leaves to green; four were fixture
gaps (corpus strengthened), twelve were configuration (excused with the evidence).

20,431 lib tests pass, 0 fail. fmt, clippy `--all-targets`, ratchet and the
unrun-tests ledger are green.

## Known-open, deliberately not in this PR

`make gate-flag-efficacy` is red — 19 flags parse but change nothing. Partially
triaged: `--color` is genuinely inert for four commands (proved against a working
control), but the obvious fix would put ANSI inside `--format json`, which embeds
the same string. That is a design call, not a hotfix.

Neither falsification gate runs in CI — both live in `tests/all.rs` and CI runs
`cargo test --lib`. That is why these were invisible.

**This PR touches `.github/workflows/quality-gate.yml`, so it needs a web-UI merge
click** — the `gh` token lacks `workflow` scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)