### PR TITLE
chore(release): cut version 3.35.0 — three gates that reported a result they had not measured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,78 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.35.0] - 2026-08-30
+
+Minor rather than patch, for the fourth release running, and for the same reason the
+last three were: **this changes what pmat reports on unchanged code.** Measured on
+paiml/interactive.paiml.com with nothing in that repository touched — 2 blocking
+violations at 3.34.0, 19 at this release. Both numbers are new; neither is a regression.
+The 2 were false, the 19 are true, and a gate that swaps one for the other is a minor.
+Read this before upgrading a gate.
+
+All three fixes are to gates that were reporting a result they had not measured.
+
+### The `sections` check could not see a heading behind an emoji
+
+Measured on paiml/interactive.paiml.com at 3.34.0. Its `README.md` carries
+
+```markdown
+## 🤝 Contributing
+## 📄 License
+```
+
+and `pmat quality-gate` answered
+
+```
+[sections] README.md - Missing required section: Contributing
+[sections] README.md - Missing required section: License
+```
+
+Both sections are there, at the right level, in the right place. The check
+asked `readme.contains("## Contributing")` against the whole file, and a
+substring test has no notion of a heading: the only headings it can recognise
+are the ones whose text begins immediately after the `## `. A README that
+decorates its headings — which is most of them — gets told to add sections it
+already has. **Two of that repository's 60 blocking violations were an emoji.**
+
+The check now parses headings and compares normalised heading *text*, so a
+leading emoji, an anchor span, or trailing punctuation no longer hides a
+section. The over-reach counter-tests are the load-bearing half and they were
+written to pass against the unfixed stub: prose containing the word is still
+not a heading, `##Contributing` with no space is still not a heading, and a
+README genuinely missing a section is still flagged. (#1106)
+
+Verified against the released binary, four fixtures, same invocation:
+
+| README under test | 3.34.0 | 3.35.0 |
+|---|---|---|
+| `## 🤝 Contributing` / `## 📄 License` | FAIL (2) | **PASS (0)** |
+| genuinely missing both sections | FAIL (2) | FAIL (2) |
+| the words appear in prose, not a heading | FAIL (2) | FAIL (2) |
+| `##Contributing` — no space, not a heading | FAIL (2) | FAIL (2) |
+
+Only the first row moves. The other three are the reason this is a narrowed
+false positive and not a weakened check.
+
+### A `pmat.toml` section pmat cannot honour resolved to defaults, silently
+
+An unrecognised or unhonoured configuration section was dropped on the floor
+and the run continued against built-in defaults, so a repository could carry a
+config pmat had never applied and get a green gate that measured something
+else entirely. (#1105)
+
+### The clippy-gate replay ran under `--cap-lints=warn`, so it could not fail
+
+`Mutation (diff)` had been red on its **baseline** — not on a mutant — since at
+least 2026-08-21, as far back as the run history goes. cargo-mutants requires a
+green baseline, so the lane produced no mutation verdict at all for nine
+consecutive nights. Two tests write a fixture crate, lint it with `pmat verify
+--stage clippy`'s own flag constants, and assert the linter REJECTS it; under
+`--cap-lints=warn` clippy reported the defect and exited 0, so the assertion
+that the gate *fails* could not itself fail. Found while triaging paiml/infra's
+nightly dead-lane switch. (#1107)
+
+
 ## [3.34.0] - 2026-08-29
 
 Minor rather than patch, for the third release running, and for the same reason: this

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4970,7 +4970,7 @@ dependencies = [
 
 [[package]]
 name = "pmat"
-version = "3.34.0"
+version = "3.35.0"
 dependencies = [
  "actix",
  "actix-rt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pmat"
 default-run = "pmat"
-version = "3.34.0"
+version = "3.35.0"
 edition = "2021"
 rust-version = "1.91.0"
 authors = ["Pragmatic AI Labs"]

--- a/README.md
+++ b/README.md
@@ -625,7 +625,7 @@ PMAT is built on the PAIML Sovereign Stack - pure-Rust, SIMD-accelerated librari
 | [aprender-zram-core](https://crates.io/crates/aprender-zram-core) | SIMD LZ4/ZSTD compression (optional) | 0.64 |
 | [aprender-contracts](https://crates.io/crates/aprender-contracts) | Provable contracts (with `aprender-contracts-macros`) | 0.64 |
 | [pmcp](https://crates.io/crates/pmcp) | MCP protocol SDK (streamable HTTP transport) | 2.17 |
-| **pmat** | Code analysis toolkit | 3.34.0 |
+| **pmat** | Code analysis toolkit | 3.35.0 |
 
 **Key Benefits:**
 - Pure Rust (no C dependencies, no FFI)

--- a/mcp.json
+++ b/mcp.json
@@ -1,6 +1,6 @@
 {
   "name": "pmat",
-  "version": "3.34.0",
+  "version": "3.35.0",
   "description": "Project Analysis and Intelligence Modeling Toolkit",
   "main": "pmat",
   "bin": {


### PR DESCRIPTION
Cuts **3.35.0**, carrying #1105, #1106 and #1107 — all merged to `master`, none shipped. #1106 is what blocks paiml/interactive.paiml.com#27 and #28.

## Why minor, not patch

By this changelog's own stated rule, for the fourth release running: **it changes what pmat reports on unchanged code.** Measured on paiml/interactive.paiml.com with nothing in that repository touched:

| | 3.34.0 (released) | 3.35.0 |
|---|---|---|
| blocking violations | 2 | 19 |

The 2 were **false**, the 19 are **true**. A release that swaps one for the other is not a patch.

## #1106 — the `sections` check could not see a heading behind an emoji

`README.md` on interactive.paiml.com carries `## 🤝 Contributing` and `## 📄 License`, and 3.34.0 answered `Missing required section: Contributing` / `: License`. The check asked `readme.contains("## Contributing")` against the whole file, and a substring test has no notion of a heading — the only headings it can recognise are those whose text begins immediately after the `## `.

**Discrimination, measured against the released binary — four fixtures, same invocation:**

| README under test | 3.34.0 | 3.35.0 |
|---|---|---|
| `## 🤝 Contributing` / `## 📄 License` | FAIL (2) | **PASS (0)** |
| genuinely missing both sections | FAIL (2) | FAIL (2) |
| the words appear in prose, not a heading | FAIL (2) | FAIL (2) |
| `##Contributing` — no space, not a heading | FAIL (2) | FAIL (2) |

Only the first row moves. The other three are the reason this is a *narrowed false positive* and not a weakened check.

## #1105 — a `pmat.toml` section pmat cannot honour resolved to defaults, silently

This is where the 19 come from, and they are real. interactive.paiml.com's `pmat.toml` declares 19 sections pmat does not read — including `[quality_gate]` (pmat reads `[quality]`) and `[custom_rules]` (pmat reads `[custom]`). That repository's gate has been running almost entirely unconfigured and nothing said so.

**⚠️ Worth stating plainly for whoever unblocks #27/#28:** shipping this release removes the two emoji false positives but does *not* by itself turn those PRs green. It replaces them with 19 true findings about an inert config. That is the correct outcome — the alternative is a gate that keeps quiet about a config it never applied — but it is a second piece of work, in that repo, not this one.

## #1107 — the clippy-gate replay ran under `--cap-lints=warn`, so it could not fail

`Mutation (diff)` had been red on its **baseline** — not on a mutant — since at least 2026-08-21. cargo-mutants requires a green baseline, so the lane produced no mutation verdict for nine consecutive nights. Found while triaging paiml/infra's nightly dead-lane switch.

## Mechanics

`Cargo.lock` bumped in the same commit as `Cargo.toml`; `README.md` and `mcp.json` carry the version too, matching how 3.34.0 was cut. `[Unreleased]` left in place above the new dated section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMdV9icqNz2jis3rB2PaKQ