### PR TITLE
fix: the serve contract tests inherited MCP_VERSION from a sibling test

### DIFF
--- a/.dogfood/receipt-20260822T073408Z.json
+++ b/.dogfood/receipt-20260822T073408Z.json
@@ -1,0 +1,163 @@
+{
+  "crate": "pmat",
+  "version": "3.32.0",
+  "timestamp": "20260822T073408Z",
+  "gates": [
+    {
+      "gate": "git-clean",
+      "result": "PASS",
+      "note": "working tree clean"
+    },
+    {
+      "gate": "version-unpublished",
+      "result": "PASS",
+      "note": "3.32.0 not yet published"
+    },
+    {
+      "gate": "changelog",
+      "result": "PASS",
+      "note": "CHANGELOG has 3.32.0"
+    },
+    {
+      "gate": "feature-scope",
+      "result": "INFO",
+      "note": "clippy/test run with: all features EXCEPT quarantined: broken-tests,red-phase-tests"
+    },
+    {
+      "gate": "fmt",
+      "result": "PASS",
+      "note": ""
+    },
+    {
+      "gate": "clippy",
+      "result": "PASS",
+      "note": "warning: pmat@3.32.0: KAIZEN-0178: generated 6 MCP tool schema(s)"
+    },
+    {
+      "gate": "test",
+      "result": "FAIL",
+      "note": "warning: pmat@3.32.0: KAIZEN-0178: generated 6 MCP tool schema(s)"
+    },
+    {
+      "gate": "coverage",
+      "result": "PASS",
+      "note": "warning: pmat@3.32.0: Writing changed file: /mnt/nvme-raid0/coverage/paiml-mcp-agent-toolkit/llvm-cov-target/debug/build"
+    },
+    {
+      "gate": "security",
+      "result": "PASS",
+      "note": "33 \u2502     { id = \"RUSTSEC-2024-0370\", reason = \"proc-macro-error: transitive via tabled_derive\u2192apr-cli\u2192aprender, no repla"
+    },
+    {
+      "gate": "security-2nd-source",
+      "result": "WARN",
+      "note": "GitHub Advisory DB reports 1 open alert(s) cargo-deny did not see (none high/critical): medium thrift(fix:0.23.0)  \u2014 RustSec and GHSA are different databases; a green cargo-deny does not mean the tree"
+    },
+    {
+      "gate": "release-binary",
+      "result": "PASS",
+      "note": "built: /home/noah/src/paiml-mcp-agent-toolkit/target/release/pmat"
+    },
+    {
+      "gate": "deterministic-tools",
+      "result": "PASS",
+      "note": "pv 0.49.0, bashrs 6.67.0, pmat 3.32.0, probador 1.0.3"
+    },
+    {
+      "gate": "pv-contracts",
+      "result": "PASS",
+      "note": "23 contract(s) valid (positive control fired)"
+    },
+    {
+      "gate": "pv-lint",
+      "result": "PASS",
+      "note": "Summary: 0 errors, 1644 warnings, 0 suppressed, 1627 new"
+    },
+    {
+      "gate": "pv-bindings",
+      "result": "REPORT",
+      "note": "pmat: 49/57 binding functions verified in source; 8 ghost(s) \u2014 NOT gating: pv 0.49.0 misses pub(super) fn and is module-blind (paiml/provable-contracts, re-arm when fixed). Triage each ghost by hand."
+    },
+    {
+      "gate": "bashrs",
+      "result": "PASS",
+      "note": "61 file(s) linted (receipt confirmed), 0 SEC/DET/IDEM errors (2 SC10xx suppressed \u2014 bashrs#226; 133 other)"
+    },
+    {
+      "gate": "renacer",
+      "result": "PASS",
+      "note": "% time     seconds  usecs/call     calls    errors syscall"
+    },
+    {
+      "gate": "pmat-verify",
+      "result": "PASS",
+      "note": "}"
+    },
+    {
+      "gate": "pmat-comply",
+      "result": "FAIL",
+      "note": "CB-200 (TDG Grade Gate) = Fail \u2014 see `pmat comply check`; 4 total fail(s), 0 Error-severity checks dark (#1008, not gated)"
+    },
+    {
+      "gate": "reachability",
+      "result": "WARN",
+      "note": "unreachable files/tests: 412 6562 (a file the build never compiles cannot be tested)"
+    },
+    {
+      "gate": "contracts-exit-integrity",
+      "result": "PASS",
+      "note": "`contracts:` recipe propagates failure (no bare for-loop, no `|| true`)"
+    },
+    {
+      "gate": "contracts",
+      "result": "PASS",
+      "note": "\u2705 contract tier holds"
+    },
+    {
+      "gate": "publish-dry-run",
+      "result": "PASS",
+      "note": "packages cleanly"
+    },
+    {
+      "gate": "cli-surface",
+      "result": "PASS",
+      "note": "71 advertised subcommand(s) answer --help"
+    },
+    {
+      "gate": "transport-decl",
+      "result": "PASS",
+      "note": "declared: cli http mcp "
+    },
+    {
+      "gate": "transport-absence",
+      "result": "PASS",
+      "note": "no undeclared mcp/http surface advertised by the binary"
+    },
+    {
+      "gate": "interface-parity",
+      "result": "PASS",
+      "note": "3 transport(s), 12 e2e test(s) against the spawned release binary"
+    },
+    {
+      "gate": "surface-derivation",
+      "result": "REPORT",
+      "note": "no manifest declared in [package.metadata.transports] \u2014 the interface may be hand-rolled per transport; nothing here can tell single-sourcing from three lists that agree (declare manifest = { path, re"
+    },
+    {
+      "gate": "probador-suite",
+      "result": "SKIP",
+      "note": "crate does not configure probador (no probar.toml, no jugar-probar dep) \u2014 probador tests WASM/TUI apps; it has no CLI/HTTP/MCP interface verb (see interface-parity)"
+    },
+    {
+      "gate": "dogfood-use",
+      "result": "PASS",
+      "note": "  13 checks, 0 failure(s)"
+    },
+    {
+      "gate": "clean-room",
+      "result": "MANUAL",
+      "note": "run `make -C ../infra/machines/clean-room clean-room-pmat` (MANDATORY release gate)"
+    }
+  ],
+  "verdict": "NO-GO"
+}

