### PR TITLE
fix: one ignore policy for both transports; HTTP in the default build

### DIFF
--- a/.github/workflows/feature-matrix.yml
+++ b/.github/workflows/feature-matrix.yml
@@ -436,7 +436,6 @@ jobs:
               'sovereign-compression':'lib-test delta unmeasured; compile-checked only',
               'syntax-highlighting':  'lib-test delta unmeasured; compile-checked only',
               'org-intelligence':     'lib-test delta unmeasured; compile-checked only',
-              'mcp-http':             'lib-test delta unmeasured; compile-checked only',
               'prometheus-metrics':   'lib-test delta unmeasured; compile-checked only',
               'raft-consensus':       'lib-test delta unmeasured; compile-checked only',
           }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,43 @@ has not changed. Read this list before upgrading a gate.
   exists, and a token walk cannot read a comment or mistake a zero-argument closure for
   an operator, so both defects are gone by construction rather than by patch. The net
   direction across the release is the one stated above, and it is downward.
+- **`cargo install pmat` now compiles the HTTP transport, and the binary is ~1 MB
+  bigger.** `mcp-http` moved into `default`, so the streamable-HTTP MCP server is in
+  every stock build rather than only in one rebuilt with `--features mcp-http`.
+  Measured on two release installs of the same tree: **53,208,360 -> 54,268,424 bytes
+  (+1.01 MiB, +2.0%)**. Six crates enter the graph — `axum 0.8.9`, `axum-core 0.5.6`,
+  `matchit 0.8.4`, `tower-http 0.7.0`, `ring 0.17.14`, `getrandom 0.2.17` — taking it
+  from 380 to 386. hyper, tower and rustls were already present via reqwest; what is
+  new is a SECOND major version of axum alongside the 0.7.9 already there, and rustls'
+  `ring` provider, which compiles C and assembly. A clean release build takes about
+  7 s longer.
+- **Nothing new listens.** Compiling the transport in does not start it. Only
+  `pmat serve --transport http` binds a socket; it binds `127.0.0.1` unless you pass
+  `--host`; and with `PMAT_MCP_HTTP_TOKEN` unset it exits 4 having bound nothing —
+  pmcp serves every request when no auth provider is wired, so "no token" means "no
+  server". `serve --help` no longer reads `[HTTP NOT COMPILED IN this build]`.
+- **`PMAT_MCP_HTTP_TOKEN` is a credential for the whole filesystem, not for one
+  project.** An authenticated caller can read anything the pmat user can read: the
+  tools take absolute paths, and `analyze_satd {"paths":["/etc"]}` returns files'
+  contents from a server started in an unrelated directory. That is how the stdio
+  server has always behaved; what changed is that reaching it no longer requires a
+  rebuild. If you run with `--host 0.0.0.0`, the 403 `Host header not in allowed
+  origins` is a browser DNS-rebinding defence and nothing more — any non-browser
+  client sets that header freely, so the bearer token is the only control on that
+  interface.
+- **The HTTP transport's JSON-RPC error codes are not yet at parity with stdio.** A
+  conforming MCP client is unaffected: `initialize`, `tools/list`, `resources/list`,
+  `prompts/list`, `ping` and the rest all round-trip. But a tool call with bad
+  arguments returns `-32603` over HTTP where stdio returns `-32602` for the identical
+  message, and a frame naming a nonexistent method collapses to `-32700` with
+  `id: null` and HTTP 400 instead of `-32601` with the id echoed.
+- **MCP tools and the CLI now walk the same files.** The MCP path used a raw
+  `WalkDir` that read no `.gitignore` and excluded no vendored or minified assets, so
+  the two surfaces described different populations of the same repository. Measured on
+  a 10-file crate: `analyze complexity` reported 11 files / cyclomatic 54 while
+  `mcp analyze_complexity` reported 27 / 2098, the difference being generated mdbook
+  output including a 137,537-byte minified `highlight.js`. Now 19 / 364. An 8-file
+  gap in `.js` handling remains and is not yet explained.
 - **`pmat quality-gate` exits 1** when it finds blocking violations, where it used to
   print them and exit 0. A CI step that has been passing against a failing tree will
   start failing, which is the point; `--report-only` (alias `--no-fail`) restores the
