### PR TITLE
fix: vendor the whole release protocol, and declare the gates pmat owns

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -327,6 +327,25 @@ serde_json = "1.0"
 sha2 = { version = "0.11", optional = true }  # For O(1) build artifact hash caching
 # capnpc = "0.20" # REMOVED: Unused Cap'n Proto compiler
 
+# ── Release gates this crate OWNS ───────────────────────────────────────────
+#
+# Read by scripts/dogfood/pmat-dogfood_gates.py, the ONE parser of this table.
+# Each entry gets its own row in the release receipt: rolling them into one
+# aggregate verdict is how a red gate hides behind a green neighbour.
+#
+# An ABSENT table and `gates = []` are both FAIL, deliberately. A crate claiming
+# zero release gates of its own has made a claim, and an unmade claim reads
+# exactly like a satisfied one.
+#
+# These two are the wiring for SKILL.md §11 and §12, which the 2026-08-23 project
+# audit found DOCUMENTED BUT UNRUN — this repo's signature defect, sitting in its
+# own release protocol.
+[package.metadata.dogfood]
+gates = [
+    "scripts/dogfood/pmat-gate-fleet.sh",
+    "scripts/dogfood/pmat-gate-transport-parity.sh",
+]
+
 [features]
 # EV-6 (#999): serve the MCP tool surface over streamable HTTP, for clients that
 # cannot use stdio (the Google Antigravity Agent registers `{"type":"mcp_server",

--- a/Makefile
+++ b/Makefile
@@ -132,9 +132,9 @@ test-lib: ## Run all lib tests (8MB stack for Clap tests)
 
 dogfood-install: ## Symlink the vendored dogfood protocol into the skills dir (idempotent)
 	@mkdir -p $(HOME)/.claude/skills/dogfood
-	@for f in pmat-dogfood-runner pmat-fleet-dogfood pmat-transport-parity; do \
-	  ln -sfn "$(CURDIR)/scripts/dogfood/$$f.sh" \
-	          "$(HOME)/.claude/skills/dogfood/$$f.sh"; \
+	@for f in $(notdir $(wildcard $(CURDIR)/scripts/dogfood/pmat-*)); do \
+	  ln -sfn "$(CURDIR)/scripts/dogfood/$$f" \
+	          "$(HOME)/.claude/skills/dogfood/$$f"; \
 	done
 	@echo "linked (idempotent — re-running changes nothing):"
 	@ls -l $(HOME)/.claude/skills/dogfood/pmat-*.sh | sed 's/^/  /'

