### PR TITLE
fix: tdg's duplication component was blind to duplication (#1050 P1)

### DIFF
--- a/.dogfood/receipt-20260822T160523Z.json
+++ b/.dogfood/receipt-20260822T160523Z.json
@@ -1,0 +1,168 @@
+{
+  "crate": "pmat",
+  "version": "3.32.0",
+  "timestamp": "20260822T160523Z",
+  "gates": [
+    {
+      "gate": "git-clean",
+      "result": "PASS",
+      "note": "working tree clean"
+    },
+    {
+      "gate": "version-unpublished",
+      "result": "PASS",
+      "note": "3.32.0 not yet published"
+    },
+    {
+      "gate": "changelog",
+      "result": "PASS",
+      "note": "CHANGELOG has 3.32.0"
+    },
+    {
+      "gate": "feature-scope",
+      "result": "INFO",
+      "note": "clippy/test run with: all features EXCEPT quarantined: broken-tests,red-phase-tests"
+    },
+    {
+      "gate": "fmt",
+      "result": "PASS",
+      "note": ""
+    },
+    {
+      "gate": "clippy",
+      "result": "PASS",
+      "note": "warning: pmat@3.32.0: KAIZEN-0178: generated 6 MCP tool schema(s)"
+    },
+    {
+      "gate": "test",
+      "result": "FAIL",
+      "note": "warning: pmat@3.32.0: KAIZEN-0178: generated 6 MCP tool schema(s)"
+    },
+    {
+      "gate": "coverage",
+      "result": "PASS",
+      "note": "warning: pmat@3.32.0: Writing changed file: /mnt/nvme-raid0/coverage/paiml-mcp-agent-toolkit/llvm-cov-target/debug/build"
+    },
+    {
+      "gate": "security",
+      "result": "PASS",
+      "note": "33 \u2502     { id = \"RUSTSEC-2024-0370\", reason = \"proc-macro-error: transitive via tabled_derive\u2192apr-cli\u2192aprender, no repla"
+    },
+    {
+      "gate": "security-2nd-source",
+      "result": "WARN",
+      "note": "GitHub Advisory DB reports 1 open alert(s) cargo-deny did not see (none high/critical): medium thrift(fix:0.23.0)  \u2014 RustSec and GHSA are different databases; a green cargo-deny does not mean the tree"
+    },
+    {
+      "gate": "release-binary",
+      "result": "PASS",
+      "note": "built: /home/noah/src/paiml-mcp-agent-toolkit/target/release/pmat"
+    },
+    {
+      "gate": "deterministic-tools",
+      "result": "PASS",
+      "note": "pv 0.63.0, bashrs 6.67.0, pmat 3.32.0, probador 1.0.3"
+    },
+    {
+      "gate": "pv-contracts",
+      "result": "PASS",
+      "note": "23 contract(s) valid (positive control fired)"
+    },
+    {
+      "gate": "pv-lint",
+      "result": "PASS",
+      "note": "Summary: 0 errors, 1653 warnings, 0 suppressed, 11 new"
+    },
+    {
+      "gate": "pv-bindings",
+      "result": "REPORT",
+      "note": "pmat: 49/57 binding functions verified in source; 8 ghost(s) \u2014 NOT gating: pv 0.49.0 misses pub(super) fn and is module-blind (paiml/provable-contracts, re-arm when fixed). Triage each ghost by hand."
+    },
+    {
+      "gate": "bashrs",
+      "result": "PASS",
+      "note": "61 file(s) linted (receipt confirmed), 0 SEC/DET/IDEM errors (2 SC10xx suppressed \u2014 bashrs#226; 133 other)"
+    },
+    {
+      "gate": "renacer",
+      "result": "PASS",
+      "note": "% time     seconds  usecs/call     calls    errors syscall"
+    },
+    {
+      "gate": "pmat-verify",
+      "result": "PASS",
+      "note": "}"
+    },
+    {
+      "gate": "pmat-comply",
+      "result": "FAIL",
+      "note": "CB-200 (TDG Grade Gate) = Fail \u2014 see `pmat comply check`; 4 total fail(s), 0 Error-severity checks dark (#1008, not gated)"
+    },
+    {
+      "gate": "reachability",
+      "result": "WARN",
+      "note": "unreachable files/tests: 412 6562 (a file the build never compiles cannot be tested)"
+    },
+    {
+      "gate": "contracts-exit-integrity",
+      "result": "PASS",
+      "note": "`contracts:` recipe propagates failure (no bare for-loop, no `|| true`)"
+    },
+    {
+      "gate": "contracts",
+      "result": "PASS",
+      "note": "\u2705 contract tier holds"
+    },
+    {
+      "gate": "publish-dry-run",
+      "result": "PASS",
+      "note": "packages cleanly"
+    },
+    {
+      "gate": "cli-surface",
+      "result": "PASS",
+      "note": "71 advertised subcommand(s) answer --help"
+    },
+    {
+      "gate": "transport-decl",
+      "result": "PASS",
+      "note": "declared: cli http mcp "
+    },
+    {
+      "gate": "transport-absence",
+      "result": "PASS",
+      "note": "no undeclared mcp/http surface advertised by the binary"
+    },
+    {
+      "gate": "interface-parity",
+      "result": "PASS",
+      "note": "3 transport(s), 12 e2e test(s) against the spawned release binary"
+    },
+    {
+      "gate": "transport-invariance",
+      "result": "SKIP",
+      "note": "no [package.metadata.unified_surface] \u2014 declare list/cli/http/probe to enable the simultaneous cross-transport check"
+    },
+    {
+      "gate": "surface-derivation",
+      "result": "REPORT",
+      "note": "no manifest declared in [package.metadata.transports] \u2014 the interface may be hand-rolled per transport; nothing here can tell single-sourcing from three lists that agree (declare manifest = { path, re"
+    },
+    {
+      "gate": "probador-suite",
+      "result": "SKIP",
+      "note": "crate does not configure probador (no probar.toml, no jugar-probar dep) \u2014 probador tests WASM/TUI apps; it has no CLI/HTTP/MCP interface verb (see interface-parity)"
+    },
+    {
+      "gate": "dogfood-use",
+      "result": "PASS",
+      "note": "  13 checks, 0 failure(s)"
+    },
+    {
+      "gate": "clean-room",
+      "result": "MANUAL",
+      "note": "run `make -C ../infra/machines/clean-room clean-room-pmat` (MANDATORY release gate)"
+    }
+  ],
+  "verdict": "NO-GO"
+}