@@ -765,7 +802,7 @@ lose them to the fix.
 serve HTTP transport not yet implemented` for a *websocket* request, throughout the
 release in which the streamable-HTTP MCP transport shipped (#999 EV-6). The message now
 names the transport that was actually requested and points at the one that works:
-`--transport http`, with `--features mcp-http` and `PMAT_MCP_HTTP_TOKEN`. The
+`--transport http`, with `PMAT_MCP_HTTP_TOKEN` set. The
 subcommand's own `--help` said `[NOT IMPLEMENTED] HTTP/WebSocket server — exits with an
 error`; it now says what is implemented, what is not (`web-socket`, `http-sse`, `both`,
 `all`, all still exit 2), that there is no `stdio` value, and — in builds without the

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,8 @@ authors = ["Pragmatic AI Labs"]
 # transport not yet implemented" and to restore HTTP "when `pmat serve` actually
 # binds" — it binds now (EV-6, #999): `pmat serve --transport http` serves the
 # tool surface over streamable HTTP, verified 401-without-token / 200-with.
-# HTTP is behind the opt-in `mcp-http` feature, so the claim is scoped rather
-# than unconditional.
+# HTTP is in the DEFAULT feature set as of 3.32.0, so all three transports the
+# description names are present in `cargo install pmat` with no flags.
 description = "PMAT - Zero-config AI context generation and code quality toolkit (CLI, MCP, HTTP)"
 homepage = "https://paiml.com"
 repository = "https://github.com/paiml/paiml-mcp-agent-toolkit"
@@ -338,7 +338,19 @@ mcp-http = ["pmcp/streamable-http"]
 # - Opt-in for other languages: --features extended-languages or all-languages
 # - Opt-in for advanced analysis: --features analytics-simd, mutation-testing, demo
 # - Full suite: --features full (equivalent to old defaults)
-default = ["core-languages", "viz", "http-client", "standard-deps"]
+# All THREE transports in the default build: CLI, MCP over stdio, HTTP.
+#
+# `mcp-http` was opt-in, so `cargo install pmat` produced a binary whose
+# `serve --help` said "[HTTP NOT COMPILED IN this build]". The crate
+# description has claimed "(CLI, MCP, HTTP)" throughout, and two of the three
+# were true by default. A user reading the description and running the install
+# command got a binary that could not do the third.
+#
+# The cost is build time and dependency surface (`pmcp/streamable-http` pulls
+# the hyper/tower stack). That is the right trade for a transport the package
+# advertises on its front page: a feature nobody can reach without knowing a
+# flag name is close to a feature that does not ship.
+default = ["core-languages", "viz", "http-client", "standard-deps", "mcp-http"]
 
 # Standard deps bundle — feature-gated for dep count reduction but enabled by default
 standard-deps = [

--- a/docs/status/unrun-tests-ledger.md
+++ b/docs/status/unrun-tests-ledger.md
@@ -14,7 +14,7 @@ Legs consulted (3):
 - `feature-matrix.yml:feature-tests[mcp-integration]`
 - `feature-matrix.yml:feature-tests[unified-protocol]`
 
-23103 of 26224 lib tests are executed; 3121 are compiled by no leg.
+23105 of 26226 lib tests are executed; 3121 are compiled by no leg.
 
 ## `<unsatisfiable>` — 18 test(s)
 
@@ -3148,12 +3148,6 @@ crate::services::languages::kotlin::tests::test_kotlin_interface_analysis
 crate::services::languages::kotlin::tests::test_kotlin_package_name_extraction
 crate::services::languages::kotlin::tests::test_simple_kotlin_class_analysis
 
-## `mcp-http` — 1 test(s)
-
-EV-6 (#999) streamable HTTP; orphan-ledger has it 'compile-checked only'. The one test behind it is an end-to-end auth check.
-
-crate::mcp_pmcp::http_server::http_e2e_tests::unauthenticated_request_is_401_and_a_valid_token_is_not
-
 ## `mcp-integration,mutation-testing` — 21 test(s)
 
 a COMBINATION no leg supplies, and the reason a per-feature ledger would have missed these: `full` enables `mutation-testing`, the `mcp-integration` leg enables the other, and each feature therefore looks covered while these 21 tests compile in neither.
@@ -3223,6 +3217,12 @@ crate::services::semantic::chunker::tests::coverage_tests::test_c_feature_disabl
 needs `cpp-ast` OFF; in `core-languages`, so ON in every leg.
 
 crate::services::semantic::chunker::tests::coverage_tests::test_cpp_feature_disabled
+
+## `not(mcp-http)` — 1 test(s)
+
+the HTTP-ABSENT branch. `mcp-http` entered `default` in 3.32.0, so every leg now compiles it in and nothing exercises the code that runs when it is out — chiefly the `serve` refusal that used to print '[HTTP NOT COMPILED IN this build]'. That path still ships for anyone building `--no-default-features`, and it is now untested by every CI leg. Recorded rather than deleted: the branch is reachable by a real build configuration, so removing the tests would hide it instead of covering it.
+
+crate::cli::commands::commands_enum::command_availability_tests::serve_help_ties_the_feature_error_to_the_token_being_set
 
 ## `not(python-ast)` — 1 test(s)
 

--- a/src/cli/commands/commands_enum/definition.rs
+++ b/src/cli/commands/commands_enum/definition.rs
@@ -905,9 +905,14 @@ pub enum Commands {
     /// Serve the MCP tool surface over streamable HTTP (`--transport http`)
     ///
     /// `--transport http` is IMPLEMENTED and round-trips MCP over HTTP: it
-    /// serves the same tools as the stdio server, is compiled in only with
-    /// `--features mcp-http`, and refuses to start without a bearer token in
-    /// `PMAT_MCP_HTTP_TOKEN` (unauthenticated requests get 401).
+    /// serves the same tools as the stdio server, is in the DEFAULT build as of
+    /// 3.32.0 (it needed `--features mcp-http` before), and refuses to start
+    /// without a bearer token in `PMAT_MCP_HTTP_TOKEN` — pmcp serves every
+    /// request when no auth provider is wired, so "no token" must mean "no
+    /// server". Unauthenticated requests get 401.
+    ///
+    /// It binds `127.0.0.1` unless you pass `--host`. Compiling the transport in
+    /// does not start it: only this subcommand binds a socket.
     ///
     /// The other `--transport` values — `web-socket`, `http-sse`, `both`,
     /// `all` — are NOT IMPLEMENTED and exit 2.

--- a/src/services/path_glob.rs
+++ b/src/services/path_glob.rs
@@ -118,8 +118,6 @@ pub fn resolve_paths_with_globs(paths: &[PathBuf]) -> Vec<PathBuf> {
 /// R22-2 (D102): Live `handlers/tools` dispatcher now shares this helper.
 #[must_use]
 pub fn expand_paths_to_source_files(paths: &[PathBuf]) -> Vec<PathBuf> {
-    use walkdir::WalkDir;
-
     let resolved = resolve_paths_with_globs(paths);
     let mut out = Vec::new();
     for path in &resolved {
@@ -131,25 +129,49 @@ pub fn expand_paths_to_source_files(paths: &[PathBuf]) -> Vec<PathBuf> {
             continue;
         }
         if path.is_dir() {
-            for entry in WalkDir::new(path)
-                .follow_links(false)
-                .into_iter()
-                .filter_entry(|e| {
-                    // Always accept the root, filter only descendant dirs/files.
-                    if e.depth() == 0 {
-                        return true;
-                    }
-                    let n = e.file_name().to_string_lossy();
-                    !(n.starts_with('.') || n == "target" || n == "node_modules")
-                })
-                .filter_map(std::result::Result::ok)
-                .filter(|e| e.file_type().is_file())
+            // ONE ignore policy, ONE implementation.
+            //
+            // This was a raw `WalkDir` filtering only hidden entries, `target`
+            // and `node_modules`. It never read .gitignore/.ignore/.pmatignore
+            // and never excluded minified or vendored assets, so the MCP tools
+            // that reach files through here analysed a different population
+            // than the CLI did for the same directory — and the two surfaces
+            // then disagreed about the same repository.
+            //
+            // Measured on ~/src/cohete (10 .rs files) before this change:
+            //
+            // ```text
+            //   pmat analyze complexity   ->  11 files, total cyclomatic    54
+            //   mcp analyze_complexity    ->  27 files, total cyclomatic  2098
+            // ```
+            //
+            // The extra 16 were generated mdbook output — `book/book/*.js` and
+            // `book/out/*.js`, including a 137,537-byte `highlight.js` across
+            // 53 lines. Minified vendor code has enormous branch counts, which
+            // is where a 39x complexity gap comes from. They are untracked but
+            // NOT gitignored, so this is the vendor/minified exclusion doing
+            // the work, not .gitignore alone.
+            //
+            // `project_files`'s doc comment already records four analyzers that
+            // hand-rolled this same walk (`cuda-tdg`, `validate-docs`,
+            // `analyze assembly-script`, `analyze web-assembly`), each of which
+            // descended into gitignored trees. This was the fifth, and the one
+            // that made two TRANSPORTS disagree rather than two commands.
+            //
+            // A directory now goes through the discovery the CLI uses. An
+            // explicitly named FILE is still passed straight through above:
+            // asking for a specific file is an instruction, not a search, and
+            // the caller may legitimately name something the walk would skip.
+            match crate::services::file_discovery::ProjectFileDiscovery::new(path.clone())
+                .discover_files()
             {
-                if let Some(ext) = entry.path().extension().and_then(|e| e.to_str()) {
-                    if SOURCE_EXTENSIONS.contains(&ext) {
-                        out.push(entry.path().to_path_buf());
-                    }
-                }
+                Ok(found) => out.extend(found),
+                // Discovery failing is not a licence to fall back to a walk
+                // with a different policy — that would reintroduce the split
+                // silently and only under error conditions, which is the worst
+                // place for it to live. Yield nothing for this root; the caller
+                // sees an empty population rather than a wrong one.
+                Err(_) => {}
             }
         }
     }
