### PR TITLE
ci: the differential gate now runs, and the sweep can no longer rewrite a baseline

### DIFF
--- a/.github/workflows/feature-matrix.yml
+++ b/.github/workflows/feature-matrix.yml
@@ -557,17 +557,76 @@ jobs:
       - name: every test is executed by some leg, or the ledger says why
         run: cargo run --release --locked --quiet --bin pmat -- analyze unrun-tests --executed '' --check-ledger
 
+
+  # ── The falsification gate that had never run.
+  #
+  # `tests/modules/quality_harness/differential_corpus.rs` asserts that no metric
+  # may read the same for an empty project and a defect-rich one. It is reachable
+  # only from `tests/all.rs`, an integration target, and every other leg runs
+  # `cargo test --lib` — so the gate written to catch unmeasured metrics was
+  # itself never measured. Run by hand for the first time it was RED, with 16
+  # constant leaves: four fixture gaps (the corpus held nothing for those
+  # counters to count, since fixed) and twelve configuration constants (excused
+  # in ALLOWED_CONSTANTS, each with the evidence that earned the excuse).
+  #
+  # NOT `continue-on-error`. A gate that cannot fail is not a gate, and this one
+  # is green at the commit that adds this job. Its sibling
+  # `make gate-flag-efficacy` is deliberately NOT wired up yet: it is still red
+  # with 18 flags that parse and change nothing (19 before this commit denied
+  # `--lower`), and landing a red gate is how the last one stopped covering
+  # anything. Wire it up in the commit that takes that count to zero.
+  #
+  # Default features on purpose — that is what `make gate-differential` runs. The
+  # harness resolves the binary through `env!("CARGO_BIN_EXE_pmat")`, so cargo
+  # builds `pmat` for the integration test itself; no separate build step.
+  #
+  # It lives HERE, not in quality-gate.yml, because `feature-gate` below is the
+  # aggregator this repository already uses to make a leg blocking — and it is a
+  # required branch-protection context, while an individual job in
+  # quality-gate.yml is not. A gate that cannot fail the merge is not a gate,
+  # which is the exact defect this gate exists to catch. `feature-gate` already
+  # carries legs that are not about features (orphan-ledger, package-size,
+  # unrun-tests); it is the general "every leg must pass" gate.
+  differential-corpus:
+    name: falsification / differential-corpus
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    # Pinned so the report path is a fact rather than a coincidence: the harness
+    # writes to `std::env::temp_dir()` (differential_corpus.rs:665), which honours
+    # TMPDIR, while the upload step below names /tmp. They agree by default on
+    # this runner; this makes them agree by construction.
+    env:
+      TMPDIR: /tmp
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # The corpora are git-initialised and `churn`/`bottleneck` read history.
+          fetch-depth: 0
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: differential-corpus
+      - name: every metric must differ between an empty and a defect-rich project
+        run: make gate-differential
+      - name: upload the per-leaf report when the gate fails
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: differential-corpus-report
+          path: /tmp/pmat-differential-corpus-report.txt
+          if-no-files-found: warn
+
   feature-gate:
     name: feature-gate
     runs-on: ubuntu-latest
-    needs: [bundles, individual, all-targets, feature-tests, orphan-ledger, package-size, unrun-tests]
+    needs: [bundles, individual, all-targets, feature-tests, orphan-ledger, package-size, unrun-tests, differential-corpus]
     if: always()
     steps:
       - name: Require every leg
         run: |
-          for r in "${{ needs.bundles.result }}" "${{ needs.individual.result }}" "${{ needs.all-targets.result }}" "${{ needs.feature-tests.result }}" "${{ needs.orphan-ledger.result }}" "${{ needs.package-size.result }}" "${{ needs.unrun-tests.result }}"; do
+          for r in "${{ needs.bundles.result }}" "${{ needs.individual.result }}" "${{ needs.all-targets.result }}" "${{ needs.feature-tests.result }}" "${{ needs.orphan-ledger.result }}" "${{ needs.package-size.result }}" "${{ needs.unrun-tests.result }}" "${{ needs.differential-corpus.result }}"; do
             if [ "$r" != "success" ]; then
-              echo "a leg failed: bundles=${{ needs.bundles.result }} individual=${{ needs.individual.result }} all-targets=${{ needs.all-targets.result }} feature-tests=${{ needs.feature-tests.result }} orphan-ledger=${{ needs.orphan-ledger.result }} package-size=${{ needs.package-size.result }} unrun-tests=${{ needs.unrun-tests.result }}"
+              echo "a leg failed: differential-corpus=${{ needs.differential-corpus.result }} bundles=${{ needs.bundles.result }} individual=${{ needs.individual.result }} all-targets=${{ needs.all-targets.result }} feature-tests=${{ needs.feature-tests.result }} orphan-ledger=${{ needs.orphan-ledger.result }} package-size=${{ needs.package-size.result }} unrun-tests=${{ needs.unrun-tests.result }}"
               exit 1
             fi
           done

