### PR TITLE
fix(ci): Mutation (diff) has never once run its gate — two blockers, stacked

### DIFF
--- a/.github/workflows/mutation-diff.yml
+++ b/.github/workflows/mutation-diff.yml
@@ -139,6 +139,28 @@ jobs:
           # The gate diffs against a merge base; a shallow clone has none.
           fetch-depth: 0
 
+      # Every `git` below this line fails without it. The container runs as
+      # root; the workspace on the self-hosted runner is owned by uid 1000, and
+      # git refuses a repository it does not trust:
+      #
+      #   fatal: detected dubious ownership in repository at
+      #   '/__w/paiml-mcp-agent-toolkit/paiml-mcp-agent-toolkit'
+      #
+      # actions/checkout works because it writes safe.directory into a
+      # TEMPORARY gitconfig under an overridden HOME and removes it in its post
+      # step, so the exemption does not outlive the action. Measured in run
+      # 33159844910, the first run in this lane's life to get past step 4:
+      # `git merge-base` failed here and the gate died with "cannot find a merge
+      # base with 'origin/master'". The nightly path fails one step earlier and
+      # for the same reason — its `git rev-list -1 --before='24 hours ago'`
+      # returns empty, which the base resolver reports as an unresolvable ref.
+      #
+      # `git config --global --add safe.directory "$GITHUB_WORKSPACE"` is the
+      # fleet's standing remedy for exactly this: sovereign-ci.yml does it in
+      # both its `test` and `coverage` container jobs, with the same comment.
+      - name: Trust the checked-out workspace (container runs as root)
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       - name: Install cargo-mutants
         run: cargo install cargo-mutants --locked
 

--- a/.github/workflows/mutation-diff.yml
+++ b/.github/workflows/mutation-diff.yml
@@ -114,6 +114,25 @@ jobs:
     container:
       image: localhost:5000/sovereign-ci:stable
     timeout-minutes: 300
+    # DECLARE THE SHELL. Measured, not assumed: every one of this lane's first
+    # seven scheduled runs (2026-08-21 .. 2026-08-27, runs 32445403699 ..
+    # 33080877162) died in "Resolve the base to diff against" with
+    #
+    #   /__w/_temp/<id>.sh: 1: set: Illegal option -o pipefail
+    #   ##[error]Process completed with exit code 2
+    #
+    # because a step in a `container:` job on this fleet's runners is launched
+    # as `sh -e {0}` — and /bin/sh in localhost:5000/sovereign-ci:stable is
+    # dash, which has no `-o pipefail`. (Bare-metal steps in the same repo get
+    # `/usr/bin/bash --noprofile --norc -e -o pipefail {0}`, which is why the
+    # script below reads as correct: it is correct, for the shell its author was
+    # looking at.) bash IS present in the image at /usr/bin/bash, so the fix is
+    # to ask for it rather than to strip the bashisms and leave the next step
+    # to rediscover this. Job-level, so a step added later cannot re-enter the
+    # trap by omission. The gate never ran once in those seven nights.
+    defaults:
+      run:
+        shell: bash
     steps:
       - uses: actions/checkout@v7
         with:

--- a/scripts/mutation-diff-gate.sh
+++ b/scripts/mutation-diff-gate.sh
@@ -91,8 +91,16 @@ cmd_run() {
     # writes, the `--project .` the gate reads it from, and `--in-place`'s notion
     # of the tree. Running from a subdirectory would clear one `mutants.out` and
     # judge another.
-    cd "$(git rev-parse --show-toplevel)" ||
+    # `cd "$(git ...)"` cannot report this failure: when the substitution
+    # fails the argument is the empty string, and `cd ""` is a bash no-op that
+    # returns 0 — so the `die` was unreachable and the script carried on from
+    # whatever directory it happened to be in. Observed in run 33159844910,
+    # where `git rev-parse` died on dubious ownership and this line still
+    # succeeded. Capture, then check.
+    local root
+    root="$(git rev-parse --show-toplevel)" && [ -n "$root" ] ||
         die "not inside a git repository, so there is no diff to gate"
+    cd "$root" || die "cannot enter the repository root '$root'"
 
     command -v cargo >/dev/null 2>&1 || die "cargo is not on PATH"
     cargo mutants --version >/dev/null 2>&1 ||


### PR DESCRIPTION
## The defect

`paiml-mcp-agent-toolkit/Mutation (diff)` is one of the seven lanes the infra
nightly audit's `lane-liveness` dead-man's switch reported dead on 2026-08-27
(infra run 33071842506):

    paiml-mcp-agent-toolkit/Mutation (diff)   DEAD no-healthy 999d (>3d) — not allowlisted

999d is the switch's sentinel for "no healthy scheduled or dispatched run has
ever been observed". It is literal: **all seven scheduled runs since the
workflow landed** — 32445403699 (2026-08-21) through 33080877162 (2026-08-27) —
failed, and the gate has never executed. On a `pull_request` without the
`mutation` label the job is skipped, so nothing else was ever measured either.

### Blocker 1 — `set -euo pipefail` under dash

Every one of those seven runs died at the same step, "Resolve the base to diff
against", with the same error:

    /__w/_temp/<id>.sh: 1: set: Illegal option -o pipefail
    ##[error]Process completed with exit code 2

A `run:` step in a `container:` job on this fleet is launched as `sh -e {0}`,
and `/bin/sh` in `localhost:5000/sovereign-ci:stable` is dash. Measured in the
image:

    $ docker run --rm --entrypoint sh localhost:5000/sovereign-ci:stable \
        -c 'command -v bash; ls -l /bin/sh'
    /usr/bin/bash
    lrwxrwxrwx 1 root root 4 Jan  5  2023 /bin/sh -> dash

bash is present, so the fix is to ask for it, not to strip the bashisms and
leave the next step to rediscover this. The shell differs by job kind, not by
repo: bare-metal steps in this same repository get
`/usr/bin/bash --noprofile --norc -e -o pipefail {0}`, which is why the script
reads as correct — it is correct, for the shell its author was looking at.
`defaults.run.shell: bash` at the job level rather than `shell: bash` on the one
step, so a step added later cannot re-enter the trap by omitting it.

### Blocker 2 — dubious ownership, visible only once blocker 1 stopped hiding it

Run 33159844910, the first in this workflow's life to reach step 8, died there:

    fatal: detected dubious ownership in repository at
      '/__w/paiml-mcp-agent-toolkit/paiml-mcp-agent-toolkit'
    mutation-diff-gate.sh: FAIL: cannot find a merge base with 'origin/master'

The container runs as root; the workspace is owned by uid 1000. Every `git` in
every step of this job fails. actions/checkout is unaffected because it writes
`safe.directory` into a temporary gitconfig under an overridden HOME and removes
it in its post step. This is not specific to the dispatch path — the nightly
path fails one step earlier, because its
`git rev-list -1 --before='24 hours ago' HEAD` returns empty.

`git config --global --add safe.directory "$GITHUB_WORKSPACE"` is the fleet's
standing remedy; paiml/.github's `sovereign-ci.yml` does it in both its `test`
and `coverage` container jobs, under the same comment.

### And a `die` that could not fire

    cd "$(git rev-parse --show-toplevel)" ||
        die "not inside a git repository, so there is no diff to gate"

When the substitution fails the argument is the empty string, and `cd ""` is a
bash no-op returning 0 — so this `die` was unreachable and the script would
carry on from whatever directory it was invoked in, clear `mutants.out` and
judge a tree it had not chosen. That is exactly what happened in 33159844910:
`git rev-parse` printed the ownership error and this line still succeeded.
Captured into a variable and checked, with a separate message for a root that
exists but cannot be entered.

## Verification — the lane, green, end to end

Dispatched on this branch. **Run 33161139340: success, every step green**,
including the gate:

    5  Trust the checked-out workspace (container runs as root)  success
    6  Install cargo-mutants                                     success
    7  Resolve the base to diff against                          success
    8  Build the gate                                            success
    9  Mutation gate on the diff                                 success

    shell: bash --noprofile --norc -e -o pipefail {0}
    diffing against origin/master
    mutation-diff-gate.sh: diffing b5f6f7c..HEAD (base origin/master)
      INFO Diff changes no Rust source files
    mutation-diff-gate.sh: handing mutants.out/ to services::mutation_gate
    diff changes no mutable Rust source; no mutants were required

That is `DiffScope::NoMutableRustSource` — the one path on which an absent
`outcomes.json` is legitimate — and it is the correct verdict for a diff that
touches only a workflow file and a shell script. What it demonstrates is the
machinery: base resolution, gate build, cargo-mutants invocation and the Rust
verdict all now run. It does **not** demonstrate a mutation run over real Rust
changes; the first nightly after this merges is what will do that, and it can
legitimately go red on a surviving mutant. That is the gate working, not this
change failing.

Also verified locally: `bash -n scripts/mutation-diff-gate.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)