### PR TITLE
fix(stabilize-paiml-mcp-agent-toolkit): gitignore .claude/ runtime cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -249,3 +249,6 @@ pmat-*.tar.gz
 *-aarch64-apple-darwin.tar.gz
 /.pmat-metrics/
 .pmat/baseline.json
+
+# AI / Agent — runtime data (never version-controlled)
+.claude/


### PR DESCRIPTION
Stabilization PR for paiml/paiml-mcp-agent-toolkit.

- CI: workflows in .github/workflows/
- Branch: fix/stabilize-paiml-mcp-agent-toolkit → master

Adds .claude/ to .gitignore to exclude local agent runtime config.