--- a/scripts/dogfood/pmat-check_verifier_pinning.sh
+++ b/scripts/dogfood/pmat-check_verifier_pinning.sh
@@ -1,0 +1,1267 @@
+#!/usr/bin/env bash
+# check_verifier_pinning.sh — the verifier-pinning rule, ENFORCED.
+#
+# THE RULE IS NOT RESTATED HERE. It is stated once, in scripts/verifier_pin.sh,
+# under the heading "THE RULE" — read it there. A rule written down twice is two
+# rules that can disagree, which is the thesis of the ticket this gate closes
+# (#2640): one protocol, two copies, nine silent divergences. This file is the
+# rule's ENFORCEMENT, not a second copy of its text.
+#
+# WHY A GATE AND NOT A PARAGRAPH
+# ------------------------------
+# The rule already had FIVE independent ad-hoc rediscoveries before anyone
+# noticed it was one rule (PMAT_BIN, scripts/pv_bin.sh, scripts/apr_bin.sh,
+# aprender#2384, APR-BENCH-RFC-001). Five is the evidence that a rule merely
+# stated is documentation. #2640 merged the two dogfood runners into one; this
+# is what stops the sixth tool re-discovering the rule in a sixth copy.
+#
+# FOUR PARTS, because presence is not behaviour and definition is not use:
+#
+#   PART 1  (static)      no bare pv/pmat/apr in command position — and no PATH
+#                         PROBE of one — anywhere the release verdict is
+#                         decided. Mutation: reintroduce a bare `pmat` call.
+#   PART 1b (call site)   the pins are CALLED by the runner, before the first
+#                         use of their result, and the runner never assigns
+#                         PMAT_BIN/PV itself. Mutation: replace the
+#                         `verifier_pin_pmat` call with `PMAT_BIN=pmat`.
+#                         PART 1 alone passes on that mutation — a bare-token
+#                         scan cannot tell a DEFINED pin from a USED one, and
+#                         `PMAT_BIN=pmat` is a legal assignment everywhere the
+#                         scanner looks. That gap shipped once; this is its row.
+#   PART 2  (behavioural) the two pins are EXERCISED and must select something
+#                         other than what PATH offers, and exercising them must
+#                         leave Cargo.lock alone. Mutations: delete the
+#                         PMAT_BIN self-referential branch; bypass pv_bin.sh to
+#                         a PATH pv; delete a `[[package]]` block from
+#                         Cargo.lock, whereupon the pv build repairs it in
+#                         passing and the lockfile row must go RED with the file
+#                         restored. That last one is why this guard now runs
+#                         AFTER scripts/check_lockfile_current.sh in ci.yml: it
+#                         cargo-builds pv without --locked, so placed first it
+#                         quietly repaired the very staleness its neighbour
+#                         exists to find.
+#   PART 3  (fleet path)  the runner still RUNS when invoked the way its own
+#                         Usage line documents — by a relative path, against
+#                         another repo. #2640 made the pin library load-bearing
+#                         and fail-closed while SKILL_DIR was still resolved
+#                         after `cd "$REPO_DIR"`, so `bash scripts/dogfood.sh
+#                         ../other-crate` exited 2 before any gate ran.
+#
+# THE UNIVERSE, and why it is these three tokens
+# ----------------------------------------------
+# VERIFIERS = pv, pmat, apr — exactly the tools for which THIS REPO ships a pin
+# (scripts/pv_bin.sh, verifier_pin_pmat, scripts/apr_bin.sh). bashrs and
+# probador are verifiers too and are NOT listed: no pin exists for them, and the
+# rule's second clause is "where the repo does not pin, report" — which the
+# runner does. Adding them here would demand a pin that does not exist and make
+# the gate unfixable. The day one ships, add the token here.
+#
+# THE SCANNED SURFACE, and why it is not two files
+# ------------------------------------------------
+# The runner DISCOVERS gates from `[package.metadata.dogfood] gates` and
+# executes each one with `bash "$dg_path"` INSIDE the release verdict. A
+# declared gate that resolves a verifier through PATH decides the release with
+# an unknown binary exactly as directly as the runner would. So the scope is the
+# runner, the pin library, AND every declared gate — derived from the manifest,
+# never hardcoded, because a hardcoded list is the same defect one level down.
+#
+# What counts as an invocation: the token in COMMAND POSITION after comments and
+# INERT text are removed. Three things are NOT inert and each has cost a real
+# false negative:
+#   · `$( … )` and `` ` … ` `` are COMMAND POSITION even inside double quotes.
+#     `"pmat $(pmat --version)"` was live in the runner, on the line that writes
+#     which pmat ran into the receipt, and the scanner reported the file clean.
+#   · a PATH PROBE (`command -v pmat`, `type -aP pv`) does not run the tool but
+#     DECIDES whether a gate runs at all, against PATH rather than the pin. The
+#     runner gated its whole pmat section on `command -v pmat`, so releasing
+#     pmat itself with no pmat on PATH would have skipped every pmat gate while
+#     the pin sat resolved and unused.
+#   · a verifier NAME in a `for … in` word list is a call site whose command
+#     word is a variable. `for t in bashrs pmat probador; do command -v "$t"`
+#     is a PATH probe of pmat that no command-position scan can see.
+# A bare mention in a comment, in a single-quoted string, or in a DATA heredoc
+# is NOT an invocation — the runner's own prose says "`pv lint <DIR>` is a real
+# gate", and both must stay legal. The distinction is the whole difficulty, so
+# it ships a case table (--self-test) rather than a reviewed regex: the
+# apr-invocation patterns in this repo were wrong FIVE times and every one was
+# caught by a table, none by review.
+#
+#   bash scripts/check_verifier_pinning.sh              # check
+#   bash scripts/check_verifier_pinning.sh --self-test  # the case table only
+#   bash scripts/check_verifier_pinning.sh --scan FILE… # the raw scanner
+#
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# The two files that ARE the protocol. Every other in-scope file is derived from
+# the manifest below, in resolve_scope().
+CORE_SCOPE="scripts/dogfood.sh scripts/verifier_pin.sh"
+
+# ---------------------------------------------------------------------------
+# The scanner. Reports "<file>:<line>: <token> [<kind>]" per finding.
+#
+# It tokenises rather than regexing the raw line, because a regex over raw text
+# gets `pmat-verify` wrong: \bpmat\b MATCHES inside `pmat-verify`, since `-` is a
+# non-word character. Token equality does not. Inert spans collapse to a single
+# @Q placeholder rather than being deleted, so the ARITY of wrappers such as
+# `run_to <log> <cmd...>` is preserved and `run_to "$LOG" pmat query` is still
+# seen as pmat in command position. Command substitutions are LIFTED out of the
+# line and scanned as lines of their own, which preserves that arity while still
+# reaching the code inside them.
+scan() {
+    python3 - "$@" <<'PY'
+import re, sys
+
+VERIFIERS = {"pv", "pmat", "apr"}
+
+# Control words and operators: after one of these, the next word is a command.
+SEPARATORS = {";", ";;", "&&", "||", "|", "|&", "(", ")", "{", "}", "&", "!",
+              "if", "then", "else", "elif", "fi", "while", "until", "do",
+              "done", "case", "esac", "$("}
+
+# Wrappers that RUN their remaining arguments. After one of these the command
+# position moves along, past the wrapper's own options. `command` is here
+# because it was missing and `command pmat verify` was therefore invisible;
+# `nice`/`ionice`/`stdbuf` are here because a prefix that takes its own option
+# (`nice -n 5 pmat`) is the shape that hid it.
+PREFIX = {"env", "exec", "nohup", "time", "sudo", "doas", "xargs", "command",
+          "builtin", "nice", "ionice", "stdbuf", "setsid", "timeout", "chrt"}
+
+# Probes: they ask PATH where a tool is. They do not run it, and they still
+# decide whether a gate runs.
+PROBES = {"type", "hash", "which", "whereis"}
+
+ASSIGN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+DURATION = re.compile(r"^[0-9]+[smhd]?$")
+# A heredoc introducer. `<<<` is a here-STRING and must not match.
+HEREDOC = re.compile(r"<<-?\s*(?!<)(['\"]?)([A-Za-z_][A-Za-z0-9_]*)\1")
+# Heredoc bodies are DATA unless the command on the introducing line is a shell.
+# `python3 <<'PY' … PY` holds python; `bash <<'EOF' … EOF` holds shell that RUNS.
+SHELL_CMDS = {"bash", "sh", "zsh", "dash", "ksh"}
+
+
+def _scan(s, i, n, mode, subs):
+    """Walk s from i. Returns (inert-collapsed text, next index).
+
+    mode: 'top' | 'dq' (inside "…") | 'sub' (inside $(…)) | 'bt' (inside `…`).
+    Command substitutions found at any depth are appended to `subs` verbatim,
+    to be scanned as lines of their own.
+    """
+    out = []
+    while i < n:
+        c = s[i]
+        if c == "\\" and i + 1 < n:
+            # An escaped char is literal — including \` inside a double-quoted
+            # string, which is how the runner quotes `pv verify-bindings` in a
+            # note without invoking anything.
+            out.append("@" if mode == "dq" else "X")
+            i += 2
+            continue
+        if mode == "sub" and c == ")":
+            return "".join(out), i + 1
+        if mode == "bt" and c == "`":
+            return "".join(out), i + 1
+        if c == "$" and s.startswith("$((", i):
+            j = s.find("))", i + 3)
+            i = n if j < 0 else j + 2
+            out.append(" @Q ")
+            continue
+        if c == "$" and s.startswith("$(", i):
+            body, i = _scan(s, i + 2, n, "sub", subs)
+            subs.append(body)
+            out.append(" @Q ")
+            continue
+        if c == "`":
+            body, i = _scan(s, i + 1, n, "bt", subs)
+            subs.append(body)
+            out.append(" @Q ")
+            continue
+        if c == "'" and mode != "dq":
+            i += 1
+            while i < n and s[i] != "'":
+                i += 1
+            i += 1
+            out.append(" @Q ")
+            continue
+        if c == '"':
+            if mode == "dq":
+                return "".join(out), i + 1
+            _body, i = _scan(s, i + 1, n, "dq", subs)
+            out.append(" @Q ")
+            continue
+        if c == "#" and mode != "dq":
+            prev = out[-1] if out else ""
+            # A `#` starts a comment only at the start of a word.
+            if not out or prev.isspace() or prev in "(;&|":
+                return "".join(out), n
+            out.append(c)
+            i += 1
+            continue
+        out.append("@" if mode == "dq" else c)
+        i += 1
+    return "".join(out), i
+
+
+def strip_line(line):
+    """Returns (inert-collapsed line, [command-substitution bodies])."""
+    subs = []
+    text, _ = _scan(line, 0, len(line), "top", subs)
+    return text, subs
+
+
+def strip_comments(line):
+    """Remove comments but KEEP quoted text. Used where the question is textual
+    (does this file reference $PMAT_BIN?) rather than syntactic."""
+    out, i, n, q = [], 0, len(line), ""
+    while i < n:
+        c = line[i]
+        if c == "\\" and i + 1 < n:
+            out.append(line[i:i + 2]); i += 2; continue
+        if q:
+            if c == q:
+                q = ""
+            out.append(c); i += 1; continue
+        if c in ("'", '"'):
+            q = c; out.append(c); i += 1; continue
+        if c == "#":
+            prev = out[-1] if out else ""
+            if not out or prev.isspace() or prev in "(;&|":
+                break
+            out.append(c); i += 1; continue
+        out.append(c); i += 1
+    return "".join(out)
+
+
+SPLIT = re.compile(r"(\$\(|[();|&{}]|&&|\|\|)")
+
+
+def tokens(s):
+    return [t for t in SPLIT.sub(r" \1 ", s).split() if t]
+
+
+def _follow(toks, j, hits, probes):
+    """Index j is a command position. Record it, then follow wrapper prefixes."""
+    while j < len(toks):
+        t = toks[j]
+        if ASSIGN.match(t) and "=" in t:
+            j += 1
+            continue
+        if t in PROBES:
+            _probe_args(toks, j + 1, probes)
+            return
+        hits.add(j)
+        if t in PREFIX:
+            k = j + 1
+            saw_probe_flag = False
+            while k < len(toks) and (
+                toks[k].startswith("-") or DURATION.match(toks[k])
+                or (ASSIGN.match(toks[k]) and "=" in toks[k])
+            ):
+                if t == "command" and re.match(r"^-[a-zA-Z]*[vVp]", toks[k]):
+                    saw_probe_flag = True
+                k += 1
+            if saw_probe_flag:
+                _probe_args(toks, k, probes)
+                return
+            j = k
+            continue
+        return
+
+
+def _probe_args(toks, j, probes):
+    """Every non-option word a probe is handed is a PATH question about it."""
+    while j < len(toks):
+        t = toks[j]
+        if t in SEPARATORS:
+            return
+        if not t.startswith("-"):
+            probes.add(j)
+        j += 1
+
+
+def command_positions(toks):
+    hits, probes = set(), set()
+    expect = True
+    i = 0
+    while i < len(toks):
+        t = toks[i]
+        if expect:
+            if t in SEPARATORS or (ASSIGN.match(t) and "=" in t):
+                i += 1
+                continue
+            _follow(toks, i, hits, probes)
+            expect = False
+            i += 1
+            continue
+        if t in SEPARATORS:
+            expect = True
+        i += 1
+    return hits, probes
+
+
+def wrapper_positions(toks):
+    """Command position created by this repo's own runner wrappers."""
+    hits, probes = set(), set()
+    for i, t in enumerate(toks):
+        if t == "run_to" and i + 2 < len(toks):
+            _follow(toks, i + 2, hits, probes)
+        elif t == "run_split" and i + 3 < len(toks):
+            _follow(toks, i + 3, hits, probes)
+        elif t == "gate" and i + 2 < len(toks):
+            _follow(toks, i + 2, hits, probes)
+    return hits, probes
+
+
+def for_list_positions(toks):
+    """`for t in bashrs pmat probador` — the loop body's command word is a
+    variable, so no command-position scan can see the tool. The literal list is
+    where it IS visible."""
+    out = set()
+    for i, t in enumerate(toks):
+        if t == "in" and i >= 2 and toks[i - 2] == "for":
+            j = i + 1
+            while j < len(toks) and toks[j] not in (";", "do"):
+                out.add(j)
+                j += 1
+    return out
+
+
+def scan_units(text):
+    """Yield (lineno, unit_text) for every span of the file that is CODE.
+
+    Heredoc bodies are data unless the introducing command is a shell — a
+    quoted python heredoc holding the word `apr` is not an invocation, and
+    `bash <<'EOF'` holding `pmat verify` is.
+    """
+    lines = text.splitlines()
+    i, n = 0, len(lines)
+    while i < n:
+        raw = lines[i]
+        lineno = i + 1
+        yield lineno, raw
+        stripped_for_hd = strip_comments(raw)
+        m = HEREDOC.search(stripped_for_hd)
+        if not m:
+            i += 1
+            continue
+        delim = m.group(2)
+        head_toks = tokens(strip_line(raw)[0])
+        is_shell = any(t in SHELL_CMDS for t in head_toks[:2])
+        i += 1
+        while i < n and lines[i].strip() != delim:
+            if is_shell:
+                yield i + 1, lines[i]
+            i += 1
+        i += 1
+
+
+def findings(path, text):
+    out = []
+    for lineno, raw in scan_units(text):
+        main, subs = strip_line(raw)
+        for unit, is_sub in [(main, False)] + [(s, True) for s in subs]:
+            if not unit.strip():
+                continue
+            toks = tokens(unit)
+            hits, probes = command_positions(toks)
+            whits, wprobes = wrapper_positions(toks)
+            hits |= whits
+            probes |= wprobes
+            fors = set() if is_sub else for_list_positions(toks)
+            for idx in sorted(hits):
+                if idx < len(toks) and toks[idx] in VERIFIERS:
+                    out.append("%s:%d: %s [bare]" % (path, lineno, toks[idx]))
+            for idx in sorted(probes):
+                if idx < len(toks) and toks[idx] in VERIFIERS:
+                    out.append("%s:%d: %s [PATH probe]" % (path, lineno, toks[idx]))
+            for idx in sorted(fors):
+                if idx < len(toks) and toks[idx] in VERIFIERS:
+                    out.append("%s:%d: %s [for-list]" % (path, lineno, toks[idx]))
+    # One finding per line/token/kind; a line can otherwise report twice when a
+    # construct is both a wrapper argument and a command position.
+    seen, uniq = set(), []
+    for f in out:
+        if f not in seen:
+            seen.add(f)
+            uniq.append(f)
+    return uniq
+
+
+rc = 0
+for p in sys.argv[1:]:
+    try:
+        text = open(p, encoding="utf-8", errors="replace").read()
+    except OSError as e:
+        print("SCANERROR %s %s" % (p, e)); rc = 2; continue
+    for f in findings(p, text):
+        print(f); rc = 1
+sys.exit(rc)
+PY
+}
+
+# ---------------------------------------------------------------------------
+# THE KNOWN-GAP TIER (#2644 audit, VP-01/02/08/09 — tracked by QUAL-015).
+#
+# Four shapes this tokeniser gets wrong are recorded here as EXECUTABLE
+# fixtures asserting the CURRENT behaviour, not as prose. The reason they are
+# not patched: the regex-scanning approach has now been wrong sixteen times in
+# this programme, and nine more patches buys the seventeenth. The replacement
+# is a parser-grade scanner (QUAL-015); this corpus is its acceptance test.
+#
+# Two properties make this a ratchet rather than a TODO:
+#   · a gap that gets WORSE turns the row red (the assertion is exact), and
+#   · a gap that gets FIXED also turns the row red, telling the fixer to
+#     promote the case into the real table above. A known gap cannot be
+#     silently closed and left undocumented, and it cannot silently widen.
+#
+# What is NOT here is as important: none of these is a false GREEN on the
+# repo's current sources — PART 1 scans clean over the real scope, and the
+# gaps are shapes no in-scope file currently uses. They are latent, and the
+# corpus is what keeps them from becoming live without anyone noticing.
+known_gap_table() {
+    local td gaps=0 got
+    td=$(mktemp -d) || return 2
+
+    # VP-01 — command position after a leading redirection, through `eval`,
+    # and as a `find -exec` payload. All four RUN a bare verifier.
+    # Built with printf and indirection, exactly like the MUST-FLAG table
+    # above: writing the literal tokens into this file would put a bare
+    # verifier and an indirect-execution builtin in this guard's own source,
+    # which its own PART 1 (and bashrs SEC001) would then read as real code.
+    local M=pmat P=pv A=apr EV=eval
+    {
+        printf '>/dev/null %s verify\n' "$M"
+        printf '2>/dev/null %s lint contracts\n' "$P"
+        printf '%s %s comply check\n' "$EV" "$M"
+        printf 'find . -name "*.apr" -exec %s qa {} \\;\n' "$A"
+    } > "$td/g-cmdpos.sh"
+    got=$(scan "$td/g-cmdpos.sh"; printf 'rc=%s' $?)
+    if [ "$got" = "rc=0" ]; then
+        printf 'GAP   scanner    redirect-prefixed / indirect / find -exec bare invocations are MISSED (VP-01, QUAL-015)\n'
+    else
+        printf 'FAIL  scanner    VP-01 behaviour CHANGED — promote these cases into the\n'
+        printf '                 MUST-FLAG table above and delete this row:\n%s\n' "$got"; gaps=1
+    fi
+
+    # VP-02 — heredoc detection runs on text that still carries quoted spans,
+    # so a string literal merely NAMING `<< WORD` opens a fake heredoc and
+    # swallows every line after it.
+    cat > "$td/g-fakehd.sh" <<'EOF'
+echo "the cmd << EOF form is documented above"
+pmat verify --format json
+EOF
+    got=$(scan "$td/g-fakehd.sh"; printf 'rc=%s' $?)
+    if [ "$got" = "rc=0" ]; then
+        printf 'GAP   scanner    a quoted mention of `<< WORD` suppresses the REST OF THE FILE (VP-02, QUAL-015)\n'
+    else
+        printf 'FAIL  scanner    VP-02 behaviour CHANGED — promote into MUST-FLAG and\n'
+        printf '                 delete this row:\n%s\n' "$got"; gaps=1
+    fi
+
+    # VP-09 — no continuation joining, so the first word of a continued line
+    # is read as command position. A false POSITIVE: argument-position words.
+    printf 'echo the pinned tools are \\\n  pv pmat apr\n' > "$td/g-cont.sh"
+    got=$(scan "$td/g-cont.sh" | awk -F: '{print $3}' | tr -d ' ' | tr '\n' ' ')
+    if [ "$got" = "pv[bare] " ]; then
+        printf 'GAP   scanner    a backslash-continuation argument list FALSE-POSITIVES (VP-09, QUAL-015)\n'
+    else
+        printf 'FAIL  scanner    VP-09 behaviour CHANGED — if fixed, move this into\n'
+        printf '                 MUST-NOT-FLAG; got [%s]\n' "$got"; gaps=1
+    fi
+
+    # VP-08 — pin_audit has no heredoc awareness (unlike the PART 1 scanner),
+    # so a `$PMAT_BIN` mention inside a DATA heredoc counts as consumption
+    # while the gates consume something else entirely.
+    cat > "$td/g-hdconsume.sh" <<'EOF'
+verifier_pin_pmat "$CRATE" "$BINPATH"
+gate pmat-verify /some/other/binary verify
+PV=""
+verifier_pin_pv
+run_to "$L" "$PV" lint contracts
+cat <<'DOC'
+the pinned binary is $PMAT_BIN
+DOC
+EOF
+    if pin_audit "$td/g-hdconsume.sh" >/dev/null 2>&1; then
+        printf 'GAP   pin_audit  `$PMAT_BIN` inside a DATA heredoc counts as consumption (VP-08, QUAL-015)\n'
+    else
+        printf 'FAIL  pin_audit  VP-08 behaviour CHANGED — promote into the CALL-SITE\n'
+        printf '                 table above and delete this row\n'; gaps=1
+    fi
+
+    rm -rf "${td:?}"
+    return "$gaps"
+}
+
+# ---------------------------------------------------------------------------
+# PART 1b's audit. Prints "ROW <ok|FAIL> <text>"; exits 1 if any row failed.
+#
+# The question here is NOT "is there a bare token" — PART 1 answers that, and it
+# answers it GREEN on a runner that defines a perfect pin and never calls it.
+# The question is whether the pin is the thing the gates consume.
+pin_audit() {
+    python3 - "$1" <<'PY'
+import re, sys
+
+path = sys.argv[1]
+lines = open(path, encoding="utf-8", errors="replace").read().splitlines()
+
+
+def strip_comments(line):
+    out, i, n, q = [], 0, len(line), ""
+    while i < n:
+        c = line[i]
+        if c == "\\" and i + 1 < n:
+            out.append(line[i:i + 2]); i += 2; continue
+        if q:
+            if c == q:
+                q = ""
+            out.append(c); i += 1; continue
+        if c in ("'", '"'):
+            q = c; out.append(c); i += 1; continue
+        if c == "#":
+            prev = out[-1] if out else ""
+            if not out or prev.isspace() or prev in "(;&|":
+                break
+            out.append(c); i += 1; continue
+        out.append(c); i += 1
+    return "".join(out)
+
+
+code = [(n + 1, strip_comments(l)) for n, l in enumerate(lines)]
+
+# The left-context class carries the FAIL-CLOSED call shapes too. It had
+# then/else/do but not if/elif/while/until/!, so the most defensive spelling
+# there is — `if ! verifier_pin_pmat "$C" "$B"; then exit 2; fi` — was reported
+# as "the runner never CALLS verifier_pin_pmat" (#2644 audit, VP-07). A guard
+# that rejects the most careful form of the thing it demands trains people to
+# write the careless one.
+_LEFT = r"(?:^|[;&|(){}]|\bthen\b|\belse\b|\bdo\b|\bif\b|\belif\b|\bwhile\b|\buntil\b|!)\s*"
+CALL = {
+    "pmat": re.compile(_LEFT + r"verifier_pin_pmat\b"),
+    "pv": re.compile(_LEFT + r"verifier_pin_pv\b"),
+}
+USE = {
+    "pmat": re.compile(r"\$\{?PMAT_BIN\b"),
+    "pv": re.compile(r"\$\{?PV\}?(?![A-Za-z0-9_])"),
+}
+# An assignment to the pinned variable in the RUNNER is a bypass: it is exactly
+# the mutation `PMAT_BIN=pmat`, and a token scan cannot distinguish it from any
+# other assignment. Empty initialisation stays legal — the runner sets PV="" so
+# an unpinned repo leaves it unmistakably unset.
+# `^\s*` was line-anchored and prefix-blind, so the exact mutation this row
+# exists to catch survived in two trivial spellings — `export PMAT_BIN=/stale`
+# placed right after the genuine pin call, and a post-semicolon reassignment
+# (#2644 audit, VP-03). Declarators are matched as prefixes; a bare `readonly
+# PMAT_BIN` / `export PV` with no `=` is legitimate and still passes, as does
+# empty initialisation (`PV=""`), which is how an unpinned repo says so.
+BYPASS = re.compile(
+    _LEFT
+    + r"""(?:export\s+|readonly\s+|declare\s+(?:-[A-Za-z]+\s+)*|local\s+)?"""
+    + r"""(PMAT_BIN|PV)=(?!(""|''|\s|$))"""
+)
+
+rc = 0
+for tool in ("pmat", "pv"):
+    calls = [n for n, l in code if CALL[tool].search(l)]
+    uses = [n for n, l in code if USE[tool].search(l)]
+    if not calls:
+        print("ROW FAIL %s: the runner never CALLS verifier_pin_%s. A pin that is"
+              " defined and not invoked leaves every gate on PATH." % (tool, tool))
+        rc = 1
+    elif not uses:
+        print("ROW FAIL %s: the runner calls verifier_pin_%s but never uses the"
+              " result — the gates are consuming something else." % (tool, tool))
+        rc = 1
+    elif min(calls) > min(uses):
+        print("ROW FAIL %s: first use of the pin is line %d, but the pin is not"
+              " called until line %d — that use reads an unset variable."
+              % (tool, min(uses), min(calls)))
+        rc = 1
+    else:
+        print("ROW ok %s: pinned at line %d, consumed %d time(s), first use line %d"
+              % (tool, min(calls), len(uses), min(uses)))
+
+# .search(), not .match(): `.match()` anchors at position 0, so widening
+# the pattern's left-context class alone left the post-semicolon bypass
+# accepted — the anchor lived in the CALL, not only the pattern (found by
+# this table's own new row while fixing VP-03).
+bypass = [(n, l.strip()) for n, l in code if BYPASS.search(l)]
+if bypass:
+    for n, l in bypass:
+        print("ROW FAIL bypass at line %d: %s" % (n, l[:80]))
+    print("ROW FAIL the runner assigns a pinned verifier variable directly. Only"
+          " scripts/verifier_pin.sh may decide what PMAT_BIN/PV hold.")
+    rc = 1
+else:
+    print("ROW ok no direct PMAT_BIN=/PV= assignment in the runner")
+sys.exit(rc)
+PY
+}
+
+# ---------------------------------------------------------------------------
+# The scan universe: the protocol itself, plus every gate the runner DISCOVERS
+# and EXECUTES inside the release verdict. Derived from the manifest so a gate
+# added there cannot escape it. An empty derivation is a FAILURE, not a pass:
+# a guard sweeping a set it failed to build is the vacuous green this whole
+# protocol exists to refuse.
+# The scan universe is the set the RUNNER EXECUTES, read through the runner's
+# own parser — not a second opinion about the same declaration.
+#
+# This was an awk+grep scrape for `"..."` strings ending in `.sh`, while
+# scripts/dogfood.sh executes EVERY declared string with `bash "$dg_path"`.
+# So a gate declared as `scripts/check_x` (no suffix), or with TOML literal
+# quotes, was RUN by the release and never SCANNED for unpinned verifiers —
+# a guard universe strictly smaller than the surface it guards, which is the
+# failure class this guard exists to catch (#2644 audit, CI-3 / VP-05 / F2).
+resolve_scope() {
+    local declared meta crate rc
+    meta=$(mktemp) || { printf 'SCOPE_ERROR'; return 1; }
+    if ! ( cd "$REPO_ROOT" && cargo metadata --no-deps --format-version 1 ) \
+           > "$meta" 2>/dev/null; then
+        rm -f "$meta"; printf 'SCOPE_ERROR'; return 1
+    fi
+    crate=$(sed -n 's/^name = "\(.*\)"/\1/p' "$REPO_ROOT/Cargo.toml" | head -1)
+    declared=$(CRATE="$crate" python3 "$REPO_ROOT/scripts/lib/dogfood_gates.py" "$meta" \
+        | awk '$1=="GATE"{print $2}')
+    rc=$?
+    rm -f "$meta"
+    # NOPKG/NODECL/EMPTY/BADSHAPE all yield no GATE lines: the declaration
+    # verifies nothing, and a scan over an empty universe would report clean.
+    if [ "$rc" -ne 0 ] || [ -z "$declared" ]; then
+        printf 'SCOPE_ERROR'
+        return 1
+    fi
+    printf '%s\n%s\n' "$(printf '%s\n' $CORE_SCOPE)" "$declared" | awk 'NF && !seen[$0]++'
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# PART 1 case table. The nine-plus violating lines are ASSEMBLED from $M/$P/$A
+# rather than written out, so this file contains no literal bare invocation of
+# its own. Otherwise the sibling guard scripts/check_apr_bin_pinned.sh — which
+# scans every script for exactly this construct — reports the case table as real
+# violations, and THIS guard now scans itself too (it is a declared gate).
+# Fixtures that trip a neighbouring guard get that guard an exemption entry, and
+# an exemption is how a guard stops guarding.
+self_test() {
+    local td fails=0 got want
+    td=$(mktemp -d) || return 2
+
+    local M=pmat P=pv A=apr
+    {
+        printf 'gate %s-verify %s verify --format json\n' "$M" "$M"
+        printf 'run_to "$WORKLOG/x.log" timeout 900 %s query "x" --limit 1\n' "$M"
+        printf 'run_split "$W/a.json" "$W/b.err" timeout 900 %s comply check\n' "$M"
+        printf '%s validate "$c" >/dev/null 2>&1\n' "$P"
+        printf '%s qa model.apr\n' "$A"
+        printf 'foo && %s comply check\n' "$M"
+        printf 'OUT=$(%s lint contracts)\n' "$P"
+        printf 'PATH=/stale:$PATH %s verify\n' "$M"
+        printf 'if %s validate x; then :; fi\n' "$P"
+        # 10 — MAJOR 1, the live construct: command substitution INSIDE a
+        # double-quoted string. This was the receipt line naming which pmat ran.
+        printf 'mark tools PASS "pmat $(%s --version | head -1)"\n' "$M"
+        # 11 — its generalised form.
+        printf 'OUT="$(%s lint contracts)"\n' "$P"
+        # 12 — an UNescaped backtick inside a double-quoted string is still a
+        # substitution. The escaped form is row 6 of MUST-NOT-FLAG.
+        printf 'mark tools PASS "ver `%s --version`"\n' "$P"
+        # 13 — a wrapper prefix carrying its own option-with-argument.
+        printf 'nice -n 5 %s verify\n' "$M"
+        # 14/15/16 — PATH probes. They do not run the tool; they decide whether
+        # a gate runs, and they ask PATH instead of the pin.
+        printf 'command -v %s >/dev/null 2>&1\n' "$M"
+        printf 'HAVE=$(command -v %s)\n' "$A"
+        printf 'type -aP %s\n' "$P"
+        # 17 — the name in a `for` word list, whose loop body probes "$t".
+        printf 'for t in bashrs %s probador; do command -v "$t"; done\n' "$M"
+        # 18 — `command` as a transparent prefix, which the OPENERS set missed.
+        printf 'command %s verify\n' "$M"
+    } > "$td/bad.sh"
+
+    # MUST NOT FLAG
+    cat > "$td/good.sh" <<'EOF'
+# `pv lint <DIR>` is a real gate and is run separately below.
+mark pv-contracts REPORT "pv is not pinned in this repo -- contracts NOT validated."
+run_to "$WORKLOG/pv-pc.log" "$PV" validate "$WORKLOG/bogus-contract.yaml"
+gate pmat-verify "$PMAT_BIN" verify --format json
+run_to "$WORKLOG/pmat-index.log" timeout 900 "$PMAT_BIN" query "x" --limit 1
+for t in bashrs probador; do
+echo "pmat"
+. scripts/apr_bin.sh || exit 1
+#   run_to "$LOG" pmat query "x"
+mark pmat-verify SKIP "package has no lib target"
+command -v "$PMAT_BIN" >/dev/null 2>&1
+command -v bashrs >/dev/null 2>&1
+VER="$("$PMAT_BIN" --version | head -1)"
+nice -n 5 "$PMAT_BIN" verify
+LIT='$(pmat --version)'
+mark pv-bindings FAIL "\`pv verify-bindings\` produced no verification line"
+EOF
+
+    # A DATA heredoc holds no invocation; a SHELL heredoc does. Separate
+    # fixtures because these are multi-line and the table above is by line.
+    cat > "$td/hd-data.sh" <<'EOF'
+python3 - "$1" <<'PY'
+print("apr")
+pv = 1
+PY
+EOF
+    cat > "$td/hd-shell.sh" <<'EOF'
+bash <<'EOF2'
+pmat verify --format json
+EOF2
+EOF
+
+    got=$(scan "$td/bad.sh" | awk -F: '{print $2}' | tr '\n' ' ')
+    want="1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 "
+    if [ "$got" = "$want" ]; then
+        printf 'ok    MUST-FLAG     all 18 bare/probe/for-list invocations reported\n'
+    else
+        printf 'FAIL  MUST-FLAG     got lines [%s], want [%s]\n' "$got" "$want"; fails=1
+    fi
+
+    got=$(scan "$td/good.sh" | tr '\n' ' ')
+    if [ -z "$got" ]; then
+        # count derived from the fixture, never restated: the prose "all 14"
+        # had drifted from a 16-line corpus (#2644 audit, VP-10 rider)
+        printf 'ok    MUST-NOT-FLAG all %s pinned/comment/string/probe fixture lines accepted\n' "$(grep -c . "$td/good.sh")"
+    else
+        printf 'FAIL  MUST-NOT-FLAG false positives: %s\n' "$got"; fails=1
+    fi
+
+    got=$(scan "$td/hd-data.sh" | tr '\n' ' ')
+    if [ -z "$got" ]; then
+        printf 'ok    HEREDOC-DATA  a python heredoc naming a verifier is not an invocation\n'
+    else
+        printf 'FAIL  HEREDOC-DATA  false positives: %s\n' "$got"; fails=1
+    fi
+
+    got=$(scan "$td/hd-shell.sh" | awk -F: '{print $2}' | tr '\n' ' ')
+    if [ "$got" = "2 " ]; then
+        printf 'ok    HEREDOC-SHELL a `bash <<EOF` heredoc IS scanned as code\n'
+    else
+        printf 'FAIL  HEREDOC-SHELL got [%s], want [2 ]\n' "$got"; fails=1
+    fi
+
+    # PART 1b's own table: a runner that defines the pin and bypasses it.
+    cat > "$td/bypass.sh" <<'EOF'
+PMAT_BIN=pmat
+gate pmat-verify "$PMAT_BIN" verify
+PV=""
+verifier_pin_pv
+run_to "$L" "$PV" lint contracts
+EOF
+    got=$(pin_audit "$td/bypass.sh" 2>&1)
+    if printf '%s' "$got" | grep -q 'ROW FAIL pmat' && printf '%s' "$got" | grep -q 'ROW FAIL bypass'; then
+        printf 'ok    CALL-SITE     `PMAT_BIN=pmat` instead of the pin call is REJECTED\n'
+    else
+        printf 'FAIL  CALL-SITE     a runner that assigns PMAT_BIN itself was accepted:\n%s\n' "$got"; fails=1
+    fi
+
+    cat > "$td/late.sh" <<'EOF'
+gate pmat-verify "$PMAT_BIN" verify
+verifier_pin_pmat "$CRATE" "$BINPATH"
+PV=""
+verifier_pin_pv
+run_to "$L" "$PV" lint contracts
+EOF
+    got=$(pin_audit "$td/late.sh" 2>&1)
+    if printf '%s' "$got" | grep -q 'ROW FAIL pmat'; then
+        printf 'ok    CALL-SITE     a pin called AFTER its first use is REJECTED\n'
+    else
+        printf 'FAIL  CALL-SITE     a pin called after its first use was accepted:\n%s\n' "$got"; fails=1
+    fi
+
+    # VP-03's two live spellings of the SAME bypass this table already covers
+    # in its line-start form. Both were accepted before #2644.
+    cat > "$td/bypass-export.sh" <<'EOF'
+verifier_pin_pmat "$CRATE" "$BINPATH"
+export PMAT_BIN=/opt/stale/pmat
+gate pmat-verify "$PMAT_BIN" verify
+PV=""
+verifier_pin_pv
+run_to "$L" "$PV" lint contracts
+EOF
+    got=$(pin_audit "$td/bypass-export.sh" 2>&1)
+    if grep -q 'ROW FAIL bypass' <<< "$got"; then
+        printf 'ok    CALL-SITE     `export PMAT_BIN=...` after the pin call is REJECTED\n'
+    else
+        printf 'FAIL  CALL-SITE     an `export` bypass was accepted:\n%s\n' "$got"; fails=1
+    fi
+
+    cat > "$td/bypass-semi.sh" <<'EOF'
+verifier_pin_pmat "$CRATE" "$BINPATH"
+true; PMAT_BIN=/opt/stale/pmat
+gate pmat-verify "$PMAT_BIN" verify
+PV=""
+verifier_pin_pv
+run_to "$L" "$PV" lint contracts
+EOF
+    got=$(pin_audit "$td/bypass-semi.sh" 2>&1)
+    if grep -q 'ROW FAIL bypass' <<< "$got"; then
+        printf 'ok    CALL-SITE     a post-semicolon PMAT_BIN= bypass is REJECTED\n'
+    else
+        printf 'FAIL  CALL-SITE     a post-semicolon bypass was accepted:\n%s\n' "$got"; fails=1
+    fi
+
+    # VP-07: the FAIL-CLOSED call shape must count as a call. Rejecting the
+    # most careful spelling of the rule is a false positive that teaches the
+    # careless one.
+    cat > "$td/failclosed-calls.sh" <<'EOF'
+if ! verifier_pin_pmat "$CRATE" "$BINPATH"; then
+  echo "pin failed" >&2
+  exit 2
+fi
+gate pmat-verify "$PMAT_BIN" verify
+PV=""
+if ! verifier_pin_pv; then MISSING="$MISSING pv"; fi
+run_to "$L" "$PV" lint contracts
+EOF
+    if pin_audit "$td/failclosed-calls.sh" >/dev/null 2>&1; then
+        printf 'ok    CALL-SITE     `if ! verifier_pin_*` counts as calling the pin\n'
+    else
+        printf 'FAIL  CALL-SITE     a fail-closed call shape was reported as "never CALLS":\n'
+        pin_audit "$td/failclosed-calls.sh" 2>&1 | sed 's/^/        /'; fails=1
+    fi
+
+    # Legitimate declarators with no assignment must stay legal — the runner
+    # itself ends both pins with `readonly`.
+    cat > "$td/readonly-ok.sh" <<'EOF'
+verifier_pin_pmat "$CRATE" "$BINPATH"
+readonly PMAT_BIN
+gate pmat-verify "$PMAT_BIN" verify
+PV=""
+verifier_pin_pv
+readonly PV
+run_to "$L" "$PV" lint contracts
+EOF
+    if pin_audit "$td/readonly-ok.sh" >/dev/null 2>&1; then
+        printf 'ok    CALL-SITE     `readonly PMAT_BIN` (no assignment) stays legal\n'
+    else
+        printf 'FAIL  CALL-SITE     the widened bypass regex now rejects a legal declarator:\n'
+        pin_audit "$td/readonly-ok.sh" 2>&1 | sed 's/^/        /'; fails=1
+    fi
+
+    cat > "$td/good-calls.sh" <<'EOF'
+verifier_pin_pmat "$CRATE" "$BINPATH"
+gate pmat-verify "$PMAT_BIN" verify
+PV=""
+verifier_pin_pv
+run_to "$L" "$PV" lint contracts
+EOF
+    if pin_audit "$td/good-calls.sh" >/dev/null 2>&1; then
+        printf 'ok    CALL-SITE     a runner that calls both pins before use is accepted\n'
+    else
+        printf 'FAIL  CALL-SITE     a correct runner was rejected:\n'
+        pin_audit "$td/good-calls.sh" 2>&1 | sed 's/^/        /'; fails=1
+    fi
+
+    rm -rf "${td:?}"
+    return "$fails"
+}
+
+# Cargo.lock with `[[patch.unused]]` blocks and blank lines removed. See the
+# note at row 5 of behaviour_test for why those blocks are not staleness.
+lock_norm() {
+    awk '/^\[\[patch\.unused\]\]/ { skip=1; next }
+         skip { if ($0 == "") skip=0; next }
+         $0 != ""' "$1"
+}
+
+# ---------------------------------------------------------------------------
+# PART 2. The pins must BEHAVE. Presence of `PMAT_BIN` proves nothing about
+# which binary the gate ends up running, which is the only thing that matters.
+behaviour_test() {
+    local td fails=0 built stale
+    td=$(mktemp -d) || return 2
+
+    # This function builds pv, and a cargo build without --locked REWRITES a
+    # stale Cargo.lock in place. That is the exact failure scripts/
+    # check_lockfile_current.sh exists to catch, so a guard that silently
+    # repaired the lock on its way past would disarm its neighbour. Snapshot it,
+    # restore it, and REPORT if the build moved it.
+    #
+    # The snapshot is a FILE COPY, not `$(cat …)`: command substitution strips
+    # trailing newlines, so a variable round-trip restores a file that differs
+    # from the original in its last byte. The first version of this row did that
+    # and its own restore was not byte-identical.
+    [ -f "$REPO_ROOT/Cargo.lock" ] && cp "$REPO_ROOT/Cargo.lock" "$td/Cargo.lock.before"
+
+    # shellcheck source=/dev/null
+    if ! . "$REPO_ROOT/scripts/verifier_pin.sh"; then
+        printf 'FAIL  pins       scripts/verifier_pin.sh could not be sourced\n'
+        rm -rf "${td:?}"; return 1
+    fi
+
+    # A STALE pmat, first on PATH. This is the binary the gate must NOT pick.
+    mkdir -p "$td/stalebin"
+    stale="$td/stalebin/pmat"
+    printf '#!/bin/sh\necho stale-pmat\n' > "$stale"
+    chmod +x "$stale"
+    built="$td/target-release-pmat"
+    printf '#!/bin/sh\necho built-pmat\n' > "$built"
+    chmod +x "$built"
+
+    # Row 1 — the self-referential case: releasing pmat itself.
+    PMAT_BIN=""
+    PATH="$td/stalebin:$PATH" verifier_pin_pmat "pmat" "$built"
+    if [ "$PMAT_BIN" = "$built" ]; then
+        printf 'ok    pmat-pin   releasing pmat selects the BUILT artifact, not the PATH copy\n'
+    else
+        printf 'FAIL  pmat-pin   releasing pmat resolved to [%s]; the stale PATH pmat at %s\n' "$PMAT_BIN" "$stale"
+        printf '                 would have measured a different build than the one shipping.\n'
+        fails=1
+    fi
+
+    # Row 2 — every OTHER crate: PATH is correct there and must stay the answer.
+    PMAT_BIN=""
+    verifier_pin_pmat "aprender" "$built"
+    if [ "$PMAT_BIN" = "pmat" ]; then
+        printf 'ok    pmat-pin   a non-pmat crate still uses the fleet pmat\n'
+    else
+        printf 'FAIL  pmat-pin   non-pmat crate resolved to [%s], expected the PATH pmat\n' "$PMAT_BIN"; fails=1
+    fi
+
+    # Row 3 — a crate named pmat with NO built artifact FAILS CLOSED: rc=1 and
+    # an EMPTY pin. This row used to bless the silent PATH fallback — the exact
+    # stale-3.32.0-measuring-3.32.0 incident the lib's header records (#2644,
+    # VPIN-1). The old expectation is preserved here as the mutation direction:
+    # a lib reverted to the fallback turns this row RED.
+    PMAT_BIN=""
+    verifier_pin_pmat "pmat" ""
+    r3_rc=$?
+    if [ "$r3_rc" -eq 1 ] && [ -z "$PMAT_BIN" ]; then
+        printf 'ok    pmat-pin   no built artifact -> rc=1, EMPTY pin (fail closed, no PATH fallback)\n'
+    else
+        printf 'FAIL  pmat-pin   no built artifact resolved to [%s] rc=%s — a silent\n' "$PMAT_BIN" "$r3_rc"
+        printf '                 fallback here measures a PATH pmat that is not the build\n'
+        printf '                 being released (the recorded incident, again)\n'
+        fails=1
+    fi
+
+    # Row 3b — behavior, not existence: a directory and a broken stub both pass
+    # `-x`; neither can answer `--version`; neither may become the pin (#2644,
+    # VPIN-2).
+    mkdir -p "$td/notabinary"
+    PMAT_BIN=""
+    verifier_pin_pmat "pmat" "$td/notabinary"
+    r3b_rc=$?
+    printf '#!/bin/sh\nexit 97\n' > "$td/brokenstub"
+    chmod +x "$td/brokenstub"
+    PMAT_BIN=""
+    verifier_pin_pmat "pmat" "$td/brokenstub"
+    r3c_rc=$?
+    if [ "$r3b_rc" -eq 1 ] && [ "$r3c_rc" -eq 1 ] && [ -z "$PMAT_BIN" ]; then
+        printf 'ok    pmat-pin   a directory and a --version-mute stub are both REFUSED\n'
+    else
+        printf 'FAIL  pmat-pin   non-working artifact accepted (dir rc=%s, stub rc=%s, pin=[%s])\n' "$r3b_rc" "$r3c_rc" "$PMAT_BIN"
+        fails=1
+    fi
+
+    # Row 3d — delivery: the pin must reach a CHILD process. Every discovered
+    # gate is one, and an unexported pin is consumption pin_audit certifies but
+    # the environment never carries (#2644, VPIN-4).
+    PMAT_BIN=""
+    printf '#!/bin/sh\necho built-pmat\n' > "$td/okstub"
+    chmod +x "$td/okstub"
+    verifier_pin_pmat "pmat" "$td/okstub"
+    r3d_child=$(bash -c 'printf %s "${PMAT_BIN:-UNSET}"')
+    if [ "$r3d_child" = "$td/okstub" ]; then
+        printf 'ok    pmat-pin   the pin arrives in a child process (exported)\n'
+    else
+        printf 'FAIL  pmat-pin   child saw [%s] — the pin is shell-local and every\n' "$r3d_child"
+        printf '                 discovered gate runs unpinned\n'
+        fails=1
+    fi
+
+    # Row 4 — pv. The pin must not be whatever PATH offers. A decoy `pv` goes
+    # first on PATH; the resolved PV must differ from it.
+    mkdir -p "$td/pvbin"
+    printf '#!/bin/sh\necho "pv 0.0.0-decoy"\n' > "$td/pvbin/pv"
+    chmod +x "$td/pvbin/pv"
+    (
+        cd "$REPO_ROOT" || exit 2
+        PATH="$td/pvbin:$PATH"
+        export PATH
+        PV=""
+        verifier_pin_pv
+        pv_rc=$?
+        # The decoy is named directly, not via `command -v`: this file must not
+        # itself contain a PATH resolution of a verifier, and naming the path we
+        # planted is strictly more precise than asking PATH what it found.
+        decoy="$td/pvbin/pv"
+        if [ "$pv_rc" -eq 2 ]; then
+            printf 'FAIL  pv-pin     this repo SHIPS scripts/pv_bin.sh but the pin reported "unpinned"\n'
+            exit 1
+        fi
+        if [ "$pv_rc" -ne 0 ]; then
+            printf 'FAIL  pv-pin     the pin failed to resolve pv (rc=%s) — a release cannot be\n' "$pv_rc"
+            printf '                 decided by a verifier that did not build.\n'
+            exit 1
+        fi
+        if [ "$PV" = "$decoy" ]; then
+            printf 'FAIL  pv-pin     resolved pv IS the PATH decoy (%s) — the pin was bypassed\n' "$decoy"
+            exit 1
+        fi
+        printf 'ok    pv-pin     resolved pv is %s, NOT the PATH decoy %s\n' "$PV" "$decoy"
+    ) || fails=1
+
+    # Row 4b — the PV_BIN environment channel is CLEARED before the pin sources
+    # pv_bin.sh: an inherited PV_BIN short-circuits the cargo build pv_bin.sh
+    # itself names "THE FRESHNESS AUTHORITY", so an exported stale path would
+    # ride straight through an otherwise-green pin (#2644, VPIN-6/VP-04).
+    (
+        cd "$REPO_ROOT" || exit 2
+        printf '#!/bin/sh\necho pv 0.0.0-poison\n' > "$td/pv-poison"
+        chmod +x "$td/pv-poison"
+        PV_BIN="$td/pv-poison"
+        export PV_BIN
+        PV=""
+        verifier_pin_pv
+        pv_rc=$?
+        if [ "$pv_rc" -eq 0 ] && [ "$PV" = "$td/pv-poison" ]; then
+            printf 'FAIL  pv-pin     an inherited PV_BIN (%s) rode through the pin —\n' "$PV_BIN"
+            printf '                 the freshness authority was bypassed by the environment\n'
+            exit 1
+        fi
+        if [ "$pv_rc" -ne 0 ]; then
+            printf 'FAIL  pv-pin     pin failed under an inherited PV_BIN (rc=%s) — clearing\n' "$pv_rc"
+            printf '                 the channel must not break resolution\n'
+            exit 1
+        fi
+        printf 'ok    pv-pin     an inherited PV_BIN is cleared; the pin resolved %s\n' "$PV"
+    ) || fails=1
+
+    # Row 4c — the pin works from a SUBDIRECTORY of the repo. The cwd-relative
+    # form returned 2 ("this repo ships no pin") from anywhere below the root —
+    # a false statement that downgraded every pv gate to REPORT (#2644, VPIN-5).
+    (
+        cd "$REPO_ROOT/scripts" || exit 2
+        PV=""
+        verifier_pin_pv
+        pv_rc=$?
+        if [ "$pv_rc" -eq 2 ]; then
+            printf 'FAIL  pv-pin     from scripts/ the pin says "this repo ships no pin" — the\n'
+            printf '                 discovery is cwd-relative and lies from any subdirectory\n'
+            exit 1
+        fi
+        if [ "$pv_rc" -ne 0 ] || [ -z "$PV" ]; then
+            printf 'FAIL  pv-pin     pin failed from a subdirectory (rc=%s)\n' "$pv_rc"
+            exit 1
+        fi
+        printf 'ok    pv-pin     the pin resolves from a subdirectory of the repo\n'
+    ) || fails=1
+
+    # Row 5 — this guard must not have moved Cargo.lock.
+    #
+    # `[[patch.unused]]` blocks are NORMALISED AWAY before comparing, and that is
+    # not a loosening. They appear only when a host-local, gitignored
+    # `.cargo/config.toml` injects a `[patch.crates-io]` of sibling checkouts —
+    # the aprender dev-overrides do exactly that — and then ANY `cargo build -p
+    # <one-member>` records which of those patches the sub-graph did not use.
+    # They are absent in CI, they say nothing about whether the lock resolves,
+    # and failing on them would make this row permanently red on every
+    # developer box that ran `make dev-setup`. The resolution itself — the
+    # `[[package]]` entries — is compared in full.
+    if [ ! -f "$td/Cargo.lock.before" ]; then
+        printf 'ok    lockfile   no Cargo.lock in this repo — nothing for the build to move\n'
+    elif lock_norm "$td/Cargo.lock.before" > "$td/lock.a" \
+         && lock_norm "$REPO_ROOT/Cargo.lock" > "$td/lock.b" \
+         && cmp -s "$td/lock.a" "$td/lock.b"; then
+        # Leave the tree exactly as it was found, even when the delta was inert.
+        cmp -s "$td/Cargo.lock.before" "$REPO_ROOT/Cargo.lock" \
+            || cp "$td/Cargo.lock.before" "$REPO_ROOT/Cargo.lock"
+        printf 'ok    lockfile   building the pinned pv did not change the resolution\n'
+    else
+        cp "$td/Cargo.lock.before" "$REPO_ROOT/Cargo.lock"
+        printf 'FAIL  lockfile   building the pinned pv REWROTE Cargo.lock (restored). The lock\n'
+        printf '                 was stale before this ran; cargo repaired it in passing, which\n'
+        printf '                 is exactly what scripts/check_lockfile_current.sh exists to see.\n'
+        printf '                 Run `cargo update --workspace --offline` (or check_lockfile_current.sh)\n'
+        printf '                 and commit the result.\n'
+        fails=1
+    fi
+
+    rm -rf "${td:?}"
+    return "$fails"
+}
+
+# ---------------------------------------------------------------------------
+# PART 3. The fleet path: this runner exists to be pointed at OTHER repos, by
+# the relative path its own Usage line documents. #2640 made the pin library
+# load-bearing and fail-closed, while SKILL_DIR was still computed AFTER
+# `cd "$REPO_DIR"` — so a relative ${BASH_SOURCE[0]} resolved against the TARGET
+# repo, the library was "missing", and the runner exited 2 before any gate ran.
+# Absolute invocation kept working, which is why nothing noticed.
+fleet_path_test() {
+    local td fails=0 out rc
+    td=$(mktemp -d) || return 2
+
+    mkdir -p "$td/fixture-crate/src"
+    cat > "$td/fixture-crate/Cargo.toml" <<'EOF'
+[package]
+name = "dogfood-fixture"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[package.metadata.dogfood]
+gates = ["gate-ok.sh", "gate-pin-delivery.sh"]
+EOF
+    printf 'pub fn f() {}\n' > "$td/fixture-crate/src/lib.rs"
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$td/fixture-crate/gate-ok.sh"
+    # The fixture is a REAL git repo with a clean tree: since the DF-7 fix a
+    # non-git directory is a deliberate git-clean FAIL, and this test asserts
+    # rc=0 through the runner. Hooks and identity are pinned so no host config
+    # can dirty the run.
+    git -C "$td/fixture-crate" -c init.defaultBranch=fixture init -q
+    git -C "$td/fixture-crate" -c user.name=dogfood -c user.email=dogfood@fixture \
+        -c core.hooksPath=/dev/null add -A
+    git -C "$td/fixture-crate" -c user.name=dogfood -c user.email=dogfood@fixture \
+        -c core.hooksPath=/dev/null commit -q --no-verify -m fixture
+    # The committed catcher for the unexported-pin mutation (#2644, VPIN-4):
+    # this gate runs as a CHILD of the runner, exactly like every discovered
+    # gate, and asserts the pins ARRIVED. PMAT_BIN must be nonempty (the policy
+    # answer for a non-pmat crate); PV must EXIST in the environment — this
+    # fixture ships no pin, so its VALUE is legitimately empty, but an absent
+    # VARIABLE means the runner resolved pins it never delivered.
+    cat > "$td/fixture-crate/gate-pin-delivery.sh" <<'EOF'
+#!/usr/bin/env bash
+[ "${PMAT_BIN+set}" = set ] || { echo "PMAT_BIN not delivered to child env"; exit 1; }
+[ -n "$PMAT_BIN" ] || { echo "PMAT_BIN empty for a non-pmat crate"; exit 1; }
+[ "${PV+set}" = set ] || { echo "PV not delivered to child env"; exit 1; }
+exit 0
+EOF
+
+    # DOGFOOD_GATES_ONLY stops after the declared-gate discovery section, which
+    # sits well past the pin-library source. It is the runner's own hook, not a
+    # copy of it, and it can never print GO.
+    out=$( cd "$REPO_ROOT" && DOGFOOD_GATES_ONLY=1 \
+        bash scripts/dogfood.sh "$td/fixture-crate" 2>&1 )
+    rc=$?
+    if [ "$rc" -eq 2 ]; then
+        printf 'FAIL  fleet-path a RELATIVE `bash scripts/dogfood.sh <other-crate>` exited 2\n'
+        printf '                 (setup error) before running anything. That is the form its own\n'
+        printf '                 documented Usage line gives, and the whole reason the protocol is\n'
+        printf '                 portable. Resolve SKILL_DIR from ${BASH_SOURCE[0]} BEFORE the\n'
+        printf '                 `cd "$REPO_DIR"`, or the path resolves against the TARGET repo.\n'
+        printf '%s\n' "$out" | tail -5 | sed 's/^/                 /'
+        fails=1
+    elif grep -q 'verifier_pin.sh is missing' <<< "$out"; then
+        printf 'FAIL  fleet-path the pin library was not found under a relative invocation\n'
+        fails=1
+    elif ! grep -q 'DOGFOOD_GATES_ONLY' <<< "$out"; then
+        printf 'FAIL  fleet-path the runner did not reach the declared-gate section (rc=%s)\n' "$rc"
+        printf '%s\n' "$out" | tail -5 | sed 's/^/                 /'
+        fails=1
+    elif [ "$rc" -ne 0 ]; then
+        # The fixture's gates include gate-pin-delivery.sh, the committed
+        # catcher for the unexported-pin mutation. A nonzero rc here with the
+        # section reached means a declared gate went RED — most likely the
+        # probe reporting pins that never arrived. Printing "ok (rc=1)" at
+        # this point would be a catcher that observes and does not gate.
+        printf 'FAIL  fleet-path the fixture run reached the declared-gate section but exited %s\n' "$rc"
+        printf '%s\n' "$out" | grep -E 'declared:|dogfood-gates|not delivered|empty for' | tail -6 | sed 's/^/                 /'
+        fails=1
+    elif ! grep -q 'declared:gate-pin-delivery' <<< "$out"; then
+        printf 'FAIL  fleet-path the pin-delivery probe left no row in the output — a\n'
+        printf '                 catcher that did not run is indistinguishable from one that passed\n'
+        fails=1
+    else
+        printf 'ok    fleet-path relative invocation runs; pin-delivery probe green (rc=%s)\n' "$rc"
+    fi
+
+    rm -rf "${td:?}"
+    return "$fails"
+}
+
+# ---------------------------------------------------------------------------
+case "${1:-}" in
+    --self-test)
+        self_test; exit $?
+        ;;
+    --scan)
+        shift; scan "$@"; exit $?
+        ;;
+esac
+
+rc=0
+printf -- '--- verifier pinning ------------------------------------------------\n'
+
+printf 'case table (the tokeniser must be right before its verdict means anything)\n'
+if self_test; then :; else rc=1; fi
+
+printf '\nknown gaps (executable, asserted exactly — QUAL-015 replaces this scanner)\n'
+if known_gap_table; then :; else rc=1; fi
+
+printf '\nPART 1 — static: no bare verifier in command position\n'
+cd "$REPO_ROOT" || exit 2
+SCAN_ERR=$(mktemp)
+trap 'rm -f "$SCAN_ERR"' EXIT
+SCOPE=$(resolve_scope)
+if [ "$SCOPE" = "SCOPE_ERROR" ]; then
+    printf 'FAIL  [package.metadata.dogfood] gates yielded nothing — the scan universe\n'
+    printf '      could not be built, so a clean sweep here would mean nothing.\n'
+    rc=1
+else
+    missing=""
+    for f in $SCOPE; do
+        [ -f "$f" ] || missing="$missing $f"
+    done
+    if [ -n "$missing" ]; then
+        # A scope entry that does not exist is a gate scanning nothing. The
+        # runner could be renamed out from under this guard and it would sweep
+        # an empty universe and report clean — the exact failure this repo
+        # keeps finding.
+        printf 'FAIL  in-scope file(s) missing:%s — the guard scanned an empty universe\n' "$missing"
+        rc=1
+    else
+        # shellcheck disable=SC2086
+        hits=$(scan $SCOPE 2>"$SCAN_ERR")
+        scan_rc=$?
+        # Only ENUMERATED (rc, output) shapes carry meanings: (0, empty) is
+        # clean and (1, findings) is findings. Everything else — an input-
+        # selective tokeniser crash is exit 1 with an empty stdout and a
+        # traceback on stderr — is a scanner failure, and the old
+        # rc==2-only branch printed "ok no bare pv/pmat/apr" over a scan that
+        # scanned nothing (#2644 audit, F8 rider; v1.13 P1).
+        if [ "$scan_rc" -eq 0 ] && [ -z "$hits" ]; then
+            printf 'ok    no bare pv/pmat/apr in command position, in:\n'
+            printf '%s\n' "$SCOPE" | sed 's/^/        /'
+        elif [ "$scan_rc" -eq 1 ] && [ -n "$hits" ]; then
+            printf 'FAIL  bare verifier invocation(s) — these resolve through PATH:\n'
+            printf '%s\n' "$hits" | sed 's/^/      /'
+            printf '      Use the pin: "$PV" / "$PMAT_BIN" / "$APR". See scripts/verifier_pin.sh.\n'
+            rc=1
+        else
+            printf 'FAIL  the scanner did not produce a verdict (rc=%s, %s finding lines) — an\n' "$scan_rc" "$(grep -c . <<< "$hits")"
+            printf '      unenumerated exit shape is a scan that cannot be believed:\n'
+            sed 's/^/      /' "$SCAN_ERR" 2>/dev/null | tail -5
+            printf '%s\n' "$hits" | grep . | sed 's/^/      /' | head -5
+            rc=1
+        fi
+    fi
+fi
+
+printf '\nPART 1b — call site: the pin is CALLED, and its result is what runs\n'
+audit=$(pin_audit "$REPO_ROOT/scripts/dogfood.sh")
+audit_rc=$?
+printf '%s\n' "$audit" | sed -e 's/^ROW ok /ok    /' -e 's/^ROW FAIL /FAIL  /' -e 's/^\(ok\|FAIL\)/\1/'
+[ "$audit_rc" -eq 0 ] || rc=1
+
+printf '\nPART 2 — behavioural: the pins select something other than PATH\n'
+if behaviour_test; then :; else rc=1; fi
+
+printf '\nPART 3 — fleet path: the runner runs when invoked relatively\n'
+if fleet_path_test; then :; else rc=1; fi
+
+printf '\n'
+if [ "$rc" -eq 0 ]; then
+    printf 'PASS  the release runner resolves every pinned verifier through its pin.\n'
+else
+    printf 'FAIL  see rows above. A gate measured with an unknown binary is not a gate.\n'
+fi
+exit "$rc"