--- a/tests/modules/serve_fail_loud.rs
+++ b/tests/modules/serve_fail_loud.rs
@@ -7,20 +7,50 @@
 
 use std::process::Command;
 
+/// Every invocation here is expected to exit, not to serve: an unimplemented
+/// transport exits 2 synchronously, and `--transport http` refuses to start
+/// without a token. If the handler ever regresses back to the old
+/// `ctrl_c().await` stub, this call blocks and the outer cargo-test timeout
+/// makes the regression loud.
 fn run_serve(args: &[&str]) -> std::process::Output {
-    // Every invocation here is expected to exit, not to serve: an unimplemented
-    // transport exits 2 synchronously, and `--transport http` refuses to start
-    // without a token. If the handler ever regresses back to the old
-    // `ctrl_c().await` stub, this call blocks and the outer cargo-test timeout
-    // makes the regression loud.
-    Command::new(env!("CARGO_BIN_EXE_pmat"))
-        .arg("serve")
-        .args(args)
-        .env("RUST_LOG", "error")
+    run_serve_with_env(args, &[])
+}
+
+/// `run_serve`, plus environment the CALLER wants the child to start from.
+///
+/// The scrubs below are applied AFTER `extra`, deliberately: they are the
+/// harness's invariants and no caller may defeat them. Applying them first
+/// would let the overlay put back exactly the variable being removed — a
+/// mistake worth naming, because the flag-efficacy harness made it and the
+/// resulting fix compiled, ran, and changed nothing.
+fn run_serve_with_env(args: &[&str], extra: &[(&str, &str)]) -> std::process::Output {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_pmat"));
+    cmd.arg("serve").args(args).env("RUST_LOG", "error");
+    for (k, v) in extra {
+        cmd.env(k, v);
+    }
+    cmd
         // `--transport http` is implemented: with a token in the environment it
         // would BIND A SOCKET and `output()` would block until killed. The test
         // must not depend on the developer's environment not having one.
         .env_remove("PMAT_MCP_HTTP_TOKEN")
+        // MCP_VERSION makes pmat ignore the subcommand entirely and start the
+        // stdio MCP server (src/bin/pmat.rs:41 — "Explicit MCP opt-in via env
+        // var always wins", for Claude Desktop). `output()` closes stdin, that
+        // server reads EOF and exits 0, and every assertion in this file about
+        // an exit code then compares against the wrong process.
+        //
+        // This is not hypothetical. `pmat_serve_websocket_fails_loudly` failed
+        // in the full-feature run with `left: Some(0), right: Some(2)` and
+        // passed when run alone. Cargo runs a binary's tests as parallel THREADS
+        // in one process, and two siblings set the variable process-wide:
+        //   tests/modules/execution_mode.rs:24
+        //   tests/modules/services_integration.rs:340
+        // Both remove it afterwards, but a child spawned inside that window
+        // inherits it. Measured directly:
+        //   env -u MCP_VERSION  pmat serve --transport web-socket -> exit 2
+        //   MCP_VERSION=1.0.0   pmat serve --transport web-socket -> exit 0, 0 bytes
+        .env_remove("MCP_VERSION")
         .output()
         .expect("failed to spawn pmat binary")
 }
