### PR TITLE
fix(quality-proxy): a missing clippy was reported as a verdict about the code

### DIFF
--- a/docs/status/unrun-tests-ledger.md
+++ b/docs/status/unrun-tests-ledger.md
@@ -14,7 +14,7 @@ Legs consulted (3):
 - `feature-matrix.yml:feature-tests[mcp-integration]`
 - `feature-matrix.yml:feature-tests[unified-protocol]`
 
-23577 of 26803 lib tests are executed; 3226 are compiled by no leg.
+23583 of 26809 lib tests are executed; 3226 are compiled by no leg.
 
 ## `<unsatisfiable>` — 18 test(s)
 

--- a/src/cli/commands/commands_enum/definition.rs
+++ b/src/cli/commands/commands_enum/definition.rs
@@ -912,13 +912,17 @@ pub enum Commands {
     ///
     /// QUICK START — no arguments, no token, nothing to assemble:
     ///
-    ///     pmat serve --transport http --port 8765
+    /// ```text
+    /// pmat serve --transport http --port 8765
+    /// ```
     ///
     /// With `PMAT_MCP_HTTP_TOKEN` unset on a loopback bind, pmat GENERATES a
     /// conforming bearer token, prints it, and prints the exact `claude mcp
     /// add` line for the port it bound, e.g.
     ///
-    ///     claude mcp add --scope user --transport http pmat http://127.0.0.1:8765/ --header "Authorization: Bearer $TOKEN"
+    /// ```text
+    /// claude mcp add --scope user --transport http pmat http://127.0.0.1:8765/ --header "Authorization: Bearer $TOKEN"
+    /// ```
     ///
     /// A generated token dies with the process, so restarting mints a new one
     /// and a client registered with the old one gets 401. Pin a stable token

--- a/src/cli/hook_clippy_gate_tests.rs
+++ b/src/cli/hook_clippy_gate_tests.rs
@@ -92,6 +92,32 @@ fn clippy_verdict(dir: &Path, lib_rs: &str) -> (bool, String) {
         String::from_utf8_lossy(&out.stdout),
         String::from_utf8_lossy(&out.stderr)
     );
+
+    // A tool that did not run has no verdict, and must not be allowed to
+    // impersonate one. On `rust:1.95-slim` (the clean-room image) the rustup
+    // shim `cargo-clippy` exists while the component does not, so this command
+    // exits non-zero having compiled nothing:
+    //
+    //   error: 'cargo-clippy' is not installed for the toolchain '1.95.0-...'
+    //
+    // `out.status.success()` is then false, which SATISFIED the two
+    // `assert!(!ok, ...)` rejection tests below — they passed while measuring
+    // nothing — and failed the counter-test with a message about lints.
+    // paiml/infra run 33091353601, GATE B2. Fail here instead, naming the tool.
+    // An `assert!` rather than the panic macro, and no unwrapping: BOTH are
+    // counted verbatim by `.pmat-ratchet.toml` (`panic_macro_calls_src`,
+    // `unwrap_calls_src_total`, each a `git grep -oF` over src/*.rs), and a fix
+    // for a measurement defect must not loosen a measurement gate. The grep is
+    // textual, so even naming those tokens in a comment moves the number.
+    let unavailable = crate::services::quality_proxy::clippy_unavailable_reason(&text);
+    assert!(
+        unavailable.is_none(),
+        "cargo clippy did not run, so this test measured nothing: {}\n\
+         Install it with `rustup component add clippy`. A missing verifier \
+         is a NO-GO, not a lint verdict.\nFull output:\n{text}",
+        unavailable.as_deref().unwrap_or("")
+    );
+
     (out.status.success(), text)
 }
 

--- a/src/services/quality_proxy_analysis.rs
+++ b/src/services/quality_proxy_analysis.rs
@@ -37,6 +37,103 @@ pub(crate) fn lint_line_severity(line: &str) -> ViolationSeverity {
     }
 }
 
