### PR TITLE
chore(release): cut version 3.36.0 — the first publication since 3.34.0

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -12,6 +12,10 @@ on:
   pull_request:
     branches: [main, master]
   workflow_dispatch:
+  schedule:
+    # AD-01: the release check below runs daily on master, so a merged release
+    # PR that published nothing is red within a day even with no further push.
+    - cron: "17 6 * * *"
 
 concurrency:
   group: quality-gate-${{ github.event.pull_request.number || github.ref }}
@@ -292,3 +296,41 @@ jobs:
       - name: Ladder gate — pmat comply
         continue-on-error: true
         run: pmat comply check --failures-only
+
+  # AD-01 (docs/specifications/agentic-delivery-pmat.md section 3.5 / 9.1): the
+  # version Cargo.toml declares must be tagged, released on GitHub and on
+  # crates.io. pmat 3.35.0's release PR merged on 2026-09-02 and none of the
+  # three happened; every gate was green because none asked. This job runs on
+  # master after a merge and on the daily schedule — never on a pull request,
+  # and it is NOT a required PR check: a PR is not a release, and a merge must
+  # not be blocked by the registry's availability. GitHub-hosted runner on
+  # purpose, so it is not starved with the self-hosted fleet.
+  release-check:
+    name: release-check
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      - name: The declared version is tagged, released and published
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -o pipefail
+          bash scripts/release-check.sh 2>&1 | tee release-check.out
+      - name: Open or refresh the issue
+        if: failure() && steps.check.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          v=$(grep -m1 '^version' Cargo.toml | cut -d'"' -f2)
+          title="release-check: $v is declared in Cargo.toml but not fully released"
+          body="$(printf 'AD-01 (docs/specifications/agentic-delivery-pmat.md section 3.5).\n\n```\n%s\n```\n\nRun: %s/%s/actions/runs/%s' "$(cat release-check.out)" "$GITHUB_SERVER_URL" "$GITHUB_REPOSITORY" "$GITHUB_RUN_ID")"
+          n=$(gh issue list --state open --search "\"$title\" in:title" --json number --jq '.[0].number // empty')
+          if [ -n "$n" ]; then gh issue comment "$n" --body "$body"; else gh issue create --title "$title" --body "$body"; fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,90 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.36.0] - 2026-09-03
+
+**3.35.0 was never published.** Its release PR (#1108) merged on 2026-09-02 but
+no tag, GitHub release or crates.io upload followed, so crates.io stopped at
+3.34.0. Everything under `[3.35.0]` below ships here for the first time,
+together with what merged since.
+
+### `pmat comply check` aborted on a box-drawing character (#1159)
+
+`lean_theorem_is_proved` bounded a `lean_theorem:` block with byte offsets
+computed over `lines().skip(1)` — never counting the first line — and patched
+the miss with `+ "lean_theorem:".len()`. Whenever the first line was longer
+than the bare key the cut landed inside the block's last line, and when that
+line was a box-drawing comment divider it landed inside a multibyte char:
+`byte index 1000 is not a char boundary; it is inside '─'`, exit 134, and every
+downstream fleet gate that runs `comply check --format json` read "could not
+parse". The bound is now the next column-0 key's line start (a char boundary by
+construction) behind a `floor_char_boundary` guard; the aprender tree that
+reproduced it now returns 166 checks. Twelve regression tests, ten of them
+contributed on #1166 by the aprender release session. (#1167)
+
+### A merged release must have become a release (AD-01, #1170)
+
+`scripts/release-check.sh` reads the version `Cargo.toml` declares and, when it
+exceeds the latest tag, requires the tag, the GitHub release and the crates.io
+version — exit 1 naming the first missing channel. A `release-check` job runs it
+on every push to master and daily, on a GitHub-hosted runner, and opens an
+issue on failure. On the tree that shipped this it was red: `Cargo.toml says
+3.35.0 but no tag v3.35.0`. The specification of the delivery pipeline it
+belongs to — twenty-one capabilities measured against pmat, the paiml-implement
+bundle and agy, a micro-enforcement matrix, a `Pmat-Ticket:` commit-trailer
+linking model, and nine further items ranked ahead of the remaining CRUX audit
+— is `docs/specifications/agentic-delivery-pmat.md` (#1168).
+
+### MCP: `quality_proxy` → `quality_check_content` — it never wrote, and now says so (CRUX-10, #1151, #1163)
+
+The tool advertised a write it never performed. It is now `quality_check_content`
+(`quality_proxy` served as a one-release alias): the schema has no `operation`
+and refuses unknown keys, `ProxyResponse.written` is always `false`, advisory
+mode reports `rejected` when `passed` is false instead of laundering it, a
+client's `quality_config` can only tighten the project's floor, and
+`satd_count` equals the SATD list. 20 tools in `tools/list`.
+
+### `mcp.json` advertised a wrong inputSchema for 19 of 19 tools (CRUX-09, #1158)
+
+The packaged manifest is now rendered from the handlers' own metadata and pinned
+by a test that fails when it drifts.
+
+### `pmat verify` withdraws its verdict over a declined stage (CRUX-01, #1161)
+
+`ok` is tri-state: `true`, `false`, or `null` with `not_measured[]` naming the
+stage that could not run — a green that skipped a stage is no longer a green.
+Strict SATD accepts the canonical markers with every standard separator.
+
+### One `Cargo.toml` line disabled clap's usage, error-context and suggestions (CRUX-05, #1160)
+
+70 of 71 subcommands printed an empty usage on error; the feature is back and
+pinned.
+
+### `build.rs` watched a path outside the repo, so no build was ever incremental (CRUX-06, #1154)
+
+A no-op `cargo build --release` went from 55 s / 4.45 GB to 0.27 s; a permanent
+test refuses any `rerun-if-changed` path outside the manifest directory.
+
+### Unreachable files are ledgered and ratcheted (CRUX-12, #1157)
+
+`docs/status/orphan-files-ledger.md` names every `.rs` file no build compiles
+with a reason from a closed enum; `orphan_files` (407) and `quarantined_files`
+(82) are ratchet metrics measured in-process, and CI's `reachability-ledger`
+job fails when the ledger drifts.
+
+### Dependencies
+
+pmcp 2.19.2 (#1113), uuid 1.26 (#1111), actix-rt 2.12 (#1110), getrandom 0.4
+(#1116), softprops/action-gh-release 3.0.3 (#1115), patch updates (#1109).
+
+### Also
+
+The CRUX architecture, performance and competitive audit — 32 items with
+falsifiable acceptance tests — is in
+`docs/specifications/pmat-architecture-crux-audit.md` (#1117), with per-item
+implementation receipts under `docs/audits/`.
+
+
 ## [3.35.0] - 2026-08-30
 
 Minor rather than patch, for the fourth release running, and for the same reason the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4986,7 +4986,7 @@ dependencies = [
 
 [[package]]
 name = "pmat"
-version = "3.35.0"
+version = "3.36.0"
 dependencies = [
  "actix",
  "actix-rt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pmat"
 default-run = "pmat"
-version = "3.35.0"
+version = "3.36.0"
 edition = "2021"
 rust-version = "1.91.0"
 authors = ["Pragmatic AI Labs"]

--- a/Makefile
+++ b/Makefile
@@ -1623,6 +1623,9 @@ release-dry:
 	@cargo release patch --dry-run
 
 # Verify release was successful
+release-check: ## AD-01: the version Cargo.toml declares must be tagged, released and on crates.io (exit 1 names the first missing channel)
+	@bash scripts/release-check.sh
+
 release-verify:
 	@echo "🔍 Verifying release..."
 	@LATEST_TAG=$$(git describe --tags --abbrev=0); \

--- a/README.md
+++ b/README.md
@@ -625,7 +625,7 @@ PMAT is built on the PAIML Sovereign Stack - pure-Rust, SIMD-accelerated librari
 | [aprender-zram-core](https://crates.io/crates/aprender-zram-core) | SIMD LZ4/ZSTD compression (optional) | 0.64 |
 | [aprender-contracts](https://crates.io/crates/aprender-contracts) | Provable contracts (with `aprender-contracts-macros`) | 0.64 |
 | [pmcp](https://crates.io/crates/pmcp) | MCP protocol SDK (streamable HTTP transport) | 2.17 |
-| **pmat** | Code analysis toolkit | 3.35.0 |
+| **pmat** | Code analysis toolkit | 3.36.0 |
 
 **Key Benefits:**
 - Pure Rust (no C dependencies, no FFI)

--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -3947,3 +3947,54 @@ roadmap:
   estimated_effort: null
   labels: []
   notes: null
+- id: PMAT-650
+  github_issue: null
+  item_type: task
+  title: 'Agentic delivery spec: docs/specifications/agentic-delivery-pmat.md — map the whiteboard''s three zones to pmat/paiml-implement/agy with acceptance tests; backlog AD-01..AD-10'
+  status: inprogress
+  priority: high
+  assigned_to: null
+  created: 2026-09-03T13:07:46Z
+  updated: 2026-09-03T13:07:46.238382271+00:00
+  spec: null
+  acceptance_criteria:
+  - Approved plan /home/noah/.claude/plans/immutable-orbiting-moore.md (reviewed by one agy /teamwork-preview lane, conversation 0a2b5862). Spec only; AD-01..AD-10 become their own tickets after it merges.
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels: []
+  notes: null
+- id: PMAT-651
+  github_issue: null
+  item_type: task
+  title: 'AD-01: post-merge release check — a merged release PR must produce a tag, a GitHub release and a crates.io version (3.35.0 never did)'
+  status: inprogress
+  priority: high
+  assigned_to: null
+  created: 2026-09-03T13:18:32Z
+  updated: 2026-09-03T13:18:32.440132243+00:00
+  spec: null
+  acceptance_criteria:
+  - 'agentic-delivery-pmat.md section 3.5 / 9.1. scripts/release-check.sh reads the version from Cargo.toml; when it exceeds the latest v* tag it requires the tag, the GitHub release and the crates.io version, else exit 1 naming the version. Control: --self-test with a fixture at 9.9.9 must fail all three legs. CI job on master (push + schedule), NOT a required PR check.'
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels: []
+  notes: null
+- id: PMAT-652
+  github_issue: null
+  item_type: task
+  title: 'AD-02: post-publish dog-food — install the version crates.io serves and run the release gate against it, writing a receipt'
+  status: inprogress
+  priority: high
+  assigned_to: null
+  created: 2026-09-03T13:22:47Z
+  updated: 2026-09-03T13:22:47.738403253+00:00
+  spec: null
+  acceptance_criteria:
+  - 'agentic-delivery-pmat.md section 3.6 / 9.2. scripts/dogfood-published.sh <version>: cargo install pmat --version <v> --locked into a temp root; the binary must report the version; scripts/dogfood-use.sh runs with BIN= that binary; the registry entry is checked (P7); receipt docs/audits/release-<v>-dogfood.md names the installed commit. Control: a fabricated version fails at the install leg, exit 1.'
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels: []
+  notes: null

--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -3930,3 +3930,20 @@ roadmap:
   estimated_effort: null
   labels: []
   notes: null
+- id: PMAT-649
+  github_issue: null
+  item_type: task
+  title: comply check panics on a char boundary in check_contract_surfaces.rs:961 (lean_theorem block slicing) — reported by the aprender release session, PMAT-742 there
+  status: inprogress
+  priority: high
+  assigned_to: null
+  created: 2026-09-03T10:14:21Z
+  updated: 2026-09-03T10:30:10.021112151+00:00
+  spec: null
+  acceptance_criteria:
+  - 'pmat 3.34.0 on paiml/aprender main 68b059ca9: thread comply-2 panicked at src/cli/handlers/comply_handlers/check_handlers/check_contract_surfaces.rs:961:23: end byte index 1000 is not a char boundary; it is inside a box-drawing char. The scan slices &block[..start + "lean_theorem:".len()] by byte arithmetic. Fix in pmat: slice on the found line''s start / floor_char_boundary. Repro: cd /mnt/nvme-raid0/agent-wt/pp-base && RUST_BACKTRACE=1 pmat comply check --format json. Contracts: contracts/document-integrity-v1.yaml, contracts/aprender/apr-serve-v1.yaml, contracts/aprender/apr-architecture-schema-v1.yaml. COORDINATION 2026-09-03: the aprender release session (its PMAT-742) said it will open a small PR against pmat for :961 (is_char_boundary guard + regression test with a box-drawing line after a lean_theorem block) — check for that PR before starting; aprender carries a disclosed, reversible stopgap meanwhile. Patch release still owed after merge.'
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels: []
+  notes: null

--- a/docs/specifications/agentic-delivery-pmat.md
+++ b/docs/specifications/agentic-delivery-pmat.md
@@ -1,0 +1,326 @@
+# Agentic Delivery — pmat, paiml-implement and agy against the whiteboard
+
+**Status:** specification, ticket PMAT-650 · **Audited at:** master `cd6f796d6` (2026-09-03), pmat 3.35.0-unpublished, `~/src/paiml-implement` `c8e2ced` (bundle v1.1.0, spec AUTO-IMPL-SKILL-001 v1.0.1), agy 1.1.25 · **Source:** the 2026-09-03 whiteboard "Agentic Delivery Architecture" (Claude Code + Fable orchestrator · quorum-reviewed sub-agents · Google Antigravity execution pool · pmat quality gates · auto-merge to GitHub and crates.io).
+
+## 0. Provenance
+
+Every status in this document was **measured** in one session by the orchestrator with the command beside it; nothing is quoted from a design document. The plan behind it (`~/.claude/plans/immutable-orbiting-moore.md`) was reviewed by one agy `/teamwork-preview` lane (conversation `0a2b5862-3ea1-4533-9b9a-758f33be4b00`, 245 s, two child conversations). The lane returned `do-not-implement-as-written` with six findings; five are applied here (§6 quorum row, §8.1 control, §9 order, §7 columns, §8 trailer). The sixth — that `~/.claude/hooks/subagent-lock.sh` and `~/src/paiml-implement/agents/*.md` do not exist — was refuted by `test -e` on all four paths; a sandboxed lane does not see the host filesystem, which is itself a fact about lane grounding this document records in §6.4.
+
+House rule, as in `docs/specifications/pmat-architecture-crux-audit.md`: a gate that cannot fail is theater; a status of PRESENT is a claim with a command that would have returned a different answer if it were false.
+
+## 1. Executive summary
+
+- The pipeline's two **"must"** arrows do not exist. Nothing produces a quorum verdict that gates a pull request (no such skill is installed; the delegate's quorum lane emits verdicts nobody consumes), and nothing dog-foods the **published** crate: the pre-publish probe (`crate-release-dogfood`) reads the packaged tarball, and no step ever installs the version crates.io serves.
+- The incident that proves the second hole: **3.35.0 was merged on 2026-09-02 (#1108) and never tagged, released or published.** crates.io's newest version is 3.34.0 (2026-08-29); `git tag` stops at `v3.34.0`; docs.rs has no 3.35.0. Every gate was green throughout, because no gate asks "did the merged release PR produce a release".
+- Of the five quantitative rules in the quality zone, `pmat quality-gate` enforces **one** (complexity). Lint lives only in `pmat verify`; churn is measured (`analyze churn`) and gated nowhere; lines-per-file exists only as a `pmat work` contract claim (`max_file_lines`, default 500); the ticket-in-commit check in the generated hook prints a warning and exits 0 (#1126).
+- "Every sub-agent must comply" is not a contract today: the worker returns a receipt with an `acceptance` exit code and no gate result; the orchestrator re-runs the acceptance command but nothing obliges the worker to have run `pmat verify`.
+- The orchestration zone's "1–3 sub-agents" is implemented as a **concurrency cap** (`CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS=3`), not as a **vote**. Fan-out to Antigravity works (`/teamwork-preview` runs headless, 2–12 min); the Goal and Grill-me modes do not exist in agy 1.1.25; the executor is not swappable; the pool is capped at 10, not 20.
+- Ticket ↔ work linking has no machine-checkable record: branch names carry ticket ids by convention, PR bodies by habit, commits by nothing.
+
+Twelve of the diagram's twenty-one capabilities are PRESENT or PARTIAL with evidence; nine are MISSING. §9 ranks the ten changes that close them, and §7 goes beyond the diagram: every enforcement is placed at the moment an agent acts, not only at CI.
+
+## 2. Doctrine
+
+1. **A gate must be able to fail**, and every gate here carries the command that shows it failing on a planted defect.
+2. **Enforce at the point of action, then again at CI.** A hook that refuses the commit is worth more than a CI leg that fails an hour later; the CI leg exists so a bypassed hook is still caught.
+3. **A sub-agent's claim is a claim.** Receipts carry the gate's own JSON; the orchestrator re-runs it; disagreement is a finding.
+4. **Nothing merges without a quorum verdict; nothing ships without dog-fooding the published bytes.** The diagram's two "must" arrows, as gates.
+5. **One orchestrator, a small quorum for judgment, a wide pool for throughput.** Claude turns are the scarce budget; agy lanes are the cheap one.
+6. **Traceability is a trailer, not a habit.** `Pmat-Ticket: PMAT-NNN` on every commit; everything else is derived.
+
+## 3. Zone 1 — Delivery pipeline
+
+> Quorum Review Skill (3 reviewers must agree) → review verdict → Pull Request (gates merge) → Build Server (CI runs the gates) → GitHub Repo (auto-merge on green) → crates.io (publish, must pass Dog Food Skill). *Nothing merges without a quorum verdict; nothing ships without dog-fooding the published crate.*
+
+### 3.1 Quorum Review Skill — MISSING
+
+**Evidence.** `ls ~/.claude/skills` → `course-marketing-image-uploads crate-release-dogfood dogfood edx-publish generate-narration narrate-animation nextdns-toggle nightly-ux-crux paiml-implement post-course-asset-roundup quiz-audit-fix render-audit` — no review or quorum skill. What exists: `~/src/paiml-implement/agents/paiml-agy-delegate.md` runs a `quorum` lane (N `agy -p` runs, cap 10) whose output is validated against `agy/quorum-schema.json` (`verdict ∈ {PASS, FAIL, do-not-implement-as-written}`, `summary`, `findings`). Nothing consumes those verdicts to gate a PR; `gh pr merge --auto` is issued by the orchestrator on its own judgment.
+
+**Acceptance test (AD-04).**
+```sh
+set -euo pipefail; fail(){ echo "FAIL: $*"; exit 1; }
+# a diff with a planted contradiction: the test asserts the opposite of the ticket
+git switch -c qr-fixture && printf '#[test]\nfn planted(){ assert_eq!(1+1, 3); }\n' >> src/lib.rs && git commit -qam 'planted' -m 'Pmat-Ticket: PMAT-0'
+quorum-review --base master --ticket PMAT-0 --out /tmp/qr.json || true
+jq -e '[.lanes[].verdict] | index("FAIL") != null' /tmp/qr.json || fail "no lane failed a planted contradiction"
+# control: the same skill on a clean diff must reach 3 PASS
+git checkout -q -- src/lib.rs; git commit -qam 'clean' -m 'Pmat-Ticket: PMAT-0' --allow-empty
+quorum-review --base master --ticket PMAT-0 --out /tmp/qr2.json
+jq -e '[.lanes[].verdict] | length == 3 and all(. == "PASS")' /tmp/qr2.json || fail "clean diff did not reach 3 PASS"
+# the merge helper refuses without the artifact
+rm /tmp/qr2.json; pmat-merge --auto 2>&1 | grep -q 'no quorum verdict' || fail "auto-merge proceeded without a verdict"
+```
+*Anti-vacuity:* the planted contradiction must be **found**, not just "any FAIL" — the finding's `file:line` must point at the planted test; the control must be 3 PASS, not "no FAIL".
+
+### 3.2 Pull Request — gates merge — PRESENT
+
+**Evidence.** `gh api repos/paiml/paiml-mcp-agent-toolkit/branches/master/protection` → `strict=true`, required contexts `ci / gate`, `feature-gate`, `docs build (docs.rs environment)`, `pmat score`, `provable ladder`; `required_approving_review_count=0`; `enforce_admins=false`. Strict means every merge puts every other PR BEHIND, which is why the cascade routine in §7 exists.
+
+**Acceptance.** `gh pr merge <n> --merge` on a PR with a red required check → `GraphQL: … Required status check … is expected` (refused). Control: green PR merges. Verified 2026-09-03 on #1163/#1164.
+
+### 3.3 Build Server — CI runs the gates — PARTIAL
+
+**Evidence.** `.github/workflows/ci.yml` calls `paiml/.github/.github/workflows/sovereign-ci.yml@main` (lint, test, coverage, security, provenance), then `gate` aggregates `ci`, `windows-check`, `reusable-pin-drift`; `quality-gate.yml` runs `pmat score` and `provable ladder`; `feature-matrix.yml` runs the feature bundles and, since #1157, `reachability-ledger`. **Not run in CI:** `pmat verify` and `pmat quality-gate --checks all` — the gate set agents are told to pass before committing is not the gate set the build server runs.
+
+**Acceptance test (part of AD-05).** A CI leg `pmat quality-gate --checks all --format json` on the merge commit; `.results.passed == true` required; control: a planted 501-line file fails it.
+
+### 3.4 GitHub Repo — auto-merge on green — PRESENT
+
+**Evidence.** `gh api repos/paiml/paiml-mcp-agent-toolkit --jq .allow_auto_merge` → `true`; `gh pr merge <n> --auto --merge` used for #1158…#1167. **Caveat measured 2026-09-03:** pushes to a PR branch created **no** workflow runs on three occasions (`actions/runs?head_sha=` → 0) while `workflow_dispatch` on the same head did (PMAT-646); auto-merge therefore waited on a check that would never appear until the runs were dispatched by hand.
+
+### 3.5 crates.io publish — MANUAL, UNVERIFIED
+
+**Evidence.** `Makefile:1363` `env -u CARGO_REGISTRY_TOKEN cargo publish --package pmat` behind an interactive prompt; `docs/release-process.md` still describes `server/Cargo.toml` and `cargo set-version`, a layout deleted in January. `git tag --sort=-creatordate | head -1` → `v3.34.0`; `gh release list` → `v3.34.0` latest; `curl https://crates.io/api/v1/crates/pmat` → `max_stable_version 3.34.0`; `Cargo.toml` → `3.35.0`; `#1108` merged 2026-09-02. **No job on `master` compares these four.**
+
+**Acceptance test (AD-01).**
+```sh
+set -euo pipefail; fail(){ echo "FAIL: $*"; exit 1; }
+v=$(grep -m1 '^version' Cargo.toml | cut -d'"' -f2)
+latest_tag=$(git tag -l 'v*' --sort=-v:refname | head -1 | sed 's/^v//')
+[ "$v" = "$latest_tag" ] && { echo "at a tag"; exit 0; }
+git tag -l "v$v" | grep -q . || fail "release-check: Cargo.toml says $v but no tag v$v"
+gh release view "v$v" >/dev/null 2>&1 || fail "release-check: no GitHub release v$v"
+curl -s "https://crates.io/api/v1/crates/pmat/$v" -H 'User-Agent: pmat-release-check' | jq -e '.version.num == "'"$v"'"' >/dev/null || fail "release-check: $v is not on crates.io"
+```
+*Anti-vacuity:* the version is read from `Cargo.toml`, never a literal; **control:** a fixture with `Cargo.toml` at 9.9.9 must fail all three legs — a check that hardcodes `3.35.0` fails the control. On master at `cd6f796d6` this test fails at the tag leg naming 3.35.0.
+
+### 3.6 must pass Dog Food Skill — PARTIAL
+
+**Evidence.** `~/.claude/skills/crate-release-dogfood/probe.sh` probes the **packaged tarball** (P1 provenance … P7 registry) and its self-test fires 5 findings on `fixtures/defective-crate` (run 2026-09-03: `SELF-TEST PASSED: 5 probe(s) fired`). The fleet protocol's canonical runner is a shim (`~/.claude/skills/dogfood/pmat-dogfood-runner.sh`) over `<aprender>/.claude/skills/apr-dogfood`; `scripts/dogfood-use.sh` runs the built binary against independent oracles (13 checks). **None of them installs the version crates.io serves and runs it.** The diagram's arrow is from *crates.io* to the skill: the bytes a stranger receives.
+
+**Acceptance test (AD-02).**
+```sh
+set -euo pipefail; fail(){ echo "FAIL: $*"; exit 1; }
+v=$1; root=$(mktemp -d)
+cargo install pmat --version "$v" --root "$root" --locked >/dev/null 2>&1 || fail "install $v from crates.io failed"
+"$root/bin/pmat" --version | grep -q "pmat $v" || fail "installed binary does not report $v"
+BIN="$root/bin/pmat" bash scripts/dogfood-use.sh || fail "dogfood-use against the installed $v failed"
+bash ~/.claude/skills/crate-release-dogfood/probe.sh --published "$v" || fail "probe P5–P7 against the published $v failed"
+```
+*Anti-vacuity:* **control:** a fabricated version (`9.9.9`) must fail at the install leg with exit 1, and the receipt `docs/audits/release-<v>-dogfood.md` must name the installed binary's `commit:` line, which the local build cannot fake.
+
+## 4. Zone 2 — Quality enforcement (pmat MCP)
+
+> pmat MCP (quality server) → Sub-Agent Level (every agent must comply) → Enforce quantitative quality — hard thresholds, not opinions: Max complexity · Lint · Churn · Lines per file · Traceability. *Gates are evaluated by the Build Server and by every sub-agent before it reports back.*
+
+### 4.1 pmat MCP quality server — PRESENT
+
+**Evidence.** `tools/list` over stdio (protocol 2024-11-05) → 20 tools: 6 core analyzers, 3 forensic analyzers, `quality_gate`, `quality_check_content` (+ its one-release alias `quality_proxy`), `pdmt_deterministic_todos`, `git_operation`, `generate_context`, `scaffold_project`, 4 agent-context tools (`docs/mcp/TOOLS.md`, pinned by `manifest_matches_server`). `quality_gate` runs the same `run_gate_suite` the CLI runs (`src/cli/analysis_utilities/quality_gate_suite.rs`), so the two surfaces cannot disagree on findings.
+
+### 4.2 Sub-Agent Level — every agent must comply — PARTIAL
+
+**Evidence.** `~/src/paiml-implement/agents/paiml-impl-worker.md` §receipt: `{"ticket","phase","files_changed","commands":[{"cmd","exit"}],"tests_added","acceptance":{"cmd","exit"},"open_questions","partial"}` — no gate field; the worker "runs acceptance_cmd before returning"; `pmat verify` is named in the brief as `gate_cmd` but nothing requires it to have run. The orchestrator re-runs `acceptance_cmd` (SKILL.md Phase 2 step 3). `~/.claude/hooks/subagent-lock.sh` denies `Edit`/`Write` without an active ticket (§2b) and `git push`/`gh pr` while a worker holds a slot (§2c) — enforcement at the point of action, for two of the moments in §7.
+
+**Acceptance test (AD-06).** A worker receipt without `gate` is treated as `partial=true` by the orchestrator (SKILL.md §6.2); a receipt whose `gate.ok` differs from the orchestrator's own `pmat verify --format json` on the same tree is recorded as a finding in the dispatch ledger. Control: a receipt with `gate.ok=true` that the rerun confirms is accepted.
+
+### 4.3 Max complexity — PRESENT
+
+**Evidence.** `pmat quality-gate --checks complexity` (`--max-complexity-p99`, default 50 — `GATE_DEFAULT_MAX_COMPLEXITY_P99`); `pmat verify` measures **changed files** at `--max-cyclomatic 30 --max-cognitive 25 --fail-on-violation` (`src/cli/verify.rs:456-458`). Two thresholds under one name; verify's is the one agents meet. Measured this week: verify stopped three tickets on pre-existing debt in touched files (CRUX-10 `proxy_operation` 15/34; CRUX-04 six functions 27–33; #1159 four functions 27–39), each refactored under the ceiling — the gate can fail and did.
+
+### 4.4 Lint, zero warnings — PARTIAL
+
+**Evidence.** `pmat verify` stage `clippy` runs `cargo clippy --all-targets -- -D warnings` (matches `ci / lint`, memory v3.26.0). `pmat quality-gate --checks` has no `lint` value (`dead-code, complexity, coverage, sections, provability, satd, entropy, security, duplicates, all`); the MCP `quality_gate` therefore cannot report a warning. The `analyze clippy` command is preview-only since 3.33.0.
+
+**Acceptance test (AD-05).** `pmat quality-gate --checks lint --format json -p <crate with one clippy warning>` → `.results.lint_violations >= 1`, `.results.passed == false`; control: the same crate with the warning fixed → 0, passed.
+
+### 4.5 Churn — MISSING as a gate
+
+**Evidence.** `pmat analyze churn --days N` measures commits per file and a churn score; `quality-gate` has no churn check (see 4.4's list); `analyze churn --help` exposes no threshold or `--fail-on` flag. `.pmat-metrics.toml` has no churn key. Nothing can fail on churn.
+
+**Acceptance test (AD-05).** `pmat quality-gate --checks churn --format json -p <repo>` with `pmat.toml [quality] max_churn_commits_90d = 5` → a file with 6 commits in 90 days is a `churn` violation naming the file and count; control: threshold 100 → 0 violations. Fixture: a temp git repo with one file committed 6 times (`git_seal` pattern from `scripts/dogfood-use.sh`).
+
+### 4.6 Lines per file — PARTIAL
+
+**Evidence.** `src/cli/handlers/work_contract_profile.rs:336` `max_file_lines … unwrap_or(500)` feeds `pmat work`'s contract claims (`universal_claims`, `rust_claims`); `pmat quality-gate` has no file-size check; nothing refuses a commit that grows a file past the cap. This repository's own `src/cli/commands/commands_enum/definition.rs` is 1,822 lines (#1118).
+
+**Acceptance test (AD-05).** `pmat quality-gate --checks file-size --format json -p <crate with a 501-line file>` → `.results.file_size_violations == 1` naming the file and its line count; control: 500 lines → 0. The threshold is read from `pmat.toml [quality] max_file_lines` (the same key `pmat work` reads), default 500.
+
+### 4.7 Traceability — link work to ticket + commit message — PARTIAL
+
+**Evidence.** The generated pre-commit hook (`src/cli/handlers/hooks_command_handlers/hook_generation.rs:396-401`) prints `Warning: Commit message should contain task ID matching $PMAT_TASK_ID_PATTERN` and reaches `echo "✅ All quality gates passed!"` regardless (#1126, unimplemented at HEAD). `pmat work` offers `add list edit delete annotate start continue checkpoint complete delegate falsify cot ledger event claim triage status sync init validate migrate list-statuses score codebase-score` — no verb links a commit, branch or PR to a ticket. `subagent-lock.sh` §2b refuses an edit without `$STATE/active-ticket`, but only while the skill's state directory exists.
+
+**Acceptance test (AD-03, AD-07).**
+```sh
+set -euo pipefail; fail(){ echo "FAIL: $*"; exit 1; }
+pmat hooks install --strict >/dev/null
+printf 'x\n' >> README.md
+git commit -qam 'no trailer' && fail "a commit without Pmat-Ticket was accepted"
+git commit -qam 'with trailer' -m 'Pmat-Ticket: PMAT-650' || fail "a commit with the trailer was refused"
+git log -1 --format='%(trailers:key=Pmat-Ticket,valueonly)' | grep -qx 'PMAT-650' || fail "trailer not readable by git"
+pmat work link PMAT-650 --commit HEAD && pmat work annotate PMAT-650 | grep -q "$(git rev-parse --short HEAD)" || fail "link not recorded"
+pmat comply check --checks CB-TRACE --format json | jq -e '.checks[] | select(.name|test("ticket trailer")) | .status == "pass"' >/dev/null || fail "comply did not see the trailer"
+```
+*Anti-vacuity:* the first commit must be **refused** (non-zero, message naming the trailer); a hook that warns and exits 0 fails this test exactly as the shipped one does today.
+
+## 5. Zone 3 — Orchestration (Claude Code + Fable)
+
+> Claude Code (harness / CLI) → Fable (model) → Orchestrator (plans · delegates · merges results). Constraints: limit xhigh reasoning; single concurrency (one orchestrator). Quorum: 1–3 sub-agents max — Opus, Sonnet, Haiku; independent reviewers; the Quorum Review Skill consumes their verdicts to gate the PR. Fan out → Google Antigravity (AGX, agent-execution layer; swappable executor — a local agent, Kimi, any runtime) → 2–20 AGX sub-agents, parallel workers. Working modes: Goal · Teamwork · Grill me · Plan. *One orchestrator, a small quorum for judgment, a wide Antigravity pool for throughput.*
+
+### 5.1 Orchestrator, xhigh, single concurrency — PARTIAL
+
+**Evidence.** The orchestrator is the `paiml-implement` skill running in Claude Code with Fable (`SKILL.md` "You are Fable, the orchestrator"). Effort is a session setting (`/effort`), not asserted by any hook. `hooks/subagent-lock.sh` keys its lock by `session_id` ("two sessions on one host neither share a cap nor clear each other's slots") — so two orchestrator sessions in the same repository are **not** prevented; the per-user lock this session hit earlier (memory: "paiml-implement subagent lock is per USER") was the previous bundle.
+
+**Acceptance test (AD-09).** With one session holding the repo lock, a second `paiml-implement` invocation in the same `repo_root` is refused at Phase 0 naming the first session id; control: a different repo proceeds.
+
+### 5.2 Quorum of 1–3 models that must agree — MISSING (the cap is PRESENT)
+
+**Evidence.** `CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS=3` (`settings.fragment.json`) enforced by `subagent-lock.sh` §2a via atomic slot directories — a **concurrency limit**. The routing table (`SKILL.md` §11) assigns Haiku/Sonnet/Opus by task class. Neither collects independent verdicts from three models nor requires them to agree; the plan-review lane's finding on this row is applied here: a cap and a vote are different capabilities, and only the cap exists.
+
+**Acceptance test.** = §3.1 (AD-04): three lanes, three verdicts, agreement required.
+
+### 5.3 Fan out to Antigravity — PARTIAL
+
+**Evidence.** `agents/paiml-agy-delegate.md`: `teamwork` lane = one `agy … -p="/teamwork-preview …"` run (measured 2026-09-03: 245 s, 2 child conversations, `status: SUCCESS`); `quorum` lane = N parallel `agy -p` runs, **cap 10**, each validated against `agy/quorum-schema.json`; lane-side hook `~/.gemini/config/hooks.json` denies `git push`/`gh pr` inside lanes. Three headless facts (AIS-006): `--dangerously-skip-permissions` is required or a lane needing a shell prints nothing and exits 0; the prompt must be attached (`-p="…"`); the default 5 m `--print-timeout` kills teamwork.
+
+**Grounding caveat (measured).** The teamwork lane that reviewed this document's plan reported four existing files as absent and labelled that finding `measured`; its five other findings were self-labelled `asserted`. A lane's `file:line` claims are claims (Doctrine 3); §7's sub-agent-report row applies to agy lanes as to Claude workers.
+
+### 5.4 Swappable executor — MISSING
+
+**Evidence.** The delegate's calling form is `agy [--sandbox] --dangerously-skip-permissions --print-timeout 25m --output-format json --json-schema <schema> -p="<prompt>"`; no indirection.
+
+**Acceptance test (AD-08).** `PAIML_EXECUTOR=kimi` with a `kimi` shim on PATH that echoes its argv → the delegate's receipt `commands[].cmd` starts with `kimi`; `PAIML_EXECUTOR=nope` → the delegate returns `partial=true` naming the unknown executor; control: unset → `agy`.
+
+### 5.5 2–20 workers — PARTIAL
+
+**Evidence.** "Cap N at 10" (`paiml-agy-delegate.md` step 4). **Acceptance test (AD-08).** `width=20` runs 20 lanes under the token budget guard; `width=21` is refused.
+
+### 5.6 Working modes — Goal MISSING · Teamwork PRESENT · Grill-me MISSING · Plan PARTIAL
+
+**Evidence.** `agy -p="/help" --dangerously-skip-permissions --print-timeout 2m` → `/agents /changelog /config /credits /effort /help /hooks /model /permissions /skills /usage` (print mode lists only commands that need no agent turn); `/teamwork-preview` runs; `/goal` and `/grillme` are absent (AIS-006, re-verified 2026-09-03); `agy --mode plan -p` works headless (memory: reference_agy_headless_plan_review).
+
+**Acceptance test (AD-10).** Each mode is a named lane template in the delegate (`goal`, `teamwork`, `grillme`, `plan`) with its own prompt prefix and schema; the receipt's `lane` names the mode; `goal` and `grillme` are implemented as teamwork prompts until agy ships the commands, and the receipt says so (`"emulated": true`).
+
+## 6. Capability ledger
+
+| # | capability | zone | status | closes with |
+|---|---|---|---|---|
+| 1 | Quorum Review Skill, 3 must agree | 1 | MISSING | AD-04 |
+| 2 | PR gates merge | 1 | PRESENT | — |
+| 3 | Build server runs the gates | 1 | PARTIAL | AD-05 (CI leg) |
+| 4 | Auto-merge on green | 1 | PRESENT | — (PMAT-646 caveat) |
+| 5 | crates.io publish, verified | 1 | MANUAL | AD-01 |
+| 6 | Dog-food the published crate | 1 | PARTIAL | AD-02 |
+| 7 | pmat MCP quality server | 2 | PRESENT | — |
+| 8 | Sub-agent level compliance | 2 | PARTIAL | AD-06 |
+| 9 | Max complexity | 2 | PRESENT | — |
+| 10 | Lint zero warnings (gate) | 2 | PARTIAL | AD-05 |
+| 11 | Churn (gate) | 2 | MISSING | AD-05 |
+| 12 | Lines per file (gate) | 2 | PARTIAL | AD-05 |
+| 13 | Traceability | 2 | PARTIAL | AD-03, AD-07 |
+| 14 | One orchestrator, xhigh | 3 | PARTIAL | AD-09 |
+| 15 | Quorum as a vote | 3 | MISSING | AD-04 |
+| 16 | Concurrency cap ≤ 3 | 3 | PRESENT | — |
+| 17 | Fan out to Antigravity | 3 | PARTIAL | AD-08, AD-10 |
+| 18 | Swappable executor | 3 | MISSING | AD-08 |
+| 19 | 2–20 workers | 3 | PARTIAL | AD-08 |
+| 20 | Goal / Grill-me modes | 3 | MISSING | AD-10 |
+| 21 | Teamwork / Plan modes | 3 | PRESENT / PARTIAL | AD-10 |
+
+## 7. Micro-enforcement matrix — beyond the diagram
+
+The diagram places the gates at the build server and at "every sub-agent before it reports back". This section places one at **every moment an agent acts**, names the enforcer, what it refuses, and how a bypass is caught. Where the enforcer column says *(AD-nn)* the row is a target; the rest is measured today.
+
+| moment | enforcer | rule | failure mode | bypass, and how it is caught |
+|---|---|---|---|---|
+| **edit** | `~/.claude/hooks/subagent-lock.sh` §2b (PreToolUse Edit/Write) | no edit in a `.pmat/` repo without `$STATE/active-ticket` | exit 2, `no active ticket. Run 'pmat work add'…` | hook is fail-open by harness design; the commit-time trailer check (below) and AD-07's comply check catch an edit that reached a commit without a ticket |
+| **edit (paths)** | `pmat work claim` (ULTRA-002) | one agent owns a path at a time | claim refused when held | unclaimed edits collide at merge; the PR's `files_changed` vs claims is checked by the orchestrator |
+| **sub-agent spawn** | `subagent-lock.sh` §2a | ≤ `CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS` (3) | exit 2 naming the cap | `transcript-gate.sh` (I-3) audits peak overlap after the fact |
+| **sub-agent report** | orchestrator (SKILL.md Phase 2 step 3) + *(AD-06)* receipt `gate` field | the receipt carries `pmat verify --format json`; the orchestrator re-runs it and `acceptance_cmd` | a receipt without `gate` is `partial=true`; disagreement is a finding in the dispatch ledger | a worker cannot bypass: the orchestrator's rerun is the verdict |
+| **agy lane report** | delegate receipt (`consensus`, `dissent`, `conversations`) | every lane verdict is a claim; `file:line` findings are re-read | a `do-not-implement-as-written` stops the phase | sandboxed lanes mis-see the filesystem (§5.3); the orchestrator re-runs `test -e` on every path a lane cites |
+| **commit** | generated pre-commit hook (`pmat hooks install`) *(AD-03: `--strict` blocks)* + **commit-msg hook** *(AD-03)* | `pmat verify` fast stages (format, complexity on changed files, satd) pass; message carries `Pmat-Ticket: PMAT-NNN` | pre-commit exit 1 on a red stage; commit-msg exit 1 naming the trailer | `git commit --no-verify` skips both; caught at PR by AD-07's comply check over every commit on the branch and by the same stages re-run in CI |
+| **push** | pre-push hook (`scripts/install-git-hooks.sh`) | pmat-book commits pushed first; ledgers current (`analyze unrun-tests --check-ledger`, `reachability --check-ledger`) | push refused | `--no-verify` on push; caught by the `reachability-ledger` CI job (#1157) and `the_committed_ledger_matches_the_tree` |
+| **PR open** | orchestrator (SKILL.md Phase 4) + PR template | body carries ticket, receipt path, named mutation RED, both-sides acceptance | a PR without them is not armed for auto-merge | AD-04's merge helper refuses `--auto` without a quorum verdict artifact |
+| **PR review** | *(AD-04)* Quorum Review Skill | three lanes, three PASS | merge helper refuses | branch protection with `required_approving_review_count=0` does not enforce it; AD-04 makes the helper the only path the bundle offers, and AD-01's post-merge check names any release merged without one |
+| **merge** | branch protection (strict, 5 contexts) + *(AD-05)* `pmat quality-gate --checks all` CI leg | every required check green on the merge commit | GitHub refuses the merge | admin merge (`enforce_admins=false`); caught by nothing today — recorded, not fixed |
+| **post-merge release** | *(AD-01)* `release-check` job on `master` | `Cargo.toml` version ⇒ tag + GitHub release + crates.io version | job fails, issue opened | a merge that bumps the version and publishes nothing is red within one CI run — the 3.35.0 case |
+| **publish** | `crate-release-dogfood` probe (self-tested) + Lane A/B readings | packaged tarball builds, links, installs, README claims hold | probe exit 1, do not publish | `cargo publish --allow-dirty/--no-verify` is P1's finding |
+| **post-publish** | *(AD-02)* `scripts/dogfood-published.sh <v>` | install from crates.io, `dogfood-use.sh` 13 checks, probe P5–P7, receipt | exit 1; the release is announced only with the receipt | the receipt names the installed `commit:` — a local build cannot forge it |
+
+Two rows are enforced by nobody today and are written down rather than hidden: the **admin merge** (branch protection does not bind admins) and the **PR review** (zero required reviews). AD-01 makes the first visible after the fact; AD-04 makes the second the bundle's only path.
+
+## 8. Ticket ↔ work linking model
+
+The machine-checkable record is the **commit trailer**:
+
+```
+Pmat-Ticket: PMAT-650
+```
+
+read with `git log --format='%(trailers:key=Pmat-Ticket,valueonly)'`. It is git-native, survives rebases and squashes that keep the message, and needs no network to check. The branch name (`PMAT-650-agentic-delivery-spec`) and the PR body line are **derived** and secondary — a branch is deleted on merge (`delete_branch_on_merge=true`), a PR body is not git.
+
+| record | who writes it | who reads it |
+|---|---|---|
+| `Pmat-Ticket:` trailer on every commit | the committer; AD-03's commit-msg hook refuses its absence | AD-07's comply check `every commit on this branch carries a trailer naming an in-progress ticket`; `pmat work link --commit` |
+| branch `PMAT-NNN-slug` | `git switch -c` in SKILL.md Phase 1 | discovery, humans |
+| PR body `Ticket PMAT-NNN` + receipt path | orchestrator, Phase 4 | AD-04 quorum lanes read the ticket to judge the diff against it |
+| ticket → commits/PR (`pmat work link`, AD-07) | orchestrator after push / after merge | `pmat work annotate`, release notes, the receipt's identity block |
+| receipt `docs/audits/impl-<ticket>-receipt.md` | orchestrator, Phase 4 | humans; AD-04 lanes; the post-merge release check names receipts missing for merged tickets (stretch) |
+
+A trailer naming a ticket that is not `inprogress` fails the comply check: linking to a closed or planned ticket is the same defect as no link.
+
+## 9. Backlog — EV order
+
+Each item ships as one ticket and one PR under the paiml-implement discipline (RED-first acceptance with a control, `pmat verify`, `make gate-artifact`, pv contract, named mutation in the PR body, receipt in `docs/audits/`). The first two answer the incident in §1 and go first; the CRUX audit's remaining items (CRUX-07 onward) rank **after** these ten — see the cross-link in `pmat-architecture-crux-audit.md` §8.0.
+
+### 9.1 AD-01 — post-merge release check (S)
+**Problem.** A merged `release/x.y.z` PR that produces no tag, release or crate is invisible to every gate (3.35.0). **Proposal.** A job in `.github/workflows/quality-gate.yml` running on `master` (push and schedule) that executes the §3.5 script; on failure it opens or refreshes an issue titled `release-check: <v> merged but not published`. **Acceptance.** §3.5, with the 9.9.9 control. **Risk.** Runner availability (the fleet was offline for hours on 2026-09-03) — the job must not be a *required* PR check; it guards `master`. **Related.** #1122 (Docker publishes 2.10.0 from a 3.35.0 crate) is the same class for the Docker channel and is folded in as a fourth leg once `docker-publish.yml` is wired.
+
+### 9.2 AD-02 — post-publish dog-food (S)
+**Problem.** Nothing exercises the bytes crates.io serves. **Proposal.** `scripts/dogfood-published.sh <version>` + `make dogfood-published VERSION=` + a step in the release process; the receipt is committed as `docs/audits/release-<v>-dogfood.md`. **Acceptance.** §3.6. **Risk.** `cargo install` needs network and ~5 min; run it once per release, not in CI on every push.
+
+### 9.3 AD-03 — commit enforcement (S)
+**Problem.** #1126: the generated hook's SATD and task-ID checks warn and exit 0; no commit-msg hook exists. **Proposal.** `pmat hooks install --strict` (and `[hooks] strict = true` in `pmat.toml`) makes both blocking, emits a `commit-msg` hook requiring `Pmat-Ticket: PMAT-\d+` (or `#\d+` for repositories without pmat work), and the bundle's `settings.fragment.json` turns strict on. **Acceptance.** §4.7 first three legs. **Control.** the shipped hook fails the test today (warn + exit 0). **Related.** #1126.
+
+### 9.4 AD-04 — Quorum Review Skill (M)
+**Problem.** §3.1/§5.2. **Proposal.** `~/.claude/skills/quorum-review`: three lanes review `git diff <base>...HEAD` against the ticket text and the receipt under `agy/quorum-schema.json`; lanes are agy by default, Claude models one at a time when agy is absent (the user's one-subagent rule); "must agree" = three PASS; the verdict file is posted as a PR comment and `pmat-merge --auto` (a thin wrapper the bundle installs) refuses without it. **Acceptance.** §3.1. **Risk.** Lane grounding (§5.3): every `file:line` a lane cites is re-read by the skill before the verdict counts.
+
+### 9.5 AD-05 — `quality-gate --checks lint,churn,file-size` and a CI leg (M)
+**Problem.** §4.4–4.6 and §3.3. **Proposal.** Three new checks in `src/cli/analysis_utilities/quality_gate_execute.rs` / `quality_gate_part2a.rs`, routed through `quality_gate_suite.rs` so MCP `quality_gate` gains them; thresholds from `pmat.toml [quality]` (`max_file_lines` — the key `work_contract_profile.rs` already reads, default 500; `max_churn_commits_90d`, default 20; lint = clippy `-D warnings` reusing the verify stage's runner); `checks_run`, `not_measured` and the differential gate's `ALLOWED_CONSTANTS` updated with reasons. A CI leg `pmat quality-gate --checks all` on the merge commit. **Acceptance.** §4.4–4.6 with their controls. **Risk.** clippy inside the gate costs a compile; `lint` is opt-in for `--checks all` on non-Rust trees (`not_applicable`).
+
+### 9.6 AD-06 — worker receipt carries the gate (S)
+**Problem.** §4.2. **Proposal.** `agents/paiml-impl-worker.md` §receipt gains `gate: {cmd, ok, stages_measured, not_measured}` from `pmat verify --format json`; `SKILL.md` §6.2 treats its absence as `partial=true`; `verify.sh` checks the agent file contains the field. **Acceptance.** §4.2.
+
+### 9.7 AD-07 — `pmat work link` + comply trailer check (M)
+**Problem.** §4.7, §8. **Proposal.** `pmat work link <ticket> --commit <sha> | --pr <n>` records on the ticket; `pmat work annotate` shows the links; comply check `CB-TRACE` walks `git log <base>..HEAD` and fails on a commit without a trailer or with a trailer naming a ticket not in progress. **Acceptance.** §4.7 last two legs.
+
+### 9.8 AD-08 — swappable executor, width 2–20 (S)
+**Problem.** §5.4, §5.5. **Proposal.** `PAIML_EXECUTOR` (`agy` default) in the delegate, executor-specific calling forms in one table, width cap 20 behind the token budget guard. **Acceptance.** §5.4, §5.5.
+
+### 9.9 AD-09 — single-orchestrator lock + effort assertion (S)
+**Problem.** §5.1. **Proposal.** `subagent-lock.sh` takes a host-level lock keyed by `repo_root` at Phase 0 (`SessionStart`), released at `SessionEnd`; Phase 0 prints the effort setting and refuses below `xhigh` unless `--effort-override` is named in the receipt. **Acceptance.** §5.1.
+
+### 9.10 AD-10 — Goal and Grill-me as lane templates (S)
+**Problem.** §5.6. **Proposal.** Four named lane templates in the delegate; `goal` and `grillme` emulate through `/teamwork-preview` prompts with `"emulated": true` in the receipt until agy ships the commands; `plan` = `agy --mode plan`. **Acceptance.** §5.6.
+
+## 10. Do-not-do
+
+- Do not make AD-01 a **required** PR check: it guards `master` after merge and would block every PR whenever the fleet is offline.
+- Do not implement the quorum as three Claude subagents in parallel: the user's rule is one subagent at a time; the lanes are agy's, or sequential.
+- Do not fold `lint`, `churn` or `file-size` into an existing threshold's count: each is a named finding type with its own `not_measured` reason (the CRUX-02 rule).
+- Do not put ticket ids in commit *subjects* as the record: subjects are rewritten on squash; trailers are the record.
+
+## 11. Definition of done
+
+- Every capability in §6 is PRESENT, or PARTIAL with the named AD item merged, or MISSING with a cited reason recorded here.
+- Every acceptance test in §3–§5 runs from a clean clone with only `git jq cargo gh` (plus `agy` for the lane tests) and fails on its control.
+- `pmat-architecture-crux-audit.md` §8.0 links here and ranks AD-01…AD-10 above CRUX-07.
+- The first post-publish receipt (`docs/audits/release-3.36.0-dogfood.md`) exists and names the installed commit.
+
+## 12. Verification ledger
+
+| claim | command | measured |
+|---|---|---|
+| no quorum skill installed | `ls ~/.claude/skills` | 12 skills, none review/quorum |
+| protection contexts | `gh api repos/paiml/paiml-mcp-agent-toolkit/branches/master/protection/required_status_checks --jq '.contexts[]'` | 5 contexts, `strict=true`, 0 reviews, admins not enforced |
+| auto-merge | `gh api repos/paiml/paiml-mcp-agent-toolkit --jq .allow_auto_merge` | `true` |
+| 3.35.0 unpublished | `git tag --sort=-creatordate \| head -1`; `gh release list`; `curl https://crates.io/api/v1/crates/pmat` | `v3.34.0`; `v3.34.0`; `max_stable_version 3.34.0`; `Cargo.toml 3.35.0` |
+| probe self-test fires | `bash ~/.claude/skills/crate-release-dogfood/probe.sh --self-test …/fixtures/defective-crate` | `5 probe(s) fired` |
+| quality-gate checks | `pmat quality-gate --help` | `dead-code, complexity, coverage, sections, provability, satd, entropy, security, duplicates, all` |
+| verify thresholds | `src/cli/verify.rs:456-458` | `--max-cyclomatic 30 --max-cognitive 25` |
+| file-size claim | `src/cli/handlers/work_contract_profile.rs:336` | `max_file_lines … unwrap_or(500)` |
+| hook warns | `src/cli/handlers/hooks_command_handlers/hook_generation.rs:396-401` | `Warning: … task ID …` then success banner |
+| work verbs | `pmat work --help` | no `link` |
+| subagent cap | `~/.claude/hooks/subagent-lock.sh:10` | `MAX="${CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS:-3}"` |
+| agy commands | `agy -p="/help" --dangerously-skip-permissions --print-timeout 2m` | 11 built-ins, no `/goal`, `/grillme` |
+| teamwork lane runs | delegate receipt, conversation `0a2b5862…` | 245 s, SUCCESS, 2 child conversations |
+| delegate width cap | `~/src/paiml-implement/agents/paiml-agy-delegate.md` step 4 | `Cap N at 10` |

--- a/docs/specifications/pmat-architecture-crux-audit.md
+++ b/docs/specifications/pmat-architecture-crux-audit.md
@@ -1,5 +1,12 @@
 # PMAT Architecture, Performance & Competitive (CRUX) Audit
 
+> **Priority note (2026-09-03).** The delivery-pipeline capabilities in
+> [`agentic-delivery-pmat.md`](agentic-delivery-pmat.md) — AD-01…AD-10: a post-merge release
+> check, post-publish dog-food, commit enforcement, a quorum review skill, `quality-gate`
+> lint/churn/file-size, worker receipts that carry the gate, ticket↔commit linking — are ranked
+> **above every remaining CRUX item** (CRUX-07 onward). Reason: 3.35.0's release PR merged and was
+> never published, and no gate in this audit would have noticed. See §8.0.
+
 ## 1. Provenance
 
 > **Audited at.** Audited against `paiml/paiml-mcp-agent-toolkit` (crate `pmat`) at
@@ -1060,6 +1067,28 @@ fix named in its row above.** Seven items meet that bar today. The other 25 are 
 draft tests, and should be treated as such.
 
 ---
+
+### 8.0 Agentic delivery — AD-01…AD-10, prioritized above CRUX-07…CRUX-32
+
+The whiteboard "Agentic Delivery Architecture" (2026-09-03) is specified in
+[`agentic-delivery-pmat.md`](agentic-delivery-pmat.md): twenty-one capabilities across the delivery
+pipeline, pmat's quality enforcement and the orchestration layer, each with a measured status, an
+acceptance test and its anti-vacuity control, plus a micro-enforcement matrix (edit, commit, push,
+PR, sub-agent report, merge, publish, post-publish) and a ticket↔work linking model (the
+`Pmat-Ticket:` commit trailer). Its backlog is implemented **before** the items below, in this order:
+
+| # | item | why first |
+|---|---|---|
+| AD-01 | post-merge release check on `master` (tag + GitHub release + crates.io version for the version `Cargo.toml` declares) | 3.35.0 merged 2026-09-02 and was never published; nothing noticed |
+| AD-02 | post-publish dog-food of the crate crates.io serves | the diagram's "must pass Dog Food Skill" arrow has no enforcer |
+| AD-03 | commit enforcement: strict hook + `Pmat-Ticket:` commit-msg trailer (#1126) | a warning that exits 0 is not a gate |
+| AD-04 | Quorum Review Skill gating `gh pr merge --auto` | "nothing merges without a quorum verdict" has no enforcer |
+| AD-05 | `quality-gate --checks lint,churn,file-size` + a CI leg | three of the five quantitative rules have no gate |
+| AD-06 | worker receipt carries `pmat verify --format json` | "every sub-agent must comply" is not a contract |
+| AD-07 | `pmat work link` + comply trailer check | traceability is a habit, not a record |
+| AD-08 · AD-09 · AD-10 | swappable executor / width 20; single-orchestrator lock; Goal and Grill-me lane templates | orchestration-zone gaps |
+
+The CRUX items already landed before this note (CRUX-01, 02, 03, 04, 05, 06, 09, 10, 12) are unaffected.
 
 ### 8.1 CRUX-01 — `pmat verify` reports `ok: true` on a tree `quality-gate` fails with 35 blocking violations
 

--- a/docs/status/unrun-tests-ledger.md
+++ b/docs/status/unrun-tests-ledger.md
@@ -14,7 +14,7 @@ Legs consulted (3):
 - `feature-matrix.yml:feature-tests[mcp-integration]`
 - `feature-matrix.yml:feature-tests[unified-protocol]`
 
-23678 of 26906 lib tests are executed; 3228 are compiled by no leg.
+23690 of 26918 lib tests are executed; 3228 are compiled by no leg.
 
 ## `<unsatisfiable>` — 2199 test(s)
 

--- a/mcp.json
+++ b/mcp.json
@@ -1,6 +1,6 @@
 {
   "name": "pmat",
-  "version": "3.35.0",
+  "version": "3.36.0",
   "description": "Project Analysis and Intelligence Modeling Toolkit",
   "main": "pmat",
   "bin": {

--- a/scripts/release-check.sh
+++ b/scripts/release-check.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# AD-01 — a merged release must have BECOME a release (agentic-delivery-pmat.md section 3.5 / 9.1).
+#
+# Why: pmat 3.35.0's release PR (#1108) merged on 2026-09-02 and nothing tagged, released or
+# published it; crates.io stayed at 3.34.0 and every gate was green, because no gate asks
+# "did the version Cargo.toml declares reach the three channels". This one does.
+#
+# Reads the version from Cargo.toml (never a literal). If it is the latest v* tag, exit 0.
+# Otherwise require, in this order, the tag, the GitHub release, and the crates.io version;
+# the first missing one exits 1 naming the version. Runs on master after merge, never as a
+# required PR check (a PR is not a release).
+#
+#   bash scripts/release-check.sh                 # judge this checkout
+#   bash scripts/release-check.sh --self-test     # prove it can fail: a 9.9.9 fixture must fail every leg
+#   CRATE=<name> REPO=<owner/name> override the crate and repository (defaults: pmat, paiml/paiml-mcp-agent-toolkit)
+set -euo pipefail
+fail(){ echo "FAIL: release-check: $*"; exit 1; }
+CRATE="${CRATE:-pmat}"
+REPO="${REPO:-paiml/paiml-mcp-agent-toolkit}"
+
+check_version(){ # $1 version → 0 if fully released, 1 naming the first missing channel
+  local v=$1
+  git tag -l "v$v" | grep -q . || { echo "FAIL: release-check: Cargo.toml says $v but no tag v$v"; return 1; }
+  gh release view "v$v" --repo "$REPO" >/dev/null 2>&1 || { echo "FAIL: release-check: no GitHub release v$v"; return 1; }
+  curl -sf --max-time 20 "https://crates.io/api/v1/crates/$CRATE/$v" -H "User-Agent: release-check ($REPO)" \
+    | jq -e --arg v "$v" '.version.num == $v and (.version.yanked | not)' >/dev/null 2>&1 \
+    || { echo "FAIL: release-check: $v is not on crates.io (or is yanked)"; return 1; }
+  echo "release-check: $v is tagged, released and on crates.io"
+}
+
+if [ "${1:-}" = "--self-test" ]; then
+  # The control: a version that exists nowhere must fail at the tag leg, and — with a
+  # planted tag — at the release leg, and — with a planted release name — at the registry
+  # leg. A check that hardcodes any real version passes none of these.
+  T=$(mktemp -d)
+  cleanup(){ case "${T:-}" in "${TMPDIR:-/tmp}"/tmp.*|/tmp/tmp.*) [ -d "$T" ] && rm -rf -- "$T";; esac; }; trap cleanup EXIT
+  git -C "$T" init -q; printf '[package]\nname = "fx"\nversion = "9.9.9"\n' > "$T/Cargo.toml"
+  git -C "$T" -c user.email=t@t -c user.name=t add . >/dev/null; git -C "$T" -c user.email=t@t -c user.name=t -c core.hooksPath=/dev/null commit -qm fx
+  out=$(cd "$T" && check_version 9.9.9 2>&1 || true)
+  grep -q 'no tag v9.9.9' <<<"$out" || fail "self-test: missing tag not reported: $out"
+  git -C "$T" tag v9.9.9
+  out=$(cd "$T" && check_version 9.9.9 2>&1 || true)
+  grep -q 'no GitHub release v9.9.9' <<<"$out" || fail "self-test: missing release not reported: $out"
+  echo "SELF-TEST PASSED: the tag and release legs fired on a 9.9.9 fixture (the registry leg is exercised by the real run)"
+  exit 0
+fi
+
+v=$(grep -m1 '^version' Cargo.toml | cut -d'"' -f2)
+[ -n "$v" ] || fail "no version in Cargo.toml"
+# Numeric tags only: this repository carries a stray `vv2.88.0`, which `sort -V` ranks above every number.
+latest_tag=$(git tag -l 'v*' | sed -E 's/^v+//' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1)
+echo "release-check: Cargo.toml $v · latest tag ${latest_tag:-none}"
+check_version "$v"

--- a/src/cli/handlers/comply_handlers/check_handlers/check_contract_surfaces.rs
+++ b/src/cli/handlers/comply_handlers/check_handlers/check_contract_surfaces.rs
@@ -32,144 +32,142 @@ const GENERIC_PLACEHOLDERS: &[&str] = &[
 /// Also detects semantic leaks: API-pattern contracts disguised as kernel-math.
 #[provable_contracts_macros::contract("pmat-core.yaml", equation = "path_exists")]
 pub(crate) fn check_contract_surface_classification(project_path: &Path) -> ComplianceCheck {
-    let contracts_dir = match resolve_contracts_dir(project_path) {
-        Some(d) => d,
-        None => {
-            return ComplianceCheck {
-                name: "CB-1305: Contract Surface Classification".into(),
-                status: CheckStatus::Skip,
-                message: "No contract YAML files found".into(),
-                severity: Severity::Info,
-            };
-        }
+    let skip = || ComplianceCheck {
+        name: "CB-1305: Contract Surface Classification".into(),
+        status: CheckStatus::Skip,
+        message: "No contract YAML files found".into(),
+        severity: Severity::Info,
     };
-
-    let mut total_contracts = 0usize;
-    let mut kernel_math = 0usize;
-    let mut cross_language = 0usize;
-    let mut schema_registry = 0usize;
-    let mut invariants_only = 0usize;
-    let mut semantic_leaks = 0usize;
-    let mut unclassified: Vec<String> = Vec::new();
-
-    for entry in walkdir::WalkDir::new(&contracts_dir)
-        .max_depth(3)
-        .into_iter()
-        .filter_map(|e| e.ok())
-    {
-        let path = entry.path();
-        if !path.is_file() {
-            continue;
-        }
-        if !path.extension().is_some_and(|e| e == "yaml" || e == "yml") {
-            continue;
-        }
+    let Some(contracts_dir) = resolve_contracts_dir(project_path) else {
+        return skip();
+    };
+    let mut tally = SurfaceTally::default();
+    for path in contract_yaml_files(&contracts_dir, 3) {
         if path
             .file_name()
             .is_some_and(|n| n.to_string_lossy().contains("binding"))
         {
             continue;
         }
-
-        total_contracts += 1;
-        let Ok(content) = std::fs::read_to_string(path) else {
+        tally.total += 1;
+        let Ok(content) = std::fs::read_to_string(&path) else {
             continue;
         };
-
         let top_keys = extract_top_level_keys(&content);
-        let class = classify_contract(&top_keys, &content);
+        tally.record(classify_contract(&top_keys, &content), &path);
+    }
+    if tally.total == 0 {
+        return skip();
+    }
+    tally.verdict()
+}
 
+/// Every `.yaml`/`.yml` file under `dir`, at most `depth` levels down.
+fn contract_yaml_files(dir: &Path, depth: usize) -> Vec<std::path::PathBuf> {
+    walkdir::WalkDir::new(dir)
+        .max_depth(depth)
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().is_file())
+        .filter(|e| {
+            e.path()
+                .extension()
+                .is_some_and(|x| x == "yaml" || x == "yml")
+        })
+        .map(|e| e.into_path())
+        .collect()
+}
+
+/// What CB-1305 counted over the contracts directory.
+#[derive(Default)]
+struct SurfaceTally {
+    total: usize,
+    kernel_math: usize,
+    cross_language: usize,
+    schema_registry: usize,
+    invariants_only: usize,
+    semantic_leaks: usize,
+    /// The first five unclassified file names, for the message.
+    unclassified: Vec<String>,
+    unclassified_count: usize,
+}
+
+impl SurfaceTally {
+    fn record(&mut self, class: ContractClass, path: &Path) {
         match class {
-            ContractClass::KernelMath => kernel_math += 1,
-            ContractClass::CrossLanguage => cross_language += 1,
-            ContractClass::SchemaRegistry => schema_registry += 1,
-            ContractClass::InvariantsOnly => invariants_only += 1,
+            ContractClass::KernelMath => self.kernel_math += 1,
+            ContractClass::CrossLanguage => self.cross_language += 1,
+            ContractClass::SchemaRegistry => self.schema_registry += 1,
+            ContractClass::InvariantsOnly => self.invariants_only += 1,
             ContractClass::SemanticLeak => {
-                semantic_leaks += 1;
-                kernel_math += 1; // structurally it IS kernel-math
+                self.semantic_leaks += 1;
+                self.kernel_math += 1; // structurally it IS kernel-math
             }
             ContractClass::Unknown => {
-                let name = path
-                    .file_name()
-                    .map(|n| n.to_string_lossy().to_string())
-                    .unwrap_or_default();
-                if unclassified.len() < 5 {
-                    unclassified.push(name);
+                self.unclassified_count += 1;
+                if self.unclassified.len() < 5 {
+                    self.unclassified.push(
+                        path.file_name()
+                            .map(|n| n.to_string_lossy().to_string())
+                            .unwrap_or_default(),
+                    );
                 }
             }
         }
     }
 
-    if total_contracts == 0 {
-        return ComplianceCheck {
-            name: "CB-1305: Contract Surface Classification".into(),
-            status: CheckStatus::Skip,
-            message: "No contract YAML files found".into(),
-            severity: Severity::Info,
-        };
-    }
-
-    let unclassified_count = unclassified.len();
-    let classified = total_contracts - unclassified_count;
-    let unclassified_pct = unclassified_count as f64 / total_contracts as f64 * 100.0;
-
-    let mut issues = Vec::new();
-
-    // FAIL if >20% unclassified
-    if unclassified_pct > 20.0 {
-        issues.push(format!(
-            "{unclassified_count}/{total_contracts} ({unclassified_pct:.0}%) contracts unclassified — leak has outpaced spec"
-        ));
-    }
-
-    // WARN on semantic leaks (generic API patterns in kernel-math schema)
-    if semantic_leaks > 0 {
-        issues.push(format!(
-            "{semantic_leaks} semantic leak(s): API-pattern contracts with generic placeholders in kernel-math schema"
-        ));
-    }
-
-    if !issues.is_empty() {
-        let severity = if unclassified_pct > 20.0 {
-            Severity::Error
-        } else {
-            Severity::Warning
-        };
-        let status = if unclassified_pct > 20.0 {
-            CheckStatus::Fail
-        } else {
-            CheckStatus::Warn
-        };
-        let unclassified_list = if unclassified.is_empty() {
+    fn verdict(&self) -> ComplianceCheck {
+        let name = "CB-1305: Contract Surface Classification";
+        let unclassified_pct = self.unclassified_count as f64 / self.total as f64 * 100.0;
+        let mut issues = Vec::new();
+        if unclassified_pct > 20.0 {
+            issues.push(format!(
+                "{}/{} ({unclassified_pct:.0}%) contracts unclassified — leak has outpaced specification",
+                self.unclassified_count, self.total
+            ));
+        }
+        if self.semantic_leaks > 0 {
+            issues.push(format!(
+                "{} semantic leak(s): API-pattern contracts with generic placeholders in kernel-math schema",
+                self.semantic_leaks
+            ));
+        }
+        if issues.is_empty() {
+            let classified = self.total - self.unclassified_count;
+            let pure_kernel = self.kernel_math.saturating_sub(self.semantic_leaks);
+            let parts: Vec<String> = [
+                ("kernel", pure_kernel),
+                ("cross-lang", self.cross_language),
+                ("registry", self.schema_registry),
+                ("invariants", self.invariants_only),
+                ("leaks", self.semantic_leaks),
+            ]
+            .iter()
+            .filter(|(_, n)| *n > 0)
+            .map(|(k, n)| format!("{k}={n}"))
+            .collect();
+            return ComplianceCheck {
+                name: name.into(),
+                status: CheckStatus::Pass,
+                message: format!(
+                    "{classified}/{} classified ({})",
+                    self.total,
+                    parts.join(", ")
+                ),
+                severity: Severity::Info,
+            };
+        }
+        let failing = unclassified_pct > 20.0;
+        let unclassified_list = if self.unclassified.is_empty() {
             String::new()
         } else {
-            format!(" [{}]", unclassified.join(", "))
+            format!(" [{}]", self.unclassified.join(", "))
         };
         ComplianceCheck {
-            name: "CB-1305: Contract Surface Classification".into(),
-            status,
-            message: format!(
-                "{}{unclassified_list}",
-                issues.join("; ")
-            ),
-            severity,
-        }
-    } else {
-        let mut parts = Vec::new();
-        let pure_kernel = kernel_math.saturating_sub(semantic_leaks);
-        if pure_kernel > 0 { parts.push(format!("kernel={pure_kernel}")); }
-        if cross_language > 0 { parts.push(format!("cross-lang={cross_language}")); }
-        if schema_registry > 0 { parts.push(format!("registry={schema_registry}")); }
-        if invariants_only > 0 { parts.push(format!("invariants={invariants_only}")); }
-        if semantic_leaks > 0 { parts.push(format!("leaks={semantic_leaks}")); }
-        ComplianceCheck {
-            name: "CB-1305: Contract Surface Classification".into(),
-            status: CheckStatus::Pass,
-            message: format!(
-                "{classified}/{total_contracts} classified ({})",
-                parts.join(", ")
-            ),
-            severity: Severity::Info,
+            name: name.into(),
+            status: if failing { CheckStatus::Fail } else { CheckStatus::Warn },
+            message: format!("{}{unclassified_list}", issues.join("; ")),
+            severity: if failing { Severity::Error } else { Severity::Warning },
         }
     }
 }
@@ -425,30 +423,26 @@ pub(crate) fn check_sovereign_dep_contracts(project_path: &Path) -> ComplianceCh
 /// for schema documentation. WARN if >20 arg structs lack doc comments.
 #[provable_contracts_macros::contract("pmat-core.yaml", equation = "path_exists")]
 pub(crate) fn check_mcp_schema_contracts(project_path: &Path) -> ComplianceCheck {
+    let name = "CB-1302: MCP Schema Contracts";
     let mcp_dir = project_path.join("src").join("mcp_pmcp");
     if !mcp_dir.exists() {
         return ComplianceCheck {
-            name: "CB-1302: MCP Schema Contracts".into(),
+            name: name.into(),
             status: CheckStatus::Skip,
             message: "No src/mcp_pmcp/ directory".into(),
             severity: Severity::Info,
         };
     }
-
     let mut total_arg_structs = 0usize;
     let mut undocumented = 0usize;
     let mut handler_files = 0usize;
-
     for entry in walkdir::WalkDir::new(&mcp_dir)
         .max_depth(2)
         .into_iter()
         .filter_map(|e| e.ok())
     {
         let path = entry.path();
-        if !path.is_file() {
-            continue;
-        }
-        if path.extension().is_none_or(|e| e != "rs") {
+        if !path.is_file() || path.extension().is_none_or(|e| e != "rs") {
             continue;
         }
         let filename = path
@@ -461,63 +455,73 @@ pub(crate) fn check_mcp_schema_contracts(project_path: &Path) -> ComplianceCheck
         if filename.contains("handler") {
             handler_files += 1;
         }
-
         let Ok(content) = std::fs::read_to_string(path) else {
             continue;
         };
-
-        let lines: Vec<&str> = content.lines().collect();
-        for (i, line) in lines.iter().enumerate() {
-            let trimmed = line.trim();
-            if trimmed.contains("struct") && trimmed.contains("Args") && !trimmed.starts_with("//") {
-                total_arg_structs += 1;
-                // Check if previous line(s) have doc comments
-                let has_doc = (i > 0 && lines[i - 1].trim().starts_with("///"))
-                    || (i > 1 && lines[i - 2].trim().starts_with("///"));
-                if !has_doc {
-                    undocumented += 1;
-                }
-            }
-        }
+        let (total, undoc) = arg_struct_census(&content);
+        total_arg_structs += total;
+        undocumented += undoc;
     }
-
     if total_arg_structs == 0 {
         return ComplianceCheck {
-            name: "CB-1302: MCP Schema Contracts".into(),
+            name: name.into(),
             status: CheckStatus::Skip,
             message: "No MCP arg structs found".into(),
             severity: Severity::Info,
         };
     }
-
-    if undocumented > 20 {
-        ComplianceCheck {
-            name: "CB-1302: MCP Schema Contracts".into(),
-            status: CheckStatus::Fail,
-            message: format!(
+    let (status, severity, message) = if undocumented > 20 {
+        (
+            CheckStatus::Fail,
+            Severity::Error,
+            format!(
                 "{undocumented}/{total_arg_structs} MCP arg structs undocumented across {handler_files} handlers — add /// doc comments with input contracts"
             ),
-            severity: Severity::Error,
-        }
+        )
     } else if undocumented > 5 {
-        ComplianceCheck {
-            name: "CB-1302: MCP Schema Contracts".into(),
-            status: CheckStatus::Warn,
-            message: format!(
+        (
+            CheckStatus::Warn,
+            Severity::Warning,
+            format!(
                 "{undocumented}/{total_arg_structs} MCP arg structs lack doc comments ({handler_files} handlers)"
             ),
-            severity: Severity::Warning,
-        }
+        )
     } else {
-        ComplianceCheck {
-            name: "CB-1302: MCP Schema Contracts".into(),
-            status: CheckStatus::Pass,
-            message: format!(
+        (
+            CheckStatus::Pass,
+            Severity::Info,
+            format!(
                 "{total_arg_structs} MCP arg structs, {handler_files} handlers ({undocumented} undocumented)"
             ),
-            severity: Severity::Info,
+        )
+    };
+    ComplianceCheck {
+        name: name.into(),
+        status,
+        message,
+        severity,
+    }
+}
+
+/// (`*Args` structs, those without a `///` line in the two lines above).
+fn arg_struct_census(content: &str) -> (usize, usize) {
+    let lines: Vec<&str> = content.lines().collect();
+    let mut total = 0usize;
+    let mut undocumented = 0usize;
+    for (i, line) in lines.iter().enumerate() {
+        let trimmed = line.trim();
+        if !(trimmed.contains("struct") && trimmed.contains("Args") && !trimmed.starts_with("//")) {
+            continue;
+        }
+        total += 1;
+        let documented = (1..=2).any(|back| {
+            i >= back && lines[i - back].trim().starts_with("///")
+        });
+        if !documented {
+            undocumented += 1;
         }
     }
+    (total, undocumented)
 }
 
 /// CB-1306: TUI Widget Contract Coverage — verify presentar widget lifecycle
@@ -527,91 +531,46 @@ pub(crate) fn check_mcp_schema_contracts(project_path: &Path) -> ComplianceCheck
 /// preconditions (not placeholders).
 #[provable_contracts_macros::contract("pmat-core.yaml", equation = "path_exists")]
 pub(crate) fn check_tui_widget_contracts(project_path: &Path) -> ComplianceCheck {
+    let name = "CB-1306: TUI Widget Contracts";
     let contracts_dir = project_path.join("contracts");
-    // Check if this is a presentar-like project (has presentar-core dep or crate)
-    // Only flag as presentar project if it HAS the presentar-core crate as workspace member
-    // (not just as a dependency)
-    let is_presentar = project_path.join("crates").join("presentar-core").exists();
-
-    if !is_presentar {
+    if !project_path.join("crates").join("presentar-core").exists() {
         return ComplianceCheck {
-            name: "CB-1306: TUI Widget Contracts".into(),
+            name: name.into(),
             status: CheckStatus::Skip,
             message: "Not a presentar/TUI project".into(),
             severity: Severity::Info,
         };
     }
-
     if !contracts_dir.exists() {
         return ComplianceCheck {
-            name: "CB-1306: TUI Widget Contracts".into(),
+            name: name.into(),
             status: CheckStatus::Fail,
             message: "presentar project has no contracts/ directory".into(),
             severity: Severity::Error,
         };
     }
-
-    // Required contract coverage for TUI widget lifecycle
     let required_domains = &[
-        ("color", "contrast_ratio"),    // WCAG color contracts
-        ("geometry", "intersection"),    // rect geometry
-        ("layout", "constrain"),         // constraint solving
+        ("color", "contrast_ratio"), // WCAG color contracts
+        ("geometry", "intersection"), // rect geometry
+        ("layout", "constrain"),      // constraint solving
     ];
-
-    let mut covered = 0usize;
-    let mut missing: Vec<&str> = Vec::new();
-
-    for entry in walkdir::WalkDir::new(&contracts_dir)
-        .max_depth(2)
-        .into_iter()
-        .filter_map(|e| e.ok())
-    {
-        let path = entry.path();
-        if !path.is_file() || !path.extension().is_some_and(|e| e == "yaml" || e == "yml") {
-            continue;
-        }
-        if let Ok(content) = std::fs::read_to_string(path) {
-            for (domain, equation) in required_domains {
-                if content.contains(equation) {
-                    covered += 1;
-                    break; // count file once even if multiple matches
-                }
-                let _ = domain; // used for diagnostics below
-            }
-        }
-    }
-
-    // Check which domains are missing
-    for (domain, equation) in required_domains {
-        let found = walkdir::WalkDir::new(&contracts_dir)
-            .max_depth(2)
-            .into_iter()
-            .filter_map(|e| e.ok())
-            .any(|e| {
-                e.path().is_file()
-                    && std::fs::read_to_string(e.path())
-                        .map(|c| c.contains(equation))
-                        .unwrap_or(false)
-            });
-        if !found {
-            missing.push(domain);
-        }
-    }
-
-    if !missing.is_empty() {
+    let contents: Vec<String> = contract_yaml_files(&contracts_dir, 2)
+        .iter()
+        .filter_map(|p| std::fs::read_to_string(p).ok())
+        .collect();
+    // A file counts once, however many domains it mentions.
+    let covered = contents
+        .iter()
+        .filter(|c| required_domains.iter().any(|(_, eq)| c.contains(eq)))
+        .count();
+    let missing: Vec<&str> = required_domains
+        .iter()
+        .filter(|(_, eq)| !contents.iter().any(|c| c.contains(eq)))
+        .map(|(domain, _)| *domain)
+        .collect();
+    if missing.is_empty() {
         ComplianceCheck {
-            name: "CB-1306: TUI Widget Contracts".into(),
-            status: CheckStatus::Warn,
-            message: format!(
-                "{covered}/{} widget domains covered, missing: {}",
-                required_domains.len(),
-                missing.join(", ")
-            ),
-            severity: Severity::Warning,
-        }
-    } else {
-        ComplianceCheck {
-            name: "CB-1306: TUI Widget Contracts".into(),
+            name: name.into(),
             status: CheckStatus::Pass,
             message: format!(
                 "{}/{} widget lifecycle domains contracted (color, geometry, layout)",
@@ -619,6 +578,17 @@ pub(crate) fn check_tui_widget_contracts(project_path: &Path) -> ComplianceCheck
                 required_domains.len()
             ),
             severity: Severity::Info,
+        }
+    } else {
+        ComplianceCheck {
+            name: name.into(),
+            status: CheckStatus::Warn,
+            message: format!(
+                "{covered}/{} widget domains covered, missing: {}",
+                required_domains.len(),
+                missing.join(", ")
+            ),
+            severity: Severity::Warning,
         }
     }
 }
@@ -948,18 +918,46 @@ fn lean_theorem_is_proved(content: &str) -> bool {
     };
     let block = &content[idx..];
     // Bound the block at the next top-level (column-0) key.
-    let end = block
-        .lines()
-        .skip(1)
-        .scan(0usize, |off, line| {
-            let start = *off;
-            *off += line.len() + 1;
-            Some((start, line))
-        })
-        .find(|(_, line)| !line.is_empty() && !line.starts_with([' ', '\t', '-', '#']))
-        .map_or(block.len(), |(start, _)| start + "lean_theorem:".len());
-    let block = &block[..end.min(block.len())];
+    //
+    // #1159: this used to compute offsets over `lines().skip(1)` — never
+    // counting the first line — and patch the miss with
+    // `+ "lean_theorem:".len()`. The bound was therefore right only when the
+    // first line was exactly the bare key; any longer first line put the cut
+    // inside the block's LAST line, and when that line was a box-drawing
+    // comment divider the cut landed inside a multibyte char and the whole
+    // `comply check` aborted (`byte index 1000 is not a char boundary`).
+    // Offsets are now accumulated over every line, ends included, so the cut
+    // is always a line start — a char boundary by construction.
+    let block = &block[..floor_char_boundary(block, next_top_level_key_offset(block))];
     block.contains("status: proved") && !block.contains("sorry")
+}
+
+/// Clamp `offset` into `s` and round it DOWN to a `char` boundary.
+///
+/// `min(s.len())` alone does not make a slice safe: `&s[..n]` panics just as
+/// hard when `n` is inside a multi-byte sequence as when it is past the end.
+/// Any offset derived from line arithmetic must pass through here.
+fn floor_char_boundary(s: &str, offset: usize) -> usize {
+    let mut end = offset.min(s.len());
+    while !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    end
+}
+
+/// The byte offset of the first column-0 key after the first line, or the
+/// block's length when there is none. Always a line start.
+fn next_top_level_key_offset(block: &str) -> usize {
+    let mut offset = 0usize;
+    for (i, line) in block.split_inclusive('\n').enumerate() {
+        let body = line.trim_end_matches(['\n', '\r']);
+        if i > 0 && !body.is_empty() && !body.starts_with([' ', '\t', '-', '#']) {
+            debug_assert!(block.is_char_boundary(offset));
+            return offset;
+        }
+        offset += line.len();
+    }
+    block.len()
 }
 
 fn level_label(n: u8) -> &'static str {
@@ -1319,41 +1317,30 @@ fn cargo_edition_is_modern(content: &str) -> bool {
 
 /// Extract dependency version from Cargo.toml content.
 fn extract_dep_version<'a>(content: &'a str, dep_name: &str) -> Option<&'a str> {
-    for line in content.lines() {
-        let trimmed = line.trim();
-        // Must start with dep name followed by space or =
-        if !trimmed.starts_with(dep_name) {
-            continue;
-        }
-        let after_name = &trimmed[dep_name.len()..];
-        if !after_name.starts_with(' ') && !after_name.starts_with('=') {
-            continue;
-        }
-        // Inline table: dep = { version = "x.y", ... }
-        if trimmed.contains('{') {
-            // Find version = "x.y" inside the braces
-            if let Some(ver_start) = trimmed.find("version") {
-                let rest = &trimmed[ver_start + "version".len()..];
-                let rest = rest.trim_start_matches([' ', '=']);
-                if let Some(inner) = rest.strip_prefix('"') {
-                    if let Some(end) = inner.find('"') {
-                        return Some(&inner[..end]);
-                    }
-                }
-            }
-            continue;
-        }
-        // Simple: dep = "x.y"
-        if let Some(eq_pos) = trimmed.find('=') {
-            let after_eq = trimmed[eq_pos + 1..].trim();
-            if let Some(inner) = after_eq.strip_prefix('"') {
-                if let Some(end) = inner.find('"') {
-                    return Some(&inner[..end]);
-                }
-            }
-        }
+    content
+        .lines()
+        .map(str::trim)
+        .filter(|line| {
+            line.strip_prefix(dep_name)
+                .is_some_and(|rest| rest.starts_with(' ') || rest.starts_with('='))
+        })
+        .find_map(dep_line_version)
+}
+
+/// The quoted version on one `name = "1.2"` or `name = { version = "1.2", .. }`
+/// line; `None` when the line names the dependency without a quoted version.
+fn dep_line_version(line: &str) -> Option<&str> {
+    if line.contains('{') {
+        let rest = &line[line.find("version")? + "version".len()..];
+        return first_quoted(rest.trim_start_matches([' ', '=']));
     }
-    None
+    first_quoted(line[line.find('=')? + 1..].trim())
+}
+
+/// The content of the leading `"…"` in `s`, if `s` starts with a quote.
+fn first_quoted(s: &str) -> Option<&str> {
+    let inner = s.strip_prefix('"')?;
+    Some(&inner[..inner.find('"')?])
 }
 
 /// Simple semver minimum check: does `actual` >= `minimum`?
@@ -1577,5 +1564,230 @@ mod ladder_evidence_not_mention_tests {
             4,
             "a proof with `sorry` in it is not a proof"
         );
+    }
+}
+
+#[cfg(test)]
+mod lean_theorem_block_bounds_tests {
+    use super::lean_theorem_is_proved;
+
+    /// #1159: the block bound was computed from offsets that skipped the
+    /// first line without counting it, then patched with
+    /// `+ "lean_theorem:".len()`. Whenever the first line is longer than the
+    /// bare key the bound lands INSIDE the block's last line — and if that
+    /// line is a box-drawing comment divider, inside a multibyte char:
+    /// `byte index N is not a char boundary; it is inside '─'`.
+    #[test]
+    fn a_box_drawing_divider_before_the_next_key_does_not_panic() {
+        // Three spaces before the comment: the miscounted bound then lands 9
+        // bytes before `next:` — two bytes into a '─' of the divider.
+        let content = "lean_theorem:   # L5\n  status: proved\n  # ─────────────\nnext: 1\n";
+        assert!(lean_theorem_is_proved(content));
+    }
+
+    /// The bound must be the next column-0 key's line start: a `sorry` in the
+    /// following key must not disqualify the theorem, and one inside the block
+    /// must.
+    #[test]
+    fn the_block_ends_at_the_next_top_level_key() {
+        let proved_then_sorry_elsewhere =
+            "lean_theorem:\n  status: proved\n  # ──\nnotes: sorry, unrelated\n";
+        assert!(lean_theorem_is_proved(proved_then_sorry_elsewhere));
+        let sorry_inside = "lean_theorem:\n  status: proved\n  proof: sorry\nnotes: fine\n";
+        assert!(!lean_theorem_is_proved(sorry_inside));
+        let unbounded = "lean_theorem:\n  status: proved\n";
+        assert!(lean_theorem_is_proved(unbounded));
+    }
+}
+
+// Regression suite contributed on #1166 (the aprender release session), carried
+// here so one PR holds the fix, its tests and the complexity refactors.
+#[cfg(test)]
+mod check_contract_surfaces_char_boundary_tests {
+    use super::*;
+
+    /// Build a YAML fixture from explicit lines. Written this way on purpose:
+    /// a `\`-continued Rust string literal eats the leading whitespace of the
+    /// next line, which would silently un-indent every nested YAML key and
+    /// turn these fixtures into a different (passing) shape.
+    fn yaml(lines: &[&str]) -> String {
+        let mut s = String::new();
+        for line in lines {
+            s.push_str(line);
+            s.push('\n');
+        }
+        s
+    }
+
+    /// (a) The real-world shape: a block-scalar first line (`lean_theorem: |`,
+    /// 15 bytes, not 13) followed by a `# ────` divider comment immediately
+    /// before the next top-level key. The old arithmetic undershot by 3 bytes
+    /// and landed inside the divider's trailing `─`.
+    #[test]
+    fn divider_comment_before_the_next_key_does_not_panic() {
+        let content = yaml(&[
+            "equations:",
+            "lean_theorem: |",
+            "  theorem foo : True := trivial",
+            "  status: proved",
+            "# ──────────────────────────────",
+            "proof_obligations:",
+            "  - id: o1",
+        ]);
+        assert!(
+            lean_theorem_is_proved(&content),
+            "the proved status inside the block must still be seen"
+        );
+    }
+
+    /// The bound must still be the next top-level key: a `status: proved`
+    /// living *after* that key belongs to another surface and must not count.
+    #[test]
+    fn divider_comment_does_not_widen_the_block_past_the_next_key() {
+        let content = yaml(&[
+            "equations:",
+            "lean_theorem: |",
+            "  theorem foo : True := trivial",
+            "# ──────────────────────────────",
+            "proof_obligations:",
+            "  status: proved",
+        ]);
+        assert!(
+            !lean_theorem_is_proved(&content),
+            "a `status: proved` under the NEXT top-level key must not promote this one"
+        );
+    }
+
+    /// (b) aprender's minimal repro, verbatim. Against pmat 3.34.0 this aborted
+    /// with `end byte index 14 is not a char boundary; it is inside '─'`.
+    #[test]
+    fn aprender_minimal_repro_does_not_panic() {
+        let content = yaml(&["equations:", "lean_theorem:\u{2500}", "", "x:"]);
+        assert!(
+            !lean_theorem_is_proved(&content),
+            "no `status: proved` anywhere — the verdict is false, not a panic"
+        );
+    }
+
+    /// (c) The next top-level line *begins* with a multi-byte character, so the
+    /// boundary offset is itself the first byte of a 2-byte sequence; landing
+    /// one byte either side of it is a panic.
+    #[test]
+    fn next_top_level_key_starting_with_a_multibyte_char_does_not_panic() {
+        let inside = yaml(&[
+            "lean_theorem: Theorems.Foo",
+            "  status: proved",
+            "\u{e9}quations: v",
+        ]);
+        assert!(
+            lean_theorem_is_proved(&inside),
+            "the block ends at the e-acute-prefixed key; `status: proved` is inside it"
+        );
+
+        let after = yaml(&[
+            "lean_theorem: Theorems.Foo",
+            "\u{e9}quations: v",
+            "  status: proved",
+        ]);
+        assert!(
+            !lean_theorem_is_proved(&after),
+            "and a proved status past that key must not leak in"
+        );
+    }
+
+    /// Well-formed input keeps exactly the verdict it had before the fix.
+    #[test]
+    fn well_formed_input_keeps_its_verdict() {
+        assert!(lean_theorem_is_proved(
+            "lean_theorem:\n  status: proved\n"
+        ));
+        assert!(!lean_theorem_is_proved("lean_theorem:\n  name: thm\n"));
+        assert!(!lean_theorem_is_proved(
+            "lean_theorem:\n  status: proved\n  body: sorry\n"
+        ));
+        assert!(!lean_theorem_is_proved("kani_harnesses:\n  - name: h\n"));
+        assert!(
+            !lean_theorem_is_proved("lean_theorem:\n  name: thm\nother:\n  status: proved\n"),
+            "the block stops at the next top-level key"
+        );
+    }
+
+    /// The offset helper reports the TRUE byte position of the next top-level
+    /// key, independent of how long the first line is — that constant-13
+    /// assumption was the defect.
+    #[test]
+    fn offset_is_independent_of_the_first_line_length() {
+        for first in [
+            "lean_theorem:",
+            "lean_theorem: |",
+            "lean_theorem: Theorems.Foo",
+            "lean_theorem: a-very-long-theorem-reference-indeed",
+        ] {
+            let block = format!("{first}\n  status: proved\nnext_key:\n");
+            let expected = block.find("next_key:").expect("fixture has the key");
+            assert_eq!(
+                next_top_level_key_offset(&block),
+                expected,
+                "first line {first:?}"
+            );
+        }
+    }
+
+    /// `lines()` strips the `\r` of a CRLF terminator, so `line.len() + 1`
+    /// undercounts by one per line. `split_inclusive` does not.
+    #[test]
+    fn offset_is_correct_for_crlf_terminators() {
+        let block = "lean_theorem: |\r\n  status: proved\r\nnext_key:\r\n";
+        let expected = block.find("next_key:").expect("fixture has the key");
+        assert_eq!(next_top_level_key_offset(block), expected);
+        assert!(lean_theorem_is_proved(block));
+    }
+
+    /// With no following top-level key the whole block is in scope.
+    #[test]
+    fn offset_defaults_to_the_whole_block() {
+        let block = "lean_theorem: |\n  status: proved\n";
+        assert_eq!(next_top_level_key_offset(block), block.len());
+        assert_eq!(next_top_level_key_offset(""), 0);
+    }
+
+    #[test]
+    fn floor_char_boundary_never_lands_inside_a_char() {
+        let s = "ab\u{2500}cd";
+        assert_eq!(floor_char_boundary(s, 0), 0);
+        assert_eq!(floor_char_boundary(s, 2), 2);
+        // 3, 4 are inside the 3-byte `\u{2500}` at bytes 2..5.
+        assert_eq!(floor_char_boundary(s, 3), 2);
+        assert_eq!(floor_char_boundary(s, 4), 2);
+        assert_eq!(floor_char_boundary(s, 5), 5);
+        // Past the end clamps, and clamping alone is not enough in general.
+        assert_eq!(floor_char_boundary(s, 999), s.len());
+        for offset in 0..=s.len() {
+            let end = floor_char_boundary(s, offset);
+            assert!(s.is_char_boundary(end), "offset {offset} -> {end}");
+        }
+    }
+
+    /// No input may panic here, whatever the byte layout: insert a 3-byte
+    /// character at every char boundary of a realistic block and require a
+    /// verdict — any verdict — rather than an abort.
+    #[test]
+    fn no_byte_layout_can_panic() {
+        let base = yaml(&[
+            "equations:",
+            "lean_theorem: Theorems.Foo",
+            "  status: proved",
+            "proof_obligations:",
+        ]);
+        for cut in 0..=base.len() {
+            if !base.is_char_boundary(cut) {
+                continue;
+            }
+            let mut mutated = String::with_capacity(base.len() + 3);
+            mutated.push_str(&base[..cut]);
+            mutated.push('\u{2500}');
+            mutated.push_str(&base[cut..]);
+            let _ = lean_theorem_is_proved(&mutated);
+        }
     }
 }


### PR DESCRIPTION
Release **3.36.0** — the first publication since 3.34.0.

## Why a minor bump
3.35.0's release PR (#1108) merged on 2026-09-02 and was never tagged, released or published; crates.io is at 3.34.0. This release carries 3.35.0's content plus everything merged since, including user-visible contract changes (the MCP tool rename `quality_proxy` → `quality_check_content`, `pmat verify`'s tri-state `ok`), so it is 3.36.0, not a patch.

## What ships (CHANGELOG 3.36.0)
- `comply check` char-boundary abort on box-drawing dividers — fixed (#1159, #1167); downstream fleet gates (aprender) re-pin to this version.
- AD-01 `release-check`: a merged release must have become a release — script + daily job on master (#1170); the agentic-delivery specification (#1168).
- CRUX-10 (#1163), CRUX-09 (#1158), CRUX-01 (#1161), CRUX-05 (#1160), CRUX-06 (#1154), CRUX-12 (#1157); 3.35.0's three gate fixes; dependency updates.

## Release commit
`Cargo.toml`, `Cargo.lock`, `README.md` (version table), `mcp.json`, `CHANGELOG.md` — the same five files as the 3.34.0 and 3.35.0 release commits.

## Gates before publish (recorded in `docs/audits/release-3.36.0-dogfood.md` after the fact)
`make validate-book` with the release binary first on PATH · `pmat verify` · `crate-release-dogfood` probe self-test then probe on the tagged merge commit · `scripts/dogfood-use.sh` against the release binary · after `cargo publish`: install from crates.io and run the release gate against the installed binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012SyZqp8jbG8cenxP9KB8Bz