--- a/docs/status/unrun-tests-ledger.md
+++ b/docs/status/unrun-tests-ledger.md
@@ -14,7 +14,7 @@ Legs consulted (3):
 - `feature-matrix.yml:feature-tests[mcp-integration]`
 - `feature-matrix.yml:feature-tests[unified-protocol]`
 
-22975 of 26096 lib tests are executed; 3121 are compiled by no leg.
+22978 of 26099 lib tests are executed; 3121 are compiled by no leg.
 
 ## `<unsatisfiable>` — 18 test(s)
 

--- a/src/cli/handlers/score_handler.rs
+++ b/src/cli/handlers/score_handler.rs
@@ -85,8 +85,21 @@ pub struct CompositeScore {
     #[serde(default)]
     pub dimensions_total: usize,
     pub rps_categories: HashMap<String, f64>,
-    pub comply_errors: usize,
-    pub comply_warnings: usize,
+    /// Failing comply checks, or `None` when comply could not be run at all.
+    ///
+    /// NOT `usize`. `compute_comply` shells out to `pmat` ON PATH, so in any
+    /// environment without an installed pmat — a CI job that only builds, a
+    /// fresh container — the spawn fails, the dimension correctly becomes
+    /// `Err(COMPLY_UNMEASURED)` and leaves the composite, and these two counts
+    /// were still reported as 0. The rendered line read
+    /// "Comply: not measured (0 errors, 0 warnings)": the sentence said
+    /// unmeasured and the numbers beside it said clean.
+    #[serde(default)]
+    pub comply_errors: Option<usize>,
+    /// Warning comply checks, or `None` when comply could not be run. See
+    /// [`CompositeScore::comply_errors`].
+    #[serde(default)]
+    pub comply_warnings: Option<usize>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -272,10 +285,9 @@ fn format_markdown(score: &CompositeScore) -> String {
     let _ = writeln!(out, "| RPS | {} |", md_value(s.rps));
     let _ = writeln!(
         out,
-        "| Comply | {} ({} errors, {} warnings) |",
+        "| Comply | {}{} |",
         md_value(s.comply),
-        score.comply_errors,
-        score.comply_warnings
+        comply_counts(score)
     );
     let _ = writeln!(out, "| Coverage | {} |", md_value(s.coverage));
     let _ = writeln!(out, "| Muda (inv) | {} |", md_value(s.muda_inv));
@@ -375,8 +387,8 @@ fn assemble_score(
     timestamp: String,
     dimensions: [Dimension; 8],
     rps_categories: HashMap<String, f64>,
-    comply_errors: usize,
-    comply_warnings: usize,
+    comply_errors: Option<usize>,
+    comply_warnings: Option<usize>,
 ) -> CompositeScore {
     debug_assert_eq!(dimensions.len(), DIMENSIONS.len());
 
@@ -564,7 +576,7 @@ fn compute_rps(path: &Path) -> (Dimension, HashMap<String, f64>) {
     }
 }
 
-async fn compute_comply(path: &Path) -> (Dimension, usize, usize) {
+async fn compute_comply(path: &Path) -> (Dimension, Option<usize>, Option<usize>) {
     debug_assert!(path.exists(), "path must exist: {}", path.display());
     // Run pmat comply check --format json as subprocess to avoid internal coupling
     let output = std::process::Command::new("pmat")
@@ -590,13 +602,23 @@ async fn compute_comply(path: &Path) -> (Dimension, usize, usize) {
                             .count();
                         let score =
                             (100.0_f64 - (errors as f64 * 10.0 + warnings as f64 * 3.0)).max(0.0);
-                        return (Ok(score), errors, warnings);
+                        return (Ok(score), Some(errors), Some(warnings));
                     }
                 }
             }
-            (Err(COMPLY_UNMEASURED.to_string()), 0, 0)
+            (Err(COMPLY_UNMEASURED.to_string()), None, None)
         }
-        _ => (Err(COMPLY_UNMEASURED.to_string()), 0, 0),
+        _ => (Err(COMPLY_UNMEASURED.to_string()), None, None),
+    }
+}
+
+/// The "(N errors, M warnings)" suffix, or nothing at all when comply did not
+/// run. Printing "(0 errors, 0 warnings)" beside "not measured" states a clean
+/// result for a check that never happened.
+fn comply_counts(score: &CompositeScore) -> String {
+    match (score.comply_errors, score.comply_warnings) {
+        (Some(e), Some(w)) => format!(" ({e} errors, {w} warnings)"),
+        _ => String::new(),
     }
 }
 