+/// Stderr fragments that mean **clippy never ran**, as opposed to clippy
+/// having run and disliked the code.
+///
+/// Each is emitted by cargo/rustup *before* any code is compiled.
+const CLIPPY_UNAVAILABLE_MARKERS: &[&str] = &[
+    // rustup: the shim exists, the component does not (rust:*-slim, and any
+    // minimal-profile toolchain):
+    //   error: 'cargo-clippy' is not installed for the toolchain '1.95.0-...'
+    "is not installed for the toolchain",
+    // rustup: the whole toolchain is missing:
+    //   error: toolchain '1.95.0-x86_64-unknown-linux-gnu' is not installed
+    // Anchored on rustup's closing quote so it cannot match a rustc diagnostic
+    // that merely contains the words.
+    "' is not installed",
+    // cargo: no `cargo-clippy` on PATH at all.
+    "no such command:",
+    // cargo (pre-1.54 wording).
+    "no such subcommand:",
+];
+
+/// Why `cargo clippy` could not deliver a verdict — `None` when it did.
+///
+/// This exists because a tool that did not run was being read as a judgement
+/// about the code. `rust:1.95-slim` installs the MINIMAL rustup profile, so
+/// `/usr/local/cargo/bin/cargo-clippy` is present as a *shim* while the clippy
+/// component is not installed. `cargo clippy` then writes, to stderr, exit 1:
+///
+/// ```text
+/// error: 'cargo-clippy' is not installed for the toolchain '1.95.0-x86_64-unknown-linux-gnu'.
+/// help: run `rustup component add clippy` to install it
+/// ```
+///
+/// Both lines begin with a rustc-shaped level prefix, so `lint_line_severity`
+/// filed the first as [`ViolationSeverity::Error`], `passed` became false, and
+/// `ProxyMode::Strict` answered `Rejected`. The caller cannot tell that
+/// rejection apart from "your code does not compile" — and the property test
+/// `test_high_quality_code_accepted` duly reported a minimal failing input
+/// (`file_path = "a.rs"`, `fn_name = "a"`), i.e. a logic bug that does not
+/// exist. Measured in paiml/infra run 33091353601, `clean-room (pmat)` GATE B2:
+/// 21024 passed, 9 failed, every failure this string.
+///
+/// A missing verifier is a NO-GO, never a verdict. Returning the reason here
+/// lets the lint stage fail loudly and name the tool.
+pub(crate) fn clippy_unavailable_reason(stderr: &str) -> Option<String> {
+    stderr.lines().find_map(|line| {
+        let trimmed = line.trim();
+        // Only cargo's/rustup's own diagnostics, not source spans that might
+        // quote one of these phrases inside the code being linted.
+        if !(trimmed.starts_with("error:") || trimmed.starts_with("error[")) {
+            return None;
+        }
+        CLIPPY_UNAVAILABLE_MARKERS
+            .iter()
+            .any(|marker| trimmed.contains(marker))
+            .then(|| trimmed.to_string())
+    })
+}
+
+/// Turn one completed `cargo clippy` run into lint findings, or into a loud
+/// error when the run produced no verdict to read.
+///
+/// Split out from [`QualityProxyService::run_lint_checks`] so the
+/// did-the-tool-even-run decision is a pure function over the process output
+/// and can be tested against the exact bytes the clean room saw.
+pub(crate) fn interpret_clippy_output(
+    output: &std::process::Output,
+) -> Result<Vec<(usize, String)>> {
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    if let Some(reason) = clippy_unavailable_reason(&stderr) {
+        anyhow::bail!(
+            "the quality proxy's lint stage did not run: {reason}\n\
+             This is a missing tool, not a finding about the code under review. \
+             Install it with `rustup component add clippy`. No lint verdict was \
+             produced, so none is reported."
+        );
+    }
+
+    let mut violations = Vec::new();
+    // Warnings are reported on a *successful* run too, so the findings are
+    // collected regardless of exit status.
+    for line in stderr.lines() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("warning:")
+            || trimmed.starts_with("error:")
+            || trimmed.starts_with("error[")
+        {
+            // Extract line number if possible
+            let line_num = 1; // Default line number
+            let message = line.to_string();
+            violations.push((line_num, message));
+        }
+    }
+
+    Ok(violations)
+}
+
 impl QualityProxyService {
     async fn analyze_content(
         &self,
@@ -132,25 +229,27 @@ impl QualityProxyService {
             }
         }
 
-        // Run lint checks using cargo clippy directly
-        let lint_violations = match self.run_lint_checks(content).await {
-            Ok(violations_found) => {
-                for (line, message) in &violations_found {
-                    violations.push(QualityViolation {
-                        violation_type: ViolationType::Lint,
-                        severity: lint_line_severity(message),
-                        location: format!("{file_path}:{line}"),
-                        message: message.clone(),
-                        suggestion: Some("Fix lint issue".to_string()),
-                    });
-                }
-                violations_found.len()
-            }
-            Err(e) => {
-                warn!("Failed to run lint checks: {}", e);
-                0
-            }
-        };
+        // Run lint checks using cargo clippy directly.
+        //
+        // A lint stage that did not run is NOT "zero lint violations". This arm
+        // used to `warn!` and substitute 0, publishing `metrics.lint_violations
+        // = 0` — a measurement nobody took — into the same QualityReport that
+        // callers read as evidence. The failure is propagated instead: the
+        // report either carries a lint measurement or it does not exist.
+        let violations_found = self
+            .run_lint_checks(content)
+            .await
+            .context("quality proxy lint stage failed; no lint measurement was produced")?;
+        for (line, message) in &violations_found {
+            violations.push(QualityViolation {
+                violation_type: ViolationType::Lint,
+                severity: lint_line_severity(message),
+                location: format!("{file_path}:{line}"),
+                message: message.clone(),
+                suggestion: Some("Fix lint issue".to_string()),
+            });
+        }
+        let lint_violations = violations_found.len();
 
         // Check documentation
         if config.require_docs {
@@ -260,27 +359,25 @@ edition = "2021"
         // style lint apart from content that does not compile. Levels are left
         // as rustc reports them so `lint_line_severity` can be trusted; the
         // caller decides what fails the gate.
-        let output = Command::new("cargo")
+        let output = match Command::new("cargo")
             .arg("clippy")
             .current_dir(temp_dir.path())
-            .output()?;
-
-        let mut violations = Vec::new();
-
-        // Warnings are reported on a *successful* run too, so the findings are
-        // collected regardless of exit status.
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        for line in stderr.lines() {
-            let trimmed = line.trim_start();
-            if trimmed.starts_with("warning:") || trimmed.starts_with("error:") || trimmed.starts_with("error[") {
-                // Extract line number if possible
-                let line_num = 1; // Default line number
-                let message = line.to_string();
-                violations.push((line_num, message));
+            .output()
+        {
+            Ok(output) => output,
+            // `cargo` itself is not on PATH. Spawning failed, so there is no
+            // stderr to classify — say so here rather than let a caller read
+            // an io error as a lint finding.
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => anyhow::bail!(
+                "the quality proxy's lint stage did not run: `cargo` is not on PATH ({e}). \
+                 This is a missing tool, not a finding about the code under review."
+            ),
+            Err(e) => {
+                return Err(e).context("failed to spawn `cargo clippy` for the quality proxy")
             }
-        }
+        };
 
-        Ok(violations)
+        interpret_clippy_output(&output)
     }
 
     async fn format_rust_code(&self, content: &str) -> Result<String> {
@@ -413,5 +510,147 @@ mod analysis_measurement_tests {
                 ViolationSeverity::Warning
             ));
         }
+    }
+}
+
+#[cfg(test)]
+mod lint_stage_availability_tests {
+    //! A missing tool must never be reported as a verdict about the code.
+    //!
+    //! These are not synthetic strings. `MISSING_COMPONENT_STDERR` is what
+    //! `cargo clippy` printed inside the `rust:1.95-slim` clean-room container
+    //! in paiml/infra run 33091353601, `clean-room (pmat)` GATE B2, where it
+    //! cost nine tests — including a proptest that reported a "minimal failing
+    //! input" for a logic bug that does not exist.
+    use super::*;
+
+    /// Verbatim from the clean-room job log (2026-08-27T17:07:27Z).
+    const MISSING_COMPONENT_LINE: &str =
+        "error: 'cargo-clippy' is not installed for the toolchain '1.95.0-x86_64-unknown-linux-gnu'.";
+    const MISSING_COMPONENT_STDERR: &str = concat!(
+        "error: 'cargo-clippy' is not installed for the toolchain '1.95.0-x86_64-unknown-linux-gnu'.\n",
+        "help: run `rustup component add clippy` to install it\n",
+    );
+
+    /// What clippy prints when it HAS run and found something.
+    const REAL_FINDINGS_STDERR: &str = "\
+    Checking temp_quality_check v0.1.0 (/tmp/.tmpXYZ)
+warning: function `simple` is never used
+ --> src/lib.rs:1:4
+warning: `temp_quality_check` (lib) generated 1 warning
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.31s
+";
+
+    /// What clippy prints when it HAS run and the content does not compile.
+    const REAL_COMPILE_ERROR_STDERR: &str = "\
+    Checking temp_quality_check v0.1.0 (/tmp/.tmpXYZ)
+error: expected one of `!` or `::`, found `is`
+ --> src/lib.rs:1:6
+error: could not compile `temp_quality_check` (lib) due to 1 previous error
+";
+
+    fn output(stderr: &str) -> std::process::Output {
+        std::process::Output {
+            // Exit status is deliberately not consulted: the missing-component
+            // run and a genuine compile error both exit non-zero.
+            status: Default::default(),
+            stdout: Vec::new(),
+            stderr: stderr.as_bytes().to_vec(),
+        }
+    }
+
+    /// THE regression. Falsification first: the same bytes, run through the
+    /// severity classifier the proxy actually uses, are an Error — which is how
+    /// "clippy is not installed" became `ProxyStatus::Rejected`. The guard is
+    /// therefore load-bearing, not decoration.
+    #[test]
+    fn a_missing_clippy_component_is_not_a_code_verdict() {
+        assert!(
+            MISSING_COMPONENT_STDERR.starts_with(MISSING_COMPONENT_LINE),
+            "the two constants must describe the same captured stderr"
+        );
+        assert!(
+            matches!(
+                lint_line_severity(MISSING_COMPONENT_LINE),
+                ViolationSeverity::Error
+            ),
+            "precondition: this line is what the proxy used to file as an Error \
+             about the code under review"
+        );
+
+        let reason = clippy_unavailable_reason(MISSING_COMPONENT_STDERR)
+            .expect("a toolchain without the clippy component ran nothing");
+        assert!(reason.contains("cargo-clippy"), "{reason}");
+
+        let err = interpret_clippy_output(&output(MISSING_COMPONENT_STDERR))
+            .expect_err("no verdict was produced, so none may be returned");
+        let msg = err.to_string();
+        assert!(msg.contains("did not run"), "{msg}");
+        assert!(
+            msg.contains("rustup component add clippy"),
+            "the failure has to name the tool and how to get it; got: {msg}"
+        );
+    }
+
+    #[test]
+    fn a_missing_toolchain_is_not_a_code_verdict() {
+        let stderr = "error: toolchain '1.95.0-x86_64-unknown-linux-gnu' is not installed\n";
+        assert!(clippy_unavailable_reason(stderr).is_some(), "{stderr}");
+        assert!(interpret_clippy_output(&output(stderr)).is_err());
+    }
+
+    #[test]
+    fn a_cargo_without_the_clippy_subcommand_is_not_a_code_verdict() {
+        for stderr in [
+            "error: no such command: `clippy`\n",
+            "error: no such subcommand: `clippy`\n",
+        ] {
+            assert!(clippy_unavailable_reason(stderr).is_some(), "{stderr}");
+            assert!(
+                interpret_clippy_output(&output(stderr)).is_err(),
+                "{stderr}"
+            );
+        }
+    }
+
+    /// The counter-test. A guard that refuses every run would hide real lint
+    /// findings, which is the same defect pointed the other way.
+    #[test]
+    fn a_clippy_run_that_actually_happened_still_reports_its_findings() {
+        assert!(clippy_unavailable_reason(REAL_FINDINGS_STDERR).is_none());
+        let found = interpret_clippy_output(&output(REAL_FINDINGS_STDERR))
+            .expect("clippy ran; its findings are a verdict");
+        assert_eq!(found.len(), 2, "{found:?}");
+        assert!(found
+            .iter()
+            .all(|(_, m)| m.trim_start().starts_with("warning:")));
+    }
+
+    /// Content that does not compile is a verdict about the content, and must
+    /// keep reaching strict mode as an Error.
+    #[test]
+    fn a_compile_error_is_still_a_verdict_about_the_code() {
+        assert!(clippy_unavailable_reason(REAL_COMPILE_ERROR_STDERR).is_none());
+        let found = interpret_clippy_output(&output(REAL_COMPILE_ERROR_STDERR))
+            .expect("clippy ran; a compile error is its answer");
+        assert!(
+            found
+                .iter()
+                .any(|(_, m)| matches!(lint_line_severity(m), ViolationSeverity::Error)),
+            "{found:?}"
+        );
+    }
+
+    /// The markers are matched only on cargo's own diagnostic lines, so a
+    /// source span that happens to quote one is still a finding.
+    #[test]
+    fn a_source_span_quoting_the_marker_is_not_mistaken_for_a_missing_tool() {
+        let stderr = "\
+warning: unused variable: `x`
+ --> src/lib.rs:2:9
+  |
+2 |     let x = \"no such command: nope\";
+";
+        assert!(clippy_unavailable_reason(stderr).is_none(), "{stderr}");
     }
 }


