### PR TITLE
fix: CB-200 refused two new below-A definitions, so they are fixed not banked

### DIFF
--- a/src/tdg/cross_file_duplication.rs
+++ b/src/tdg/cross_file_duplication.rs
@@ -58,6 +58,7 @@
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
+use crate::services::duplicate_detector::types::CloneReport;
 use crate::services::duplicate_detector::{
     DuplicateDetectionConfig, DuplicateDetectionEngine, Language as CloneLanguage,
 };
@@ -129,17 +130,43 @@ impl CrossFileDuplication {
 /// TDG grades more languages than the clone engine tokenizes (Go, Java, Ruby,
 /// Lua, SQL, Lean, …); those files are counted as UNMEASURED rather than as
 /// clean, which is the whole point of #1050.
+/// The extension table, as DATA rather than control flow.
+///
+/// This was a `match` with eight arms. It is the same mapping either way, and a
+/// table is the honest shape for a lookup: adding a language is a row, not a
+/// branch, and the reader sees the whole mapping as one object.
+///
+/// It also stops the incumbent complexity scanner charging this function 10 for
+/// being a dictionary. That scanner counts every `=>` as a decision point, which
+/// is the miscalibration `crate::services::ttg` exists to replace — TTG scores a
+/// `match` 1 for the DISPATCH, on McCabe's own CASE caveat, and takes
+/// `classify_command` from 73 to 1 on exactly this shape. TTG is not wired to
+/// the production grader yet, so the old charge still applies here and CB-200's
+/// ratchet refused the new debt. Restructuring a dictionary into a dictionary is
+/// a fair answer to that; raising the baseline would not have been.
+const CLONE_LANGUAGES: &[(&str, CloneLanguage)] = &[
+    ("rs", CloneLanguage::Rust),
+    ("ts", CloneLanguage::TypeScript),
+    ("tsx", CloneLanguage::TypeScript),
+    ("js", CloneLanguage::JavaScript),
+    ("jsx", CloneLanguage::JavaScript),
+    ("py", CloneLanguage::Python),
+    ("c", CloneLanguage::C),
+    ("h", CloneLanguage::C),
+    ("cpp", CloneLanguage::Cpp),
+    ("cc", CloneLanguage::Cpp),
+    ("cxx", CloneLanguage::Cpp),
+    ("hpp", CloneLanguage::Cpp),
+    ("kt", CloneLanguage::Kotlin),
+    ("kts", CloneLanguage::Kotlin),
+];
+
 fn clone_language(path: &Path) -> Option<CloneLanguage> {
-    match path.extension().and_then(|e| e.to_str()) {
-        Some("rs") => Some(CloneLanguage::Rust),
-        Some("ts" | "tsx") => Some(CloneLanguage::TypeScript),
-        Some("js" | "jsx") => Some(CloneLanguage::JavaScript),
-        Some("py") => Some(CloneLanguage::Python),
-        Some("c" | "h") => Some(CloneLanguage::C),
-        Some("cpp" | "cc" | "cxx" | "hpp") => Some(CloneLanguage::Cpp),
-        Some("kt" | "kts") => Some(CloneLanguage::Kotlin),
-        _ => None,
-    }
+    let ext = path.extension().and_then(|e| e.to_str())?;
+    CLONE_LANGUAGES
+        .iter()
+        .find(|(name, _)| *name == ext)
+        .map(|(_, language)| *language)
 }
 
 /// Lines that carry code, by the SAME rule the per-file scorer
@@ -158,19 +185,85 @@ fn code_line_count(source: &str) -> usize {
 ///
 /// `files` is the gradable population the project score is computed over, so
 /// the duplication verdict covers exactly the files the score claims to cover.
+/// The subset of `files` the clone engine can actually read: a known extension
+/// AND readable bytes.
+///
+/// Split out of `measure` because they are two questions — WHICH FILES can be
+/// measured, and WHAT do they say — and answering them in one function put the
+/// two `let ... else` skips and the emptiness test on the same control-flow
+/// budget as the detection and the aggregation.
+///
+/// The two skips are silent by design, and that is safe HERE only because the
+/// caller reports the denominator: `measure` returns `files_measured` alongside
+/// `files_total`, so a file dropped here shows up as coverage that is less than
+/// 1, not as a clean result. A silent skip with no denominator is the defect
+/// this whole module was written to fix.
+fn readable_sources(files: &[PathBuf]) -> Vec<(PathBuf, String, CloneLanguage)> {
+    files
+        .iter()
+        .filter_map(|path| {
+            let language = clone_language(path)?;
+            let source = std::fs::read_to_string(path).ok()?;
+            Some((path.clone(), source, language))
+        })
+        .collect()
+}
+
+/// Duplicated-line ratio per file, from a whole-project clone report.
+///
+/// Split out of `measure` for the same reason `readable_sources` was: turning a
+/// clone report into per-file ratios is its own question, and inlining it put a
+/// nested walk and a division guard on the same control-flow budget as the
+/// detection.
+///
+/// Distinct duplicated LINE NUMBERS per file — a SET, not a sum. A line covered
+/// by two overlapping clone groups is one duplicated line, and summing instance
+/// lengths (which is what `compute_hotspots` does for its severity ranking) can
+/// report more duplicated lines than the file has.
+fn per_file_ratios(
+    report: &CloneReport,
+    sources: &[(PathBuf, String, CloneLanguage)],
+) -> HashMap<PathBuf, f64> {
+    let mut duplicated_lines: HashMap<&Path, HashSet<usize>> = HashMap::new();
+    for group in &report.groups {
+        for instance in &group.fragments {
+            let lines = duplicated_lines.entry(instance.file.as_path()).or_default();
+            lines.extend(instance.start_line..=instance.end_line);
+        }
+    }
+
+    sources
+        .iter()
+        .filter_map(|(path, source, _)| {
+            // A file of nothing but comments has no denominator; it is not
+            // 0% duplicated, it is unmeasurable, so it is absent from the map
+            // rather than present as a zero.
+            let code_lines = code_line_count(source);
+            if code_lines == 0 {
+                return None;
+            }
+            let duplicated = duplicated_lines.get(path.as_path()).map_or(0, HashSet::len);
+            // `u32::try_from` then `f64::from`: both conversions are checked or
+            // lossless, so no lint needs silencing. The ratchet counting allow
+            // attributes sits exactly on its ceiling, and one is a worse way to
+            // pay for a cast than simply not making a lossy one.
+            let ratio = match (u32::try_from(duplicated), u32::try_from(code_lines)) {
+                (Ok(dup), Ok(total)) if total > 0 => {
+                    (f64::from(dup) / f64::from(total)).clamp(0.0, 1.0)
+                }
+                // A file with more than u32::MAX lines is not a file we can
+                // report a meaningful ratio for; absent beats wrong.
+                _ => return None,
+            };
+            Some((path.clone(), ratio))
+        })
+        .collect()
+}
+
 pub(crate) fn measure(files: &[PathBuf]) -> CrossFileDuplication {
     let files_total = files.len();
 
-    let mut sources: Vec<(PathBuf, String, CloneLanguage)> = Vec::new();
-    for path in files {
-        let Some(language) = clone_language(path) else {
-            continue;
-        };
-        let Ok(source) = std::fs::read_to_string(path) else {
-            continue;
-        };
-        sources.push((path.clone(), source, language));
-    }
+    let sources = readable_sources(files);
 
     if sources.is_empty() {
         return CrossFileDuplication::unmeasured(
@@ -193,30 +286,7 @@ pub(crate) fn measure(files: &[PathBuf]) -> CrossFileDuplication {
         }
     };
 
-    // Distinct duplicated LINE NUMBERS per file. A set, not a sum: a line
-    // covered by two overlapping clone groups is one duplicated line, and
-    // summing instance lengths (which is what `compute_hotspots` does for its
-    // severity ranking) can report more duplicated lines than the file has.
-    let mut duplicated_lines: HashMap<&Path, HashSet<usize>> = HashMap::new();
-    for group in &report.groups {
-        for instance in &group.fragments {
-            let lines = duplicated_lines.entry(instance.file.as_path()).or_default();
-            for line in instance.start_line..=instance.end_line {
-                lines.insert(line);
-            }
-        }
-    }
-
-    let mut per_file = HashMap::with_capacity(sources.len());
-    for (path, source, _) in &sources {
-        let code_lines = code_line_count(source);
-        if code_lines == 0 {
-            continue;
-        }
-        let duplicated = duplicated_lines.get(path.as_path()).map_or(0, HashSet::len);
-        let ratio = (duplicated as f64 / code_lines as f64).clamp(0.0, 1.0);
-        per_file.insert(path.clone(), ratio);
-    }
+    let per_file = per_file_ratios(&report, &sources);
 
     CrossFileDuplication {
         ratio: Some(report.summary.duplication_ratio.clamp(0.0, 1.0)),


### PR DESCRIPTION
The ratchet worked on its author.

Rebuilding the index against master and re-deriving the baseline:

```
CB-200 REGRESSED: 1690 definitions below grade A, recorded baseline 1688.
2 new one(s) since the baseline was taken. Fix them, or revert what added them.
Raising `[tdg] baseline` is not the fix.
```

Both were mine, from the cross-file duplication work in #1051. **Fixed rather
than banked.**

## `clone_language` — A-, cc 10

An eight-arm `match` from extension to language. The incumbent scanner charges
+1 per `=>`, so a dictionary scored 10. Now a `const` table: adding a language is
a row, not a branch.

Worth naming plainly — **this is the exact miscalibration `services::ttg` exists
to replace.** TTG scores a `match` 1 for the *dispatch* (McCabe's own CASE
caveat) and takes `classify_command` from cc 73 to **D 1** on this very shape.
TTG isn't wired to the production grader yet, so the old charge still applies. A
dictionary rewritten as a dictionary is a fair answer; raising the baseline would
not have been, and neither would waiting for TTG.

## `measure` — A-, cc 10

Two extractions, each its own question:

* **`readable_sources`** — *which* files can be measured. Its two skips are
  silent by design, and that is safe only because the caller reports the
  denominator (`files_measured` beside `files_total`), so a dropped file shows as
  coverage below 1, never as a clean result.
* **`per_file_ratios`** — *what* they say.

A file of nothing but comments is now **absent** from the ratio map rather than
present as a zero: no denominator means unmeasurable, not 0% duplicated.

## Three self-inflicted traps, all the same shape

The `clamp` needed a cast, and the obvious fix was an allow attribute — which
would have pushed that ratchet 497 → 498. Replaced with `u32::try_from` then
`f64::from`: both checked or lossless, so nothing needs silencing.

The count then **still** read 498, because the comment explaining the decision
contained the literal token the ratchet greps for. That is the **third time this
cycle** a literal-string ratchet has counted my own prose as code (after
`panic!(` twice). The metric is a `git grep -oF`; it cannot tell code from a
comment — exactly like the complexity scanner this release fixed, for the same
reason.

## Verification

baseline / ledger / ratchet tests pass · 16 cross-file duplication tests pass ·
`clippy --all-targets --locked -- -D warnings` exits 0 · ratchets
**20387 / 788 / 497**, all at ceiling, this adds zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012166727hFzq4xzFKFjUJPc