@@ -72,6 +102,46 @@ fn pmat_serve_without_a_token_refuses_to_start_and_says_why() {
             "stderr must not name `{dead}`, which does not start this server, got: {stderr}"
         );
     }
+}
+
+/// An ambient `MCP_VERSION` must not be able to answer for `pmat serve`.
+///
+/// This is the flake that failed the 3.32.0 release dogfood: the full-feature
+/// run reported `left: Some(0), right: Some(2)` for the websocket test, and the
+/// same test passed when run alone. Cargo runs a binary's tests as parallel
+/// THREADS in one process, so a sibling's process-wide `set_var` is visible to
+/// any child spawned in that window — `execution_mode.rs:24` and
+/// `services_integration.rs:340` both set `MCP_VERSION`, and both remove it
+/// afterwards, which closes the window without closing the hole.
+///
+/// With the variable set, pmat ignores the subcommand and starts the stdio MCP
+/// server; `output()` closes stdin; the server reads EOF and exits 0. Every
+/// exit-code assertion in this file is then comparing against a different
+/// program. Measured:
+///
+/// ```text
+/// env -u MCP_VERSION  pmat serve --transport web-socket  -> exit 2
+/// MCP_VERSION=1.0.0   pmat serve --transport web-socket  -> exit 0, 0 bytes
+/// ```
+///
+/// The variable is passed HERE as explicit child environment rather than set on
+/// this process, because setting it process-wide would recreate for every other
+/// test the exact race this test exists to close.
+#[test]
+fn an_ambient_mcp_version_cannot_defeat_the_serve_contract() {
+    let out = run_serve_with_env(&["--transport", "web-socket"], &[("MCP_VERSION", "1.0.0")]);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "the harness must scrub MCP_VERSION so an unimplemented transport still \
+         fails loudly; exit 0 means pmat ran the MCP stdio server instead and \
+         hit EOF\nstderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("websocket"),
+        "the refusal must still name the transport, got: {stderr}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
This is the `test` gate that held the 3.32.0 release dogfood at NO-GO.

## The failure

`pmat_serve_websocket_fails_loudly` failed the full-feature run with
`left: Some(0), right: Some(2)` and **passed when run alone**.

Not a product regression. An environment leak between tests — and the exit code
the assertion compared against belonged to a different program.

## The cause

Cargo runs a test binary's tests as parallel **threads in one process**. Two
siblings set `MCP_VERSION` process-wide:

```
tests/modules/execution_mode.rs:24
tests/modules/services_integration.rs:340
```

Both remove it afterwards, which closes the window without closing the hole: a
child spawned inside that window inherits it. And `MCP_VERSION` makes pmat ignore
the subcommand entirely and start the stdio MCP server — *"Explicit MCP opt-in
via env var always wins"*, `src/bin/pmat.rs:41`, deliberate, for Claude Desktop.
`output()` closes stdin, that server reads EOF, and exits 0.

Measured directly, which is what settled it after a wrong first hypothesis:

```
env -u MCP_VERSION  pmat serve --transport web-socket  -> exit 2
MCP_VERSION=1.0.0   pmat serve --transport web-socket  -> exit 0, 0 bytes
```

## The fix

`run_serve` already scrubbed `PMAT_MCP_HTTP_TOKEN` for exactly this class of
reason — *"the test must not depend on the developer's environment"*. It now
scrubs `MCP_VERSION` too. Same rule, second variable.

The scrubs apply **after** any caller-supplied environment, deliberately: they
are the harness's invariants and no caller may defeat them. Applying them first
would let the overlay put back the variable being removed — the mistake the
flag-efficacy harness made, where the fix compiled, ran, and changed the count
by zero.

The pinning test passes `MCP_VERSION` as explicit **child** environment rather
than setting it on this process, because a process-wide `set_var` would recreate
for every other test the exact race the test exists to close.

## RED-first

```
remove .env_remove("MCP_VERSION")
  -> an_ambient_mcp_version_cannot_defeat_the_serve_contract FAILS with
     left: Some(0), right: Some(2)   <- the original flake's exact signature
restored -> 7 serve tests pass
```

## Wider exposure (not fixed here)

Eight further test files spawn `CARGO_BIN_EXE_pmat` and are latently vulnerable
to the same window. Noted rather than widened mid-release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012166727hFzq4xzFKFjUJPc