--- a/.pmat-gates.toml
+++ b/.pmat-gates.toml
@@ -96,7 +96,20 @@ exclude = [
 # The re-derivation test caught this before it was committed, which is the whole
 # argument for re-deriving rather than transcribing: a baseline one higher than
 # the truth is one free regression.
-baseline = 1904
+#
+# 2026-08-22, LOWERED 1904 -> 1688 (216 fewer), and none of it is code that was
+# rewritten. Two measurement defects were fixed in the grader:
+#   * `count_complexity` charged every zero-argument closure `||` as a branch
+#   * it evaluated control-flow keywords on COMMENT lines, including the `*`
+#     continuation lines of a block comment
+# and the index this was first measured against was STALE — `built_at`
+# 2026-08-21T13:26, missing the 265 definitions added since, because
+# `pmat query` does not rebuild a stale index, it only builds an absent one.
+# Re-measured against a forced-fresh index at 23,716 definitions.
+#
+# A baseline may only go down, and banking a beaten one is not optional: slack
+# is headroom a regression hides in.
+baseline = 1688
 
 [entropy]
 # Entropy analysis configuration (#227)

--- a/docs/status/unrun-tests-ledger.md
+++ b/docs/status/unrun-tests-ledger.md
@@ -14,7 +14,7 @@ Legs consulted (3):
 - `feature-matrix.yml:feature-tests[mcp-integration]`
 - `feature-matrix.yml:feature-tests[unified-protocol]`
 
-23085 of 26206 lib tests are executed; 3121 are compiled by no leg.
+23103 of 26224 lib tests are executed; 3121 are compiled by no leg.
 
 ## `<unsatisfiable>` — 18 test(s)
 

--- a/src/cli/handlers/tdg_handlers/formatting.rs
+++ b/src/cli/handlers/tdg_handlers/formatting.rs
@@ -353,11 +353,11 @@ fn format_tdg_score_json(
             // grades more languages than the clone engine tokenizes, so a mixed
             // repo measures only its readable subset. Publishing the size of
             // that subset is what stops the number being read as whole-tree.
-            "files_measured": p.cross_file_duplication_coverage.map(|(m, _)| m),
-            "files_total": p.cross_file_duplication_coverage.map(|(_, t)| t),
+            "files_measured": p.cross_file_duplication_coverage.map(|c| c.measured),
+            "files_total": p.cross_file_duplication_coverage.map(|c| c.total),
             "covers_every_graded_file": p
                 .cross_file_duplication_coverage
-                .map(|(m, t)| m == t),
+                .map(crate::tdg::project_score::CrossFileDuplicationCoverage::covers_every_graded_file),
         })),
         "score": {
             // Null, not 0.0/"F". A machine consumer averaging `total` over a
@@ -733,7 +733,11 @@ mod cap_disclosure_tests {
     fn partial_duplication_coverage_reaches_json() {
         let mut project = ProjectScore::aggregate(vec![file_at(100.0), file_at(100.0)]);
         project.cross_file_duplication_ratio = Some(0.1);
-        project.cross_file_duplication_coverage = Some((1, 2));
+        project.cross_file_duplication_coverage =
+            Some(crate::tdg::project_score::CrossFileDuplicationCoverage {
+                measured: 1,
+                total: 2,
+            });
         let score = project.average();
 
         let json = format_tdg_score_json(&score, None, false, Some(&project)).expect("render");

--- a/src/cli/handlers/tdg_handlers/formatting.rs
+++ b/src/cli/handlers/tdg_handlers/formatting.rs
@@ -335,6 +335,30 @@ fn format_tdg_score_json(
             .map(format_grade),
         "f_grade_count": project.map(|p| p.f_grade_count),
         "not_measured": nothing_was_measured(project),
+        // Issue #1050. The duplication component measured only WITHIN each file,
+        // so ten byte-identical files each scored the full 20/20 and their mean
+        // did too — full marks for a tree `analyze duplicates` calls 100%
+        // duplicated. The project-wide number now exists; it has to be legible
+        // here or the fix is invisible to every machine consumer.
+        //
+        // `measured: false` is the case that matters: TDG grades languages the
+        // clone engine has no tokenizer for (Go, Java, Ruby, Lua, …), and for
+        // those the component is UNMEASURED, not clean. A null ratio beside a
+        // stated reason is the only shape that cannot be misread as zero.
+        "duplication": project.map(|p| serde_json::json!({
+            "cross_file_ratio": p.cross_file_duplication_ratio,
+            "measured": p.cross_file_duplication_ratio.is_some(),
+            "unmeasured_reason": p.cross_file_duplication_unmeasured,
+            // A ratio over PART of a tree is not a ratio for the tree: TDG
+            // grades more languages than the clone engine tokenizes, so a mixed
+            // repo measures only its readable subset. Publishing the size of
+            // that subset is what stops the number being read as whole-tree.
+            "files_measured": p.cross_file_duplication_coverage.map(|(m, _)| m),
+            "files_total": p.cross_file_duplication_coverage.map(|(_, t)| t),
+            "covers_every_graded_file": p
+                .cross_file_duplication_coverage
+                .map(|(m, t)| m == t),
+        })),
         "score": {
             // Null, not 0.0/"F". A machine consumer averaging `total` over a
             // tree folded an unreadable directory in as a genuine zero, and one
@@ -647,6 +671,79 @@ mod cap_disclosure_tests {
         assert_eq!(value["grade_capped"], true);
         assert_eq!(value["grade_uncapped"], "A+");
         assert_eq!(value["f_grade_count"], 1);
+    }
+
+    /// Issue #1050: a duplication verdict the detector could NOT reach must say
+    /// so in the payload. A component that silently keeps its full 20/20 because
+    /// nothing could measure it is the defect this whole change exists to
+    /// remove, and a disclosure that never leaves `ProjectScore` is no
+    /// disclosure at all — `--format json` is where a machine consumer looks.
+    #[test]
+    fn an_unmeasured_duplication_component_is_disclosed_in_json() {
+        let mut project = ProjectScore::aggregate(vec![file_at(100.0), file_at(100.0)]);
+        project.record_cross_file_duplication(
+            &crate::tdg::cross_file_duplication::CrossFileDuplication::unmeasured(
+                "no file among the 2 graded has a clone tokenizer",
+                2,
+            ),
+        );
+        let score = project.average();
+
+        let json = format_tdg_score_json(&score, None, false, Some(&project)).expect("render");
+        let value: serde_json::Value = serde_json::from_str(&json).expect("valid json");
+
+        assert_eq!(
+            value["duplication"]["measured"], false,
+            "an unreachable population must not be reported as measured"
+        );
+        assert!(
+            value["duplication"]["cross_file_ratio"].is_null(),
+            "no ratio may be invented, got {}",
+            value["duplication"]["cross_file_ratio"]
+        );
+        assert!(
+            value["duplication"]["unmeasured_reason"]
+                .as_str()
+                .is_some_and(|r| r.contains("clone tokenizer")),
+            "the payload must say WHY, got {}",
+            value["duplication"]["unmeasured_reason"]
+        );
+    }
+
+    /// The measured case is equally explicit: `0.0` here means the detector ran
+    /// and found nothing, which a reader must be able to tell apart from the
+    /// null above.
+    #[test]
+    fn a_measured_duplication_ratio_reaches_json() {
+        let mut project = ProjectScore::aggregate(vec![file_at(100.0)]);
+        project.record_cross_file_duplication(
+            &crate::tdg::cross_file_duplication::CrossFileDuplication::measured_at(0.42),
+        );
+        let score = project.average();
+
+        let json = format_tdg_score_json(&score, None, false, Some(&project)).expect("render");
+        let value: serde_json::Value = serde_json::from_str(&json).expect("valid json");
+        assert_eq!(value["duplication"]["measured"], true);
+        assert_eq!(value["duplication"]["cross_file_ratio"], 0.42);
+        assert!(value["duplication"]["unmeasured_reason"].is_null());
+    }
+
+    /// Partial coverage must be visible in the payload, not just on the struct.
+    #[test]
+    fn partial_duplication_coverage_reaches_json() {
+        let mut project = ProjectScore::aggregate(vec![file_at(100.0), file_at(100.0)]);
+        project.cross_file_duplication_ratio = Some(0.1);
+        project.cross_file_duplication_coverage = Some((1, 2));
+        let score = project.average();
+
+        let json = format_tdg_score_json(&score, None, false, Some(&project)).expect("render");
+        let value: serde_json::Value = serde_json::from_str(&json).expect("valid json");
+        assert_eq!(value["duplication"]["files_measured"], 1);
+        assert_eq!(value["duplication"]["files_total"], 2);
+        assert_eq!(
+            value["duplication"]["covers_every_graded_file"], false,
+            "a ratio over half the tree must not present as whole-tree"
+        );
     }
 
     /// An uncapped run must not grow a cap note out of nowhere.

--- a/src/services/duplicate_detector/engine.rs
+++ b/src/services/duplicate_detector/engine.rs
@@ -76,14 +76,25 @@ impl DuplicateDetectionEngine {
         content: &str,
         lang: Language,
     ) -> Result<Vec<CodeFragment>> {
-        let tokens = self.feature_extractor.extract_features(content, lang);
         let lines: Vec<&str> = content.lines().collect();
         let mut fragments = self.extract_function_fragments(path, &lines, lang)?;
 
-        // If no functions found, treat entire file as one fragment
-        if fragments.is_empty() && tokens.len() >= self.config.min_tokens {
-            let fragment = self.create_fragment(path, content, tokens, 1, lines.len(), lang)?;
-            fragments.push(fragment);
+        // If no functions found, treat entire file as one fragment.
+        //
+        // The whole-file tokenization this needs used to run UNCONDITIONALLY,
+        // one line above, while being read only inside this branch — so every
+        // file that does contain functions was tokenized twice: once here and
+        // discarded, once more per function by `try_add_fragment`. Tokenization
+        // is 98.7% of `detect_duplicates` (measured: 7.33s of 7.43s over 2,647
+        // files), so the discarded pass was most of the run. Deferring it into
+        // the branch that reads it changes no fragment, no signature and no
+        // ratio; it only stops paying for an answer nobody asked for.
+        if fragments.is_empty() {
+            let tokens = self.feature_extractor.extract_features(content, lang);
+            if tokens.len() >= self.config.min_tokens {
+                let fragment = self.create_fragment(path, content, tokens, 1, lines.len(), lang)?;
+                fragments.push(fragment);
+            }
         }
 
         Ok(fragments)

--- a/src/tdg/analyzer_ast/analyzer_impl2_metrics.rs
+++ b/src/tdg/analyzer_ast/analyzer_impl2_metrics.rs
@@ -192,8 +192,36 @@ impl TdgAnalyzerAst {
         // verbatim, so identical input must serialise identically.
         ungraded.sort_by(|a, b| a.path.cmp(&b.path));
 
+        // Issue #1050: the duplication component measured WITHIN each file and
+        // nothing else, so ten byte-identical files each scored 20/20 and the
+        // mean of those scores scored 20/20 too — full marks for a tree
+        // `analyze duplicates` calls 100% duplicated. The detector runs ONCE
+        // here, over the files already walked.
+        //
+        // It does NOT produce the same number as `analyze duplicates` — that
+        // command's headline comes from block hashing over a wider walk, and on
+        // this repo the two read 22.025% and 7.709%. See the module docs on
+        // `crate::tdg::cross_file_duplication` for the measured comparison. What
+        // is guaranteed is ordering, not equality.
+        //
+        // Deliberately over the files that were actually GRADED, not over
+        // `found.gradable`: the duplication verdict must cover exactly the
+        // population the rest of the score covers, or the component would be
+        // describing a different tree from every other component.
+        let graded: Vec<std::path::PathBuf> = scores
+            .iter()
+            .filter_map(|score| score.file_path.clone())
+            .collect();
+        let duplication = crate::tdg::cross_file_duplication::measure(&graded);
+        crate::tdg::cross_file_duplication::apply(
+            &mut scores,
+            &duplication,
+            self.config.weights.duplication,
+        );
+
         let mut project = ProjectScore::aggregate(scores);
         project.ungraded_files = ungraded;
+        project.record_cross_file_duplication(&duplication);
         Ok(project)
     }
 

--- a/src/tdg/cross_file_duplication.rs
+++ b/src/tdg/cross_file_duplication.rs
@@ -1,0 +1,378 @@
+//! The project-level half of the TDG duplication component (issue #1050).
+//!
+//! Every duplication scorer TDG has ever had takes ONE file's source and looks
+//! for repeated token sequences inside it. That is a real measurement, and at
+//! single-file scope it is the only one available. What it cannot see is the
+//! commonest kind of duplication there is: the same code sitting in two
+//! different files. Ten byte-identical files each contain 0% internal
+//! duplication, so each scored the full 20/20, and the project score — a mean of
+//! those per-file components — scored 20/20 as well. The component awarded full
+//! marks precisely because it had no way to look.
+//!
+//! Measured on the pre-fix binary, over a tree of ten distinct files and the
+//! same tree with a byte-identical copy of every file added:
+//!
+//! ```text
+//!            analyze duplicates   tdg duplication component
+//! clean10          0.0%           20.0 / 20
+//! cloned20        88.2%           20.0 / 20
+//! ```
+//!
+//! This module closes that gap with `DuplicateDetectionEngine` (MinHash + LSH).
+//!
+//! ## It does NOT agree numerically with `analyze duplicates`, and cannot
+//!
+//! An earlier draft of this comment claimed the two "agree by construction
+//! rather than by coincidence". That is false, and it was caught by an
+//! adversarial review before it shipped. `analyze duplicates`' headline number
+//! comes from `find_duplicate_blocks` — hash-bucketed LINE BLOCKS over
+//! `ProjectFileDiscovery`'s walk. `DuplicateDetectionEngine` appears there only
+//! in `find_structural_similarities`, as a supplementary near-miss pass, with a
+//! different config and a different denominator. Measured:
+//!
+//! ```text
+//! tree       analyze duplicates      tdg cross_file_ratio
+//! pmat/src   22.025% (4004 files)     7.709% (1569 files)
+//! duende     70.005% (  79 files)    83.579% (  57 files)
+//! pepita      7.832%                 15.174% (20/30)
+//! pzsh       14.096% (  29 files)    15.353% (16/46)
+//! ```
+//!
+//! They agree only on degenerate 0%/100% fixtures. Two things drive the gap:
+//! the denominators differ (TDG measures over the files it GRADED, which is a
+//! subset), and block-hashing and MinHash-LSH answer different questions.
+//!
+//! So do not read the two numbers as the same quantity, and do not "fix" one to
+//! match the other without deciding which question you meant to ask. What this
+//! module guarantees is ORDERING, not equality: a tree with more cross-file
+//! duplication loses more of the component than one with less.
+//!
+//! ## What it does NOT do
+//!
+//! It does not touch single-file analysis. `pmat tdg <one file>` still reports
+//! within-file duplication, because cross-file duplication is undefined for a
+//! population of one and the within-file number is a legitimate measurement at
+//! that scope. The defect was never that the number existed; it was that a
+//! within-file number was presented as a PROJECT verdict.
+
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+
+use crate::services::duplicate_detector::{
+    DuplicateDetectionConfig, DuplicateDetectionEngine, Language as CloneLanguage,
+};
+use crate::tdg::score::TdgScore;
+
+/// Cross-file duplication over the files a project score covers.
+#[derive(Debug, Default)]
+pub(crate) struct CrossFileDuplication {
+    /// Project-wide duplicated-line ratio in `0.0..=1.0`, or `None` when the
+    /// detector could not be run at all. `None` is never rendered as 0.0: a
+    /// ratio of zero is a measurement that found nothing, and "we could not
+    /// look" must not read the same as "we looked and it was clean".
+    pub(crate) ratio: Option<f64>,
+    /// Why `ratio` is `None`, in the words a reader gets.
+    pub(crate) unmeasured_reason: Option<String>,
+    /// Duplicated-line ratio per file, keyed by the path as walked.
+    per_file: HashMap<PathBuf, f64>,
+    /// How many of the graded files the detector could actually read.
+    pub(crate) files_measured: usize,
+    /// How many files the project score covers.
+    pub(crate) files_total: usize,
+}
+
+impl CrossFileDuplication {
+    /// True when the detector ran over every file the score covers.
+    pub(crate) fn is_complete(&self) -> bool {
+        self.ratio.is_some() && self.files_measured == self.files_total
+    }
+
+    /// A verdict the detector could not reach, carrying the reason.
+    ///
+    /// The reason is not optional. "Unmeasured" without a cause is the same
+    /// dead end as a plausible zero: a reader learns that the number is missing
+    /// but not whether that is expected (a Go tree) or a fault to chase.
+    pub(crate) fn unmeasured(reason: impl Into<String>, files_total: usize) -> Self {
+        Self {
+            ratio: None,
+            unmeasured_reason: Some(reason.into()),
+            per_file: HashMap::new(),
+            files_measured: 0,
+            files_total,
+        }
+    }
+
+    /// A verdict with a measured project-wide ratio and no per-file attribution.
+    /// Renderer tests use this; `measure` builds the real thing.
+    #[cfg(test)]
+    pub(crate) fn measured_at(ratio: f64) -> Self {
+        Self {
+            ratio: Some(ratio),
+            unmeasured_reason: None,
+            per_file: HashMap::new(),
+            files_measured: 1,
+            files_total: 1,
+        }
+    }
+}
+
+/// The clone engine's language for a path, or `None` when it has no tokenizer
+/// for that extension.
+///
+/// A SUPERSET of `cli::analysis::duplicates_detection`'s table — not the same
+/// one, which an earlier version of this comment claimed. That table has `ts`,
+/// `js`, `c`, `cpp|cc|cxx`; this adds `tsx`, `jsx`, `h`, `hpp`. The difference
+/// is deliberate (a `.tsx` file is TypeScript and the engine tokenizes it) but
+/// it is a difference, and describing it as sameness would send the next reader
+/// to the wrong file to change it.
+///
+/// TDG grades more languages than the clone engine tokenizes (Go, Java, Ruby,
+/// Lua, SQL, Lean, …); those files are counted as UNMEASURED rather than as
+/// clean, which is the whole point of #1050.
+fn clone_language(path: &Path) -> Option<CloneLanguage> {
+    match path.extension().and_then(|e| e.to_str()) {
+        Some("rs") => Some(CloneLanguage::Rust),
+        Some("ts" | "tsx") => Some(CloneLanguage::TypeScript),
+        Some("js" | "jsx") => Some(CloneLanguage::JavaScript),
+        Some("py") => Some(CloneLanguage::Python),
+        Some("c" | "h") => Some(CloneLanguage::C),
+        Some("cpp" | "cc" | "cxx" | "hpp") => Some(CloneLanguage::Cpp),
+        Some("kt" | "kts") => Some(CloneLanguage::Kotlin),
+        _ => None,
+    }
+}
+
+/// Lines that carry code, by the SAME rule the per-file scorer
+/// (`analyze_duplication_ast`) uses for its denominator: non-blank, not a
+/// comment. Both ratios therefore sit on one scale, so a file cannot be scored
+/// differently depending on which of the two paths reached it.
+fn code_line_count(source: &str) -> usize {
+    source
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty() && !l.starts_with("//") && !l.starts_with("/*"))
+        .count()
+}
+
+/// Run the project-wide clone detector over `files`.
+///
+/// `files` is the gradable population the project score is computed over, so
+/// the duplication verdict covers exactly the files the score claims to cover.
+pub(crate) fn measure(files: &[PathBuf]) -> CrossFileDuplication {
+    let files_total = files.len();
+
+    let mut sources: Vec<(PathBuf, String, CloneLanguage)> = Vec::new();
+    for path in files {
+        let Some(language) = clone_language(path) else {
+            continue;
+        };
+        let Ok(source) = std::fs::read_to_string(path) else {
+            continue;
+        };
+        sources.push((path.clone(), source, language));
+    }
+
+    if sources.is_empty() {
+        return CrossFileDuplication::unmeasured(
+            format!(
+                "no file among the {files_total} graded has a clone tokenizer \
+                 (supported: rs, ts, js, py, c, cpp, kt)"
+            ),
+            files_total,
+        );
+    }
+
+    let engine = DuplicateDetectionEngine::new(DuplicateDetectionConfig::default());
+    let report = match engine.detect_duplicates(&sources) {
+        Ok(report) => report,
+        Err(error) => {
+            return CrossFileDuplication::unmeasured(
+                format!("clone detection failed: {error}"),
+                files_total,
+            )
+        }
+    };
+
+    // Distinct duplicated LINE NUMBERS per file. A set, not a sum: a line
+    // covered by two overlapping clone groups is one duplicated line, and
+    // summing instance lengths (which is what `compute_hotspots` does for its
+    // severity ranking) can report more duplicated lines than the file has.
+    let mut duplicated_lines: HashMap<&Path, HashSet<usize>> = HashMap::new();
+    for group in &report.groups {
+        for instance in &group.fragments {
+            let lines = duplicated_lines.entry(instance.file.as_path()).or_default();
+            for line in instance.start_line..=instance.end_line {
+                lines.insert(line);
+            }
+        }
+    }
+
+    let mut per_file = HashMap::with_capacity(sources.len());
+    for (path, source, _) in &sources {
+        let code_lines = code_line_count(source);
+        if code_lines == 0 {
+            continue;
+        }
+        let duplicated = duplicated_lines.get(path.as_path()).map_or(0, HashSet::len);
+        let ratio = (duplicated as f64 / code_lines as f64).clamp(0.0, 1.0);
+        per_file.insert(path.clone(), ratio);
+    }
+
+    CrossFileDuplication {
+        ratio: Some(report.summary.duplication_ratio.clamp(0.0, 1.0)),
+        unmeasured_reason: None,
+        per_file,
+        files_measured: sources.len(),
+        files_total,
+    }
+}
+
+/// The penalty a duplication ratio earns, in points off the component.
+///
+/// DEVIATION, recorded deliberately. The brief specified the curve
+/// `(ratio * 40.0).min(20.0)` from `impl Scorer for DuplicationDetector` in
+/// `src/tdg/scorers/duplication_scoring.rs`. That file is NOT COMPILED — neither
+/// `src/tdg/scorers/` nor `src/tdg/analyzer.rs` is declared as a module anywhere
+/// in the crate, and `ScorerSet` has no reference outside them. The scorer this
+/// build actually runs is `TdgAnalyzerAst::analyze_duplication_ast`, whose curve
+/// is `(ratio * 20.0).min(20.0)` above a 10% floor. Matching the LIVE curve is
+/// what delivers the property the brief asked for — one scale whichever path
+/// reaches a tree — so that is the curve used here. Adopting the dead file's
+/// steeper curve would have created the very split it was meant to prevent.
+///
+/// The 10% floor comes from the same live scorer. It is a noise floor, not a
+/// silence: a tree measured below it still reports its measured ratio through
+/// `ProjectScore::cross_file_duplication_ratio`, so "measured 8%, under the
+/// floor" is legible and never presented as "not duplicated".
+fn penalty_for(ratio: f64, weight: f32) -> f32 {
+    if ratio <= 0.1 {
+        return 0.0;
+    }
+    ((ratio as f32) * 20.0).min(weight)
+}
+
+/// Fold cross-file duplication into the per-file duplication components.
+///
+/// A file's component becomes the WORSE of its two measurements — the
+/// within-file duplication `analyze_duplication_ast` already found, and the
+/// cross-file duplication measured here. Taking the worse of the two means
+/// project analysis can only ever lower a file's duplication score relative to
+/// analysing that file alone, never raise it: whatever `pmat tdg <file>` says
+/// about a file, `pmat tdg <dir>` will not claim it is cleaner.
+pub(crate) fn apply(scores: &mut [TdgScore], measured: &CrossFileDuplication, weight: f32) {
+    if measured.ratio.is_none() {
+        return;
+    }
+
+    for score in scores.iter_mut() {
+        let Some(path) = score.file_path.as_ref() else {
+            continue;
+        };
+        let Some(&ratio) = measured.per_file.get(path) else {
+            continue;
+        };
+
+        // Recovered rather than re-derived: whatever the within-file scorer
+        // decided is exactly what this file already lost.
+        let within_penalty = (weight - score.duplication_ratio).max(0.0);
+        let cross_penalty = penalty_for(ratio, weight);
+
+        score.duplication_ratio = (weight - within_penalty.max(cross_penalty)).max(0.0);
+        score.calculate_total();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_full_ratio_costs_the_whole_component() {
+        assert!((penalty_for(1.0, 20.0) - 20.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn the_penalty_never_exceeds_the_component_weight() {
+        for percent in 0..=100 {
+            let penalty = penalty_for(f64::from(percent) / 100.0, 20.0);
+            assert!(
+                (0.0..=20.0).contains(&penalty),
+                "ratio {percent}% produced penalty {penalty}, outside the 0..=20 weight"
+            );
+        }
+    }
+
+    #[test]
+    fn a_ratio_under_the_noise_floor_costs_nothing() {
+        assert!((penalty_for(0.05, 20.0)).abs() < f32::EPSILON);
+        assert!(penalty_for(0.5, 20.0) > 0.0);
+    }
+
+    #[test]
+    fn code_lines_ignore_blanks_and_comments() {
+        let source = "fn a() {}\n\n// note\n/* block */\nfn b() {}\n";
+        assert_eq!(code_line_count(source), 2);
+    }
+
+    #[test]
+    fn unknown_extensions_have_no_clone_tokenizer() {
+        assert!(clone_language(Path::new("a.go")).is_none());
+        assert!(clone_language(Path::new("a.lua")).is_none());
+        assert!(clone_language(Path::new("a.rs")).is_some());
+    }
+
+    /// A tree of languages the clone engine cannot tokenize must come back
+    /// UNMEASURED, never as a clean 0.0 ratio.
+    #[test]
+    fn a_tree_the_engine_cannot_read_is_unmeasured_not_clean() {
+        let measured = measure(&[PathBuf::from("a.go"), PathBuf::from("b.lua")]);
+        assert!(measured.ratio.is_none(), "must not report a ratio");
+        assert!(!measured.is_complete());
+        assert_eq!(measured.files_total, 2);
+        assert_eq!(measured.files_measured, 0);
+        let reason = measured.unmeasured_reason.expect("a reason");
+        assert!(reason.contains("clone tokenizer"), "got {reason}");
+    }
+
+    /// An unmeasured result must leave every component exactly as it found it —
+    /// it must not invent a penalty any more than it may award full marks.
+    #[test]
+    fn an_unmeasured_result_changes_no_score() {
+        let mut scores = vec![TdgScore {
+            duplication_ratio: 20.0,
+            file_path: Some(PathBuf::from("a.go")),
+            ..TdgScore::default()
+        }];
+        let before = scores[0].clone();
+        apply(&mut scores, &CrossFileDuplication::default(), 20.0);
+        assert_eq!(scores[0], before);
+    }
+
+    /// Project analysis may only ever lower a file's duplication component,
+    /// never raise it above what single-file analysis reported.
+    #[test]
+    fn cross_file_analysis_never_improves_a_files_duplication_score() {
+        let path = PathBuf::from("dirty.rs");
+        // A file the within-file scorer already docked to 4.0/20.
+        let mut scores = vec![TdgScore {
+            duplication_ratio: 4.0,
+            file_path: Some(path.clone()),
+            ..TdgScore::default()
+        }];
+        let measured = CrossFileDuplication {
+            ratio: Some(0.2),
+            unmeasured_reason: None,
+            // A cross-file penalty (0.2 * 20 = 4.0) SMALLER than the within-file
+            // one (16.0), so the worse of the two must win.
+            per_file: HashMap::from([(path, 0.2)]),
+            files_measured: 1,
+            files_total: 1,
+        };
+        apply(&mut scores, &measured, 20.0);
+        assert!(
+            (scores[0].duplication_ratio - 4.0).abs() < f32::EPSILON,
+            "the within-file penalty was the worse one and must stand, got {}",
+            scores[0].duplication_ratio
+        );
+    }
+}

--- a/src/tdg/cross_file_duplication_tests.rs
+++ b/src/tdg/cross_file_duplication_tests.rs
@@ -1,0 +1,399 @@
+//! The TDG duplication component must measure duplication ACROSS the files it
+//! grades, not only inside each one.
+//!
+//! Issue #1050. `impl Scorer for DuplicationDetector` and its live successor
+//! `analyze_duplication_ast` both take a single file's source. Ten byte-identical
+//! files each have 0% *internal* duplication, so each scored the full 20/20 and
+//! the project aggregate — a mean of per-file components — scored 20/20 too.
+//! `TdgScore::default()` seeds `duplication_ratio: 20.0`, and nothing at project
+//! level ever lowered it, so the component awarded full marks for a tree it had
+//! no way to measure.
+//!
+//! Measured on the fixtures below against the pre-fix binary:
+//!
+//! ```text
+//!            analyze duplicates   tdg total              duplication component
+//! clean10          0.0%           99.7727279663086       20.0 / 20
+//! cloned20        88.2%           99.77272033691406      20.0 / 20
+//! ```
+//!
+//! The two totals differ only in f32 summation noise at the seventh decimal.
+//! `cloned20` is `clean10` plus a byte-identical copy of every one of its files,
+//! so every OTHER per-file component has an identical mean across the two trees
+//! by construction: any difference these tests observe is attributable to
+//! duplication and to nothing else.
+
+use crate::tdg::TdgAnalyzer;
+use std::path::Path;
+
+/// Ten structurally distinct Rust files. Distinct at the level the clone engine
+/// actually measures: the detector normalises identifiers and literals, so a
+/// templated corpus that merely renames variables is a Type-2 clone family and
+/// scores 96.8% duplicated. These differ in control flow and construct.
+const DISTINCT_FILES: [(&str, &str); 10] = [
+    (
+        "f0.rs",
+        r#"use std::collections::HashMap;
+pub struct Ledger { rows: HashMap<String, i64> }
+impl Ledger {
+    pub fn post(&mut self, key: &str, amount: i64) {
+        *self.rows.entry(key.to_string()).or_insert(0) += amount;
+    }
+    pub fn balance(&self) -> i64 { self.rows.values().sum() }
+}
+"#,
+    ),
+    (
+        "f1.rs",
+        r#"pub enum Token { Word(String), Number(f64), Punct(char) }
+pub fn classify(raw: &str) -> Token {
+    match raw.parse::<f64>() {
+        Ok(n) => Token::Number(n),
+        Err(_) if raw.len() == 1 => Token::Punct(raw.chars().next().unwrap_or('?')),
+        Err(_) => Token::Word(raw.to_owned()),
+    }
+}
+"#,
+    ),
+    (
+        "f2.rs",
+        r#"pub trait Sink { fn accept(&mut self, line: &str); }
+pub struct Counter { pub seen: usize }
+impl Sink for Counter {
+    fn accept(&mut self, line: &str) { if !line.is_empty() { self.seen += 1 } }
+}
+"#,
+    ),
+    (
+        "f3.rs",
+        r#"pub fn fib(n: u32) -> u64 {
+    let (mut a, mut b) = (0u64, 1u64);
+    for _ in 0..n { let t = a + b; a = b; b = t; }
+    a
+}
+"#,
+    ),
+    (
+        "f4.rs",
+        r#"use std::fmt;
+#[derive(Debug)]
+pub struct Rect { pub w: f32, pub h: f32 }
+impl fmt::Display for Rect {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}x{} area={}", self.w, self.h, self.w * self.h)
+    }
+}
+"#,
+    ),
+    (
+        "f5.rs",
+        r#"pub fn quicksort<T: Ord + Clone>(v: &[T]) -> Vec<T> {
+    if v.len() <= 1 { return v.to_vec(); }
+    let pivot = v[v.len() / 2].clone();
+    let less: Vec<T> = v.iter().filter(|x| **x < pivot).cloned().collect();
+    let more: Vec<T> = v.iter().filter(|x| **x > pivot).cloned().collect();
+    let mut out = quicksort(&less);
+    out.push(pivot);
+    out.extend(quicksort(&more));
+    out
+}
+"#,
+    ),
+    (
+        "f6.rs",
+        r#"pub const GREETINGS: [&str; 3] = ["hola", "salut", "ciao"];
+pub fn greet(idx: usize) -> String {
+    GREETINGS.get(idx % GREETINGS.len()).map(|g| format!("{g}!")).unwrap_or_default()
+}
+"#,
+    ),
+    (
+        "f7.rs",
+        r#"pub struct Retry { pub attempts: u8, pub backoff_ms: u64 }
+impl Default for Retry {
+    fn default() -> Self { Retry { attempts: 3, backoff_ms: 250 } }
+}
+impl Retry {
+    pub fn delay_for(&self, attempt: u8) -> u64 { self.backoff_ms << attempt.min(6) }
+}
+"#,
+    ),
+    (
+        "f8.rs",
+        r#"pub fn hamming(a: &[u8], b: &[u8]) -> Option<u32> {
+    if a.len() != b.len() { return None; }
+    Some(a.iter().zip(b).map(|(x, y)| (x ^ y).count_ones()).sum())
+}
+"#,
+    ),
+    (
+        "f9.rs",
+        r#"use std::io::{self, BufRead};
+pub fn longest_line<R: BufRead>(r: R) -> io::Result<String> {
+    let mut best = String::new();
+    for line in r.lines() {
+        let line = line?;
+        if line.len() > best.len() { best = line; }
+    }
+    Ok(best)
+}
+"#,
+    ),
+];
+
+/// Write the ten distinct files into `root`.
+fn write_clean_tree(root: &Path) {
+    std::fs::create_dir_all(root).expect("mkdir clean tree");
+    for (name, body) in DISTINCT_FILES {
+        std::fs::write(root.join(name), body).expect("write distinct file");
+    }
+}
+
+/// Write the ten distinct files into `root` AND a byte-identical copy of each
+/// into `root/copy`.
+fn write_cloned_tree(root: &Path) {
+    write_clean_tree(root);
+    let copy = root.join("copy");
+    std::fs::create_dir_all(&copy).expect("mkdir copy dir");
+    for (name, body) in DISTINCT_FILES {
+        std::fs::write(copy.join(name), body).expect("write cloned file");
+    }
+}
+
+async fn score_tree(root: &Path) -> crate::tdg::ProjectScore {
+    let analyzer = TdgAnalyzer::new().expect("analyzer");
+    analyzer
+        .analyze_project(root)
+        .await
+        .expect("analyze project")
+}
+
+/// RED: on the pre-fix code both trees report a duplication component of exactly
+/// 20.0 — full marks for a tree that is 100% duplicated by the very engine
+/// `analyze duplicates` reports 88.2% with.
+#[tokio::test]
+async fn a_cloned_tree_scores_worse_on_duplication_than_a_clean_one() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let clean_root = tmp.path().join("clean");
+    let cloned_root = tmp.path().join("cloned");
+    write_clean_tree(&clean_root);
+    write_cloned_tree(&cloned_root);
+
+    let clean = score_tree(&clean_root).await;
+    let cloned = score_tree(&cloned_root).await;
+
+    assert_eq!(clean.total_files, 10, "clean tree file count");
+    assert_eq!(cloned.total_files, 20, "cloned tree file count");
+
+    let clean_dup = clean.average().duplication_ratio;
+    let cloned_dup = cloned.average().duplication_ratio;
+
+    assert!(
+        cloned_dup < clean_dup,
+        "a 100%-duplicated tree must score WORSE on duplication than a clean one, \
+         got cloned={cloned_dup} clean={clean_dup} (equal means the component was never measured)"
+    );
+
+    let clean_total = clean.average_score.expect("clean average");
+    let cloned_total = cloned.average_score.expect("cloned average");
+    assert!(
+        cloned_total < clean_total,
+        "the duplicated tree must score worse overall: cloned={cloned_total} clean={clean_total}"
+    );
+}
+
+/// COUNTER-TEST: "always penalise" must not pass. A genuinely clean tree keeps
+/// full marks on duplication, so the fix cannot be a blanket deduction.
+#[tokio::test]
+async fn a_clean_tree_keeps_full_duplication_marks() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path().join("clean");
+    write_clean_tree(&root);
+
+    let project = score_tree(&root).await;
+    let dup = project.average().duplication_ratio;
+
+    assert!(
+        (dup - 20.0).abs() < f32::EPSILON,
+        "ten structurally distinct files are not duplicated; component must stay at 20.0, got {dup}"
+    );
+    let total = project.average_score.expect("average");
+    assert!(
+        total > 95.0,
+        "a clean tree must still grade well, got {total}"
+    );
+}
+
+/// COUNTER-TEST: the penalty is bounded by the component's own weight, so a
+/// pathological tree cannot drive the component — or the total — negative.
+#[tokio::test]
+async fn the_duplication_penalty_is_bounded_at_the_component_weight() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path().join("pathological");
+    std::fs::create_dir_all(&root).expect("mkdir");
+    // Forty byte-identical copies: the worst case the ratio can express.
+    for i in 0..40 {
+        std::fs::write(root.join(format!("f{i}.rs")), DISTINCT_FILES[5].1).expect("write clone");
+    }
+
+    let project = score_tree(&root).await;
+    let dup = project.average().duplication_ratio;
+    let total = project.average_score.expect("average");
+
+    assert!(
+        (0.0..=20.0).contains(&dup),
+        "duplication component must stay within its 0..=20 weight, got {dup}"
+    );
+    assert!(
+        dup < 1.0,
+        "a 40x-duplicated tree must lose essentially the whole component, got {dup}"
+    );
+    assert!(total >= 0.0, "total must never go negative, got {total}");
+}
+
+/// COUNTER-TEST: single-file analysis still produces a score, and cross-file
+/// duplication must NOT leak into it.
+///
+/// The fixture puts TWO BYTE-IDENTICAL FILES SIDE BY SIDE and grades one of
+/// them. That placement is the whole test: an earlier version of it graded a
+/// file whose clones lived in a subdirectory, and the mutation this is meant to
+/// catch — "analyze_file runs the project detector over its parent directory" —
+/// passed against it, because the parent directory held no clones. A guard that
+/// its own named mutation walks straight through is not a guard.
+///
+/// Cross-file duplication is undefined for a population of one, so the honest
+/// answer here is the within-file measurement: `dupe_a.rs` repeats nothing
+/// inside itself, so it keeps the full component even though `dupe_b.rs` next to
+/// it is the same bytes.
+#[tokio::test]
+async fn a_single_file_still_scores_and_is_unaffected_by_cross_file_duplication() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path().join("pair");
+    std::fs::create_dir_all(&root).expect("mkdir");
+    let body = DISTINCT_FILES[5].1;
+    std::fs::write(root.join("dupe_a.rs"), body).expect("write a");
+    std::fs::write(root.join("dupe_b.rs"), body).expect("write b");
+
+    // The PROJECT verdict over this pair is heavily duplicated ...
+    let project = score_tree(&root).await;
+    assert!(
+        project.average().duplication_ratio < 20.0,
+        "the pair IS duplicated at project scope, got {}",
+        project.average().duplication_ratio
+    );
+
+    // ... while the SINGLE FILE keeps its within-file measurement.
+    let analyzer = TdgAnalyzer::new().expect("analyzer");
+    let one = analyzer
+        .analyze_file(&root.join("dupe_a.rs"))
+        .await
+        .expect("single file score");
+
+    assert!(
+        one.total > 0.0,
+        "single file must still score, got {}",
+        one.total
+    );
+    assert!(
+        (one.duplication_ratio - 20.0).abs() < f32::EPSILON,
+        "dupe_a.rs repeats nothing WITHIN itself, so single-file mode reports the full \
+         component; it must not borrow the project's cross-file verdict. got {}",
+        one.duplication_ratio
+    );
+}
+
+/// A tree TDG grades but the clone engine has no tokenizer for must report that
+/// the duplication component was NOT MEASURED. "We could not look" must never be
+/// rendered as the clean 20/20 that "we looked and found nothing" earns — that
+/// is the #1050 defect itself, one level up.
+#[tokio::test]
+async fn a_language_the_clone_engine_cannot_read_is_disclosed_as_unmeasured() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path().join("goproj");
+    std::fs::create_dir_all(&root).expect("mkdir");
+    // Go is graded by TDG and has no clone tokenizer. Two byte-identical files,
+    // so a detector that COULD read them would report heavy duplication.
+    let body = "package main\n\nfunc Add(a int, b int) int {\n\treturn a + b\n}\n\nfunc Mul(a int, b int) int {\n\treturn a * b\n}\n";
+    std::fs::write(root.join("a.go"), body).expect("write");
+    std::fs::write(root.join("b.go"), body).expect("write");
+
+    let project = score_tree(&root).await;
+    assert!(project.total_files >= 2, "Go files should still be graded");
+
+    assert!(
+        project.cross_file_duplication_ratio.is_none(),
+        "an unreadable population must not produce a ratio, got {:?}",
+        project.cross_file_duplication_ratio
+    );
+    assert!(
+        project
+            .not_measured
+            .iter()
+            .any(|f| f == "cross_file_duplication_ratio"),
+        "the gap must be NAMED in not_measured, got {:?}",
+        project.not_measured
+    );
+    let reason = project
+        .cross_file_duplication_unmeasured
+        .expect("a reason must accompany the gap");
+    assert!(
+        reason.contains("clone tokenizer"),
+        "the reason must say why, got {reason}"
+    );
+}
+
+/// The measured ratio is recorded on the project score even when it is clean, so
+/// a reader can tell "measured, and it was 0%" from "never measured".
+#[tokio::test]
+async fn a_measured_clean_tree_records_its_ratio_rather_than_staying_silent() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path().join("clean");
+    write_clean_tree(&root);
+
+    let project = score_tree(&root).await;
+    assert_eq!(
+        project.cross_file_duplication_ratio,
+        Some(0.0),
+        "a clean tree was MEASURED at 0.0, which is not the same as unmeasured"
+    );
+    assert!(
+        project.not_measured.is_empty(),
+        "nothing is unmeasured here, got {:?}",
+        project.not_measured
+    );
+    assert!(project.cross_file_duplication_unmeasured.is_none());
+}
+
+/// A tree the clone engine can read only PART of must publish how much of it
+/// the duplication verdict actually covers. A ratio over the Rust half of a
+/// Rust+Go repo is not that repo's duplication, and a reader who cannot see the
+/// covered population will take it for the whole one.
+#[tokio::test]
+async fn a_partly_readable_tree_discloses_how_much_it_covered() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path().join("mixed");
+    write_clean_tree(&root); // 10 Rust files, all readable
+                             // Two Go files TDG grades and the clone engine cannot tokenize.
+    let go = "package main\n\nfunc Add(a int, b int) int {\n\treturn a + b\n}\n";
+    std::fs::write(root.join("a.go"), go).expect("write a.go");
+    std::fs::write(root.join("b.go"), go).expect("write b.go");
+
+    let project = score_tree(&root).await;
+    let (measured, total) = project
+        .cross_file_duplication_coverage
+        .expect("coverage must be recorded");
+
+    assert_eq!(
+        total, project.total_files,
+        "total must be the graded population"
+    );
+    assert!(
+        measured < total,
+        "the Go files are not readable by the clone engine, so coverage must be \
+         partial: measured={measured} total={total}"
+    );
+    assert_eq!(measured, 10, "the ten Rust files are the readable subset");
+    // The ratio IS measured -- over that subset -- so it is not null, and the
+    // coverage numbers are what keep it from being read as whole-tree.
+    assert!(project.cross_file_duplication_ratio.is_some());
+}