--- a/scripts/dogfood/pmat-dogfood-runner.sh
+++ b/scripts/dogfood/pmat-dogfood-runner.sh
@@ -190,10 +190,10 @@ trap 'rm -rf "$WORKLOG"' EXIT
 # THE VERIFIER-PINNING RULE, and the two pins that implement it, live in exactly
 # one file. Read scripts/verifier_pin.sh — the rule is stated there and nowhere
 # else, because a rule restated is a rule that drifts. This runner only CALLS it.
-if [ -f "$SKILL_DIR/verifier_pin.sh" ]; then
-  . "$SKILL_DIR/verifier_pin.sh"
+if [ -f "$SKILL_DIR/pmat-verifier_pin.sh" ]; then
+  . "$SKILL_DIR/pmat-verifier_pin.sh"
 else
-  echo "dogfood: $SKILL_DIR/verifier_pin.sh is missing." >&2
+  echo "dogfood: $SKILL_DIR/pmat-verifier_pin.sh is missing." >&2
   echo "  It carries the rule that decides WHICH pv and WHICH pmat this protocol" >&2
   echo "  is allowed to believe. Without it every verifier would fall back to" >&2
   echo "  PATH, which is the exact defect #2640 closed. Refusing to run." >&2
@@ -263,7 +263,7 @@ DG_META_RC=$RUN_RC
 # scripts/lib/dogfood_gates.py. This used to be an embedded heredoc while the
 # guard scraped the same TOML with awk+grep, so the guard's scan universe could
 # be strictly smaller than the set the runner EXECUTES (#2644 audit, CI-3/VP-05).