### PR DESCRIPTION
## The defect

`clean-room (pmat)` GATE B2 fails with `test result: FAILED. 21024 passed; 9
failed` — [paiml/infra run 33091353601](https://github.com/paiml/infra/actions/runs/33091353601),
job `98586479383`. The clean-room image is `rust:1.95-slim`, a MINIMAL-profile
toolchain, so every one of the nine failures is this string:

```
error: 'cargo-clippy' is not installed for the toolchain '1.95.0-x86_64-unknown-linux-gnu'.
help: run `rustup component add clippy` to install it
```

**The tool being absent is infra's problem** and is fixed there
([paiml/infra#348](https://github.com/paiml/infra/pull/348)). **What is ours is
that we read it as a judgement about the code under review.**

`run_lint_checks` shells out to `cargo clippy` and classifies each stderr line
with `lint_line_severity`, which keys on rustc's level prefix. The rustup error
starts with `error:`, so it was filed as `ViolationSeverity::Error`, `passed`
went false, and `ProxyMode::Strict` answered `ProxyStatus::Rejected` — a
rejection produced by a run that compiled nothing. The caller cannot tell it
apart from "your code does not compile". `test_high_quality_code_accepted` duly
reported a *minimal failing input* — `file_path = "a.rs"`, `fn_name = "a"`,
`param_name = "_"` — for a logic bug that does not exist.

`analyze_content` compounded it. When `run_lint_checks` returned `Err` it
logged a warning and substituted `0`, publishing `metrics.lint_violations = 0`
— a measurement nobody took — into the same `QualityReport` callers read as
evidence. **A lint stage that did not run is not zero lint violations.**

`hook_clippy_gate_tests::clippy_verdict` had the same defect one layer up. With
clippy absent `out.status.success()` is false, which **satisfied** both
`assert!(!ok, ...)` rejection tests — they passed while measuring nothing — and
failed only the counter-test, with a message about lints.

## The change

- `clippy_unavailable_reason` — the pure did-the-tool-even-run decision. It
  matches cargo's and rustup's own pre-compilation diagnostics, and only on
  lines carrying a level prefix, so a source span quoting one of the phrases is
  still a finding.
- `interpret_clippy_output` — split out of `run_lint_checks` so that decision is
  a pure function over the process output and can be tested against the exact
  bytes the clean room saw. Returns `Err` naming the tool when clippy did not
  run; unchanged otherwise. A spawn failure with `ErrorKind::NotFound` (no
  `cargo` at all) is likewise an error, not stderr to classify.
- `analyze_content` propagates the lint failure instead of fabricating `0`.
- `clippy_verdict` refuses to interpret a run that did not happen.

## Verified by running the actual clean room

The gate was reproduced end to end in a real `rust:1.95-slim` container
provisioned by `machines/clean-room/` with the infra fix applied, source copied
in by the harness's own `_copy-source`:

| | Mode B |
|---|---|
| before (run 33091353601) | B2 `21024 passed; 9 failed` |
| this branch, first pass | B2 `21037 passed; 2 failed` |
| this branch, second pass | B2 `21039 passed; 0 failed`, **B3 `286 passed; 2 failed`** |
| this branch, final | **`=== MODE B (pmat): ALL GATES PASSED ===` — 6 passed, 0 failed** |

```
--- GATE B-pre PASSED (1s) ---
--- GATE B0 PASSED   cargo check
--- GATE B1 PASSED   cargo build (debug)
--- GATE B2 PASSED   test result: ok. 21039 passed; 0 failed; 154 ignored
--- GATE B3 PASSED   test result: ok. 286 passed; 0 failed; 58 ignored
--- GATE B4 PASSED   cargo check --no-default-features
```

Exactly how the runs were staged, since it matters: the container was
provisioned by `machines/clean-room/` (`_create` + `_provision`) and the tree
copied in by the harness's own `_copy-source` at commit `e74dc72d`. The FINAL
run above then had only `definition.rs` (the second commit's one file) copied in
with `docker cp`, to keep the warm build cache — a full `_copy-source` deletes
`/build/pmat` including its `target/`. Mode A was not run; the failure is in
Mode B. `CARGO_BUILD_JOBS` was 8, not the 2 the Makefile pins for pmat
(PMAT-169); peak container memory was 5.7 GiB of 32, so that did not mask a
memory ceiling, but it is not the CI configuration byte for byte.

Three defects surfaced along the way, all **caused or uncovered by this change**
and fixed in it rather than waived:

```
.pmat-ratchet.toml is red at HEAD:
  panic_macro_calls_src: 787 count exceeds the baseline 786
  unwrap_calls_src_total: 20388 count exceeds the baseline 20387
```

The new guard used `panic!` and one `.unwrap()`, both of which
`.pmat-ratchet.toml` counts with a textual `git grep -oF` over `src/*.rs`. A fix
for a measurement defect must not loosen a measurement gate, so the guard was
rewritten as an `assert!` over an `Option` and the test constant restructured to
need no unwrapping — **the baselines are untouched**. (The grep is textual
enough that merely naming the tokens in a comment moved the number by one; the
comment is worded around it.) Measured: `git grep -oF '.unwrap()' -- 'src/*.rs'
| wc -l` = 20387 and `git grep -oF 'panic!(' -- 'src/*.rs' | wc -l` = 786 on
this branch, byte-identical to `origin/master`.

```
the unrun-tests ledger has drifted. ... RENDERED TEXT DIFFERS: true
```

Regenerated with `pmat analyze unrun-tests --write-ledger` (built from this
branch). The whole diff is `23577 of 26803` → `23583 of 26809`: the six new
tests, **all executed by a CI leg**, `3226 compiled by no leg` unchanged.

Both gates now pass locally, run against the committed tree:

```
$ cargo test --lib -- the_committed_ledger_matches_the_tree \
    the_committed_ratchet_holds_at_head every_committed_metric_command_still_measures \
    arm_a_max_unwrap_calls_is_judged_against_a_live_measurement
test result: ok. 4 passed; 0 failed
```

**Third: GATE B3, reached for the first time** (second commit). With B2 green,
Mode B advanced to the doctests and found two four-space-indented shell blocks
in `Commands::Serve`'s doc comment. rustdoc treats an indented block exactly
like an unannotated fence — as Rust — so `pmat serve --transport http --port
8765` was being handed to the compiler. Present on `origin/master`, in a file
this branch does not otherwise touch; it survived because gates.sh stops Mode B
at the first failure and B2 has been red since clippy went missing, so B3 had
not executed. A gate behind a red gate is not a gate. Fenced as ```` ```text ````;
`cargo test --doc` goes from 346 collected doctests to 344 and from
`286 passed; 2 failed` to `286 passed; 0 failed`.

## Other measurements

```
$ cargo test --lib -- hook_clippy_gate quality_proxy --test-threads 4
test result: ok. 84 passed; 0 failed
$ cargo clippy --lib --tests -- -D warnings     # rc 0
$ cargo fmt --all -- --check                    # rc 0
```

### Falsified against the real thing

The built test binary was run with a `cargo` stub reproducing `rust:1.95-slim`
exactly — the `cargo-clippy` **shim** on `PATH`, `cargo clippy` erroring. On
`origin/master` that reproduces the clean-room log byte for byte:

```
---- services::quality_proxy::tests::test_proxy_high_quality_code stdout ----
panicked at src/services/quality_proxy_tests.rs:27:9:
assertion failed: matches!(response.status, ProxyStatus::Accepted)

---- cli::hook_clippy_gate_tests::the_historical_roster_line_... stdout ----
panicked at src/cli/hook_clippy_gate_tests.rs:108:5:
expected clippy::unnecessary_sort_by, got:
error: 'cargo-clippy' is not installed for the toolchain '1.95.0-x86_64-unknown-linux-gnu'.

---- ...property_tests::test_high_quality_code_accepted stdout ----
Test failed: assertion failed: matches!(response.status, ProxyStatus::Accepted)
minimal failing input: file_path = "a.rs", fn_name = "a", param_name = "_"
```

On this branch, with the same stub, the same tests say what is actually wrong:

```
called `Result::unwrap()` on an `Err` value: quality proxy lint stage failed;
no lint measurement was produced
Caused by:
    the quality proxy's lint stage did not run: error: 'cargo-clippy' is not
    installed for the toolchain '1.95.0-x86_64-unknown-linux-gnu'.
    This is a missing tool, not a finding about the code under review. Install
    it with `rustup component add clippy`. No lint verdict was produced, so
    none is reported.

cargo clippy did not run, so this test measured nothing: error: 'cargo-clippy'
is not installed for the toolchain '1.95.0-x86_64-unknown-linux-gnu'.
Install it with `rustup component add clippy`. A missing verifier is a NO-GO,
not a lint verdict.
```

The new `lint_stage_availability_tests` carry that stderr verbatim from the job
log and assert, first, that `lint_line_severity` still classifies its first line
as an `Error` — i.e. the guard is load-bearing, not decoration — with
counter-tests that a real clippy run's findings and a real compile error are
still verdicts.

## Behaviour change for callers

`proxy_operation` now returns `Err` when the lint stage cannot run, where it
previously returned a `Rejected` (strict mode) or an `Accepted` carrying a
fabricated `lint_violations: 0`. All three call sites — `mcp_pmcp`,
`mcp/handlers`, `pdmt_quality_integration` — already propagate, so the message
reaches the user of the tool instead of a verdict nobody measured.

## Not fixed here

`auto_fix_content` still swallows a failed `format_rust_code` with
`if let Ok(formatted) = …`, so on a toolchain without the `rustfmt` component
(also absent from `rust:1.95-slim`) an `auto_format: true` request silently does
no formatting. That is a "silently did less than asked", not a fabricated
verdict, and no observed failure traces to it — flagging rather than changing it,
because making it loud would newly red `test_auto_fix_mode_removes_satd` in the
clean room until infra also supplies `rustfmt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