@@ -744,8 +766,8 @@ mod gated_verdict_tests {
             "2026-08-13T00:00:00Z".into(),
             dims(values),
             HashMap::new(),
-            0,
-            0,
+            Some(0),
+            Some(0),
         )
     }
 
@@ -981,7 +1003,90 @@ mod tests {
         std::fs::create_dir_all(path).expect("mkdir");
     }
 
+    fn comply_fixture(errors: Option<usize>, warnings: Option<usize>) -> CompositeScore {
+        let dims: [Dimension; 8] = std::array::from_fn(|_| Ok(80.0));
+        let mut score = assemble_score(
+            "sha".into(),
+            "ts".into(),
+            dims,
+            HashMap::new(),
+            errors,
+            warnings,
+        );
+        score.comply_errors = errors;
+        score.comply_warnings = warnings;
+        score
+    }
+
+    /// An unmeasured comply must not report zero failures.
+    ///
+    /// `compute_comply` shells out to `pmat` ON PATH. In any environment
+    /// without an installed pmat — a CI job that only builds, a fresh
+    /// container — the spawn fails, the dimension correctly becomes
+    /// `Err(COMPLY_UNMEASURED)` and leaves the composite, and the two counts
+    /// were still `usize` and therefore `0`. The rendered line read
+    ///
+    ///     Comply:      not measured  (0 errors, 0 warnings)
+    ///
+    /// with the sentence saying unmeasured and the numbers beside it saying
+    /// clean. Caught by `make gate-differential` on its first CI run, where
+    /// `pmat score :: comply_errors` and `comply_warnings` were 0 for an empty
+    /// project and a defect-rich one alike — constant because they were never
+    /// measured, not because the projects agreed.
+    #[test]
+    fn an_unmeasured_comply_reports_no_counts_at_all() {
+        let score = comply_fixture(None, None);
+
+        assert_eq!(
+            comply_counts(&score),
+            "",
+            "an unmeasured comply must print no counts, not (0 errors, 0 warnings)"
+        );
+
+        let json = serde_json::to_value(&score).expect("serialize");
+        assert!(
+            json["comply_errors"].is_null(),
+            "unmeasured must serialise as null, not 0: {}",
+            json["comply_errors"]
+        );
+        assert!(
+            json["comply_warnings"].is_null(),
+            "{}",
+            json["comply_warnings"]
+        );
+    }
+
+    /// The counter-test: a comply that DID run still reports its counts.
+    ///
+    /// Without this, deleting the counts entirely would pass the test above.
+    #[test]
+    fn a_measured_comply_still_reports_its_counts() {
+        let score = comply_fixture(Some(2), Some(7));
+
+        assert_eq!(comply_counts(&score), " (2 errors, 7 warnings)");
+
+        let json = serde_json::to_value(&score).expect("serialize");
+        assert_eq!(json["comply_errors"], 2);
+        assert_eq!(json["comply_warnings"], 7);
+    }
+
+    /// A measured, genuinely clean comply is distinguishable from an unmeasured
+    /// one — which is the whole point, and what `Some(0)` vs `None` encodes.
+    #[test]
+    fn measured_zero_is_not_the_same_as_unmeasured() {
+        let clean = comply_fixture(Some(0), Some(0));
+        let unmeasured = comply_fixture(None, None);
+
+        assert_ne!(
+            comply_counts(&clean),
+            comply_counts(&unmeasured),
+            "a clean comply and an unrun one must not render identically"
+        );
+        assert_eq!(comply_counts(&clean), " (0 errors, 0 warnings)");
+    }
+
     fn dummy_score(sub: SubScores, composite: f64, comply_errors: usize) -> CompositeScore {
+        let comply_errors = Some(comply_errors);
         CompositeScore {
             sha: "abc1234".into(),
             timestamp: "2026-04-24T08:00:00Z".into(),
@@ -996,7 +1101,7 @@ mod tests {
             dimensions_total: DIMENSIONS.len(),
             rps_categories: HashMap::new(),
             comply_errors,
-            comply_warnings: 0,
+            comply_warnings: Some(0),
         }
     }
 
@@ -1413,7 +1518,14 @@ mod tests {
     #[test]
     fn unmeasured_dimensions_are_excluded_from_the_composite() {
         let (dims, measured) = unmeasured_subject();
-        let score = assemble_score("sha".into(), "ts".into(), dims, HashMap::new(), 0, 0);
+        let score = assemble_score(
+            "sha".into(),
+            "ts".into(),
+            dims,
+            HashMap::new(),
+            Some(0),
+            Some(0),
+        );
 
         let expected = geometric_mean(&measured);
         let composite = score.composite.expect("four dimensions were measured");
@@ -1442,7 +1554,14 @@ mod tests {
     #[test]
     fn unmeasured_dimensions_are_null_and_disclosed() {
         let (dims, _) = unmeasured_subject();
-        let score = assemble_score("sha".into(), "ts".into(), dims, HashMap::new(), 0, 0);
+        let score = assemble_score(
+            "sha".into(),
+            "ts".into(),
+            dims,
+            HashMap::new(),
+            Some(0),
+            Some(0),
+        );
 
         assert_eq!(score.sub_scores.coverage, None);
         assert_eq!(score.sub_scores.evoscore, None);
@@ -1475,7 +1594,14 @@ mod tests {
     #[test]
     fn nothing_measured_yields_no_composite_and_no_grade() {
         let dims: [Dimension; 8] = std::array::from_fn(|i| Err(format!("dim {i} unmeasurable")));
-        let score = assemble_score("sha".into(), "ts".into(), dims, HashMap::new(), 0, 0);
+        let score = assemble_score(
+            "sha".into(),
+            "ts".into(),
+            dims,
+            HashMap::new(),
+            Some(0),
+            Some(0),
+        );
         assert_eq!(score.composite, None);
         assert_eq!(score.grade, "n/a");
         assert_eq!(score.dimensions_measured, 0);
@@ -1542,7 +1668,14 @@ mod tests {
     #[test]
     fn test_renderers_say_not_measured_instead_of_a_number() {
         let (dims, _) = unmeasured_subject();
-        let score = assemble_score("sha".into(), "ts".into(), dims, HashMap::new(), 0, 0);
+        let score = assemble_score(
+            "sha".into(),
+            "ts".into(),
+            dims,
+            HashMap::new(),
+            Some(0),
+            Some(0),
+        );
 
         let text = render_score(&score, &RepoScoreOutputFormat::Text).unwrap();
         assert!(text.contains("not measured"), "text: {text}");
@@ -1561,7 +1694,14 @@ mod tests {
     #[test]
     fn test_cross_validate_xv011_high_composite_on_partial_measurement() {
         let (dims, _) = unmeasured_subject();
-        let mut score = assemble_score("sha".into(), "ts".into(), dims, HashMap::new(), 1, 0);
+        let mut score = assemble_score(
+            "sha".into(),
+            "ts".into(),
+            dims,
+            HashMap::new(),
+            Some(1),
+            Some(0),
+        );
         score.composite = Some(85.0);
         let violations = cross_validate(&score);
         assert!(

--- a/src/cli/handlers/score_handler_compute.rs
+++ b/src/cli/handlers/score_handler_compute.rs
@@ -28,14 +28,28 @@ fn compute_pv_lint(path: &Path) -> Dimension {
         }
         let src_dir = path.join("src");
         if src_dir.exists() {
-            let critical = ["forward", "backward", "optimizer", "checkpoint",
-                "sampling", "kv_cache", "quantize", "kernel", "matmul", "gemm"];
+            let critical = [
+                "forward",
+                "backward",
+                "optimizer",
+                "checkpoint",
+                "sampling",
+                "kv_cache",
+                "quantize",
+                "kernel",
+                "matmul",
+                "gemm",
+            ];
             let has_critical = critical.iter().any(|kw| {
-                walkdir::WalkDir::new(&src_dir).into_iter().flatten()
+                walkdir::WalkDir::new(&src_dir)
+                    .into_iter()
+                    .flatten()
                     .filter(|e| e.path().extension().is_some_and(|ext| ext == "rs"))
-                    .any(|e| std::fs::read_to_string(e.path())
-                        .map(|c| c.contains(&format!("pub fn {kw}")))
-                        .unwrap_or(false))
+                    .any(|e| {
+                        std::fs::read_to_string(e.path())
+                            .map(|c| c.contains(&format!("pub fn {kw}")))
+                            .unwrap_or(false)
+                    })
             });
             if has_critical {
                 // Measured, and deliberately harsh: safety-critical kernels
@@ -71,7 +85,12 @@ fn compute_pv_lint(path: &Path) -> Dimension {
 fn score_via_pv_score(path: &Path) -> Option<f64> {
     let contracts_dir = path.join("contracts");
     let output = std::process::Command::new("pv")
-        .args(["score", &contracts_dir.display().to_string(), "--format", "json"])
+        .args([
+            "score",
+            &contracts_dir.display().to_string(),
+            "--format",
+            "json",
+        ])
         .current_dir(path)
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::null())
@@ -96,16 +115,22 @@ fn score_via_pv_score(path: &Path) -> Option<f64> {
     if let Some(scores) = val.get("scores").and_then(|s| s.as_array()) {
         if !scores.is_empty() {
             let n = scores.len() as f64;
-            let avg_d3 = scores.iter()
+            let avg_d3 = scores
+                .iter()
                 .filter_map(|s| s.get("kani_coverage").and_then(|v| v.as_f64()))
-                .sum::<f64>() / n;
-            let avg_d4 = scores.iter()
+                .sum::<f64>()
+                / n;
+            let avg_d4 = scores
+                .iter()
                 .filter_map(|s| s.get("lean_coverage").and_then(|v| v.as_f64()))
-                .sum::<f64>() / n;
+                .sum::<f64>()
+                / n;
             if avg_d3 > 0.0 || avg_d4 > 0.0 {
                 crate::status_eprintln!(
                     "  PV Score: {:.1}% (Kani avg: {:.0}%, Lean avg: {:.0}%)",
-                    mean_score * 100.0, avg_d3 * 100.0, avg_d4 * 100.0
+                    mean_score * 100.0,
+                    avg_d3 * 100.0,
+                    avg_d4 * 100.0
                 );
             }
         }
@@ -243,9 +268,18 @@ fn compute_pipeline_depth(path: &Path) -> f64 {
         if let Ok(content) = std::fs::read_to_string(&ps_path) {
             if let Ok(val) = serde_json::from_str::<serde_json::Value>(&content) {
                 let totals = val.get("totals");
-                let obligations = totals.and_then(|t| t.get("obligations")).and_then(|v| v.as_u64()).unwrap_or(0);
-                let kani = totals.and_then(|t| t.get("kani_harnesses")).and_then(|v| v.as_u64()).unwrap_or(0);
-                let lean = totals.and_then(|t| t.get("lean_proved")).and_then(|v| v.as_u64()).unwrap_or(0);
+                let obligations = totals
+                    .and_then(|t| t.get("obligations"))
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(0);
+                let kani = totals
+                    .and_then(|t| t.get("kani_harnesses"))
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(0);
+                let lean = totals
+                    .and_then(|t| t.get("lean_proved"))
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(0);
                 if obligations > 0 {
                     // Score based on L4+L5 coverage: kani/obligations + lean/obligations
                     let l4_ratio = (kani as f64 / obligations as f64).min(1.0);
@@ -263,7 +297,7 @@ fn compute_pipeline_depth(path: &Path) -> f64 {
 }
 
 /// CD5: Contract drift detection. Compares contract YAML mtimes vs source file mtimes.
- // Available for future CD5 scoring integration
+// Available for future CD5 scoring integration
 /// Returns (stale_count, total_count, drift_ratio).
 /// A contract is "stale" if the YAML is >30 days older than the most recently modified
 /// source file that references it (via #[contract] annotation).
@@ -283,11 +317,21 @@ fn compute_contract_drift(path: &Path) -> (usize, usize, f64) {
 
     for entry in entries.flatten() {
         let p = entry.path();
-        if p.extension().is_none_or(|e| e != "yaml") { continue; }
-        if p.file_name().is_some_and(|n| n.to_string_lossy().contains("binding")) { continue; }
+        if p.extension().is_none_or(|e| e != "yaml") {
+            continue;
+        }
+        if p.file_name()
+            .is_some_and(|n| n.to_string_lossy().contains("binding"))
+        {
+            continue;
+        }
 
-        let Ok(yaml_meta) = std::fs::metadata(&p) else { continue };
-        let Ok(yaml_mtime) = yaml_meta.modified() else { continue };
+        let Ok(yaml_meta) = std::fs::metadata(&p) else {
+            continue;
+        };
+        let Ok(yaml_mtime) = yaml_meta.modified() else {
+            continue;
+        };
 
         total += 1;
 
@@ -300,8 +344,13 @@ fn compute_contract_drift(path: &Path) -> (usize, usize, f64) {
             vec![path.join("src")]
         } else if path.join("crates").exists() {
             std::fs::read_dir(path.join("crates"))
-                .into_iter().flatten().flatten()
-                .filter_map(|e| { let s = e.path().join("src"); s.exists().then_some(s) })
+                .into_iter()
+                .flatten()
+                .flatten()
+                .filter_map(|e| {
+                    let s = e.path().join("src");
+                    s.exists().then_some(s)
+                })
                 .collect()
         } else {
             vec![]
@@ -309,7 +358,9 @@ fn compute_contract_drift(path: &Path) -> (usize, usize, f64) {
 
         for sdir in &src_dirs {
             for e in walkdir::WalkDir::new(sdir).into_iter().flatten() {
-                if e.path().extension().is_none_or(|ext| ext != "rs") { continue; }
+                if e.path().extension().is_none_or(|ext| ext != "rs") {
+                    continue;
+                }
                 if let Ok(content) = std::fs::read_to_string(e.path()) {
                     if content.contains(&search_pattern) {
                         if let Ok(meta) = std::fs::metadata(e.path()) {
@@ -336,7 +387,11 @@ fn compute_contract_drift(path: &Path) -> (usize, usize, f64) {
         }
     }
 
-    let drift = if total > 0 { stale as f64 / total as f64 } else { 0.0 };
+    let drift = if total > 0 {
+        stale as f64 / total as f64
+    } else {
+        0.0
+    };
     (stale, total, drift)
 }
 
@@ -418,7 +473,10 @@ mod kani_proofs {
         let result = geometric_mean(&values);
         assert!(result >= 0.0, "geometric_mean must be non-negative");
         assert!(result <= 100.0, "geometric_mean must not exceed max input");
-        assert!(result.is_finite() || result == 0.0, "geometric_mean must be finite or zero");
+        assert!(
+            result.is_finite() || result == 0.0,
+            "geometric_mean must be finite or zero"
+        );
     }
 
     /// Prove: geometric_mean of empty slice returns 0.
@@ -435,7 +493,10 @@ mod kani_proofs {
         kani::assume(v > 0.0 && v <= 100.0 && v.is_finite());
         let result = geometric_mean(&[v]);
         // Allow small floating-point epsilon
-        assert!((result - v).abs() < 1e-10, "single-value geometric mean must equal the value");
+        assert!(
+            (result - v).abs() < 1e-10,
+            "single-value geometric mean must equal the value"
+        );
     }
 
     /// Prove: geometric_mean with any zero input returns 0.
@@ -486,7 +547,10 @@ fn cross_validate(score: &CompositeScore) -> Vec<Violation> {
 
     // XV-001: TDG grade gate pass should correlate with decent code quality
     // CB-200 passes when comply has no TDG failures, but RPS Code Quality can still be low
-    if score.comply_errors == 0 {
+    // `Some(0)`, not `0`: an UNMEASURED comply must not read as a clean one.
+    // While these were `usize`, a run with no `pmat` on PATH reported 0 errors
+    // and fired every invariant that means "comply is clean".
+    if score.comply_errors == Some(0) {
         if let Some(cq) = score.rps_categories.get("Code Quality") {
             if *cq < 40.0 {
                 v.push(Violation {
@@ -504,7 +568,8 @@ fn cross_validate(score: &CompositeScore) -> Vec<Violation> {
 
     // XV-003: High coverage should mean decent testing score
     if s.coverage.is_some_and(|c| c >= 90.0) {
-        if let (Some(cov), Some(ts)) = (s.coverage, score.rps_categories.get("Testing Excellence")) {
+        if let (Some(cov), Some(ts)) = (s.coverage, score.rps_categories.get("Testing Excellence"))
+        {
             if *ts < 60.0 {
                 v.push(Violation {
                     id: "XV-003",
@@ -526,7 +591,7 @@ fn cross_validate(score: &CompositeScore) -> Vec<Violation> {
 
     // XV-008: Clean comply should correlate with decent RPS
     if let Some(rps) = s.rps {
-        if score.comply_errors == 0 && rps < 60.0 {
+        if score.comply_errors == Some(0) && rps < 60.0 {
             v.push(Violation {
                 id: "XV-008",
                 message: format!("Comply 0 errors but RPS {rps:.0} < 60"),
@@ -539,7 +604,9 @@ fn cross_validate(score: &CompositeScore) -> Vec<Violation> {
         if file_health >= 90.0 && muda_inv < 70.0 {
             v.push(Violation {
                 id: "XV-009",
-                message: format!("File health {file_health:.0} (A) but Muda inv {muda_inv:.0} < 70"),
+                message: format!(
+                    "File health {file_health:.0} (A) but Muda inv {muda_inv:.0} < 70"
+                ),
             });
         }
     }
@@ -574,4 +641,3 @@ fn cross_validate(score: &CompositeScore) -> Vec<Violation> {
 
     v
 }
-

--- a/src/cli/handlers/score_handler_display.rs
+++ b/src/cli/handlers/score_handler_display.rs
@@ -10,9 +10,20 @@ fn print_stack_quality(path: &Path) {
     };
 
     let sovereign = [
-        "aprender", "trueno", "trueno-graph", "trueno-db", "trueno-rag",
-        "trueno-viz", "trueno-zram-core", "pmcp", "renacer", "certeza",
-        "bashrs", "probar", "presentar-core", "ruchy",
+        "aprender",
+        "trueno",
+        "trueno-graph",
+        "trueno-db",
+        "trueno-rag",
+        "trueno-viz",
+        "trueno-zram-core",
+        "pmcp",
+        "renacer",
+        "certeza",
+        "bashrs",
+        "probar",
+        "presentar-core",
+        "ruchy",
     ];
 
     let mut found = Vec::new();
@@ -56,9 +67,12 @@ fn read_latest_composite(metrics_dir: &Path) -> Option<CompositeScore> {
                 if let Ok(content) = std::fs::read_to_string(entry.path()) {
                     if let Ok(score) = serde_json::from_str::<CompositeScore>(&content) {
                         if score.composite.is_some_and(|c| c > 0.0)
-                            && latest.as_ref().is_none_or(|l| score.timestamp > l.timestamp) {
-                                latest = Some(score);
-                            }
+                            && latest
+                                .as_ref()
+                                .is_none_or(|l| score.timestamp > l.timestamp)
+                        {
+                            latest = Some(score);
+                        }
                     }
                 }
             }
@@ -159,17 +173,25 @@ fn format_text(score: &CompositeScore) -> String {
     out.push_str(&format!("{}\n", c::subheader("Sub-Scores")));
     out.push_str(&sub_score_line("RPS:", score.sub_scores.rps));
     out.push_str(&format!(
-        "  {:<12} {}  ({} errors, {} warnings)\n",
+        "  {:<12} {}{}\n",
         "Comply:",
         optional_score(score.sub_scores.comply),
-        score.comply_errors,
-        score.comply_warnings
+        match (score.comply_errors, score.comply_warnings) {
+            // Counts only when they were actually counted. This used to print
+            // "not measured  (0 errors, 0 warnings)" whenever `pmat` was not on
+            // PATH — a clean bill of health for a check that never ran.
+            (Some(e), Some(w)) => format!("  ({e} errors, {w} warnings)"),
+            _ => String::new(),
+        }
     ));
     out.push_str(&sub_score_line("Coverage:", score.sub_scores.coverage));
     out.push_str(&sub_score_line("Muda (inv):", score.sub_scores.muda_inv));
     out.push_str(&sub_score_line("EvoScore:", score.sub_scores.evoscore));
     out.push_str(&sub_score_line("DBC:", score.sub_scores.dbc));
-    out.push_str(&sub_score_line("File Health:", score.sub_scores.file_health));
+    out.push_str(&sub_score_line(
+        "File Health:",
+        score.sub_scores.file_health,
+    ));
     out.push_str(&sub_score_line("PV Lint:", score.sub_scores.pv_lint));
 
     // A red gate changes what the composite MEANS: it is then the mean over the
@@ -178,7 +200,10 @@ fn format_text(score: &CompositeScore) -> String {
     // would be a third meaning for one field (#983).
     if !score.gated_by.is_empty() {
         out.push('\n');
-        out.push_str(&format!("{}\n", c::subheader("Gated (verdict, not average)")));
+        out.push_str(&format!(
+            "{}\n",
+            c::subheader("Gated (verdict, not average)")
+        ));
         for dim in &score.gated_by {
             out.push_str(&format!(
                 "  {:<12} {}\n",

--- a/tests/modules/quality_harness/flag_efficacy.rs
+++ b/tests/modules/quality_harness/flag_efficacy.rs
@@ -103,6 +103,21 @@ const DENY_FLAGS: &[&str] = &[
     "--auto-commit",
     "--commit",
     "--apply",
+    // `comply ratchet --lower` REWRITES `.pmat-ratchet.toml` — its own help says
+    // "every baseline the tree has beaten is rewritten to the measured value,
+    // and the entry's `justification` ... is removed". The sweep was invoking it
+    // unattended and booking the result as a no-op.
+    //
+    // Precisely: probes run with the CORPUS as cwd, so this could not reach
+    // THIS repository's baselines. It was a no-op only because no corpus
+    // carries a `.pmat-ratchet.toml`, so the handler bails before it writes —
+    // and the corpus is a thing we add files to (it just gained an `examples/`
+    // and a `.min.` file so two satd counters could move). The first corpus to
+    // carry a ratchet file would have its baselines silently lowered, and the
+    // sweep would record that as "changes nothing".
+    //
+    // A flag that rewrites a file is not a flag to probe for observable output.
+    "--lower",
 ];
 
 /// The fast subset, run by default so this is affordable on every commit.
@@ -1383,6 +1398,38 @@ fn declined_preconditions_are_skipped_not_blamed() {
             "must be skipped, not blamed on its flags: {what}"
         );
     }
+}
+
+/// A flag whose own help says it REWRITES a tracked file must never be swept.
+///
+/// `comply ratchet --lower` was being swept, and booked as a no-op. It is one
+/// only by accident: no corpus carries a `.pmat-ratchet.toml`, so the handler
+/// bails before it writes. Probes run with the corpus as cwd, so this never
+/// reached THIS repository — but the corpus is a thing we add files to, and the
+/// first one to carry a ratchet file would have its baselines silently lowered
+/// with the damage recorded as "changes nothing".
+///
+/// The two halves are asserted together so neither can drift alone: the help
+/// must still describe a rewrite, AND the flag must be denied. If `--lower`
+/// ever stops mutating, this fails and says so, rather than leaving a flag
+/// permanently over-denied for a reason that expired.
+#[test]
+fn a_flag_that_rewrites_a_tracked_file_is_never_swept() {
+    let cwd = std::env::current_dir().expect("cwd");
+    let help = help_for(&["comply", "ratchet"], &cwd)
+        .expect("`pmat comply ratchet --help` must be readable");
+
+    assert!(
+        help.contains("rewritten") || help.contains("rewrite"),
+        "--lower's help no longer describes a rewrite. Re-check whether it still \
+         mutates before leaving it in DENY_FLAGS:\n{help}"
+    );
+    assert!(
+        DENY_FLAGS.contains(&"--lower"),
+        "a flag whose own help says it rewrites a tracked file must be in \
+         DENY_FLAGS, or the sweep will invoke it against whatever tree it is \
+         pointed at"
+    );
 }
 
 /// Every allow-listed no-op must name a demonstrated effect, and none may


### PR DESCRIPTION
Two gaps of the same shape: **a gate that exists and nothing runs it**, and **a
mutating flag that nothing stops**.

## The gate nobody ran

`make gate-differential` asserts that no metric may read the same for an empty
project and a defect-rich one. Before this PR it was referenced **zero times in
any workflow** — it lives in `tests/all.rs`, and every CI leg runs
`cargo test --lib`. The gate written to catch unmeasured metrics was itself never
measured. Run by hand for the first time it was red, with 16 constant leaves
(fixed in #1038: four fixture gaps, twelve configuration constants excused with
evidence).

**Where it lives is the point.** `feature-gate` is this repo's aggregator for
"every leg must pass" and **is** a required branch-protection context; the jobs in
`quality-gate.yml` are required individually, so a new one there would report and
never block. Adding a gate that cannot fail the merge would have reproduced the
exact defect the gate detects. It is now in `feature-gate`'s `needs` and result
loop.

Verified the same way the incident that motivated it was: `feature-gate` shows
`failure` on pre-fix run `32459201954` — which is how `clippy --all-targets`
blocks a merge despite not being a required context by name.

`gate-flag-efficacy` is **deliberately not wired up**: still red at 18 no-op
flags. Landing a red gate is how the last one stopped covering anything.

## The flag nothing stopped

`comply ratchet --lower` rewrites `.pmat-ratchet.toml` — its own help says *"every
baseline the tree has beaten is rewritten … and the entry's `justification` … is
removed"* — and the sweep was invoking it unattended, booking the result as a
no-op. `DENY_FLAGS` matches exactly, not by prefix, so `--write` never covered it.

Stated precisely, because my first draft overstated it: probes run with the
**corpus** as cwd, so this never could reach this repository's baselines. It was a
no-op only because no corpus carries a `.pmat-ratchet.toml` — and the corpus is a
thing we add files to; it just gained an `examples/` and a `.min.` file so two
satd counters could move. The first corpus to carry a ratchet file would be
silently lowered, with the damage recorded as "changes nothing".

The test cross-checks the **binary's own help** rather than restating the
constant: the help must still describe a rewrite AND the flag must be denied, so
neither half can drift and an expired reason cannot leave a flag over-denied.

## Measured

| | before | after |
|---|---|---|
| `gate-differential` in CI | not run at all | required via `feature-gate` |
| flag sweep no-ops | 19 | **18** (`--lower` now `[mutating flag]`) |

RED-proved: removing `--lower` from `DENY_FLAGS` fails the new test. Locally
green: differential gate (0 inert, 0 constant leaves), ratchet, unrun-tests
ledger, `cargo fmt`, and `clippy --all-targets -D warnings` under **rustc 1.98**
(the version CI now installs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)