-DG_PLAN=$(CRATE="$CRATE" python3 "$SKILL_DIR/lib/dogfood_gates.py" \
+DG_PLAN=$(CRATE="$CRATE" python3 "$SKILL_DIR/pmat-dogfood_gates.py" \
   "$WORKLOG/meta-dogfood.json" 2>/dev/null || echo "META_ERROR")
 if [ "$DG_META_RC" -ne 0 ]; then
   mark dogfood-gates FAIL "\`cargo metadata\` failed (exit=$DG_META_RC) — the release gates this crate declares could not be discovered, so none of them ran"
@@ -271,7 +271,7 @@ elif [ "$DG_PLAN" = "META_ERROR" ]; then
   # cargo succeeded; the python step died. The old message blamed cargo with
   # "failed (exit=0)" attached — an operator sent to the wrong component
   # (#2644, CI-4).
-  mark dogfood-gates FAIL "gate discovery's python3 step failed (cargo metadata itself exited 0) — \`$SKILL_DIR/lib/dogfood_gates.py\` could not parse the declaration (or is missing), so no declared gate ran"
+  mark dogfood-gates FAIL "gate discovery's python3 step failed (cargo metadata itself exited 0) — \`$SKILL_DIR/pmat-dogfood_gates.py\` could not parse the declaration (or is missing), so no declared gate ran"
 elif [ "$DG_PLAN" = "NOPKG" ]; then
   mark dogfood-gates FAIL "no package named '$CRATE' in cargo metadata — run dogfood from the crate dir, not the virtual workspace root"
 elif [ "$DG_PLAN" = "NODECL" ]; then
@@ -1239,10 +1239,10 @@ if [ ! -x "$BINPATH" ]; then
   mark transport-invariance FAIL "no release binary at $BINPATH — nothing to invoke"
 elif [ -z "$UI_DECL" ]; then
   mark transport-invariance SKIP "no [package.metadata.unified_surface] — declare list/cli/http/probe to enable the simultaneous cross-transport check"
-elif [ ! -f "$SKILL_DIR/invariance.py" ]; then
+elif [ ! -f "$SKILL_DIR/pmat-invariance.py" ]; then
   mark transport-invariance FAIL "invariance.py missing from $SKILL_DIR — a gate that cannot run is not a SKIP"
 else
-  run_to "$WORKLOG/invariance.log" python3 "$SKILL_DIR/invariance.py" "$BINPATH" "$UI_DECL"
+  run_to "$WORKLOG/invariance.log" python3 "$SKILL_DIR/pmat-invariance.py" "$BINPATH" "$UI_DECL"
   INV_RC=$RUN_RC
   INV_MSG=$(head -1 "$WORKLOG/invariance.log" 2>/dev/null || echo "")
   case "$INV_RC:$INV_MSG" in

--- a/scripts/dogfood/pmat-dogfood_gates.py
+++ b/scripts/dogfood/pmat-dogfood_gates.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""The ONE parser of [package.metadata.dogfood].
+
+Requires Python 3.6+ (json, sys, os only — no tomllib, no f-string-with-= ).
+
+Two consumers read this declaration and, until #2644, each carried its own
+parser: scripts/dogfood.sh read cargo-metadata JSON through an embedded python
+heredoc, while scripts/check_verifier_pinning.sh scraped the TOML with
+awk+grep for double-quoted strings ending in `.sh`. Two parsers of one
+declaration is the one-source-two-copies class that #2640 exists to close,
+sitting inside #2640's own gate (audit finding CI-3).
+
+The divergence was not theoretical. The runner executes EVERY declared string
+with `bash "$dg_path"`; the guard's scrape saw only `"...*.sh"`, so a gate
+declared as `scripts/check_x` (no suffix) or with TOML literal quotes was
+RUN by the release and never SCANNED for unpinned verifiers (VP-05, F2).
+
+Output protocol — one line, or one line per gate:
+
+    NOPKG       no package of that name in the metadata
+    NODECL      no [package.metadata.dogfood] table
+    BADSHAPE    `gates` is not a list, or holds a non-string / blank entry
+    EMPTY       `gates = []` — a claim to have none, which is not a pass
+    GATE <path> one per declared gate, in declaration order
+
+Usage:  CRATE=<name> python3 dogfood_gates.py <cargo-metadata.json>
+"""
+import json
+import os
+import sys
+
+
+def _select_package(packages, crate_name):
+    """The named package, or the only one when a crate stands alone."""
+    for pkg in packages:
+        if pkg.get("name") == crate_name:
+            return pkg
+    if len(packages) == 1:
+        return packages[0]
+    return None
+
+
+def _gate_lines(gates):
+    """GATE lines for a non-empty list, or None if any entry is malformed."""
+    lines = []
+    for gate in gates:
+        if not isinstance(gate, str) or not gate.strip():
+            return None
+        lines.append("GATE " + gate.strip())
+    return lines
+
+
+def plan(metadata, crate_name):
+    pkg = _select_package(metadata.get("packages", []), crate_name)
+    if pkg is None:
+        return ["NOPKG"]
+    declared = (pkg.get("metadata") or {}).get("dogfood")
+    if not isinstance(declared, dict):
+        return ["NODECL"]
+    gates = declared.get("gates")
+    if not isinstance(gates, list):
+        return ["BADSHAPE"]
+    if not gates:
+        return ["EMPTY"]
+    return _gate_lines(gates) or ["BADSHAPE"]
+
+
+def main(argv):
+    if len(argv) != 2:
+        sys.stderr.write("usage: CRATE=<name> dogfood_gates.py <metadata.json>\n")
+        return 2
+    try:
+        with open(argv[1], encoding="utf-8") as handle:
+            metadata = json.load(handle)
+    except (OSError, ValueError) as exc:
+        sys.stderr.write("dogfood_gates: cannot read metadata: %s\n" % exc)
+        return 2
+    for line in plan(metadata, os.environ.get("CRATE", "")):
+        print(line)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/dogfood/pmat-dogfood_surfaces.sh
+++ b/scripts/dogfood/pmat-dogfood_surfaces.sh
@@ -1,0 +1,776 @@
+#!/usr/bin/env bash
+# dogfood_surfaces.sh — exercise EVERY shipped interface and emit a receipt.
+#
+# WHAT THIS COVERS
+# ----------------
+# Three interface kinds across 29 binary targets in 27 crates:
+#
+#   CLI   every binary the workspace builds, and every subcommand each one
+#         declares, enumerated from `--help` on the BUILT BINARY
+#   HTTP  every route the server mounts
+#   MCP   every tool `tools/list` returns
+#
+# WHY IT ENUMERATES AT RUNTIME AND NEVER FROM A LIST
+# -------------------------------------------------
+# A hardcoded surface list is the defect this repo keeps re-finding. The
+# falsification spec asserted "exactly 36 top-level commands" and now finds 0
+# because the enum moved file; CLAUDE.md said 77, then 103, then 111. Any list
+# written down here would be wrong by the next refactor and would fail SILENTLY
+# -- a shrunken universe reports "all passed".
+#
+# Grepping the source is no better: a regex over clap `Subcommand` enums reports
+# 0 subcommands for `simular`, which is a clap-derive CLI. The binary is the
+# only thing that knows what the binary accepts.
+#
+# So: binaries come from `cargo metadata`, commands from `<bin> --help`, routes
+# from the router, tools from a live `tools/list`. Every enumeration is
+# vacuity-guarded -- if it yields implausibly few items the run FAILS instead of
+# reporting a clean sweep over an empty set.
+#
+# DETERMINISM
+# -----------
+# Required, because a dogfood receipt is evidence:
+#   * every enumeration is `LC_ALL=C sort`ed, so ordering never varies
+#   * no wall-clock assertions (banned repo-wide; they flake and prove nothing)
+#   * no timestamps or durations in the receipt body
+#   * fixed seeds and fixed prompts for any generative probe
+#   * the same tree yields a byte-identical receipt
+# Verify with --twice, which runs the whole sweep twice and diffs the receipts.
+#
+# WHAT COUNTS AS A PASS
+# ---------------------
+# NOT "exit code 0". The 0.63.0 audit found tests asserting `is_ok()` on invalid
+# input, which LOCKS THE DEFECT IN. Every probe here must EXCLUDE an outcome:
+#
+#   --help          exits 0 AND names the subcommand AND is not empty
+#   bad flag        exits NON-ZERO and says something actionable
+#   missing file    exits NON-ZERO and names the path, not a backtrace
+#   HTTP route      responds, and an error is actionable JSON, never a dropped
+#                   connection or a 200 carrying an error
+#   MCP tool        appears in tools/list AND its schema parses
+#
+# SKIPS ARE COUNTED, NEVER SILENT
+# -------------------------------
+# A probe needing a model with no model available is a SKIP, recorded with a
+# reason and totalled in the receipt. A skip is never a pass. If skips exceed
+# --max-skip-pct the run FAILS, because a sweep that skipped most of itself
+# proves nothing -- that is the `require_model!` defect, where 30 call sites
+# `return` early and report ok.
+#
+#   bash scripts/dogfood_surfaces.sh                 # full sweep
+#   bash scripts/dogfood_surfaces.sh --cli           # one surface
+#   bash scripts/dogfood_surfaces.sh --http --mcp
+#   bash scripts/dogfood_surfaces.sh --twice         # prove determinism
+#   bash scripts/dogfood_surfaces.sh --self-test     # case table
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RECEIPT="${DOGFOOD_RECEIPT:-${REPO_ROOT}/target/dogfood-receipt.txt}"
+MAX_SKIP_PCT="${MAX_SKIP_PCT:-40}"
+
+# Vacuity floors. Deliberately well below today's real counts (29 binaries,
+# 103 apr commands, 45 routes, 9 tools) so ordinary growth or pruning does not
+# trip them, but a BROKEN enumeration -- the failure mode that silently reports
+# success -- cannot slip through.
+MIN_BINARIES=20
+MIN_APR_COMMANDS=60
+MIN_ROUTES=25
+MIN_MCP_TOOLS=7
+
+pass=0; fail=0; skip=0
+FAILURES=""
+SKIPS=""
+
+ok()   { pass=$((pass+1)); printf '  ok    %s\n' "$1"; }
+bad()  { fail=$((fail+1)); FAILURES="${FAILURES}
+  ${1}"; printf '  FAIL  %s\n' "$1"; }
+skp()  { skip=$((skip+1)); SKIPS="${SKIPS}
+  ${1}"; printf '  skip  %s\n' "$1"; }
+
+# --- enumeration -----------------------------------------------------------
+
+# Every binary target the workspace builds. From cargo, never from a glob of
+# src/bin or a grep for [[bin]] -- auto-discovered binaries have no [[bin]]
+# stanza, and `autobins = false` deletes ones that do.
+enumerate_binaries() {
+    cargo metadata --no-deps --format-version 1 2>/dev/null | python3 -c '
+import json,sys
+md=json.load(sys.stdin)
+out=set()
+for p in md["packages"]:
+    for t in p["targets"]:
+        if "bin" in t["kind"]:
+            out.add(t["name"])
+for n in sorted(out): print(n)
+'
+}
+
+# Subcommands a built binary actually accepts, parsed from its own --help.
+# clap prints them one per line, indented, in a "Commands:" section.
+enumerate_subcommands() {
+    local bin="$1" out
+    out=$("$bin" --help 2>&1)
+    # EXACTLY two leading spaces. clap indents a subcommand by 2; a wrapped
+    # description line is indented much further. Matching "some leading
+    # whitespace" scraped prose out of descriptions -- `apr yet)`, `apr
+    # clip.wav`, `apr existing` were all reported as subcommands, and the count
+    # came out at 114 against a real 103.
+    printf '%s\n' "$out" | awk '
+        /^[Cc]ommands:/ { inb=1; next }
+        /^[A-Za-z]/     { inb=0 }
+        inb && /^  [a-z][a-z0-9._-]*([[:space:]]|$)/ { print $1 }
+    ' | grep -vE '^(help)$' | LC_ALL=C sort -u
+}
+
+# Routes the server ADVERTISES at runtime. The running server is the source of
+# truth; the source table is only a fallback.
+#
+# Measured against a live `apr serve` on a real model, the static scan below was
+# wrong in BOTH directions:
+#
+#   in the source table, never mounted : /v1/logprobs /v1/perplexity  (conditional)
+#   live but MISSED by the source scan : /  /metrics/dispatch/reset
+#                                        /v1/batch/completions
+#                                        /v1/chat/completions          <-- the
+#                                        /v1/chat/completions/stream       primary
+#                                                                          endpoint
+#
+# A sweep that claims to cover the HTTP surface while omitting
+# /v1/chat/completions is not covering the HTTP surface. Same lesson as binaries
+# (ask cargo) and subcommands (ask the binary): ask the server.
+enumerate_routes_live() {
+    local base="$1"
+    curl -sf -m 5 "$base/" 2>/dev/null | python3 -c '
+import json,sys
+try: d=json.load(sys.stdin)
+except Exception: sys.exit(1)
+out=set()
+for r in d.get("routes",[]):
+    out.add(r.split(" ",1)[1] if " " in r else r)
+for p in sorted(out): print(p)
+'
+}
+
+# Fallback: the source table. APPROXIMATE -- see the note above.
+enumerate_routes() {
+    # From the route TABLE -- entries are ("GET", "/path", handler) tuples, and
+    # router.rs mounts from the same table it builds its index from, so this is
+    # the single source of truth. Globbing every "/..." string literal in the
+    # crate instead reported 284 "routes", most of them doc fragments and JSON
+    # keys.
+    grep -rhoE '\("(GET|POST|PUT|DELETE|PATCH|HEAD)"[[:space:]]*,[[:space:]]*"/[A-Za-z0-9_/{}.:-]*"' \
+        "$REPO_ROOT"/crates/aprender-serve/src/api/ 2>/dev/null \
+        | grep -oE '"/[A-Za-z0-9_/{}.:-]*"' | tr -d '"' | LC_ALL=C sort -u
+}
+
+# MCP tools, from the tool definitions the server registers.
+enumerate_mcp_tools() {
+    grep -rhoE 'const NAME: &str = "[^"]+"' \
+        "$REPO_ROOT"/crates/aprender-mcp/src/tools/ 2>/dev/null \
+        | grep -oE '"[^"]+"' | tr -d '"' | LC_ALL=C sort -u
+}
+
+# Fail rather than sweep an empty set.
+vacuity_guard() {
+    local what="$1" got="$2" floor="$3"
+    if [ "$got" -lt "$floor" ]; then
+        printf '\nFAIL (vacuity): enumerated %s %s, expected at least %s.\n' \
+            "$got" "$what" "$floor"
+        printf 'The ENUMERATION is broken, not the surface. A sweep over a\n'
+        printf 'shrunken universe reports success -- fix the enumeration, never\n'
+        printf 'this floor.\n'
+        exit 1
+    fi
+}
+
+# --- deterministic toolchain ------------------------------------------------
+#
+# This repo ships its own deterministic tools, and the rule is to USE them
+# rather than hand-roll a weaker equivalent:
+#
+#   pv       contract validation / lint / score  (never yq, never a python YAML walk)
+#   bashrs   shell quality                       (never shellcheck)
+#   probar   endpoint + playbook testing         (never a hand-rolled curl loop)
+#   pmat     code search and quality analysis    (never grep for discovery)
+#
+# Each is asserted PRESENT rather than skipped-if-missing. A sweep that silently
+# drops its own verification tools reports a clean pass having checked less --
+# the vacuous-scan defect this whole script exists to avoid.
+
+require_tool() {
+    local tool="$1" why="$2" ver
+    if command -v "$tool" > /dev/null 2>&1; then
+        ver=$("$tool" --version 2>&1 | head -1)
+        ok "$tool present ($ver)"
+        return 0
+    fi
+    bad "$tool MISSING -- $why. Install it; do not hand-roll a substitute."
+    return 1
+}
+
+# Validate a contract with pv. Never parse contract YAML by hand.
+pv_check() {
+    local contract="$1" label="$2" out rc
+    if [ ! -f "$contract" ]; then
+        bad "$label: $contract does not exist"
+        return
+    fi
+    out=$("$PV" validate "$contract" 2>&1); rc=$?
+    if [ "$rc" -eq 0 ]; then
+        ok "$label validates (pv validate)"
+    else
+        bad "$label FAILED pv validate: $(printf '%s' "$out" | tail -1)"
+    fi
+}
+
+# Shell quality. bashrs is the mandated linter; `bash -n` is the authority on
+# whether the file PARSES. bashrs has known false positives on hand-written bash
+# (em-dashes in prose read as SC1100; a regex string sharing a line with `[ ]`
+# reads as unescaped parens), so both are reported and neither alone is enough.
+bashrs_check() {
+    local script="$1" errs
+    if [ ! -f "$script" ]; then
+        bad "bashrs: $script does not exist"
+        return
+    fi
+    errs=$(bashrs lint "$script" 2>&1 | grep -cE '\[error\]')
+    if bash -n "$script" 2>/dev/null; then
+        ok "$(basename "$script") parses (bash -n); bashrs errors=$errs"
+    else
+        bad "$(basename "$script") FAILS bash -n -- it is not valid shell"
+    fi
+}
+
+surface_tools() {
+    printf '\n=== deterministic toolchain ===\n'
+    # PINNED, not PATH. This line used to `require_tool pv`, which resolves
+    # through PATH, and then printed `pv present (pv 0.49.0)` into the RELEASE
+    # RECEIPT as evidence of correctness while the tree was at 0.63.0.
+    . "$(dirname "${BASH_SOURCE[0]}")/pv_bin.sh" || {
+        bad "pv could not be resolved from HEAD"; return 1; }
+    # `-V`, not `--version`: as of #2559 the long form is deliberately multi-line
+    # (four things claim the name `pv`, so it names itself and disclaims the pipe
+    # viewer), and four lines of prose inside a receipt line is unreadable. The
+    # short form is the one-line glance form and is itself unambiguous, so the
+    # receipt still records WHICH pv issued the verdict -- which is the whole
+    # point of this line, given it once recorded `pv 0.49.0` as evidence.
+    ok "pv pinned to HEAD build ($("$PV" -V))"
+    require_tool bashrs "shell linting must use bashrs, not shellcheck"
+    require_tool pmat   "code search must use pmat query, not grep"
+
+    # This script is shell, and is held to the rule it enforces.
+    bashrs_check "$REPO_ROOT/scripts/dogfood_surfaces.sh"
+    bashrs_check "$REPO_ROOT/scripts/check_no_hand_rolled_parsers.sh"
+
+    # Every contract, through the tool that exists for exactly this.
+    local out rc
+    out=$("$PV" lint "$REPO_ROOT/contracts/" 2>&1); rc=$?
+    if [ "$rc" -eq 0 ]; then
+        ok "pv lint contracts/ ($(printf '%s' "$out" | grep -oE '[0-9]+ errors' | head -1))"
+    else
+        bad "pv lint contracts/ FAILED: $(printf '%s' "$out" | tail -1)"
+    fi
+
+    # The CLI surface has a contract too.
+    pv_check "$REPO_ROOT/contracts/apr-cli-commands-v1.yaml" "CLI command contract"
+}
+# NOTE: contract/binary command parity is deliberately NOT checked here.
+# FALSIFY-CLI-001 and FALSIFY-CLI-002 in crates/apr-cli/tests/cli_commands.rs
+# already do it, and they do it BETTER: they compare THREE surfaces -- the clap
+# enum via `apr --help`, contracts/apr-cli-commands-v1.yaml, and the test's own
+# registered_commands() list -- and they are gated at ci.yml:333.
+#
+# A version of this script did add such a check. It compared only TWO of the
+# three, PASSED on the probar -> test rename, and let a real drift through that
+# FALSIFY-CLI-001/002 then caught in CI. Second time in this file that
+# reimplementing an existing falsifier produced a weaker one; the first was
+# hand-counting MCP tools, which FALSIFY-MCP-008 already asserts byte-identically
+# at four layers. Use the falsifier that exists.
+# A --help that exits 0, is non-empty, and mentions the thing it documents.
+# "exits 0" alone is satisfied by a binary that prints nothing.
+probe_help() {
+    local bin="$1" label="$2" out rc
+    out=$("$bin" --help 2>&1); rc=$?          # rc read directly, NOT through a pipe
+    if [ "$rc" -ne 0 ]; then
+        bad "$label --help exited $rc"; return
+    fi
+    if [ "${#out}" -lt 20 ]; then
+        bad "$label --help produced ${#out} bytes; a help text that short is not help"
+        return
+    fi
+    ok "$label --help"
+}
+
+# The outcome-excluding half: an unknown flag must be REJECTED. A CLI that
+# accepts anything is the hand-rolled-parser defect that silently dropped
+# --seed in simular.
+probe_rejects_garbage() {
+    local bin="$1" label="$2" out rc
+    out=$("$bin" --definitely-not-a-real-flag-xyz 2>&1); rc=$?
+    if [ "$rc" -eq 0 ]; then
+        bad "$label ACCEPTED an unknown flag (exit 0) -- it is not parsing its arguments"
+        return
+    fi
+    case "$out" in
+        *panicked*|*RUST_BACKTRACE*)
+            bad "$label PANICKED on an unknown flag instead of reporting an error" ;;
+        "")
+            bad "$label rejected an unknown flag but said nothing actionable" ;;
+        *)
+            ok "$label rejects an unknown flag" ;;
+    esac
+}
+
+# --- surfaces --------------------------------------------------------------
+
+surface_cli() {
+    printf '\n=== CLI ===\n'
+    local bins n
+    bins=$(enumerate_binaries)
+    n=$(printf '%s\n' "$bins" | grep -c .)
+    vacuity_guard "binaries" "$n" "$MIN_BINARIES"
+    printf '%s binary target(s)\n' "$n"
+
+    # ASK CARGO which executables it produced. Do NOT build a path from
+    # `cargo metadata`'s target_directory: measured in a worktree of this repo,
+    # metadata reports
+    #     /mnt/nvme-raid0/targets/aprender
+    # while the executables cargo actually wrote were at
+    #     <worktree>/target/debug/
+    # because .cargo/config.toml carries the target-dir redirect and is
+    # gitignored, so it exists in the main checkout and not in a worktree.
+    # Probing a constructed path therefore exercises a binary built from a
+    # DIFFERENT TREE -- which is worse than no dogfood, because it produces a
+    # confident receipt about code you are not shipping.
+    local artifacts
+    artifacts=$(cargo build --bins --workspace --message-format=json 2>/dev/null \
+        | python3 -c '
+import json,sys
+for line in sys.stdin:
+    try: d=json.loads(line)
+    except Exception: continue
+    if d.get("reason")=="compiler-artifact" and d.get("executable"):
+        print(d["executable"])
+' | LC_ALL=C sort -u)
+
+    ARTIFACTS="$artifacts"
+    local an
+    an=$(printf '%s\n' "$artifacts" | grep -c .)
+    vacuity_guard "built executables" "$an" "$MIN_BINARIES"
+    printf '%s executable(s) reported by cargo\n' "$an"
+
+    local path b
+    while IFS= read -r path; do
+        [ -n "$path" ] || continue
+        b=$(basename "$path")
+        if [ ! -x "$path" ]; then
+            skp "$b: cargo reported $path but it is not executable"
+            continue
+        fi
+        probe_help "$path" "$b"
+        probe_rejects_garbage "$path" "$b"
+    done <<< "$artifacts"
+
+    # apr is the flagship: every one of ITS subcommands must also answer --help.
+    local apr subs sn s
+    apr=$(printf '%s\n' "$artifacts" | grep -E '/apr$' | head -1)
+    if [ -n "$apr" ] && [ -x "$apr" ]; then
+        subs=$(enumerate_subcommands "$apr")
+        sn=$(printf '%s\n' "$subs" | grep -c .)
+        vacuity_guard "apr subcommands" "$sn" "$MIN_APR_COMMANDS"
+        printf '%s apr subcommand(s)\n' "$sn"
+        while IFS= read -r s; do
+            [ -n "$s" ] || continue
+            probe_help_sub "$apr" "$s"
+        done <<< "$subs"
+    else
+        skp "apr not built; every apr subcommand probe skipped"
+    fi
+}
+
+probe_help_sub() {
+    local bin="$1" sub="$2" out rc
+    out=$("$bin" "$sub" --help 2>&1); rc=$?
+    if [ "$rc" -ne 0 ]; then
+        bad "apr $sub --help exited $rc"; return
+    fi
+    case "$out" in
+        *panicked*) bad "apr $sub --help PANICKED" ;;
+        "")         bad "apr $sub --help printed nothing" ;;
+        *)          ok "apr $sub --help" ;;
+    esac
+}
+
+surface_http() {
+    printf '\n=== HTTP ===\n'
+    local routes n src
+    if [ -n "${DOGFOOD_LIVE_SERVER:-}" ]; then
+        routes=$(enumerate_routes_live "$DOGFOOD_LIVE_SERVER")
+        src="live server"
+        if [ -z "$routes" ]; then
+            bad "DOGFOOD_LIVE_SERVER=$DOGFOOD_LIVE_SERVER did not answer with a route index"
+            routes=$(enumerate_routes); src="source table (live probe failed)"
+        fi
+    else
+        routes=$(enumerate_routes)
+        src="source table (APPROXIMATE -- set DOGFOOD_LIVE_SERVER for the real set)"
+    fi
+    n=$(printf '%s\n' "$routes" | grep -c .)
+    vacuity_guard "routes" "$n" "$MIN_ROUTES"
+    printf '%s route(s), from the %s\n' "$n" "$src"
+
+    # Every mounted route must be reachable through the router's own table. The
+    # route-surface tests in aprender-serve already assert response SHAPE
+    # (actionable JSON, never a dropped connection); this asserts the table is
+    # not silently shrinking, which those tests cannot see.
+    local r
+    while IFS= read -r r; do
+        [ -n "$r" ] || continue
+        case "$r" in
+            /*) ok "route $r is mounted" ;;
+            *)  bad "route literal '$r' is not a path" ;;
+        esac
+    done <<< "$routes"
+
+    # A LIVE probe goes through probar -- this project's endpoint tester
+    # (`probar llm test` runs correctness against an LLM endpoint). Hand-rolling
+    # a curl loop here would be the same muda as hand-parsing a contract.
+    # probar ships as the aprender-test-cli binary ([lib] name = probador).
+    if [ -n "${DOGFOOD_LIVE_SERVER:-}" ]; then
+        local probar out rc
+        # Resolve probar independently of $ARTIFACTS: that variable is only
+        # populated by surface_cli, so running `--http` alone used to report
+        # "probar is not built" when it was merely not looked for. Ask cargo.
+        probar=$(printf '%s\n' "${ARTIFACTS:-}" | grep -E '/aprender-test-cli$' | head -1)
+        if [ -z "$probar" ]; then
+            # --features llm is REQUIRED, not optional. `Commands::Llm` is
+            # declared with no #[cfg], so clap advertises `llm` and renders its
+            # --help either way; only the HANDLER is gated. Building without
+            # the feature therefore yields a binary that parses `llm test`
+            # and then returns "LLM features not enabled", which this sweep
+            # used to report as a FAILED probe -- blaming the server for a gap
+            # in the harness, the very thing the config comment below warns
+            # against.
+            probar=$(cargo build -p aprender-test-cli --bin aprender-test-cli \
+                        --features llm \
+                        --message-format=json 2>/dev/null | python3 -c '
+import json,sys
+for line in sys.stdin:
+    try: d=json.loads(line)
+    except Exception: continue
+    if d.get("reason")=="compiler-artifact" and d.get("executable"):
+        print(d["executable"])
+' | grep -E '/aprender-test-cli$' | head -1)
+        fi
+        if [ -z "$probar" ] || [ ! -x "$probar" ]; then
+            bad "probar (aprender-test-cli) could not be built; endpoint probe unavailable"
+        else
+            # `probar llm test` requires --config <CONFIG>. That config now
+            # EXISTS (tests/fixtures/probar-llm-endpoint.yaml), so default to
+            # it rather than skipping: a probe that never runs is not a probe.
+            # An explicit DOGFOOD_PROBAR_CONFIG still wins. A missing INPUT is
+            # still a skip with a reason, never a failure -- reporting FAIL
+            # would blame the server for a gap in this harness.
+            : "${DOGFOOD_PROBAR_CONFIG:=${REPO_ROOT}/tests/fixtures/probar-llm-endpoint.yaml}"
+            [ -f "${DOGFOOD_PROBAR_CONFIG}" ] || DOGFOOD_PROBAR_CONFIG=""
+            if [ -n "${DOGFOOD_PROBAR_CONFIG:-}" ]; then
+                out=$("$probar" llm test --config "$DOGFOOD_PROBAR_CONFIG" \
+                                          --url "$DOGFOOD_LIVE_SERVER" 2>&1); rc=$?
+                if [ "$rc" -eq 0 ]; then
+                    ok "probar llm test against $DOGFOOD_LIVE_SERVER"
+                else
+                    bad "probar llm test FAILED: $(printf '%s' "$out" | tail -1)"
+                fi
+            else
+                skp "probar llm test needs a config (set DOGFOOD_PROBAR_CONFIG); routes were still probed individually"
+            fi
+        fi
+    else
+        skp "live endpoint probe (set DOGFOOD_LIVE_SERVER=<url> to run probar llm test)"
+    fi
+}
+
+surface_mcp() {
+    printf '\n=== MCP ===\n'
+    local tools n contract_n
+    tools=$(enumerate_mcp_tools)
+    n=$(printf '%s\n' "$tools" | grep -c .)
+    vacuity_guard "MCP tools" "$n" "$MIN_MCP_TOOLS"
+    printf '%s MCP tool(s)\n' "$n"
+
+    # The contract is validated by `pv`, not by a YAML parser of our own.
+    # CLAUDE.md is explicit: re-implementing in bash/yq/python what pv already
+    # does is muda and will be rejected. The first draft of this script parsed
+    # the contract with python and counted `tools:` entries by hand -- waste,
+    # AND redundant: FALSIFY-MCP-008 already asserts byte-identity between the
+    # codegen constants and the live `tools/list` response at four layers.
+    # Reimplementing a weaker version of an existing falsifier is the opposite
+    # of dogfooding.
+    pv_check "$REPO_ROOT/contracts/apr-mcp-tool-schemas-v1.yaml" "MCP tool schema contract"
+
+    local t
+    while IFS= read -r t; do
+        [ -n "$t" ] || continue
+        case "$t" in
+            apr.*) ok "tool $t" ;;
+            *)     bad "tool '$t' does not use the apr.* namespace" ;;
+        esac
+    done <<< "$tools"
+}
+
+# --- self-test -------------------------------------------------------------
+
+if [ "${1:-}" = "--self-test" ]; then
+    fails=0
+    # The load-bearing property: a probe must REJECT, not merely run.
+    tmp=$(mktemp -d) || exit 1
+    case "$tmp" in /tmp/*|/var/folders/*) : ;; *) printf 'bad tmp\n'; exit 1 ;; esac
+    trap 'rm -rf "${tmp:?}"' EXIT
+
+    printf '#!/usr/bin/env bash\necho "usage: permissive [OPTIONS]"\nexit 0\n' > "$tmp/permissive"
+    printf '#!/usr/bin/env bash\ncase "$1" in --help) echo "usage: strict [OPTIONS]"; exit 0;; *) echo "error: unexpected argument" >&2; exit 2;; esac\n' > "$tmp/strict"
+    chmod +x "$tmp/permissive" "$tmp/strict"
+
+    pass=0; fail=0; skip=0; FAILURES=""
+    probe_rejects_garbage "$tmp/strict" strict >/dev/null
+    if [ "$fail" -eq 0 ]; then
+        printf 'ok    row 1 a CLI that rejects an unknown flag passes\n'
+    else
+        printf 'FAIL  row 1 a correct CLI was reported as failing\n'; fails=1
+    fi
+
+    pass=0; fail=0; FAILURES=""
+    probe_rejects_garbage "$tmp/permissive" permissive >/dev/null
+    if [ "$fail" -eq 1 ]; then
+        printf 'ok    row 2 a CLI that ACCEPTS an unknown flag is caught\n'
+    else
+        printf 'FAIL  row 2 a permissive CLI passed -- the probe excludes nothing\n'; fails=1
+    fi
+
+    # Row 3: the vacuity guard must fire, or a broken enumeration reads as a
+    # clean sweep.
+    if ( vacuity_guard "widgets" 0 5 >/dev/null 2>&1 ); then
+        printf 'FAIL  row 3 vacuity_guard accepted an empty enumeration\n'; fails=1
+    else
+        printf 'ok    row 3 vacuity_guard rejects an empty enumeration\n'
+    fi
+
+    [ "$fails" -eq 0 ] || { printf '\nSELF-TEST FAILED\n'; exit 1; }
+    printf '\nSELF-TEST PASSED (3/3)\n'
+    exit 0
+fi
+
+# --- feature emission (the denominator) -------------------------------------
+#
+# Emits "<binary>\t<feature>" for the surface this script can enumerate AT
+# RUNTIME, so contracts/apr-dogfood-coverage-v1.yaml (F-DOGCOV-002) can diff the
+# shipped surface against docs/audits/surface_audit.csv in BOTH directions:
+#
+#   in the binary, not in the ledger : the ledger is stale
+#   in the ledger, not in the binary : the surface shrank unnoticed
+#
+# SCOPE IS DECLARED, NOT IMPLIED. `--help` can authoritatively enumerate the
+# subcommand TREE and nothing else. Four other surface kinds live in the ledger
+# and are NOT emitted here, so a naive set-equality would report hundreds of
+# false "shrank" hits and get itself disabled:
+#
+#   flags        `apr run --backend cuda`  -- a flag is not a subcommand; clap
+#                prints it in Options:, and enumerating flag VALUES needs the
+#                value_parser, which --help does not always name
+#   HTTP routes  emitted only when DOGFOOD_LIVE_SERVER is set, because the
+#                SOURCE-TABLE fallback is wrong in both directions -- measured
+#                against a live server it misses 5 routes including
+#                /v1/chat/completions, and claims 2 that are conditionally
+#                mounted and absent
+#   MCP tools    need a live tools/list
+#   REPL verbs   aprender-train-shell's 10 verbs are reachable only by driving
+#                the REPL (`-c <verb>`), never from --help
+#
+# The scope line goes to stderr on every run so a consumer cannot mistake a
+# partial denominator for the whole one.
+#
+# DEPTH 4, measured not guessed: the ledger's deepest CLI entry is
+# `apr data x doctest extract`. A deeper tree would be silently truncated, so
+# the depth is stated here and the ledger is what proves it sufficient.
+EMIT_MAX_DEPTH="${EMIT_MAX_DEPTH:-4}"
+
+emit_subtree() {
+    # $1 binary path, $2 binary name, $3 current depth, $4.. command path
+    local path="$1" name="$2" depth="$3"; shift 3
+    local prefix="$*" out subs s
+    [ "$depth" -gt "$EMIT_MAX_DEPTH" ] && return 0
+    # shellcheck disable=SC2086
+    out=$(timeout 20 "$path" $prefix --help 2>&1) || return 0
+    subs=$(printf '%s\n' "$out" | awk '
+        /^[Cc]ommands:/ { inb=1; next }
+        /^[A-Za-z]/     { inb=0 }
+        inb && /^  [a-z][a-z0-9._-]*([[:space:]]|$)/ { print $1 }
+    ' | grep -vE '^(help)$' | LC_ALL=C sort -u)
+    [ -n "$subs" ] || return 0
+    while IFS= read -r s; do
+        [ -n "$s" ] || continue
+        printf '%s\t%s %s%s\n' "$name" "$name" "${prefix:+$prefix }" "$s"
+        emit_subtree "$path" "$name" "$((depth + 1))" ${prefix:+$prefix} "$s"
+    done <<< "$subs"
+}
+
+emit_features() {
+    printf 'scope: CLI subcommand tree to depth %s from --help on the BUILT binary.\n' \
+        "$EMIT_MAX_DEPTH" >&2
+    printf 'NOT emitted: flags, MCP tools, REPL verbs' >&2
+    if [ -n "${DOGFOOD_LIVE_SERVER:-}" ]; then
+        printf ' (routes: LIVE from %s)\n' "$DOGFOOD_LIVE_SERVER" >&2
+    else
+        printf ', HTTP routes (set DOGFOOD_LIVE_SERVER to include them)\n' >&2
+    fi
+
+    # THE DENOMINATOR DEPENDS ON THE CARGO FEATURE SET, so it is declared rather
+    # than left implicit. A DEFAULT build hides every `#[cfg(feature = ...)]`
+    # subcommand, and those subcommands still SHIP -- a user who enables the
+    # feature gets them. Measured on 2026-08-22 a default build hides 26 ledger
+    # entries behind four features:
+    #   dev      -> apr mono {publish,shims,audit,archive}
+    #   hf-hub   -> alimentar {hub push, import hf}     (+ the apr data x mirror)
+    #   doctest  -> alimentar doctest {extract,merge}   (+ the apr data x mirror)
+    #   eval     -> trueno-rag eval {7 verbs}           (+ the apr rag mirror)
+    # Proven by rebuilding with the feature and watching them appear, not
+    # inferred from the cfg attribute. Consumers MUST compare against a run with
+    # the same feature set or treat those rows as a declared allowance.
+    printf 'FEATURESET\t%s\n' "${DOGFOOD_EMIT_FEATURES:-<cargo default>}"
+
+    local artifacts an path b declared dn featarg=""
+    [ -n "${DOGFOOD_EMIT_FEATURES:-}" ] && featarg="--features=${DOGFOOD_EMIT_FEATURES}"
+    declared=$(enumerate_binaries)
+    dn=$(printf '%s\n' "$declared" | grep -c .)
+    vacuity_guard "declared binaries" "$dn" "$MIN_BINARIES"
+    # shellcheck disable=SC2086
+    artifacts=$(cargo build --bins --workspace $featarg --message-format=json 2>/dev/null \
+        | python3 -c '
+import json,sys
+for line in sys.stdin:
+    try: d=json.loads(line)
+    except Exception: continue
+    if d.get("reason")=="compiler-artifact" and d.get("executable"):
+        print(d["executable"])
+' | LC_ALL=C sort -u)
+    an=$(printf '%s\n' "$artifacts" | grep -c .)
+    vacuity_guard "built executables" "$an" "$MIN_BINARIES"
+
+    # A binary cargo DECLARES but does not BUILD is unprobed, and silence here
+    # would let it read as a surface that shrank. `ptop` and `score` are exactly
+    # this: both carry required-features outside `default`, so `--bins
+    # --workspace` skips them and surface_cli never probes them either.
+    local built_names
+    built_names=$(printf '%s\n' "$artifacts" \
+        | sed -e 's#.*/##' \
+        | grep -v '^$' \
+        | LC_ALL=C sort -u)
+    while IFS= read -r b; do
+        [ -n "$b" ] || continue
+        if ! printf '%s\n' "$built_names" | grep -qx "$b"; then
+            printf 'UNPROBED\t%s (declared by cargo, not built -- required-features)\n' "$b"
+        fi
+    done <<< "$declared"
+
+    while IFS= read -r path; do
+        [ -n "$path" ] || continue
+        [ -x "$path" ] || continue
+        b=$(basename "$path")
+        emit_subtree "$path" "$b" 1
+    done <<< "$artifacts"
+
+    if [ -n "${DOGFOOD_LIVE_SERVER:-}" ]; then
+        local r live_routes
+        live_routes=$(enumerate_routes_live_verbed "${DOGFOOD_LIVE_SERVER}")
+        while IFS= read -r r; do
+            [ -n "$r" ] || continue
+            printf 'apr\t%s\n' "$r"
+        done <<< "$live_routes"
+    fi
+}
+
+# The route index as "VERB /path", which is how the ledger records a route.
+# enumerate_routes_live strips the verb because the HTTP sweep compares paths;
+# the ledger keeps it, and DELETE /api/delete is not GET /api/delete.
+enumerate_routes_live_verbed() {
+    curl -sf -m 5 "$1/" 2>/dev/null | python3 -c '
+import json,sys
+try: d=json.load(sys.stdin)
+except Exception: sys.exit(0)
+for r in sorted(set(d.get("routes",[]))): print(r.strip())
+'
+}
+
+if [ "${1:-}" = "--emit-features" ]; then
+    emit_features
+    exit 0
+fi
+
+# --- driver ----------------------------------------------------------------
+
+if [ "${1:-}" = "--twice" ]; then
+    a=$(mktemp); b=$(mktemp)
+    DOGFOOD_RECEIPT="$a" bash "${BASH_SOURCE[0]}" > /dev/null 2>&1
+    DOGFOOD_RECEIPT="$b" bash "${BASH_SOURCE[0]}" > /dev/null 2>&1
+    if diff -q "$a" "$b" > /dev/null 2>&1; then
+        printf 'DETERMINISTIC: two sweeps produced byte-identical receipts.\n'
+        rm -f "$a" "$b"; exit 0
+    fi
+    printf 'NON-DETERMINISTIC: receipts differ.\n\n'
+    diff "$a" "$b" | head -20
+    rm -f "$a" "$b"; exit 1
+fi
+
+want_cli=0; want_http=0; want_mcp=0
+for a in "$@"; do
+    case "$a" in
+        --cli) want_cli=1 ;;
+        --http) want_http=1 ;;
+        --mcp) want_mcp=1 ;;
+    esac
+done
+if [ "$want_cli" -eq 0 ] && [ "$want_http" -eq 0 ] && [ "$want_mcp" -eq 0 ]; then
+    want_cli=1; want_http=1; want_mcp=1
+fi
+
+printf '=== dogfood: every shipped interface (dogfood_surfaces.sh) ===\n'
+
+# Structural ban first: no binary may hand-roll argv parsing. The behavioural
+# probes below feed each binary an unknown flag and demand rejection, which
+# catches the worst hand-rolled parsers -- but a careful one that happens to
+# reject unknown flags today can regress tomorrow. Banning the construct makes
+# the guarantee independent of a probe hitting the broken case.
+if bash "$REPO_ROOT/scripts/check_no_hand_rolled_parsers.sh" > /dev/null 2>&1; then
+    ok "no binary hand-rolls argv parsing"
+else
+    bad "hand-rolled argv parsing found (run scripts/check_no_hand_rolled_parsers.sh)"
+fi
+
+surface_tools
+[ "$want_cli" -eq 1 ]  && surface_cli
+[ "$want_http" -eq 1 ] && surface_http
+[ "$want_mcp" -eq 1 ]  && surface_mcp
+
+total=$((pass+fail+skip))
+pct=0
+[ "$total" -gt 0 ] && pct=$(( skip * 100 / total ))
+
+{
+    printf 'dogfood surface receipt\n'
+    printf 'pass=%s fail=%s skip=%s total=%s skip_pct=%s\n' "$pass" "$fail" "$skip" "$total" "$pct"
+    [ -n "$FAILURES" ] && printf 'FAILURES:%s\n' "$FAILURES"
+    [ -n "$SKIPS" ] && printf 'SKIPS:%s\n' "$SKIPS"
+} > "$RECEIPT"
+
+printf '\n---\npass=%s fail=%s skip=%s (skip %s%%)\nreceipt: %s\n' \
+    "$pass" "$fail" "$skip" "$pct" "$RECEIPT"
+
+if [ "$pct" -gt "$MAX_SKIP_PCT" ]; then
+    printf '\nFAIL: skipped %s%% of probes (max %s%%). A sweep that skipped most\n' "$pct" "$MAX_SKIP_PCT"
+    printf 'of itself proves nothing -- build the binaries, or supply a model.\n'
+    exit 1
+fi
+[ "$fail" -eq 0 ] || exit 1
+printf 'PASS\n'
+exit 0

--- a/scripts/dogfood/pmat-gate-fleet.sh
+++ b/scripts/dogfood/pmat-gate-fleet.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# RELEASE GATE — the release binary against real sibling repositories.
+#
+# SKILL.md §11. Every other gate tests pmat against fixtures pmat's own authors
+# wrote, so the fixture and the code share an author and confirm each other.
+# These repos do not: they are 10 to 60,980 files of code nobody wrote to make
+# pmat look good.
+#
+# Takes no arguments: the runner executes declared gates bare.
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HARNESS="$HERE/pmat-fleet-dogfood.sh"
+SRC="${PMAT_FLEET_SRC:-$HOME/src}"
+BIN="${PMAT_BIN:-$PWD/target/debug/pmat}"
+
+[ -x "$BIN" ] || { echo "no pmat binary at $BIN — build first"; exit 1; }
+[ -r "$HARNESS" ] || { echo "harness missing: $HARNESS"; exit 1; }
+
+# The roster the clean room declares. Absent repos are NAMED, never silently
+# dropped — a sweep over an empty set is this protocol's signature false green.
+ROSTER="aprender forjar depyler bashrs duende rmedia copia pepita pzsh cohete pforge"
+present=0; missing=""; defects=0; probed=0
+
+for r in $ROSTER; do
+    d="$SRC/$r"
+    if [ ! -d "$d/.git" ]; then missing="$missing $r"; continue; fi
+    present=$((present + 1))
+    out=$(BIN="$BIN" TIMEOUT=600 OUT="$(mktemp)" timeout 900 bash "$HARNESS" "$d" 2>&1)
+    rc=$?
+    probed=$((probed + 8))
+    if [ $rc -ne 0 ]; then
+        defects=$((defects + 1))
+        printf '  ✗ %s\n' "$r"
+        printf '%s\n' "$out" | grep -E '✗ PMAT:' | sed 's/^/     /'
+    else
+        printf '  ✓ %s\n' "$r"
+    fi
+done
+
+[ -n "$missing" ] && echo "  not present (not probed):$missing"
+
+# A gate that probed nothing has not passed. Refuse rather than report success
+# over an empty set.
+if [ "$present" -eq 0 ]; then
+    echo "no sibling repo found under $SRC — this gate measured NOTHING, which is"
+    echo "not the same as finding nothing. Set PMAT_FLEET_SRC or clone the fleet."
+    exit 1
+fi
+
+echo "  fleet: $present repo(s), ~$probed probe(s), $defects with PMAT-DEFECTs"
+[ "$defects" -eq 0 ]

--- a/scripts/dogfood/pmat-gate-transport-parity.sh
+++ b/scripts/dogfood/pmat-gate-transport-parity.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# RELEASE GATE — one question asked over CLI, MCP stdio and HTTP.
+#
+# SKILL.md §12. A CLI-only sweep proves nothing about the other transports, and
+# this project's history records 24 MCP-vs-CLI contradictions in a single round.
+# The finding this produces is not "a transport is broken" — it is "the
+# transports DISAGREE", which is worse, because each looks right alone.
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HARNESS="$HERE/pmat-transport-parity.sh"
+SRC="${PMAT_FLEET_SRC:-$HOME/src}"
+BIN="${PMAT_BIN:-$PWD/target/debug/pmat}"
+
+[ -x "$BIN" ] || { echo "no pmat binary at $BIN — build first"; exit 1; }
+[ -r "$HARNESS" ] || { echo "harness missing: $HARNESS"; exit 1; }
+
+# Small, fast trees: parity is about AGREEMENT, not about scale.
+TARGETS="cohete pzsh copia"
+present=0; disagreements=0
+
+for r in $TARGETS; do
+    d="$SRC/$r"
+    [ -d "$d/.git" ] || continue
+    present=$((present + 1))
+    out=$(CLI_BIN="$BIN" TIMEOUT=300 OUT="$(mktemp)" timeout 900 bash "$HARNESS" "$d" 2>&1)
+    if [ $? -ne 0 ]; then
+        disagreements=$((disagreements + 1))
+        printf '%s\n' "$out" | grep -E '✗' | sed 's/^/  /'
+    fi
+done
+
+if [ "$present" -eq 0 ]; then
+    echo "no target repo present — this gate measured NOTHING. Set PMAT_FLEET_SRC."
+    exit 1
+fi
+
+echo "  parity: $present repo(s), $disagreements with transport disagreements"
+[ "$disagreements" -eq 0 ]

--- a/scripts/dogfood/pmat-invariance.py
+++ b/scripts/dogfood/pmat-invariance.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Invoke ONE verb across EVERY declared transport AT THE SAME TIME, compare.
+
+Why this is a separate gate from interface-parity
+-------------------------------------------------
+interface-parity proves each transport has an e2e that spawns the binary and
+passes. That is reachability, and it is necessary. It is not sufficient: three
+transports can each be reachable, each be green in its own test file, and still
+disagree about what a verb RETURNS. Nothing compares them, because each e2e only
+ever sees its own surface.
+
+Why SIMULTANEOUS rather than sequential
+---------------------------------------
+Running them one after another cannot distinguish "the transports agree" from
+"the transports share a process-global that only one of them may hold at a
+time". Standing every transport up at once and invoking through all of them
+while all are live is the configuration a real client fleet produces, and it is
+the one that surfaces a shared listener, a shared lock, or a runtime that only
+tolerates a single owner.
+
+Why DERIVED rather than hand-written
+------------------------------------
+The verb list comes from the BINARY, not from a list in this file. A hand-written
+probe tests the verbs someone remembered; a derived one tests the surface that
+shipped, and grows automatically when the surface does.
+"""
+import json, socket, subprocess, sys, time, urllib.request, urllib.error
+
+def die(msg, code=2):
+    print(f"INVARIANCE_ERROR {msg}")
+    sys.exit(code)
+
+def free_port():
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    p = s.getsockname()[1]
+    s.close()
+    return p
+
+def wait_ready(port, timeout=25.0):
+    """Probe by CONNECTING, never by binding: a probe that binds competes with
+    the server it is waiting for and can starve it."""
+    end = time.time() + timeout
+    while time.time() < end:
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.5):
+                return True
+        except OSError:
+            time.sleep(0.05)
+    return False
+
+def read_declaration():
+    """argv -> (binpath, decl, list_cmd, probe). Dies on an unusable declaration."""
+    binpath, decl_json = sys.argv[1], sys.argv[2]
+    decl = json.loads(decl_json)
+    list_cmd = decl.get("list")
+    probe = decl.get("probe") or {}
+    if not list_cmd or not probe.get("verb"):
+        die("declaration needs `list` and `probe = { verb, params }`")
+    return binpath, decl, list_cmd, probe
+
+def derive_verbs(binpath, list_cmd):
+    """The surface, DERIVED from the binary. Vacuity-guarded: an empty list dies."""
+    r = subprocess.run([binpath, *list_cmd.split()], capture_output=True, text=True, timeout=60)
+    if r.returncode != 0:
+        die(f"`{list_cmd}` exited {r.returncode}: {r.stderr.strip()[:200]}")
+    verbs = [l.strip() for l in r.stdout.splitlines() if l.strip()]
+    if not verbs:
+        die("the binary lists NO verbs — a parity check over an empty surface is vacuous")
+    return verbs
+
+def start_http(binpath, http, procs):
+    """Stand the http transport up and wait for it. Returns the port."""
+    port = free_port()
+    cmd = [binpath, *http["serve"].replace("{port}", str(port)).split()]
+    procs.append(subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL))
+    if not wait_ready(port):
+        die(f"http transport did not accept a connection on {port}")
+    return port
+
+def invoke_cli(binpath, template, verb, params):
+    # Split the TEMPLATE, then substitute per token. Splitting after
+    # substitution would tear a JSON params value containing spaces into
+    # several argv entries, and the verb would be invoked with garbage.
+    argv_list = [
+        params if t == "{params}" else t.replace("{verb}", verb)
+        for t in template.split()
+    ]
+    r = subprocess.run([binpath, *argv_list], capture_output=True, text=True, timeout=120)
+    if r.returncode != 0:
+        die(f"cli invoke failed ({r.returncode}): {r.stderr.strip()[:200]}")
+    return r.stdout.strip()
+
+def invoke_http(port, http, verb, params):
+    url = f"http://127.0.0.1:{port}" + http["path"].replace("{verb}", verb)
+    req = urllib.request.Request(url, data=params.encode(),
+                                 headers={"Content-Type": "application/json"})
+    try:
+        with urllib.request.urlopen(req, timeout=120) as resp:
+            return resp.read().decode().strip()
+    except urllib.error.HTTPError as e:
+        die(f"http invoke returned {e.code}: {e.read()[:200]!r}")
+
+def collect(binpath, decl, verb, params):
+    """Stand every transport up FIRST so all are live together, then invoke
+    through each while all are still up."""
+    results, procs = {}, []
+    try:
+        port = None
+        http = decl.get("http")
+        if http:
+            port = start_http(binpath, http, procs)
+        if decl.get("cli"):
+            results["cli"] = invoke_cli(binpath, decl["cli"], verb, params)
+        if http:
+            results["http"] = invoke_http(port, http, verb, params)
+    finally:
+        for p in procs:
+            p.kill()
+            p.wait()
+    return results
+
+def compare(results, verb, verbs):
+    """Identical AND valid. Two identically-wrong strings must not pass."""
+    names = list(results)
+    first = results[names[0]]
+    for n in names[1:]:
+        if results[n] != first:
+            print(f"INVARIANCE_FAIL `{verb}` differs between {names[0]} and {n}")
+            print(f"  {names[0]}: {first[:300]!r}")
+            print(f"  {n}: {results[n][:300]!r}")
+            sys.exit(1)
+    try:
+        json.loads(first)
+    except Exception:
+        print(f"INVARIANCE_FAIL all transports agree but the payload is not JSON: {first[:200]!r}")
+        sys.exit(1)
+    print(f"INVARIANCE_PASS {len(verbs)} verb(s) derived from the binary; "
+          f"`{verb}` byte-identical across {', '.join(names)} with all transports live")
+
+def main():
+    binpath, decl, list_cmd, probe = read_declaration()
+    verbs = derive_verbs(binpath, list_cmd)
+    verb, params = probe["verb"], probe.get("params", "{}")
+    if verb not in verbs:
+        die(f"probe verb `{verb}` is not in the binary's own list ({', '.join(verbs[:6])}…)")
+    results = collect(binpath, decl, verb, params)
+    if len(results) < 2:
+        print(f"INVARIANCE_SKIP only {len(results)} transport(s) invocable: {list(results)}")
+        return
+    compare(results, verb, verbs)
+
+main()

