### PR TITLE
fix: token generation was Unix-only — serve --transport http dies on Windows (#1081)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5014,6 +5014,7 @@ dependencies = [
  "flate2",
  "fs2",
  "futures",
+ "getrandom 0.2.17",
  "gimli 0.34.0",
  "git2",
  "glob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,6 +182,12 @@ parking_lot = { version = "0.12", optional = true }
 dirs = { version = "6.0", optional = true }
 roaring = { version = "0.11", optional = true }
 rand = { version = "0.10", optional = true }
+# Portable OS entropy. ALREADY in the tree three times as a transitive dep, so
+# this adds no supply-chain surface and no build time — it just names what was
+# already being compiled. Direct because `mcp-http` generates a bearer token and
+# must do so on Windows too: reading /dev/urandom by hand shipped in 3.32.0 and
+# failed with "The system cannot find the path specified" (#1081).
+getrandom = "0.2"
 rayon = { version = "1.10", optional = true }
 # Optional: saves 67 transitive deps when disabled - falls back to shell `git` commands
 git2 = { version = "0.21", default-features = false, features = ["https"], optional = true }

--- a/src/cli/handlers/mcp_onboarding.rs
+++ b/src/cli/handlers/mcp_onboarding.rs
@@ -52,16 +52,32 @@ pub const REQUIRED_ACCEPT: &str = "application/json, text/event-stream";
 
 /// Read `n` bytes from the operating system's CSPRNG.
 ///
-/// `/dev/urandom` rather than a crate: this must work in every feature
-/// combination that can compile `mcp-http`, and `rand` is optional (it arrives
-/// via `standard-deps`). A dependency-free read of the same kernel pool that
-/// `getrandom` uses on Linux keeps token generation from being coupled to a
-/// feature flag.
+/// `getrandom`, not a hand-rolled `/dev/urandom` read. The first version opened
+/// that file directly, to avoid depending on `rand` — which is optional, arriving
+/// via `standard-deps`, and so cannot be relied on by every feature combination
+/// that can compile `mcp-http`. The GOAL was right; the mechanism was Unix-only,
+/// and 3.32.0 shipped a token generator that cannot run on Windows at all:
+///
+/// ```text
+/// Error: could not read the OS random source (/dev/urandom) to generate a
+/// bearer token: The system cannot find the path specified. (os error 3)
+/// ```
+///
+/// Its own doc comment said "the same kernel pool that `getrandom` uses on
+/// Linux" — it named the platform and shipped as though that were universal
+/// (#1081).
+///
+/// The trade it was avoiding did not exist: `getrandom` is ALREADY compiled into
+/// every build as a transitive dependency (three versions in `Cargo.lock`), so
+/// naming it directly costs no supply-chain surface and no build time, and it
+/// has no feature coupling — which is strictly better than the file read for the
+/// `--no-default-features --features mcp-http` case the original was protecting.
 fn os_entropy(n: usize) -> std::io::Result<Vec<u8>> {
-    use std::io::Read;
-    let mut file = std::fs::File::open("/dev/urandom")?;
     let mut buf = vec![0u8; n];
-    file.read_exact(&mut buf)?;
+    // getrandom::Error does not implement std::error::Error in 0.2, so it
+    // cannot go through io::Error::other directly. Its Display is the useful
+    // part (it names the OS call that failed), so carry that.
+    getrandom::getrandom(&mut buf).map_err(|e| std::io::Error::other(e.to_string()))?;
     Ok(buf)
 }
 
@@ -86,7 +102,7 @@ fn hex(bytes: &[u8]) -> String {
 pub fn generate_token() -> Result<String> {
     let bytes = os_entropy(GENERATED_TOKEN_BYTES).map_err(|e| {
         anyhow::anyhow!(
-            "could not read the OS random source (/dev/urandom) to generate a \
+            "could not read the OS random source to generate a \
              bearer token: {e}. Set one yourself instead, e.g. \
              `export PMAT_MCP_HTTP_TOKEN=$(openssl rand -hex 24)`"
         )


### PR DESCRIPTION
Closes #1081. **Shipped in 3.32.0.**

`pmat serve --transport http` with no token — the one-command onboarding path this release added — cannot run on Windows:

```
Error: could not read the OS random source (/dev/urandom) to generate a bearer
token: The system cannot find the path specified. (os error 3)
```

## The doc comment named the flaw without noticing it

`os_entropy` opened `/dev/urandom` directly, justified as avoiding a dependency on optional `rand`:

> A dependency-free read of the same kernel pool that `getrandom` uses **on Linux**

It reasoned about one platform and shipped as though that were universal.

## The trade it was avoiding did not exist

```
$ grep -c 'name = "getrandom"' Cargo.lock
3                          # already in the tree, three versions
rand in the default feature closure: True
```

`getrandom` was **already compiled into every build** transitively, so naming it directly costs no supply-chain surface and no build time — and it has no feature coupling, which serves the `--no-default-features --features mcp-http` case *better* than the file read did.

## Verified

```
generated token: pmat-567cf5266374c692e13351b3b4180433f5aa30e7e89429c3  (53 chars)
prints the 'claude mcp add' line: yes
tools over HTTP with that token: 19
mcp_onboarding suite: 12 passed, 0 failed
```

**Counter-test still holds** — a short token is still refused (`must be at least 16 characters; got 7`). Generation goes *through* `BearerToken::new`, not around it, so the security floor is untouched.

## How it was caught

Nothing in pmat's CI exercises `serve --transport http` on Windows — `windows-check` builds and stops. This came from the pmat-book's Chapter 3.4 suite running on `windows-latest`: the **first time that book's tests have ever executed in CI**, because every job previously died on a deprecated `actions/upload-artifact@v3` before checkout.

A book that runs its own examples across three platforms turned out to be a better integration test of this feature than the tool's own suite. Two repos had to be fixed before either could see it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)