--- a/src/tdg/cross_file_duplication_tests.rs
+++ b/src/tdg/cross_file_duplication_tests.rs
@@ -379,9 +379,10 @@ async fn a_partly_readable_tree_discloses_how_much_it_covered() {
     std::fs::write(root.join("b.go"), go).expect("write b.go");
 
     let project = score_tree(&root).await;
-    let (measured, total) = project
+    let coverage = project
         .cross_file_duplication_coverage
         .expect("coverage must be recorded");
+    let (measured, total) = (coverage.measured, coverage.total);
 
     assert_eq!(
         total, project.total_files,

--- a/src/tdg/formatters/tests.rs
+++ b/src/tdg/formatters/tests.rs
@@ -98,6 +98,9 @@ mod tests {
                 files_truncated: count > 0,
                 list_filter: None,
                 ungraded_files: Vec::new(),
+                cross_file_duplication_ratio: None,
+                cross_file_duplication_unmeasured: None,
+                cross_file_duplication_coverage: None,
             };
             assert_box_is_rectangular(
                 &format_project(&project),
@@ -435,6 +438,9 @@ mod tests {
             files_truncated: true,
             list_filter: None,
             ungraded_files: Vec::new(),
+            cross_file_duplication_ratio: None,
+            cross_file_duplication_unmeasured: None,
+            cross_file_duplication_coverage: None,
         };
 
         let output = format_project(&project);

--- a/src/tdg/formatters/tests_coverage.rs
+++ b/src/tdg/formatters/tests_coverage.rs
@@ -332,6 +332,9 @@ mod coverage_instrumented_tests {
             files_truncated: false,
             list_filter: None,
             ungraded_files: Vec::new(),
+            cross_file_duplication_ratio: None,
+            cross_file_duplication_unmeasured: None,
+            cross_file_duplication_coverage: None,
         };
         let output = format_project(&project);
         assert!(output.contains("Project TDG Score Report"));
@@ -365,6 +368,9 @@ mod coverage_instrumented_tests {
             files_truncated: false,
             list_filter: None,
             ungraded_files: Vec::new(),
+            cross_file_duplication_ratio: None,
+            cross_file_duplication_unmeasured: None,
+            cross_file_duplication_coverage: None,
         };
         let output = format_project(&project);
         assert!(output.contains("70.0/100"));

--- a/src/tdg/mod.rs
+++ b/src/tdg/mod.rs
@@ -8,6 +8,8 @@ pub mod baseline_analyzer;
 pub mod config;
 /// The single Known-Defects gate both `analyze_source` implementations apply.
 pub(crate) mod critical_defect_gate;
+/// Issue #1050: the PROJECT-level half of the duplication component.
+pub(crate) mod cross_file_duplication;
 #[allow(clippy::all)]
 pub mod cuda_simd;
 pub mod cuda_simd_defects; // Defect taxonomy extracted for file health (CB-040)
@@ -144,3 +146,7 @@ pub use cuda_simd::{
     KaizenMetrics, MemoryAccessIssue, PopperScore, ReproducibilityScore, StatisticalRigorScore,
     TileDimensionResult, TileIssue, TransparencyScore,
 };
+
+/// Issue #1050: the duplication component must measure ACROSS files.
+#[cfg(test)]
+mod cross_file_duplication_tests;

--- a/src/tdg/project_score.rs
+++ b/src/tdg/project_score.rs
@@ -129,7 +129,39 @@ pub struct ProjectScore {
     /// take it for the whole — the same over-claim as #1050 itself, one step
     /// smaller. `None` when no project walk ran.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub cross_file_duplication_coverage: Option<(usize, usize)>,
+    pub cross_file_duplication_coverage: Option<CrossFileDuplicationCoverage>,
+}
+
+/// How much of the graded tree the cross-file duplication verdict actually covers.
+///
+/// A NAMED struct, not the `(usize, usize)` tuple this started as, for two
+/// reasons that turned out to be the same reason.
+///
+/// The differential-corpus gate flagged it: serialized as a tuple this is a raw
+/// two-element array, so `cross_file_duplication_coverage[].len` was a numeric
+/// leaf reading 2 for an empty project and 2 for a defect-rich one — a constant
+/// masquerading as a measurement. It could have been allow-listed as "fixed
+/// arity", and that would have been true and useless.
+///
+/// The better answer is that `[1, 2]` is a bad payload anyway: a consumer has to
+/// know positionally which number is which, and getting it backwards silently
+/// inverts the meaning. Named fields cannot be read backwards. Nothing consumed
+/// this field yet — it was added in the same change — so naming it cost nothing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct CrossFileDuplicationCoverage {
+    /// Files the clone engine could tokenize and therefore measure.
+    pub measured: usize,
+    /// Files TDG graded. Always >= `measured`.
+    pub total: usize,
+}
+
+impl CrossFileDuplicationCoverage {
+    /// True when the verdict covers every graded file, so the ratio describes
+    /// the whole tree rather than a subset of it.
+    #[must_use]
+    pub fn covers_every_graded_file(self) -> bool {
+        self.measured == self.total
+    }
 }
 
 impl ProjectScore {
@@ -215,8 +247,10 @@ impl ProjectScore {
         measured: &crate::tdg::cross_file_duplication::CrossFileDuplication,
     ) {
         self.cross_file_duplication_ratio = measured.ratio;
-        self.cross_file_duplication_coverage =
-            Some((measured.files_measured, measured.files_total));
+        self.cross_file_duplication_coverage = Some(CrossFileDuplicationCoverage {
+            measured: measured.files_measured,
+            total: measured.files_total,
+        });
         if let Some(reason) = measured.unmeasured_reason.clone() {
             self.cross_file_duplication_unmeasured = Some(reason);
             // GH #704's convention: an unmeasured field is null AND named, so

--- a/src/tdg/project_score.rs
+++ b/src/tdg/project_score.rs
@@ -101,6 +101,35 @@ pub struct ProjectScore {
     /// numbers were computed over is not the population that was walked.
     #[serde(default)]
     pub ungraded_files: Vec<UngradedFile>,
+    /// Duplication measured ACROSS the graded files, in `0.0..=1.0`, or `None`
+    /// when the clone detector could not be run over them (issue #1050).
+    ///
+    /// The duplication component used to be a per-file measurement only: ten
+    /// byte-identical files each contain 0% *internal* duplication, so each
+    /// scored the full 20/20 and their mean did too. `analyze duplicates` called
+    /// the same tree 100% duplicated. The component awarded full marks exactly
+    /// because it had no way to look across files.
+    ///
+    /// `None` is not 0.0. A ratio of zero is a measurement that found nothing;
+    /// `None` says the measurement was never taken, and is named in
+    /// `not_measured` alongside the reason so no reader has to infer it from a
+    /// plausible-looking number.
+    #[serde(default)]
+    pub cross_file_duplication_ratio: Option<f64>,
+    /// Why `cross_file_duplication_ratio` is `None`, when it is.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cross_file_duplication_unmeasured: Option<String>,
+    /// How many of the graded files the clone detector could actually read, and
+    /// how many the score covers, as `(measured, total)`.
+    ///
+    /// A ratio measured over PART of the tree is not a ratio for the tree. TDG
+    /// grades Go, Java, Ruby, Lua and more; the clone engine tokenizes seven
+    /// languages. On a mixed repo the duplication verdict describes only the
+    /// subset it could read, and a reader who cannot see that subset's size will
+    /// take it for the whole — the same over-claim as #1050 itself, one step
+    /// smaller. `None` when no project walk ran.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cross_file_duplication_coverage: Option<(usize, usize)>,
 }
 
 impl ProjectScore {
@@ -167,6 +196,35 @@ impl ProjectScore {
             files_truncated: false,
             list_filter: None,
             ungraded_files: Vec::new(),
+            // Set by `record_cross_file_duplication` when a PROJECT walk has
+            // actually run the detector. `aggregate` alone cannot know: it is
+            // handed scores, not files.
+            cross_file_duplication_ratio: None,
+            cross_file_duplication_unmeasured: None,
+            cross_file_duplication_coverage: None,
+        }
+    }
+
+    /// Record the project-wide duplication verdict on this score.
+    ///
+    /// Kept separate from `aggregate` because `aggregate` receives per-file
+    /// scores and has no access to the files themselves — and because a caller
+    /// that never ran the detector must not be able to imply that it did.
+    pub(crate) fn record_cross_file_duplication(
+        &mut self,
+        measured: &crate::tdg::cross_file_duplication::CrossFileDuplication,
+    ) {
+        self.cross_file_duplication_ratio = measured.ratio;
+        self.cross_file_duplication_coverage =
+            Some((measured.files_measured, measured.files_total));
+        if let Some(reason) = measured.unmeasured_reason.clone() {
+            self.cross_file_duplication_unmeasured = Some(reason);
+            // GH #704's convention: an unmeasured field is null AND named, so
+            // "could not measure" can never be read as "measured, and fine".
+            let field = "cross_file_duplication_ratio".to_string();
+            if !self.not_measured.contains(&field) {
+                self.not_measured.push(field);
+            }
         }
     }
 

--- a/tests/modules/execution_mode.rs
+++ b/tests/modules/execution_mode.rs
@@ -27,9 +27,31 @@ mod binary_main_tests {
     ///
     /// Taking the value as an argument removes the shared mutable state
     /// entirely, which is strictly better than serialising access to it.
-    fn detect_execution_mode_test(mcp_version: Option<&str>) -> String {
-        let is_mcp =
-            !std::io::stdin().is_terminal() && std::env::args().len() == 1 || mcp_version.is_some();
+    ///
+    /// ALL THREE inputs are parameters, and the third and fourth are why. The
+    /// first version of this fix took only `mcp_version` and still read
+    /// `stdin().is_terminal()` and `args().len()` from the process — so
+    /// `detect_execution_mode_test(None)` returned "Cli" when a test FILTER was
+    /// passed (argv > 1) and "Mcp" when the whole suite ran (argv == 1). It
+    /// passed every filtered run and failed the release dogfood, which runs the
+    /// suite whole.
+    ///
+    /// That is worse than the tautology it replaced. `mode == "Cli" || mode ==
+    /// "Mcp"` could not fail; an assertion that depends on how the harness was
+    /// invoked fails INTERMITTENTLY, which costs more to diagnose than an
+    /// assertion that never fires. The fix for a tautology is to make the
+    /// function decidable, not to assert one arbitrary branch of an ambient
+    /// condition.
+    ///
+    /// The shape mirrors the real `classify_execution_mode` in src/bin/pmat.rs,
+    /// which is already pure for exactly this reason: "so it can be unit-tested
+    /// without touching real stdin / env vars (see GH-285 regression test)".
+    fn detect_execution_mode_test(
+        mcp_version: Option<&str>,
+        no_args: bool,
+        stdin_is_pipe: bool,
+    ) -> String {
+        let is_mcp = stdin_is_pipe && no_args || mcp_version.is_some();
 
         if is_mcp {
             "Mcp".to_string()
@@ -40,7 +62,14 @@ mod binary_main_tests {
 
     #[test]
     fn test_execution_mode_detection_with_mcp_version() {
-        assert_eq!(detect_execution_mode_test(Some("1.0.0")), "Mcp");
+        // The opt-in wins whatever stdin and argv say — all four combinations.
+        for (no_args, piped) in [(true, true), (true, false), (false, true), (false, false)] {
+            assert_eq!(
+                detect_execution_mode_test(Some("1.0.0"), no_args, piped),
+                "Mcp",
+                "MCP_VERSION must win with no_args={no_args} stdin_is_pipe={piped}"
+            );
+        }
     }
 
     /// Without the opt-in, the mode is decided by stdin and argv alone.
@@ -52,7 +81,28 @@ mod binary_main_tests {
     /// filter, so `args().len() == 1` does not hold), which is decidable.
     #[test]
     fn test_execution_mode_detection_without_mcp_version() {
-        assert_eq!(detect_execution_mode_test(None), "Cli");
+        // Without the opt-in the decision is stdin AND argv, so each case is
+        // named rather than one being asserted as if it were the only one.
+        assert_eq!(
+            detect_execution_mode_test(None, true, true),
+            "Mcp",
+            "bare `pmat` with piped stdin is the MCP auto-detect"
+        );
+        assert_eq!(
+            detect_execution_mode_test(None, true, false),
+            "Cli",
+            "bare `pmat` on a terminal is CLI"
+        );
+        assert_eq!(
+            detect_execution_mode_test(None, false, true),
+            "Cli",
+            "a subcommand with piped stdin is CLI — the subcommand wins"
+        );
+        assert_eq!(
+            detect_execution_mode_test(None, false, false),
+            "Cli",
+            "a subcommand on a terminal is CLI"
+        );
     }
 
     #[test]

--- a/tests/modules/execution_mode.rs
+++ b/tests/modules/execution_mode.rs
@@ -4,7 +4,6 @@
 #[cfg(test)]
 mod binary_main_tests {
     use std::env;
-    use std::io::IsTerminal;
 
     /// The execution-mode decision, with MCP_VERSION passed IN rather than read
     /// from the process.


### PR DESCRIPTION
Closes the P1 from the fleet dogfood. Batched with the mode-helper fix and the
banked TDG baseline — two commits, one CI run.

## The defect

`pmat tdg` awarded its duplication component **full marks regardless of actual
duplication**. Two trees, same file count, same size:

| tree | `analyze duplicates` | `tdg` duplication |
|---|---|---|
| 10 byte-identical files | **100.0%** | 20.0 / 20 |
| 10 distinct files | **0.0%** | 20.0 / 20 |

Byte-identical. On real repos it was **anti-correlated** with `analyze
duplicates`.

**Cause:** the per-file scorer takes one tree and one source, so it measures
*within-file* duplication. Ten byte-identical files each have 0% internal
duplication, each scores 20/20, and the mean is 20/20 — full marks for a tree
that is entirely copies. The "absence rendered as success" shape, inside the
grader.

## The fix

`analyze_project` runs the clone engine **once** over the files it actually
graded; each file's component becomes the **worse** of its within-file and
cross-file penalty, so project mode can only ever *lower* a score, never raise
one.

| tree | `analyze duplicates` | before | after |
|---|---|---|---|
| clean10 | 0.0% | 20.0 | **20.0** — untouched |
| cloned20 | 88.2% | 20.0 | **2.472** |
| dup10 | 100.0% | 20.0 | **0.0** |

A clean tree is **bit-identical** before and after. That counter-test matters
more than the headline: a fix that penalised everything would be as wrong as one
that penalised nothing, and far easier to ship by accident.

**Unmeasurable is not clean.** A tree the clone engine cannot tokenize (Go,
Java, Ruby, Lua, SQL, Lean) now reports `measured: false`,
`cross_file_ratio: null` and a written `unmeasured_reason` instead of full marks.

## Two false comments, caught before shipping

Adversarial review found both. They claimed this uses *"the SAME engine `analyze
duplicates` uses, so the two agree by construction."* **They do not agree and
cannot** — that command's headline comes from `find_duplicate_blocks` (hash-
bucketed line blocks over a wider walk); this uses MinHash+LSH over the graded
subset:

```
tree       analyze duplicates      tdg cross_file_ratio
pmat/src   22.025% (4004 files)     7.709% (1569 files)
duende     70.005% (  79 files)    83.579% (  57 files)
```

The comments now carry that table and state what **is** guaranteed: **ordering,
not equality.** A second claim that the language table was "deliberately the
same" as the CLI's was also false — it is a superset (adds `tsx`, `jsx`, `h`,
`hpp`) and now says so. *A wrong reason is worse than no reason.*

## One adversarial check came back VIOLATED — and the check was wrong

It required duende (83.6% duplication) to score worse **in total** than pzsh
(15.4%). TDG's total aggregates seven components and duende is better on the
other six. The **duplication component** is correctly ordered — 18.07 vs 19.03 —
which is the actual requirement. Recorded in the commit so nobody later "fixes"
the aggregate to satisfy an over-specified check.

## Also in this batch

* **`detect_execution_mode_test` was still ambient**, and my previous fix made it
  worse than the tautology it replaced: it returned "Cli" with a test filter and
  "Mcp" without one, so every filtered run passed and the release dogfood failed.
  Now pure in all three inputs, all four cases named. **1,537 pass, 0 fail** on
  the unfiltered target that caught it.
* **`[tdg] baseline` 1904 → 1688.** The tree beat it by 216 — not code anyone
  rewrote, but the closure/comment grader fix landing, plus a **stale index**
  (`built_at` a day old; `pmat query` does not rebuild a stale index, only an
  absent one). A baseline may only go down.

## Verification

19 tests against 9 named mutations, RED-proven. 1,389 tdg tests pass. Ratchets
20387 / 788 / 497 — all at ceiling, this adds zero. Ledger regenerated **last**,
after the final test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012166727hFzq4xzFKFjUJPc