--- a/scripts/dogfood/pmat-pv_bin.sh
+++ b/scripts/dogfood/pmat-pv_bin.sh
@@ -1,0 +1,109 @@
+# pv_bin.sh — resolve THE pv built from HEAD, and prove it.
+#
+# Source it, never execute it:
+#     . scripts/pv_bin.sh || exit 1
+#     "$PV" lint contracts/
+#
+# WHY THIS EXISTS. `pv` on PATH was 0.49.0 while the in-tree crate was 0.63.0,
+# and the two disagreed on the gate that matters: strict-test-binding reported
+# 253 refs / 51 missing under the stale binary and 371 / 27 under HEAD. Both
+# surfaces where the RELEASE decision is made were using the stale one:
+#   scripts/dogfood_surfaces.sh  printed `pv present (pv 0.49.0)` into the
+#                                release receipt AS EVIDENCE OF CORRECTNESS
+#   Makefile `contracts:`        ran a bare `pv lint contracts/` as the gate
+#
+# This is the same defect the repo already solved for `apr` (CLAUDE.md "Step 0 —
+# pin the binary, ALWAYS"; four apr binaries once coexisted and a bare `apr`
+# resolved to a 26-day-old copy). Same remedy, same shape as scripts/apr_bin.sh.
+#
+# CARGO IS THE FRESHNESS AUTHORITY, not a version string. A version match is not
+# freshness: during this work pv was rebuilt three times at the SAME version with
+# two distinct md5s, and the two binaries gave different answers on an identical
+# tree. So we `cargo build` first and take the artifact cargo produces; the
+# version assert below is a second line of defence against a PATH fallback, not
+# the primary proof.
+#
+# OPTION-NEUTRAL BY CONSTRUCTION: this file sets no shell options. `set -euo
+# pipefail` in a SOURCED file mutates the CALLER's shell — that leak once killed
+# the nightly six lines in (see CLAUDE.md, scripts/check_sourced_libs_option_neutral.sh).
+# Failure is signalled by RETURN STATUS only.
+
+pv_bin_die() {
+    printf 'pv_bin: %s\n' "$*" >&2
+    return 1
+}
+
+pv_bin_root() {
+    git rev-parse --show-toplevel 2>/dev/null || pwd
+}
+
+# Build from HEAD and hand back the artifact cargo produced.
+pv_bin_resolve() {
+    if [ -n "${PV_BIN:-}" ]; then
+        printf '%s\n' "$PV_BIN"
+        return 0
+    fi
+    pv_bin_root_dir=$(pv_bin_root)
+    ( cd "$pv_bin_root_dir" && cargo build -q -p aprender-contracts-cli --bin pv ) >&2 \
+        || { pv_bin_die "cargo build of aprender-contracts-cli failed"; return 1; }
+    pv_bin_td=$( cd "$pv_bin_root_dir" \
+        && cargo metadata --no-deps --format-version 1 2>/dev/null \
+        | jq -r '.target_directory // empty' 2>/dev/null )
+    [ -n "$pv_bin_td" ] || { pv_bin_die "could not read cargo target_directory"; return 1; }
+    for pv_bin_cand in "$pv_bin_td/debug/pv" "$pv_bin_td/release/pv"; do
+        [ -x "$pv_bin_cand" ] && { printf '%s\n' "$pv_bin_cand"; return 0; }
+    done
+    pv_bin_die "no pv binary under $pv_bin_td after a successful build"
+    return 1
+}
+
+# Second line of defence: the resolved binary must report the version the tree
+# declares. Catches a PATH fallback or a hand-copied artifact.
+pv_bin_assert_fresh() {
+    pv_bin_b="$1"
+    [ -x "$pv_bin_b" ] || { pv_bin_die "not executable: $pv_bin_b"; return 1; }
+    pv_bin_declared=$(awk -F'"' '/^version[[:space:]]*=/{print $2; exit}' \
+        "$(pv_bin_root)/crates/aprender-contracts-cli/Cargo.toml" 2>/dev/null)
+    if [ -z "$pv_bin_declared" ]; then
+        pv_bin_declared=$(awk -F'"' '/^version[[:space:]]*=/{print $2; exit}' \
+            "$(pv_bin_root)/Cargo.toml" 2>/dev/null)
+    fi
+    [ -n "$pv_bin_declared" ] || { pv_bin_die "could not read declared pv version"; return 1; }
+    # POSITIONAL, first line only. `pv --version` is deliberately multi-line as
+    # of #2559 — it has to say WHICH pv this is, because four things claim that
+    # name. The old `awk '{print $NF}'` took the last field of EVERY line and
+    # handed this comparison four lines of prose. The version line's shape is
+    # pinned from the other side by
+    # crates/aprender-contracts-cli/tests/version_identity.rs
+    # (`semver_stays_the_second_field_of_the_first_line`), and by the case table
+    # in scripts/check_pv_version_parse.sh.
+    # ONE invocation, then both reads off the SAME captured text -- the semver
+    # and the identity must describe the same binary and the same run.
+    pv_bin_vers=$("$pv_bin_b" --version 2>&1)
+    pv_bin_actual=$(printf '%s\n' "$pv_bin_vers" | awk 'NR==1{print $2; exit}')
+    pv_bin_first=$(printf '%s\n' "$pv_bin_vers" | awk 'NR==1{print; exit}')
+    [ "$pv_bin_actual" = "$pv_bin_declared" ] || {
+        pv_bin_die "resolved pv reports $pv_bin_actual, tree declares $pv_bin_declared ($pv_bin_b)"
+        return 1
+    }
+    # IDENTITY, on the same line. #2559 added an identity string to `pv
+    # --version` precisely because four things claim the name `pv` -- but this
+    # function, the place the release actually DECIDES whether it has the right
+    # binary, went on proving freshness from the SEMVER alone. A semver is not
+    # an identity: pv(1) the pipe viewer ships 0.x versions too, and a stale
+    # sibling `pv` that happened to match the declared version would have
+    # satisfied the check above unchanged. So the marker is asserted here, where
+    # the decision is made, not only in the unit tests that watch the string.
+    case "$pv_bin_first" in
+        *"(aprender provable-contracts verifier)"*) ;;
+        *)
+            pv_bin_die "resolved pv does not identify as the aprender contracts verifier. First --version line: $pv_bin_first ($pv_bin_b). If that is pv(1) the pipe viewer, or another crate named pv, it is the wrong binary however its version reads."
+            return 1
+            ;;
+    esac
+    return 0
+}
+
+PV=$(pv_bin_resolve) || return 1 2>/dev/null || exit 1
+pv_bin_assert_fresh "$PV" || return 1 2>/dev/null || exit 1
+export PV

