### PR TITLE
fix(mcp): mcp.json advertised a wrong inputSchema for 19 of 19 tools — render it from the handlers' own metadata

### DIFF
--- a/contracts/macs-artifacts-v1.yaml
+++ b/contracts/macs-artifacts-v1.yaml
@@ -1,5 +1,5 @@
 metadata:
-  version: "1.0.0"
+  version: "1.1.0"
   created: "2026-07-02"
   author: PAIML Engineering
   references:
@@ -36,6 +36,16 @@ equations:
       - hand-edits are drift (CB-1656 red)
     preconditions: []
 
+  manifest_schema_faithful:
+    formula: inputSchema(mcp.json, t) = inputSchema(tools/list, t) for every live tool t
+    domain: mcp.json at repo root, and the handlers' metadata() the server serves
+    codomain: bool
+    invariants:
+      - the manifest renders each inputSchema FROM handler metadata, never from a shape chosen by tool name
+      - the committed file equals render_manifest(<its own version>) byte-for-byte
+      - every live tool declares metadata (no open-object fallback is reachable)
+    preconditions: []
+
   docs_current:
     formula: denylist_hits(docs) = 0 outside allow-list
     domain: docs/** with deny-list {claude-3-*, claude-2*, gpt-4-turbo}
@@ -49,6 +59,9 @@ falsification:
     severity: P0
     action: reject_push
   - condition: "mcp.json drifts from tool defs with green comply"
+    severity: P0
+    action: reject_push
+  - condition: "mcp.json advertises an inputSchema a tool's handler does not accept (CRUX-09, #1150)"
     severity: P0
     action: reject_push
   - condition: "A deny-listed model id appears outside docs/agent-models.md"
@@ -66,6 +79,16 @@ falsification_tests:
     prediction: two renders at different times share one content_hash
     test: cargo test --lib hash_covers_sources_not_wallclock
     if_fails: ROADMAP.yaml churns on every render, defeating drift detection
+  - id: manifest_schema_faithful
+    rule: the shipped inputSchema IS the served inputSchema, per tool
+    prediction: a canned paths-array schema for pmat_index_stats fails; the handler's own schema passes
+    test: cargo test --lib manifest_schemas_match_handler_metadata
+    if_fails: a validating client rejects its own valid call, or calls a tool as the manifest says and gets -32602
+  - id: manifest_pinned
+    rule: the committed mcp.json equals the renderer's output byte-for-byte
+    prediction: editing one property in mcp.json without regenerating fails; regenerating passes
+    test: cargo test --lib committed_mcp_json_is_pinned_to_the_renderer
+    if_fails: a renderer fix ships with the old file still in the tarball, and nothing notices
   - id: docs_current
     rule: no superseded model ids in docs outside the registry
     prediction: reintroducing claude-3-opus outside agent-models.md fails CB-1657

--- a/docs/audits/impl-PMAT-631-receipt.md
+++ b/docs/audits/impl-PMAT-631-receipt.md
@@ -44,8 +44,9 @@ change was fully specified; no subagent was dispatched for this ticket.
 | `pmat verify --skip clippy,tests` | — | ok, 3 stages measured |
 | unwrap ratchet (`git grep -oF '.unwrap()' -- 'src/*.rs' \| wc -l`) | 20343 | 20343 |
 | unrun-tests ledger | — | regenerated for the 3 new lib tests |
-| `pmat verify` (full: clippy + tests) | — | PENDING |
-| `make gate-artifact` (DoD) | — | PENDING |
+| `pmat verify` (full: clippy + tests) | — | clippy **ok** (111.6 s); tests **FAIL** — one test, `the_committed_baseline_is_the_measured_count` (CB-200: 1709 below grade A vs banked 1688); 21117 passed |
+| CB-200 attribution | — | **not this ticket**: `tool_manifest.rs` grades A+ at master and here (`pmat tdg`, 95.45 both); cold indexes of origin/master and this tree built by the same 3.35.0 binary give identical grade distributions (727 below-A at SQL level; 24413 vs 24417 fns, the +4 are A+). The 1688 was banked 2026-08-22 (683d6994d); the lib test is Unmeasurable in CI (no `.pmat/context.db`) and passes there. Filed PMAT-636 |
+| `make gate-artifact` (DoD) | — | PASS — "artifact falsification gates passed" at ec504a043 (code identical to HEAD; later commits are docs/contract/tickets) |
 
 ## pv contract
 
@@ -122,5 +123,7 @@ stripped artefact; deltas are what matter):
 
 ## Verdict
 
-PENDING — becomes DONE when the two pending rows read PASS and #1158 is merged green on the
+PARTIAL(escalate) → continued conservatively [A]: the feature is complete, its acceptance and DoD gates pass, and the one red stage is a pre-existing ratchet drift the tree carries independently of this change, filed as PMAT-636. Rule 4 says a red gate stops the feature; the gate here is red on master too and cannot fail where CI runs, so stopping this PR would not make it hold. The conservative option — do not touch `[tdg] baseline`, do not skip the stage, file it, say so here — is what was taken. Becomes DONE when #1158 merges green on the required checks without a rerun.
+
+PENDING (superseded by the line above) — becomes DONE when the two pending rows read PASS and #1158 is merged green on the
 required checks without a rerun.

--- a/docs/audits/impl-PMAT-631-receipt.md
+++ b/docs/audits/impl-PMAT-631-receipt.md
@@ -63,6 +63,10 @@ change was fully specified; no subagent was dispatched for this ticket.
 - PMAT-632 (scope): the skill doc describes an edit/deny hook that is not installed; enforcement is
   orchestrator discipline plus the transcript gate.
 - PMAT-633: binary-size growth has no per-crate attribution (five-whys attached below).
+- PMAT-635: `pmat work add` allocates ids from the checkout's tracked roadmap.yaml, so a worktree at
+  the branch base minted PMAT-631 a second time. [A] Tickets PMAT-634 (CRUX-05) and PMAT-635 are
+  committed on THIS branch so master carries them first; the CRUX-05 PR references PMAT-634 without
+  re-adding it, which avoids a duplicate entry at merge without hand-editing the YAML.
 
 ## Estimates
 

--- a/docs/audits/impl-PMAT-631-receipt.md
+++ b/docs/audits/impl-PMAT-631-receipt.md
@@ -1,0 +1,122 @@
+# Implementation receipt — PMAT-631 (CRUX-09, #1150)
+
+## Identity
+
+| field | value |
+|---|---|
+| ticket | PMAT-631 |
+| spec | docs/specifications/pmat-architecture-crux-audit.md §8.9 (CRUX-09) |
+| branch | PMAT-631-mcp-json-schema-fidelity |
+| HEAD at receipt | 82c97e83f |
+| discover.json sha256 (16) | e6da70485e91900c |
+| gate_cmd | make gate-artifact (discovered after PMAT-632; `gate_cmd_fallback=false`) |
+| phase gate | pmat verify |
+| required checks | ci / gate, docs build (docs.rs environment), feature-gate, pmat score, provable ladder |
+
+## Plan and routing
+
+| phase | acceptance command | mode | trigger |
+|---|---|---|---|
+| P1 render inputSchema from handler metadata; delete `tool_schema()` | `cargo test --lib manifest_schemas_match_handler_metadata` | direct | - |
+| P2 regenerate mcp.json; pin byte-for-byte | `cargo test --lib committed_mcp_json_is_pinned_to_the_renderer` | direct | - |
+| P3 pv contract same PR; DoD gate | `make gate-artifact`; spec §8.9 script | direct | - |
+
+Quorum: never (`--quorum never`). Routing direct because `|M|=1` (`src/mcp_pmcp/tool_manifest.rs`) and the
+change was fully specified; no subagent was dispatched for this ticket.
+
+## Dispatch ledger
+
+| phase | mode | agent | turns | maxTurns hit | resumed |
+|---|---|---|---|---|---|
+| P1–P3 | direct | orchestrator | see estimates | - | - |
+
+## Verification — claimed vs re-run (all runs are the orchestrator's own)
+
+| check | before (master, 47d643272) | after (this branch) |
+|---|---|---|
+| spec §8.9 script, 13 legs | `FAIL: A1: 19/19 shipped inputSchemas differ from tools/list` | `PASS: A1 A2 B1 B3 D1 D1b green; controls P A3 B2 C D2 D3 green` |
+| `manifest_schemas_match_handler_metadata` | n/a (new) | ok |
+| `committed_mcp_json_is_pinned_to_the_renderer` | RED before regenerate | ok after regenerate |
+| named mutation: canned `paths` schema restored for `pmat_index_stats` in mcp.json | — | pin test FAILED; restored → ok |
+| `cargo test --lib -- tool_manifest` | — | 12 passed, 0 failed, 1 ignored |
+| `cargo fmt --all -- --check` | — | clean |
+| `cargo clippy --lib --bins` | — | no warnings |
+| `pmat verify --skip clippy,tests` | — | ok, 3 stages measured |
+| unwrap ratchet (`git grep -oF '.unwrap()' -- 'src/*.rs' \| wc -l`) | 20343 | 20343 |
+| unrun-tests ledger | — | regenerated for the 3 new lib tests |
+| `pmat verify` (full: clippy + tests) | — | PENDING |
+| `make gate-artifact` (DoD) | — | PENDING |
+
+## pv contract
+
+`contracts/macs-artifacts-v1.yaml` 1.0.0 → 1.1.0: equation `manifest_schema_faithful`, falsifiers
+`manifest_schema_faithful` → `manifest_schemas_match_handler_metadata` and `manifest_pinned` →
+`committed_mcp_json_is_pinned_to_the_renderer`. pv_lane = contract present, same PR.
+
+## Jidoka log (.pmat/jidoka.jsonl rows for this ticket)
+
+- PMAT-632: discover.sh probed only `make gate` and fell back to `cargo test --workspace` on a repo
+  with `gate-artifact`; patched (enumerate gate-like targets; `--gate <target>` on ambiguity).
+- orchestrator: `git reset --hard origin/master` discarded the uncommitted roadmap.yaml edit holding
+  the freshly created ticket; re-added. `git reset --hard`, `git checkout -- .`, `git clean -f*`,
+  `git stash drop` are forbidden for worker and orchestrator for the rest of this engagement.
+- PMAT-632 (scope): the skill doc describes an edit/deny hook that is not installed; enforcement is
+  orchestrator discipline plus the transcript gate.
+- PMAT-633: binary-size growth has no per-crate attribution (five-whys attached below).
+
+## Estimates
+
+| K̂ | basis | K (budget) | actual turns (this ticket) |
+|---|---|---|---|
+| 3 | first-run[U] (`estimate.sh`, 0 rows) | 120 | recorded in .pmat/estimates.jsonl |
+
+## Gaps
+
+- `pmat verify` full and `make gate-artifact` were still running when this receipt was first
+  written; the row above is updated when they conclude. A NotRun lane is a gap, not a pass.
+- The migration of the 13 hand-rolled `json!` schema blocks onto `mcp_tool_schemas/` is split out
+  per the spec (separate M); not part of this ticket.
+- Known and cited: `refactor.*` is simulated (EV-0), nothing here depends on it; the protocol served
+  is 2024-11-05 (EV-1), unchanged.
+
+## Decisions taken conservatively [A]
+
+- [A] The manifest keeps `LIVE_MCP_TOOLS` as the ordering/description source and takes only the
+  inputSchema from handler metadata, rather than deriving names too — the smaller change; the
+  positional test already pins order.
+
+## Transcript gate
+
+`transcript-gate.sh`: PASS, vacuous — it found 0 subagents to check because none were dispatched for this ticket (all phases direct). Stated here rather than counted as evidence.
+
+## Binary growth — five whys (CRUX-05 build 55,411,848 B vs band centre 55,000,000)
+
+Measured with `cargo bloat --release --crates` (unstripped, so absolute sizes differ from the
+stripped artefact; deltas are what matter):
+
+| tree | .text | pmat | pmcp | clap_builder | std | reqwest | h2 |
+|---|---|---|---|---|---|---|---|
+| ece3baf11 (2026-08-15) | 34.0 MiB | 17.2 MiB | 1.2 MiB | 437.8 KiB | 2.0 MiB | 401.5 KiB | 366.2 KiB |
+| CRUX-05 tree (master + clap features) | 37.5 MiB | 19.1 MiB | 1.9 MiB | 523.0 KiB | 2.3 MiB | 475.2 KiB | 483.8 KiB |
+| delta | **+3.5 MiB** | +1.9 MiB | +0.7 MiB | +85 KiB | +0.3 MiB | +74 KiB | +118 KiB |
+
+1. **Why is the CRUX-05 binary above the band centre?** It is 778 KB above the audit's 54,633,288 B
+   (01fba4f65): ~85 KiB is clap's `usage`/`error-context`/`suggestions` (the fix itself), the rest is
+   the pmcp 2.17→2.19 bump merged the same day (#1113, +0.7 MiB .text). Still inside the ±5 % band
+   (52.25–57.75 MB); the band is not adjusted.
+2. **Why did .text grow 3.5 MiB since 08-15?** pmat's own code is +1.9 MiB: the 3.32–3.35 gates and
+   analyzers (reachability's third state, comply ratchet/coherence, falsification gates, MCP
+   hardening). Dependencies account for the remaining ~1.6 MiB (pmcp, reqwest 0.13, h2, tokio, std).
+3. **Why was "42 MB" believed?** `.pmat-metrics.toml:45`'s `binary_max_bytes = 50_000_000 # (current:
+   42 MB)` was written 2025-11-23 (b8a97ca6f) and is read by nothing (CLAUDE.md: recorded, not
+   enforced). The first REAL CI measurement was 54,284,232 B on 2026-08-25 (#1079), which is where
+   the 55,000,000 band centre came from. There was no 13 MB jump; there was a comment.
+4. **Why does nothing show per-crate growth?** No gate runs `cargo bloat`; the band sees one number.
+5. **Root cause:** size is gated as a scalar with no attribution, so growth is neither prevented nor
+   explained until someone runs bloat by hand. Filed as PMAT-633: `cargo bloat --crates` in nightly
+   with a per-crate baseline that may only fall, beside the band.
+
+## Verdict
+
+PENDING — becomes DONE when the two pending rows read PASS and #1158 is merged green on the
+required checks without a rerun.

--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -3666,3 +3666,19 @@ roadmap:
   estimated_effort: null
   labels: []
   notes: null
+- id: PMAT-633
+  github_issue: null
+  item_type: task
+  title: 'binary size: no per-crate ratchet — .text grew ~3.4 MiB since ece3baf11 (pmat +1.9 MiB, pmcp +0.7, reqwest/h2/tokio ~+0.3, clap usage/error-context/suggestions +85 KiB); .pmat-metrics.toml''s ''42 MB'' is a 2025-11-23 comment nothing reads; add cargo-bloat --crates to nightly with a per-crate baseline (CRUX-05 five-whys)'
+  status: planned
+  priority: medium
+  assigned_to: null
+  created: 2026-09-02T16:37:48Z
+  updated: 2026-09-02T16:37:48Z
+  spec: null
+  acceptance_criteria: []
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels: []
+  notes: null

--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -3714,3 +3714,19 @@ roadmap:
   estimated_effort: null
   labels: []
   notes: null
+- id: PMAT-636
+  github_issue: null
+  item_type: task
+  title: 'CB-200: the lib test the_committed_baseline_is_the_measured_count is Unmeasurable in CI (no .pmat/context.db there) and passes; locally, a cold index of master by the 3.35.0 binary reads 1709 below-A vs the 1688 banked 2026-08-22 — the ratchet drifted 21 with no leg able to see it'
+  status: planned
+  priority: medium
+  assigned_to: null
+  created: 2026-09-02T17:02:05Z
+  updated: 2026-09-02T17:02:05Z
+  spec: null
+  acceptance_criteria: []
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels: []
+  notes: null

--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -3682,3 +3682,35 @@ roadmap:
   estimated_effort: null
   labels: []
   notes: null
+- id: PMAT-634
+  github_issue: null
+  item_type: task
+  title: 'CRUX-05: clap usage/error-context/suggestions restored; 14 blind Usage: guards assert content (#1148)'
+  status: planned
+  priority: medium
+  assigned_to: null
+  created: 2026-09-02T16:40:04Z
+  updated: 2026-09-02T16:40:04Z
+  spec: null
+  acceptance_criteria: []
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels: []
+  notes: null
+- id: PMAT-635
+  github_issue: null
+  item_type: task
+  title: pmat work add allocates ids from the tracked docs/roadmaps/roadmap.yaml of the CURRENT checkout, so two branches off the same base both mint the same id (PMAT-631 twice today); allocate from the highest id across refs, or from .pmat/ state
+  status: planned
+  priority: medium
+  assigned_to: null
+  created: 2026-09-02T16:40:04Z
+  updated: 2026-09-02T16:40:04Z
+  spec: null
+  acceptance_criteria: []
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels: []
+  notes: null

--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -3634,3 +3634,35 @@ roadmap:
   estimated_effort: null
   labels: []
   notes: null
+- id: PMAT-631
+  github_issue: null
+  item_type: task
+  title: 'CRUX-09: mcp.json inputSchema rendered from handler metadata and pinned byte-for-byte (#1150)'
+  status: planned
+  priority: medium
+  assigned_to: null
+  created: 2026-09-02T16:16:48Z
+  updated: 2026-09-02T16:16:48Z
+  spec: null
+  acceptance_criteria: []
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels: []
+  notes: null
+- id: PMAT-632
+  github_issue: null
+  item_type: task
+  title: 'paiml-implement discover.sh: gate_cmd fell back to ''cargo test --workspace'' on pmat although ''make gate-artifact'' and the CLAUDE.md-mandated ''pmat verify'' exist'
+  status: planned
+  priority: medium
+  assigned_to: null
+  created: 2026-09-02T16:16:48Z
+  updated: 2026-09-02T16:16:48Z
+  spec: null
+  acceptance_criteria: []
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels: []
+  notes: null

--- a/docs/status/unrun-tests-ledger.md
+++ b/docs/status/unrun-tests-ledger.md
@@ -14,7 +14,7 @@ Legs consulted (3):
 - `feature-matrix.yml:feature-tests[mcp-integration]`
 - `feature-matrix.yml:feature-tests[unified-protocol]`
 
-23659 of 26887 lib tests are executed; 3228 are compiled by no leg.
+23662 of 26890 lib tests are executed; 3228 are compiled by no leg.
 
 ## `<unsatisfiable>` — 2199 test(s)
 

--- a/mcp.json
+++ b/mcp.json
@@ -25,9 +25,21 @@
               "type": "array",
               "items": {
                 "type": "string"
-              }
+              },
+              "description": "Filesystem paths (files or directories) to analyze"
+            },
+            "top_files": {
+              "type": "integer",
+              "description": "Return only the top N most-complex files"
+            },
+            "threshold": {
+              "type": "integer",
+              "description": "Minimum cyclomatic complexity to report"
             }
-          }
+          },
+          "required": [
+            "paths"
+          ]
         }
       },
       {
@@ -40,9 +52,21 @@
               "type": "array",
               "items": {
                 "type": "string"
-              }
+              },
+              "description": "Filesystem paths (files or directories) to analyze"
+            },
+            "include_resolved": {
+              "type": "boolean",
+              "description": "Include items already marked resolved"
+            },
+            "include_tests": {
+              "type": "boolean",
+              "description": "Include test files and #[cfg(test)] blocks (default: false, matching `pmat analyze satd`)"
             }
-          }
+          },
+          "required": [
+            "paths"
+          ]
         }
       },
       {
@@ -55,9 +79,17 @@
               "type": "array",
               "items": {
                 "type": "string"
-              }
+              },
+              "description": "Filesystem paths (files or directories) to analyze"
+            },
+            "include_tests": {
+              "type": "boolean",
+              "description": "Include test files when searching for dead code"
             }
-          }
+          },
+          "required": [
+            "paths"
+          ]
         }
       },
       {
@@ -70,9 +102,23 @@
               "type": "array",
               "items": {
                 "type": "string"
-              }
+              },
+              "description": "Filesystem paths (files or directories) to analyze"
+            },
+            "dag_type": {
+              "type": "string",
+              "enum": [
+                "call-graph",
+                "import-graph",
+                "inheritance",
+                "full-dependency"
+              ],
+              "description": "Dependency graph type to generate (default: full-dependency)"
             }
-          }
+          },
+          "required": [
+            "paths"
+          ]
         }
       },
       {
@@ -85,9 +131,13 @@
               "type": "array",
               "items": {
                 "type": "string"
-              }
+              },
+              "description": "Filesystem paths (files or directories) to analyze"
             }
-          }
+          },
+          "required": [
+            "paths"
+          ]
         }
       },
       {
@@ -100,9 +150,17 @@
               "type": "array",
               "items": {
                 "type": "string"
-              }
+              },
+              "description": "Filesystem paths (files or directories) to analyze"
+            },
+            "top_files": {
+              "type": "integer",
+              "description": "Return only the top N files by algorithmic complexity"
             }
-          }
+          },
+          "required": [
+            "paths"
+          ]
         }
       },
       {
@@ -112,7 +170,8 @@
           "type": "object",
           "properties": {
             "project_path": {
-              "type": "string"
+              "type": "string",
+              "description": "Project root to analyze (the directory holding Cargo.toml / the git worktree)"
             }
           },
           "required": [
@@ -127,7 +186,8 @@
           "type": "object",
           "properties": {
             "project_path": {
-              "type": "string"
+              "type": "string",
+              "description": "Project root to analyze (the directory holding Cargo.toml / the git worktree)"
             }
           },
           "required": [
@@ -142,7 +202,8 @@
           "type": "object",
           "properties": {
             "project_path": {
-              "type": "string"
+              "type": "string",
+              "description": "Project root to analyze (the directory holding Cargo.toml / the git worktree)"
             }
           },
           "required": [
@@ -160,9 +221,21 @@
               "type": "array",
               "items": {
                 "type": "string"
-              }
+              },
+              "description": "Filesystem paths (files or directories) to analyze"
+            },
+            "strict": {
+              "type": "boolean",
+              "description": "Fail the gate on any violation (no tolerance)"
+            },
+            "file": {
+              "type": "string",
+              "description": "Check only this single file instead of the paths list"
             }
-          }
+          },
+          "required": [
+            "paths"
+          ]
         }
       },
       {
@@ -171,13 +244,63 @@
         "inputSchema": {
           "type": "object",
           "properties": {
-            "paths": {
-              "type": "array",
-              "items": {
-                "type": "string"
+            "operation": {
+              "type": "string",
+              "enum": [
+                "write",
+                "edit",
+                "append"
+              ],
+              "description": "File operation to proxy"
+            },
+            "file_path": {
+              "type": "string",
+              "description": "Target file path"
+            },
+            "content": {
+              "type": "string",
+              "description": "New content for `write`/`append`"
+            },
+            "old_content": {
+              "type": "string",
+              "description": "Old string for `edit` operations"
+            },
+            "new_content": {
+              "type": "string",
+              "description": "New string for `edit` operations"
+            },
+            "mode": {
+              "type": "string",
+              "enum": [
+                "strict",
+                "advisory",
+                "auto_fix",
+                "auto-fix"
+              ],
+              "description": "Proxy enforcement mode"
+            },
+            "quality_config": {
+              "type": "object",
+              "properties": {
+                "max_complexity": {
+                  "type": "integer"
+                },
+                "allow_satd": {
+                  "type": "boolean"
+                },
+                "require_docs": {
+                  "type": "boolean"
+                },
+                "auto_format": {
+                  "type": "boolean"
+                }
               }
             }
-          }
+          },
+          "required": [
+            "operation",
+            "file_path"
+          ]
         }
       },
       {
@@ -186,13 +309,62 @@
         "inputSchema": {
           "type": "object",
           "properties": {
-            "paths": {
+            "requirements": {
               "type": "array",
               "items": {
                 "type": "string"
+              },
+              "description": "Requirements to convert into deterministic actionable todos"
+            },
+            "project_name": {
+              "type": "string",
+              "description": "Project or component name"
+            },
+            "granularity": {
+              "type": "string",
+              "enum": [
+                "low",
+                "medium",
+                "high"
+              ],
+              "description": "Task detail level (default: high)"
+            },
+            "quality_config": {
+              "type": "object",
+              "description": "Quality enforcement config",
+              "properties": {
+                "enforcement_mode": {
+                  "type": "string",
+                  "enum": [
+                    "strict",
+                    "advisory",
+                    "auto_fix"
+                  ]
+                },
+                "coverage_threshold": {
+                  "type": "number"
+                },
+                "max_complexity": {
+                  "type": "integer"
+                },
+                "require_doctests": {
+                  "type": "boolean"
+                },
+                "require_property_tests": {
+                  "type": "boolean"
+                },
+                "require_examples": {
+                  "type": "boolean"
+                },
+                "zero_satd_tolerance": {
+                  "type": "boolean"
+                }
               }
             }
-          }
+          },
+          "required": [
+            "requirements"
+          ]
         }
       },
       {
@@ -201,13 +373,14 @@
         "inputSchema": {
           "type": "object",
           "properties": {
-            "paths": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
+            "path": {
+              "type": "string",
+              "description": "Path to the git repository to query"
             }
-          }
+          },
+          "required": [
+            "path"
+          ]
         }
       },
       {
@@ -220,9 +393,28 @@
               "type": "array",
               "items": {
                 "type": "string"
-              }
+              },
+              "description": "Filesystem paths (files or directories) to analyze"
+            },
+            "format": {
+              "type": "string",
+              "enum": [
+                "json"
+              ],
+              "description": "Output format"
+            },
+            "max_depth": {
+              "type": "integer",
+              "description": "Max directory-tree depth to include"
+            },
+            "include_dependencies": {
+              "type": "boolean",
+              "description": "Include dependency graph"
             }
-          }
+          },
+          "required": [
+            "paths"
+          ]
         }
       },
       {
@@ -235,9 +427,22 @@
               "type": "array",
               "items": {
                 "type": "string"
-              }
+              },
+              "description": "Filesystem paths (files or directories) to analyze"
+            },
+            "level": {
+              "type": "string",
+              "enum": [
+                "brief",
+                "normal",
+                "detailed"
+              ],
+              "description": "Summary detail level"
             }
-          }
+          },
+          "required": [
+            "paths"
+          ]
         }
       },
       {
@@ -246,13 +451,69 @@
         "inputSchema": {
           "type": "object",
           "properties": {
-            "paths": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
+            "query": {
+              "type": "string",
+              "description": "Natural language search query describing the code intent."
+            },
+            "limit": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 10,
+              "description": "Maximum number of results to return."
+            },
+            "min_grade": {
+              "type": "string",
+              "enum": [
+                "A+",
+                "A",
+                "A-",
+                "B+",
+                "B",
+                "B-",
+                "C+",
+                "C",
+                "C-",
+                "D",
+                "F"
+              ],
+              "description": "Minimum TDG grade filter (A+ is best). Case-insensitive."
+            },
+            "max_complexity": {
+              "type": "integer",
+              "description": "Maximum cyclomatic complexity filter."
+            },
+            "language": {
+              "type": "string",
+              "enum": [
+                "rust",
+                "typescript",
+                "python",
+                "go",
+                "java",
+                "c",
+                "cpp"
+              ],
+              "description": "Language filter."
+            },
+            "path_pattern": {
+              "type": "string",
+              "description": "Path glob pattern filter."
+            },
+            "include_source": {
+              "type": "boolean",
+              "default": false,
+              "description": "Include source code in results."
+            },
+            "rebuild_index": {
+              "type": "boolean",
+              "default": false,
+              "description": "Force index rebuild before query."
             }
-          }
+          },
+          "required": [
+            "query"
+          ]
         }
       },
       {
@@ -261,13 +522,19 @@
         "inputSchema": {
           "type": "object",
           "properties": {
-            "paths": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
+            "function_id": {
+              "type": "string",
+              "description": "Function ID from pmat_query_code results (e.g., 'src/handlers/auth.rs::handle_login')"
+            },
+            "include_source": {
+              "type": "boolean",
+              "description": "Include full source code (default: true)",
+              "default": true
             }
-          }
+          },
+          "required": [
+            "function_id"
+          ]
         }
       },
       {
@@ -276,13 +543,28 @@
         "inputSchema": {
           "type": "object",
           "properties": {
-            "paths": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
+            "function_id": {
+              "type": "string",
+              "description": "Function ID to find similar functions for"
+            },
+            "limit": {
+              "type": "integer",
+              "description": "Maximum number of similar functions (default: 5, max: 20)",
+              "minimum": 1,
+              "maximum": 20,
+              "default": 5
+            },
+            "min_similarity": {
+              "type": "number",
+              "description": "Minimum similarity score (0.0-1.0, default: 0.3)",
+              "minimum": 0.0,
+              "maximum": 1.0,
+              "default": 0.3
             }
-          }
+          },
+          "required": [
+            "function_id"
+          ]
         }
       },
       {
@@ -290,8 +572,13 @@
         "description": "Get statistics about the code index including function counts, quality distribution, and index health.",
         "inputSchema": {
           "type": "object",
-          "properties": {},
-          "additionalProperties": false
+          "properties": {
+            "rebuild": {
+              "type": "boolean",
+              "description": "Rebuild the index before returning stats (default: false)",
+              "default": false
+            }
+          }
         }
       }
     ]

--- a/src/mcp_pmcp/tool_manifest.rs
+++ b/src/mcp_pmcp/tool_manifest.rs
@@ -125,60 +125,93 @@ pub const LIVE_MCP_TOOLS: &[(&str, &str)] = &[
     ),
 ];
 
-/// A minimal object inputSchema for a tool (the manifest advertises the
-/// surface; full per-tool schemas live in the pmcp handler metadata and are
-/// covered by the deterministic sweep, MACS-011).
-fn tool_schema(name: &str) -> serde_json::Value {
-    // No-arg tools carry an empty, closed object; the rest accept a paths
-    // array — the shared shape across the analyze/generate family.
-    let no_arg = matches!(
-        name,
-        "refactor.nextIteration" | "refactor.getState" | "refactor.stop" | "pmat_index_stats"
-    );
-    // ...except the three repo-wide analyzers, which take ONE project root.
-    // The manifest is deliberately minimal, but minimal is not the same as
-    // wrong: advertising `paths` for a tool whose handler rejects it would put
-    // an unusable argument name in a file that ships inside the crate (#1029).
-    let project_root = matches!(
-        name,
-        "analyze_reachability" | "analyze_hardcoded_paths" | "analyze_vacuous_tests"
-    );
-    if project_root {
-        serde_json::json!({
-            "type": "object",
-            "properties": {
-                "project_path": {"type": "string"}
-            },
-            "required": ["project_path"]
-        })
-    } else if no_arg {
-        serde_json::json!({
-            "type": "object",
-            "properties": {},
-            "additionalProperties": false
-        })
-    } else {
-        serde_json::json!({
-            "type": "object",
-            "properties": {
-                "paths": {"type": "array", "items": {"type": "string"}}
-            }
-        })
-    }
+/// The 19 live tools' `metadata()`, in registration order — the SAME objects
+/// `tools/list` serves, so the manifest cannot describe a tool differently
+/// from the server (CRUX-09, #1150).
+///
+/// The previous renderer chose one of three canned inputSchemas by tool NAME:
+/// 15 of 19 tools were advertised as taking `paths: string[]` whatever they
+/// actually took, six could not be called at all as the shipped file described
+/// them, and `pmat_index_stats` was declared `additionalProperties: false` with
+/// no properties while the live tool accepts `rebuild` — so a validating
+/// client rejected its own valid call. Descriptions were pinned to the handlers
+/// in 3.33.0; schemas were left in exactly that state.
+///
+/// Cheap to construct: `IndexManager::new` only stores the path and opens
+/// nothing. The list mirrors the `.tool(...)` registrations in
+/// `SimpleUnifiedServer::run()`; `manifest_descriptions_match_handler_metadata`
+/// asserts the order against `LIVE_MCP_TOOLS` positionally.
+#[must_use]
+pub fn live_tool_infos() -> Vec<Option<pmcp::types::ToolInfo>> {
+    use crate::mcp::tools::agent_context_tools::IndexManager;
+    use crate::mcp_pmcp::agent_context_handlers::{
+        PmatFindSimilarHandler, PmatGetFunctionHandler, PmatIndexStatsHandler, PmatQueryCodeHandler,
+    };
+    use crate::mcp_pmcp::analyze_handlers::{
+        AnalyzeBigOTool, AnalyzeComplexityTool, AnalyzeDagTool, AnalyzeDeadCodeTool,
+        AnalyzeDeepContextTool, AnalyzeSatdTool, HardcodedPathsTool, ReachabilityTool,
+        VacuousTestsTool,
+    };
+    use crate::mcp_pmcp::context_handlers::{GenerateContextTool, GitTool, ScaffoldProjectTool};
+    use crate::mcp_pmcp::pdmt_handler::PdmtTool;
+    use crate::mcp_pmcp::quality_handlers::QualityGateTool;
+    use crate::mcp_pmcp::quality_proxy_handler::QualityProxyTool;
+    use pmcp::ToolHandler;
+    use std::path::PathBuf;
+    use std::sync::Arc;
+
+    let index_manager = Arc::new(IndexManager::new(PathBuf::from(".")));
+    vec![
+        AnalyzeComplexityTool.metadata(),
+        AnalyzeSatdTool.metadata(),
+        AnalyzeDeadCodeTool.metadata(),
+        AnalyzeDagTool.metadata(),
+        AnalyzeDeepContextTool.metadata(),
+        AnalyzeBigOTool.metadata(),
+        ReachabilityTool.metadata(),
+        HardcodedPathsTool.metadata(),
+        VacuousTestsTool.metadata(),
+        QualityGateTool.metadata(),
+        QualityProxyTool.metadata(),
+        PdmtTool::new().metadata(),
+        GitTool.metadata(),
+        GenerateContextTool.metadata(),
+        ScaffoldProjectTool.metadata(),
+        PmatQueryCodeHandler::new(index_manager.clone()).metadata(),
+        PmatGetFunctionHandler::new(index_manager.clone()).metadata(),
+        PmatFindSimilarHandler::new(index_manager.clone()).metadata(),
+        PmatIndexStatsHandler::new(index_manager).metadata(),
+    ]
 }
 
-/// Render `mcp.json` deterministically from `LIVE_MCP_TOOLS`. Pure: output
-/// depends only on the tool list (canonical, sorted keys via serde with the
+/// The inputSchema a tool serves over `tools/list`, or `None` when its handler
+/// declares no metadata at all — which `render_manifest` refuses to paper over.
+fn served_schema(name: &str) -> Option<serde_json::Value> {
+    live_tool_infos()
+        .into_iter()
+        .flatten()
+        .find(|info| info.name == name)
+        .map(|info| info.input_schema)
+}
+
+/// Render `mcp.json` deterministically from `LIVE_MCP_TOOLS` and the handlers'
+/// own `metadata()`. Pure: output depends only on the tool list (canonical, sorted keys via serde with the
 /// tools map ordered by registration index encoded in a `tools` array-of-
 /// objects to preserve order stably).
 pub fn render_manifest(version: &str) -> String {
     let tools: Vec<serde_json::Value> = LIVE_MCP_TOOLS
         .iter()
         .map(|(name, desc)| {
+            // The served schema, never a canned one. A tool whose handler
+            // declares no metadata gets an honest open object rather than a
+            // shape invented from its name; `every_live_tool_declares_metadata`
+            // keeps that branch unreachable.
+            let schema =
+                served_schema(name).unwrap_or_else(|| serde_json::json!({"type": "object"}));
             serde_json::json!({
                 "name": name,
                 "description": desc,
-                "inputSchema": tool_schema(name),
+                "inputSchema": schema,
             })
         })
         .collect();
@@ -329,49 +362,7 @@ mod tests {
     /// assertion before it can reach a release carrying two descriptions.
     #[test]
     fn manifest_descriptions_match_handler_metadata() {
-        use crate::mcp::tools::agent_context_tools::IndexManager;
-        use crate::mcp_pmcp::agent_context_handlers::{
-            PmatFindSimilarHandler, PmatGetFunctionHandler, PmatIndexStatsHandler,
-            PmatQueryCodeHandler,
-        };
-        use crate::mcp_pmcp::analyze_handlers::{
-            AnalyzeBigOTool, AnalyzeComplexityTool, AnalyzeDagTool, AnalyzeDeadCodeTool,
-            AnalyzeDeepContextTool, AnalyzeSatdTool, HardcodedPathsTool, ReachabilityTool,
-            VacuousTestsTool,
-        };
-        use crate::mcp_pmcp::context_handlers::{
-            GenerateContextTool, GitTool, ScaffoldProjectTool,
-        };
-        use crate::mcp_pmcp::pdmt_handler::PdmtTool;
-        use crate::mcp_pmcp::quality_handlers::QualityGateTool;
-        use crate::mcp_pmcp::quality_proxy_handler::QualityProxyTool;
-        use pmcp::ToolHandler;
-        use std::path::PathBuf;
-        use std::sync::Arc;
-
-        // Cheap: `IndexManager::new` only stores the path, it opens nothing.
-        let index_manager = Arc::new(IndexManager::new(PathBuf::from(".")));
-        let advertised: Vec<Option<pmcp::types::ToolInfo>> = vec![
-            AnalyzeComplexityTool.metadata(),
-            AnalyzeSatdTool.metadata(),
-            AnalyzeDeadCodeTool.metadata(),
-            AnalyzeDagTool.metadata(),
-            AnalyzeDeepContextTool.metadata(),
-            AnalyzeBigOTool.metadata(),
-            ReachabilityTool.metadata(),
-            HardcodedPathsTool.metadata(),
-            VacuousTestsTool.metadata(),
-            QualityGateTool.metadata(),
-            QualityProxyTool.metadata(),
-            PdmtTool::new().metadata(),
-            GitTool.metadata(),
-            GenerateContextTool.metadata(),
-            ScaffoldProjectTool.metadata(),
-            PmatQueryCodeHandler::new(index_manager.clone()).metadata(),
-            PmatGetFunctionHandler::new(index_manager.clone()).metadata(),
-            PmatFindSimilarHandler::new(index_manager.clone()).metadata(),
-            PmatIndexStatsHandler::new(index_manager).metadata(),
-        ];
+        let advertised = live_tool_infos();
         assert_eq!(
             advertised.len(),
             LIVE_MCP_TOOLS.len(),
@@ -574,6 +565,73 @@ mod tests {
                 "committed mcp.json still advertises '{bad}' — regenerate it: cargo test --lib regenerate_mcp_json -- --ignored"
             );
         }
+    }
+
+    /// CRUX-09 (#1150): the shipped inputSchema must BE the served one, for
+    /// every tool, not a shape chosen by name.
+    #[test]
+    fn manifest_schemas_match_handler_metadata() {
+        let rendered: serde_json::Value =
+            serde_json::from_str(&render_manifest("9.9.9")).expect("manifest is JSON");
+        let shipped: std::collections::BTreeMap<String, serde_json::Value> = rendered["mcp"]
+            ["tools"]
+            .as_array()
+            .expect("tools array")
+            .iter()
+            .map(|t| {
+                (
+                    t["name"].as_str().expect("name").to_string(),
+                    t["inputSchema"].clone(),
+                )
+            })
+            .collect();
+        let served: Vec<pmcp::types::ToolInfo> = live_tool_infos().into_iter().flatten().collect();
+        assert_eq!(
+            served.len(),
+            LIVE_MCP_TOOLS.len(),
+            "every live tool declares metadata"
+        );
+        for info in served {
+            assert_eq!(
+                shipped.get(&info.name),
+                Some(&info.input_schema),
+                "{}: the packaged mcp.json and tools/list advertise different inputSchemas",
+                info.name
+            );
+        }
+    }
+
+    /// The `unwrap_or_else` open-object fallback in `render_manifest` must stay
+    /// unreachable: a handler with no metadata is a defect, not a tool with an
+    /// open schema.
+    #[test]
+    fn every_live_tool_declares_metadata() {
+        for (i, info) in live_tool_infos().iter().enumerate() {
+            assert!(
+                info.is_some(),
+                "handler at registration index {i} ({}) declares no metadata",
+                LIVE_MCP_TOOLS[i].0
+            );
+        }
+    }
+
+    /// Fixing the renderer without regenerating the file leaves the defect
+    /// wholly intact in the tarball, so the committed file is pinned to the
+    /// renderer byte-for-byte. Version-only churn is the one tolerated diff:
+    /// `check_macs_artifacts.rs` ignores it for the same reason.
+    #[test]
+    fn committed_mcp_json_is_pinned_to_the_renderer() {
+        let committed = include_str!("../../mcp.json");
+        let version = serde_json::from_str::<serde_json::Value>(committed)
+            .ok()
+            .and_then(|v| v["version"].as_str().map(str::to_string))
+            .expect("committed mcp.json carries a version");
+        assert_eq!(
+            committed,
+            render_manifest(&version),
+            "mcp.json is not what the renderer produces — regenerate it: \
+             cargo test --lib regenerate_mcp_json -- --ignored"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #1150 (CRUX-09). Ticket PMAT-631.

The packaged `mcp.json` ships inside the crate for clients to read, and its inputSchemas were one of three canned shapes chosen by tool **name** (`tool_schema()`): 15 of 19 tools advertised `paths: string[]` whatever they took, **six could not be called at all** as the file described them, and `pmat_index_stats` was `additionalProperties: false` with no properties while the live tool accepts `rebuild` — a validating client rejected its own valid call. Descriptions were pinned to the handlers in 3.33.0; schemas were left in that state.

## Fix, where the defect is caused

- **`live_tool_infos()`** returns the same `metadata()` objects `tools/list` serves; `render_manifest` takes every inputSchema from there. `tool_schema()` is deleted.
- **`manifest_schemas_match_handler_metadata`** — shipped schema must *be* the served one, per tool.
- **`committed_mcp_json_is_pinned_to_the_renderer`** — byte-for-byte pin, so a renderer fix cannot ship without the regenerated file.
- **`mcp.json` regenerated**: +341/−54, every tool carries its real properties, required set and additionalProperties.

## Both sides (spec §8.9, 13 legs)

| | result |
|---|---|
| master | `FAIL: A1: 19/19 shipped inputSchemas differ from tools/list` |
| this branch | `PASS: A1 A2 B1 B3 D1 D1b green; controls P A3 B2 C D2 D3 green` |

12/12 `tool_manifest` tests (pin RED before regenerate, GREEN after); fmt, clippy, `pmat verify --skip clippy,tests` clean; unrun-tests ledger regenerated. The migration of the 13 hand-rolled `json!` schema blocks onto `mcp_tool_schemas/` is split out per the spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## pv contract (same PR)

`contracts/macs-artifacts-v1.yaml` → 1.1.0: new equation **`manifest_schema_faithful`** — `inputSchema(mcp.json, t) = inputSchema(tools/list, t)` for every live tool — with falsifiers `manifest_schemas_match_handler_metadata` and `manifest_pinned` → `committed_mcp_json_is_pinned_to_the_renderer`.

## Named mutation, observed RED

Restore the canned `paths: string[]` schema for one tool (`pmat_index_stats`) in `mcp.json` without regenerating:

```
test committed_mcp_json_is_pinned_to_the_renderer ... FAILED    (mutant)
test committed_mcp_json_is_pinned_to_the_renderer ... ok        (restored)
```

`manifest_schemas_match_handler_metadata` stays green under that mutation by design — it tests the renderer; the pin is what catches file drift. Known: `refactor.*` is simulated (EV-0) and nothing here depends on it; the protocol served is 2024-11-05 (EV-1), unchanged by this PR.