@@ -274,6 +296,78 @@ fn longest_common_parent(paths: &[PathBuf]) -> Option<PathBuf> {
             out.push(c);
         }
         Some(out)
+    }
+}
+
+#[cfg(test)]
+mod parity_tests {
+    use super::*;
+
+    /// A directory walk must honour the project's ignore policy, so the MCP
+    /// tools and the CLI describe the same population.
+    ///
+    /// RED: restore the raw `WalkDir` (hidden / `target` / `node_modules` only)
+    /// and this fails — the minified file is admitted.
+    ///
+    /// The live case, measured on ~/src/cohete (10 .rs files):
+    ///
+    /// ```text
+    ///   pmat analyze complexity   ->  11 files, total cyclomatic    54
+    ///   mcp analyze_complexity    ->  27 files, total cyclomatic  2098
+    /// ```
+    ///
+    /// The extra files were generated mdbook output — `book/book/*.js`,
+    /// `book/out/*.js` — including a 137,537-byte `highlight.js` across 53
+    /// lines. Minified vendor code carries enormous branch counts, which is
+    /// where a 39x complexity gap comes from. After the fix: 19 files, 364.
+    #[test]
+    fn a_directory_walk_excludes_what_the_cli_excludes() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let root = dir.path();
+        std::fs::create_dir_all(root.join("src")).expect("mkdir src");
+        std::fs::create_dir_all(root.join("book/out")).expect("mkdir book");
+        std::fs::write(root.join("src/lib.rs"), "pub fn f() -> i32 { 1 }\n").expect("lib.rs");
+
+        // A minified vendor asset: one very long line, the shape that carries a
+        // huge branch count and no meaning for a quality report.
+        let minified = format!("var a={};{}", 1, "if(a){a++}else{a--};".repeat(2000));
+        std::fs::write(root.join("book/out/highlight.js"), &minified).expect("highlight.js");
+
+        let found = expand_paths_to_source_files(&[root.to_path_buf()]);
+        let names: Vec<String> = found
+            .iter()
+            .map(|p| p.strip_prefix(root).unwrap_or(p).display().to_string())
+            .collect();
+
+        assert!(
+            names.iter().any(|n| n.ends_with("lib.rs")),
+            "the real source file must still be found, got {names:?}"
+        );
+        assert!(
+            !names.iter().any(|n| n.contains("highlight.js")),
+            "a minified vendor asset under book/ must not be analysed as source \
+             — this is what made MCP report 27 files where the CLI reported 11. \
+             got {names:?}"
+        );
+    }
+
+    /// ...and an explicitly NAMED file is still passed straight through.
+    ///
+    /// The counter-test. Without it, "exclude everything" satisfies the
+    /// assertion above. Naming a file is an instruction, not a search: a caller
+    /// may legitimately ask about something a directory walk would skip.
+    #[test]
+    fn an_explicitly_named_file_is_never_filtered_out() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let odd = dir.path().join("vendor.min.js");
+        std::fs::write(&odd, "var a=1;\n").expect("write");
+
+        let found = expand_paths_to_source_files(&[odd.clone()]);
+        assert_eq!(
+            found,
+            vec![odd],
+            "a path named explicitly is an instruction, not a search"
+        );
     }
 }
 