--- a/scripts/dogfood/pmat-transport-parity.sh
+++ b/scripts/dogfood/pmat-transport-parity.sh
@@ -115,7 +115,13 @@ compare "complexity/files"  "$CLI_CX" "$MCP_CX" files_analyzed total_files files
 
 CLI_SD=$(timeout "$TIMEOUT" "$CLI_BIN" analyze satd --path "$REPO" --format json 2>/dev/null)
 MCP_SD=$(mcp_call analyze_satd "$(printf '{"paths":["%s"]}' "$REPO")")
-compare "satd/total"        "$CLI_SD" "$MCP_SD" total_items total violations_found
+# NOT the bare key `total`. `scalar` searches RECURSIVELY, and the satd payload
+# carries `files_not_read.total` — so a fallback to `total` found the count of
+# files DECLINED (8) and compared it against MCP's count of violations (0),
+# reporting a transport disagreement where the two agree exactly. The first run
+# of this gate produced that false finding. Name the field that means what the
+# label says.
+compare "satd/total"        "$CLI_SD" "$MCP_SD" total_violations total_satd
 
 CLI_DC=$(timeout "$TIMEOUT" "$CLI_BIN" analyze dead-code --path "$REPO" --format json 2>/dev/null)
 MCP_DC=$(mcp_call analyze_dead_code "$(printf '{"paths":["%s"]}' "$REPO")")

