### PR TITLE
fix(test): the clippy-gate replay ran under `--cap-lints=warn`, so it could not fail

### DIFF
--- a/src/cli/hook_clippy_gate_tests.rs
+++ b/src/cli/hook_clippy_gate_tests.rs
@@ -85,6 +85,33 @@ fn clippy_verdict(dir: &Path, lib_rs: &str) -> (bool, String) {
         // Its own target dir: the fixture must not read or write the real one.
         .env("CARGO_TARGET_DIR", dir.join("t"))
         .env("RUSTC_WORKSPACE_WRAPPER", "")
+        // AND ITS OWN LINT LEVELS. `--cap-lints=warn` caps EVERY diagnostic at
+        // warn, so `-D warnings` cannot promote one to an error and clippy
+        // exits 0 having found the defect and declined to act on it:
+        //
+        //   note: the `clippy::question_mark` lint ignores `-D warnings`
+        //
+        // Nothing in this file asks for that. It arrives in the environment:
+        // `scripts/mutation-diff-gate.sh` runs cargo-mutants with
+        // `--cap-lints true` (deliberately — a mutant must not be killed by a
+        // lint), cargo-mutants implements that by appending to the rustflags it
+        // passes down, and the baseline `cargo test` it spawns hands them to
+        // every child, this fixture's clippy included. So the two rejection
+        // tests below saw a PASS from a linter that had been told it may not
+        // fail, and the nightly `Mutation (diff)` lane has been red on the
+        // baseline since at least 2026-08-21 (paiml/infra triage 2026-08-30).
+        //
+        // Measured, both directions, on the same fixture:
+        //
+        //   RUSTFLAGS="-C linker=clang"                    -> exit 101
+        //   RUSTFLAGS="-C linker=clang --cap-lints=warn"   -> exit 0, "warning:"
+        //
+        // The fixture is a dependency-free crate that is only ever `check`ed,
+        // so it needs no inherited rustflags at all; the safe scrub is to drop
+        // both spellings. `CARGO_ENCODED_RUSTFLAGS` takes precedence over
+        // `RUSTFLAGS` when set, so removing only one leaves the cap in place.
+        .env_remove("RUSTFLAGS")
+        .env_remove("CARGO_ENCODED_RUSTFLAGS")
         .output()
         .expect("spawn cargo clippy");
     let text = format!(
@@ -116,6 +143,23 @@ fn clippy_verdict(dir: &Path, lib_rs: &str) -> (bool, String) {
          Install it with `rustup component add clippy`. A missing verifier \
          is a NO-GO, not a lint verdict.\nFull output:\n{text}",
         unavailable.as_deref().unwrap_or("")
+    );
+
+    // A LINT THAT MAY NOT FAIL HAS NO VERDICT EITHER — the same class as the
+    // absent component above, one step further in. Under `--cap-lints=warn`
+    // clippy still reports the defect, so the output looks like a real run;
+    // only the exit status is silently defanged, and a rejection test reading
+    // that status records a pass. The scrub above removes the two environment
+    // variables that carry it, and this catches any OTHER route to the same
+    // state (a `[build] rustflags` in a config.toml, a wrapper, a future
+    // cargo-mutants that passes it another way) rather than trusting that the
+    // scrub was exhaustive. Clippy names the condition itself, so ask it.
+    let defanged = text.contains("ignores `-D warnings`") || text.contains("--cap-lints");
+    assert!(
+        !defanged,
+        "cargo clippy ran with its lints capped, so it could not fail and this \
+         test measured nothing. A linter told it may not fail is not a verdict, \
+         it is a formality.\nFull output:\n{text}"
     );
 
     (out.status.success(), text)


### PR DESCRIPTION
Found while triaging paiml/infra's nightly dead-lane switch on 2026-08-30:
`Mutation (diff)` is one of the fleet lanes it watches, and it has been red on
its **baseline** — not on a mutant — since at least 2026-08-21, the far end of
its run history. cargo-mutants needs a green baseline, so the lane has produced
**no mutation verdict at all** for nine consecutive nights.

```
test result: FAILED. 21095 passed; 2 failed; 154 ignored
    cli::hook_clippy_gate_tests::the_historical_roster_line_is_rejected_by_the_gates_own_lints
    cli::hook_clippy_gate_tests::the_historical_slug_parser_is_rejected_and_its_fix_is_not
*** result: Failure(101)
```

## What CI actually saw

Both tests write a fixture crate, lint it with `pmat verify --stage clippy`'s
own flag constants, and assert the linter **rejects** it. Clippy reported the
defect and exited 0:

```
warning: this block may be rewritten with the `?` operator
  = note: `-D clippy::question-mark` implied by `-D warnings`
warning: `replay` (lib) generated 1 warning (1 duplicate)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.11s
```

`warning`, not `error` — with `-D warnings` acknowledged in the same breath.

## Root cause, and it is not in this file

`scripts/mutation-diff-gate.sh:137` runs cargo-mutants with `--cap-lints true`,
deliberately and correctly: a mutant must not be killed by a lint. cargo-mutants
implements that by appending `--cap-lints=warn` to the rustflags it passes down
— visible on every rustc line in the CI log — and the baseline `cargo test` it
spawns hands that environment to every child, including the `cargo clippy` these
tests spawn for their fixture.

A cap applies to **all** lints, so `-D warnings` cannot promote anything to an
error. The linter finds the defect and declines to act on it; the rejection
tests read `status.success()` and record a pass; the assertion then fails on
that pass. Nothing about the fixture, the lints, or `CLIPPY_LINTS` was wrong.

Reproduced standalone on the same fixture, both directions:

```
RUSTFLAGS="-C linker=clang"                    -> exit 101
RUSTFLAGS="-C linker=clang --cap-lints=warn"   -> exit 0
  = note: the `clippy::question_mark` lint ignores `-D warnings`
```

## The fix

The fixture is a dependency-free crate that is only ever `check`ed, so it needs
no inherited rustflags. `clippy_verdict` now scrubs **both** `RUSTFLAGS` and
`CARGO_ENCODED_RUSTFLAGS` for the child, alongside the `CARGO_TARGET_DIR` and
`RUSTC_WORKSPACE_WRAPPER` it already isolates. Removing only one is not enough —
`CARGO_ENCODED_RUSTFLAGS` wins when set.

## The poka-yoke

A linter *told it may not fail* is the same class as a linter that *is not
installed* — and this file already refuses to accept a verdict from the second.
So it now refuses a **capped** one too, by asking clippy (which names the
condition itself) rather than trusting the scrub to have been exhaustive. That
covers any other route to the same state: a `[build] rustflags` in a
config.toml, a wrapper, a future cargo-mutants that passes the cap another way.

## Proven to discriminate

On the built test binary, three ways:

```
fixed,   capped env (what CI has) .... ok.     8 passed; 0 failed
pre-fix, capped env ................. FAILED. 6 passed; 2 failed
    the_historical_roster_line_is_rejected_by_the_gates_own_lints ... FAILED
    the_historical_slug_parser_is_rejected_and_its_fix_is_not ....... FAILED
    cargo clippy ran with its lints capped, so it could not fail and
    this test measured nothing. A linter told it may not fail is not a
    verdict, it is a formality.
pre-fix, UNCAPPED env (a dev box) ... ok.     8 passed; 0 failed
```

The third line is why this survived: it reproduces **only** under the cap, i.e.
only inside the mutation lane — precisely the lane nobody could read, because
its baseline never got as far as producing a report.

No `.unwrap()` and no panic-macro call added, so `.pmat-ratchet.toml`'s
`unwrap_calls_src_total` and `panic_macro_calls_src` are unmoved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMdV9icqNz2jis3rB2PaKQ