--- a/src/services/path_glob.rs
+++ b/src/services/path_glob.rs
@@ -362,7 +362,7 @@ mod parity_tests {
         let odd = dir.path().join("vendor.min.js");
         std::fs::write(&odd, "var a=1;\n").expect("write");
 
-        let found = expand_paths_to_source_files(&[odd.clone()]);
+        let found = expand_paths_to_source_files(std::slice::from_ref(&odd));
         assert_eq!(
             found,
             vec![odd],

--- a/src/services/path_glob.rs
+++ b/src/services/path_glob.rs
@@ -165,7 +165,20 @@ pub fn expand_paths_to_source_files(paths: &[PathBuf]) -> Vec<PathBuf> {
             match crate::services::file_discovery::ProjectFileDiscovery::new(path.clone())
                 .discover_files()
             {
-                Ok(found) => out.extend(found),
+                // The extension whitelist STILL applies. Discovery decides which
+                // files the project admits; `SOURCE_EXTENSIONS` decides which of
+                // those this function is about. Dropping the second filter when
+                // the first was introduced widened the population by everything
+                // discovery admits and this list does not — `Cargo.toml` first
+                // among them — and the MCP satd payload duly reported 15 declined
+                // files where the CLI reported 14, one extra under
+                // `examples_demo_fuzz_generated`. Two filters, two questions;
+                // replacing one with the other is not the same as composing them.
+                Ok(found) => out.extend(found.into_iter().filter(|f| {
+                    f.extension()
+                        .and_then(|e| e.to_str())
+                        .is_some_and(|ext| SOURCE_EXTENSIONS.contains(&ext))
+                })),
                 // Discovery failing is not a licence to fall back to a walk
                 // with a different policy — that would reintroduce the split
                 // silently and only under error conditions, which is the worst

--- a/src/services/unrun_tests/reasons.rs
+++ b/src/services/unrun_tests/reasons.rs
@@ -118,9 +118,15 @@ pub const REASONS: &[(&str, &str)] = &[
          This ledger measures the delta: 32 tests.",
     ),
     (
-        "mcp-http",
-        "EV-6 (#999) streamable HTTP; orphan-ledger has it 'compile-checked \
-         only'. The one test behind it is an end-to-end auth check.",
+        "not(mcp-http)",
+        "the HTTP-ABSENT branch. `mcp-http` entered `default` in 3.32.0, so \
+         every leg now compiles it in and nothing exercises the code that runs \
+         when it is out — chiefly the `serve` refusal that used to print \
+         '[HTTP NOT COMPILED IN this build]'. That path still ships for anyone \
+         building `--no-default-features`, and it is now untested by every CI \
+         leg. Recorded rather than deleted: the branch is reachable by a real \
+         build configuration, so removing the tests would hide it instead of \
+         covering it.",
     ),
     (
         "mcp-integration,mutation-testing",


### PR DESCRIPTION
## 1. MCP and the CLI analysed different files

`expand_paths_to_source_files` — the path every MCP tool reaches files through —
was a raw `WalkDir` filtering only hidden entries, `target` and `node_modules`.
It never read `.gitignore` and never excluded minified or vendored assets. The
CLI uses `ProjectFileDiscovery`. **Same repo, two populations, two answers.**

Measured on `~/src/cohete`, which has 10 `.rs` files:

| | files | total cyclomatic |
|---|---|---|
| `pmat analyze complexity` | 11 | 54 |
| `mcp analyze_complexity` **before** | 27 | **2098** |
| `mcp analyze_complexity` **after** | 19 | **364** |

The extra files were generated mdbook output — `book/book/*.js`,
`book/out/*.js` — including a **137,537-byte `highlight.js` across 53 lines**.
Minified vendor code carries enormous branch counts; that is where a 39× gap
comes from. They are untracked but *not* gitignored, so the vendor/minified
exclusion is doing the work here, not `.gitignore` alone.

**This is the fifth instance of a documented class.** `project_files`' own doc
comment names four analyzers that hand-rolled this same walk and concludes *"One
ignore policy, one implementation."* This was the only one that made two
**transports** disagree rather than two commands — and the comment directly above
the MCP complexity tool records fixing a *previous* instance of the class: they
unified the **analyzer** and left the **discovery** split.

An explicitly named **file** still passes straight through — naming a file is an
instruction, not a search. That is the counter-test; without it "exclude
everything" would satisfy the first assertion.

> **Not fully closed.** An 8-file gap remains in `.js` handling: the CLI excludes
> all 16 JS files in that tree, MCP admits 8. The 39× complexity error is fixed
> and RED-proven; the residual difference is narrowed, shown **not** to be the
> minified-asset cause, and not yet explained.

## 2. All three transports in the default build

`mcp-http` was opt-in, so `cargo install pmat` produced a binary whose
`serve --help` read `[HTTP NOT COMPILED IN this build]` — while the crate
description says *"(CLI, MCP, HTTP)"*. Two of three were true by default.

A transport nobody can reach without knowing a flag name is close to one that
does not ship, and it cannot be dogfooded by anyone who has not been told the
flag. Cost is build time and dependency surface (`pmcp/streamable-http` pulls
hyper/tower) — the right trade for a transport advertised on the front page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012166727hFzq4xzFKFjUJPc