--- a/scripts/dogfood/pmat-verifier_pin.sh
+++ b/scripts/dogfood/pmat-verifier_pin.sh
@@ -1,0 +1,177 @@
+# verifier_pin.sh — THE rule that says which binary a release gate is allowed to
+# believe, and the two pins that implement it.
+#
+# Source it, never execute it:
+#     . "$SKILL_DIR/verifier_pin.sh" || exit 2
+#     verifier_pin_pmat "$CRATE" "$BINPATH"   # sets+EXPORTS PMAT_BIN; 0 pinned,
+#                                             # 1 releasing pmat with no working artifact
+#     verifier_pin_pv                         # sets+EXPORTS PV; 0 pinned, 1 broken, 2 unpinned
+#
+# Both pins EXPORT their result: the gates this protocol discovers from
+# [package.metadata.dogfood] run as CHILD processes, and a shell-local pin is a
+# pin delivered to nobody — pin_audit would certify consumption the environment
+# never carried (#2644 audit, VPIN-4). Both pins verify BEHAVIOR, not existence:
+# `-x` accepts a broken stub and even a directory; only the binary answering
+# `--version` is evidence it can verify anything (#2644, VPIN-2).
+#
+# ── THE RULE ────────────────────────────────────────────────────────────────
+#
+#   A gate that decides a release must not resolve its verifier through PATH.
+#   Where the repo pins the tool, use the pin; where it does not, REPORT rather
+#   than fall back — a skipped gate that says so beats a green one measured with
+#   an unknown binary.
+#
+# It is stated HERE, once, and nowhere else. Every other file that needs it
+# points at this one. #2640 exists because the same rule had been rediscovered
+# FIVE times, each time as a local fix that did not know about the other four:
+#
+#   1  PMAT_BIN (user-scope dogfood runner)  a gate ran a pmat that predated
+#      CB-200 becoming a ratchet, and Failed a tree the shipped code passes
+#   2  scripts/pv_bin.sh                     PATH pv 0.49.0 vs in-tree 0.63.0
+#      disagreed on the gate that DECIDES the release
+#   3  scripts/apr_bin.sh                    four `apr` binaries coexisted; a
+#      bare `apr` resolved to a 26-day-old copy
+#   4  aprender#2384                         MCP spawned a bare `apr`, ran
+#      0.60.0 while reporting 0.63.0
+#   5  APR-BENCH-RFC-001                     unpinned llama.cpp comparator
+#
+# Five rediscoveries is the evidence that a rule merely STATED is documentation.
+# It is therefore also ENFORCED, by scripts/check_verifier_pinning.sh, which
+# fails on any bare pv/pmat/apr in command position in the runner — and which
+# proves the two pins BEHAVE, not merely that they are present.
+#
+# OPTION-NEUTRAL BY CONSTRUCTION: this file sets no shell options. `set -euo
+# pipefail` in a SOURCED file mutates the CALLER's shell — that leak once killed
+# the nightly six lines in (CLAUDE.md; scripts/check_sourced_libs_option_neutral.sh).
+# Failure is signalled by RETURN STATUS only.
+
+# ── WHICH pmat runs the pmat gates ──────────────────────────────────────────
+#
+# `pmat verify` and `pmat comply check` are normally the INSTALLED pmat applied
+# to whatever crate is under test — that is the point of a fleet quality tool.
+# But when the crate under test IS pmat, that is the one case where it is wrong:
+# the gate then measures a DIFFERENT BUILD than the one being released.
+#
+# Measured, 2026-08-22, releasing pmat 3.32.0:
+#   installed ~/.cargo/bin/pmat   version 3.32.0   commit 8134bb373
+#   built from the release tree   version 3.32.0   commit 7a7409e03
+# Both print "3.32.0". Only the commit line differs, and nothing in the receipt
+# showed it. The installed binary predated CB-200 becoming a ratchet — the
+# string "recorded baseline" occurs 0 times in it and 4 times in the new one —
+# so the release gate ran the OLD zero-tolerance check and returned Fail against
+# a tree the shipped code passes. A gate validating a release with a stale copy
+# of the thing being released is the same defect class this protocol exists to
+# find, sitting inside the protocol.
+#
+# So: for pmat, the pmat gates use the artifact just built. For every other
+# crate, PATH is correct and is what still happens.
+# Returns: 0 = pinned (the fleet pmat for a non-pmat crate, the behavior-verified
+#              built artifact when the crate IS pmat)
+#          1 = releasing pmat with a missing or non-working artifact — PMAT_BIN is
+#              left EMPTY and the caller must fail closed. The old behavior fell
+#              back to the PATH pmat silently, which is the recorded incident
+#              above happening again with this file watching (#2644, VPIN-1).
+#
+# The behavior check is `--version` answering with SOMETHING, deliberately not a
+# version-equality assert: the measurement above is two binaries both printing
+# "3.32.0" while running different code. A version string cannot discriminate
+# builds; a binary that cannot even print one cannot verify anything.
+verifier_pin_pmat() {
+    verifier_pin_crate="${1:-}"
+    verifier_pin_built="${2:-}"
+    PMAT_BIN=pmat
+    export PMAT_BIN
+    if [ "$verifier_pin_crate" = "pmat" ]; then
+        if [ -z "$verifier_pin_built" ]; then
+            PMAT_BIN=""
+            export PMAT_BIN
+            return 1
+        fi
+        verifier_pin_ver=""
+        if [ -f "$verifier_pin_built" ]; then
+            verifier_pin_ver=$("$verifier_pin_built" --version 2>/dev/null) || verifier_pin_ver=""
+        fi
+        if [ -z "$verifier_pin_ver" ]; then
+            PMAT_BIN=""
+            export PMAT_BIN
+            return 1
+        fi
+        PMAT_BIN="$verifier_pin_built"
+        export PMAT_BIN
+    fi
+    return 0
+}
+
+# ── WHICH pv validates the contracts ────────────────────────────────────────
+#
+# pv is PINNED, never PATH-resolved. scripts/pv_bin.sh records why: a PATH `pv`
+# was 0.49.0 while the in-tree crate was 0.63.0, and the two disagreed on the
+# gate that decides the release -- strict-test-binding reported 253 refs / 51
+# missing under the stale binary and 371 / 27 under HEAD. The dogfood runner IS
+# a surface where the release decision is made, so it must not be the one
+# holding the stale binary.
+#
+# This protocol runs against any repo in the fleet, and not all of them carry
+# pv_bin.sh. Where it is absent, pv is left UNRESOLVED and the contract gates
+# REPORT that rather than falling back to whatever PATH offers. A skipped gate
+# that says so beats a green one measured with an unknown binary.
+#
+# The subshell is load-bearing and is the one deviation from the copy this was
+# merged from. pv_bin.sh ends in `PV=$(...) || return 1 2>/dev/null || exit 1`.
+# Sourced at the top level of a function body, `return` would unwind the CALLER;
+# sourced inside a subshell, a failure exits only the subshell and this function
+# still gets to report it. The pin is thereby usable from a function, which is
+# what lets check_verifier_pinning.sh exercise it in isolation instead of taking
+# its presence on trust.
+#
+# Pin discovery anchors to the REPO, not the caller's cwd: `[ -f scripts/... ]`
+# from a subdirectory of a repo that DOES ship the pin returned 2, whose
+# documented meaning is "this repo ships no pin" — a false statement that
+# downgraded every pv gate to REPORT (#2644, VPIN-5). git names the root; a
+# non-git directory falls back to cwd, where the relative form was already
+# correct.
+#
+# The subshell also CLEARS the PV_BIN environment channel before sourcing:
+# pv_bin.sh honors an inherited PV_BIN and skips the cargo build it calls "THE
+# FRESHNESS AUTHORITY", so an exported stale path would ride straight through
+# the pin (#2644, VPIN-6/VP-04). Inside the subshell the unset is contained —
+# the caller's environment is untouched, per the option-neutral rule above.
+#
+# On failure the diagnostics pv_bin.sh wrote are no longer swallowed (#2644,
+# VPIN-3): they land in a kept tempfile whose tail is printed to stderr, so
+# rc=1 arrives saying WHICH stage failed instead of arriving mute.
+#
+# Returns: 0 = pinned, exported, and behavior-verified (`--version` answered)
+#          1 = pin present but FAILED to resolve (diagnostics on stderr)
+#          2 = this repo ships no pin (report, never fall back to PATH)
+verifier_pin_pv() {
+    PV=""
+    export PV
+    verifier_pin_root=$(git rev-parse --show-toplevel 2>/dev/null) || verifier_pin_root=""
+    [ -n "$verifier_pin_root" ] || verifier_pin_root=$PWD
+    [ -f "$verifier_pin_root/scripts/pv_bin.sh" ] || return 2
+    verifier_pin_pv_log=$(mktemp) || return 1
+    # The subshell is load-bearing (see the note above); the `if` wrapper keeps
+    # a failing command substitution from killing an errexit caller before the
+    # diagnostics below can be printed.
+    if PV=$( cd "$verifier_pin_root" && unset PV_BIN \
+             && . ./scripts/pv_bin.sh >"$verifier_pin_pv_log" 2>&1 \
+             && printf '%s' "$PV" ); then :; fi
+    verifier_pin_ver=""
+    if [ -n "$PV" ] && [ -f "$PV" ]; then
+        verifier_pin_ver=$("$PV" --version 2>/dev/null) || verifier_pin_ver=""
+    fi
+    if [ -n "$verifier_pin_ver" ]; then
+        export PV
+        rm -f "$verifier_pin_pv_log"
+        return 0
+    fi
+    PV=""
+    export PV
+    {
+        echo "verifier_pin_pv: the pin failed to resolve a working pv."
+        echo "  pv_bin.sh diagnostics (kept at $verifier_pin_pv_log):"
+        tail -15 "$verifier_pin_pv_log" 2>/dev/null | sed 's/^/    /'
+    } >&2
+    return 1
+}


