### PR TITLE
deps(deps): bump wasmparser to 0.258 with the two call sites it breaks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7905,9 +7905,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.255.0"
+version = "0.258.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8e329ef4b5d46e73b91d3ac6924417cad55a8cbbf869c199283383427c3320b"
+checksum = "d9a61719f93a87b16d325921e251800c4833f8fab50fa21c7de73aed50086313"
 dependencies = [
  "bitflags 2.13.0",
  "hashbrown 0.17.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -356,7 +356,7 @@ crossterm = { version = "0.29", optional = true }
 sys-info = { version = "0.9.1", optional = true }
 
 # Storage backends (sled/rocksdb REMOVED - migrated to libsql/trueno-db)
-wasmparser = { version = "0.255", optional = true }
+wasmparser = { version = "0.258", optional = true }
 shell-words = { version = "1.1.0", optional = true }
 crc32fast = { version = "1.5.0", optional = true }
 # pest = "2.8.2"  # REMOVED: WorkflowParser never instantiated, DslCompiler uses serde

--- a/src/wasm/profiler_async.rs
+++ b/src/wasm/profiler_async.rs
@@ -85,7 +85,13 @@ impl AsyncProfiler {
             let payload = payload?;
 
             if let Payload::CodeSectionEntry(body) = payload {
-                let size = body.range().len();
+                // wasmparser 0.258 changed `FunctionBody::range()` to
+                // `Range<u64>`, and `Range<u64>` has no `len()` — that method
+                // comes from `ExactSizeIterator`, which is implemented only for
+                // the pointer-sized ranges. Subtracting is the same arithmetic
+                // `len()` did, stated explicitly.
+                let r = body.range();
+                let size = usize::try_from(r.end - r.start).unwrap_or(usize::MAX);
                 function_sizes.push(size);
                 total_size += size;
             }

--- a/src/wasm/security_patterns.rs
+++ b/src/wasm/security_patterns.rs
@@ -81,7 +81,15 @@ impl PatternDetector {
                 if let Some(location) = pattern.matches(&operators) {
                     self.found.push(VulnerabilityMatch {
                         pattern: pattern.name.to_string(),
-                        location: body.range().clone(),
+                        // `FunctionBody::range()` is `Range<u64>` as of
+                        // wasmparser 0.258; `VulnerabilityMatch::location` is a
+                        // byte offset into a buffer we already hold in memory,
+                        // so it stays `Range<usize>` and the conversion is here.
+                        location: {
+                            let r = body.range();
+                            usize::try_from(r.start).unwrap_or(usize::MAX)
+                                ..usize::try_from(r.end).unwrap_or(usize::MAX)
+                        },
                         severity: pattern.severity.clone(),
                         operator_index: location,
                     });


### PR DESCRIPTION
Supersedes #1101, which cannot build.

`wasmparser` 0.258 changed `FunctionBody::range()` from `Range<usize>` to `Range<u64>`, and both of pmat's uses are written against the old type:

```
error[E0599]: no method named `len` found for struct `Range<Idx>`
  --> src/wasm/profiler_async.rs:88:41
   |    let size = body.range().len();

error[E0308]: mismatched types
  --> src/wasm/security_patterns.rs:84:35
   |    location: body.range().clone(),
   |              expected `Range<usize>`, found `Range<u64>`
```

`Range<u64>` has no `len()` because that method comes from `ExactSizeIterator`, implemented only for the pointer-sized ranges — so the first is not a missing import, it is arithmetic that has to be written out.

### Why `try_from` and not `as`

Both conversions are `usize::try_from(..).unwrap_or(usize::MAX)`. On a 32-bit target a `u64` offset can genuinely exceed `usize`, and `as` would wrap it into a small **in-range** number — a silently wrong offset into a buffer, which is worse than a saturated one.

`VulnerabilityMatch::location` stays `Range<usize>`: it indexes a buffer already held in memory, so the conversion belongs at the boundary rather than in the type.

### Verified with the feature that reaches this code

```
cargo check  --features wasm-ast --locked                              0 errors
cargo clippy --features wasm-ast --all-targets --locked -- -D warnings 0 errors
cargo test   --features wasm-ast --locked --lib wasm    678 passed, 0 failed
cargo fmt --all -- --check                                             clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)