### PR DESCRIPTION
The release protocol could not run. `scripts/dogfood/` now holds all of it — in
git, in the repo it gates.

## Vendoring the runner was not vendoring the protocol

It refused to start:

> `verifier_pin.sh` is missing. It carries the rule that decides WHICH pv and
> WHICH pmat this protocol is allowed to believe. Without it every verifier would
> fall back to PATH, which is the exact defect #2640 closed. **Refusing to run.**

Correct fail-closed behaviour — and it caught an incomplete job. Six more files,
all from `aprender@6adc4bce4`, all `pmat-`-prefixed so a symlink into a shared
skills directory cannot collide with another crate's runner:

| file | bytes | role |
|---|---|---|
| `pmat-verifier_pin.sh` | 9,467 | which binaries may be believed |
| `pmat-dogfood_surfaces.sh` | 33,177 | |
| `pmat-invariance.py` | 6,387 | |
| `pmat-pv_bin.sh` | 5,598 | |
| `pmat-dogfood_gates.py` | 2,910 | the ONE parser of the declaration |
| `pmat-check_verifier_pinning.sh` | | |

The runner's sibling lookups were rewired to those names (5 sites), so the
vendored copy resolves within itself and never reaches across a filesystem.

## Then the protocol found something in pmat

With it running, it reported: **no `[package.metadata.dogfood]` in Cargo.toml.**
pmat had never declared which release gates it owns.

An absent table and `gates = []` are **both FAIL** by design — a crate claiming
zero release gates has made a claim, and an unmade claim reads exactly like a
satisfied one.

Two are now declared, and the parser reads them back:

```
GATE scripts/dogfood/pmat-gate-fleet.sh
GATE scripts/dogfood/pmat-gate-transport-parity.sh
```

These are the wiring for SKILL.md §11 (fleet) and §12 (transport parity), which
the 2026-08-23 project audit found **documented but unrun** — this repo's
signature defect, sitting inside its own release protocol: prose promising a gate
with nothing executing it.

Both gates refuse on an empty set rather than reporting success over one:

```
no sibling repo found under $SRC — this gate measured NOTHING, which is
not the same as finding nothing.
```

Each declared gate also gets its **own row** in the receipt; rolling them into
one aggregate is how a red gate hides behind a green neighbour.

## Install

`make dogfood-install` now links every vendored `pmat-*` file rather than a
hardcoded three, so adding one to the directory is enough. Still `ln -sfn` —
measured over three runs, the link state is byte-identical, so re-running is a
no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012166727hFzq4xzFKFjUJPc