### PR TITLE
docs(audit): release receipt for 3.37.0 — published, dog-food GO; PMAT-669/670/671 completed

### DIFF
--- a/docs/audits/impl-PMAT-671-receipt.md
+++ b/docs/audits/impl-PMAT-671-receipt.md
@@ -1,5 +1,12 @@
 # impl receipt — PMAT-671: release 3.37.0
 
+> **Scope of the PR that adds this file:** docs only — this receipt, the AD-02 dog-food receipt
+> (`docs/audits/release-3.37.0-dogfood-published.md`) and three roadmap rows flipped to completed.
+> The code, the version bump and the quorum artifact it cites are already on master:
+> `git show 9beccfbd1` (merge of #1189), `5cfa31439` (cut), `2edf6c5a4`, `ac2b6a874`,
+> `e5734f499` (verdict commit; `docs/audits/quorum-PMAT-671.json` on master). Nothing here is
+> asserted about this diff; every claim below names the commit or artifact on master that carries it.
+
 ## Identity
 
 | field | value |

--- a/docs/audits/impl-PMAT-671-receipt.md
+++ b/docs/audits/impl-PMAT-671-receipt.md
@@ -1,0 +1,41 @@
+# impl receipt — PMAT-671: release 3.37.0
+
+## Identity
+
+| field | value |
+|---|---|
+| ticket | PMAT-671 |
+| release PR | #1189 (`release/3.37.0`), merged as 9beccfbd1 |
+| tag / release | `v3.37.0` on 9beccfbd1; https://github.com/paiml/paiml-mcp-agent-toolkit/releases/tag/v3.37.0 |
+| crates.io | pmat 3.37.0 (`cargo publish --locked` from the tag checkout) |
+| carried | #1188 → #1186 (PMAT-670), #1187 → #1185 (PMAT-669), on top of CRUX-07 (#1183) and AD-01…AD-10 |
+| routing | direct; quorum on the release diff (AD-04): 3 runs — see below |
+
+## Why one PR
+
+The runner fleet was saturated (the fix PRs' legs sat queued for hours), so the release branch merged both reviewed fix branches and went through one CI cycle instead of three. GitHub marked #1187 and #1188 merged when their heads reached master through #1189.
+
+## Gates (re-run by the orchestrator)
+
+| gate | result |
+|---|---|
+| `pmat verify --format json` on 5cfa31439 | format/satd/clippy/tests ok; complexity withdrawn on a clean tree, re-measured at 30/25 on the changed files: no violation, 3/2 control exits 1 |
+| ledgers | `analyze unrun-tests --check-ledger` 0, `analyze reachability --check-ledger` 0 |
+| `make validate-book` with the 3.37.0 release binary first on PATH | PASS with controls (Ch05, 07, 13, 14) |
+| `scripts/work-ladder-claim-audit.sh` against the release binary | GREEN; `--self-test` OK (RED against a no-op pmat) |
+| quorum run 1 (5cfa31439) | lane 2 FAIL: audit script lacked `--self-test`, used python3 → fixed (2edf6c5a4) |
+| quorum run 2 (2edf6c5a4) | lane 3 FAIL: a claimed compile error in `require_equation` (refuted by the build; expression simplified anyway) + L0 is a ladder level, docs said L1..L5 (fixed); lane 2 FAIL: no dog-food receipt in the cut (by design: AD-02 runs on the published crate; noted on the row and in the PR) → ac2b6a874 |
+| quorum run 3 (ac2b6a874) | 3/3 PASS — `docs/audits/quorum-PMAT-671.json` |
+| PR checks | 40/40 green on e5734f499 (verdict commit), auto-merged |
+| `scripts/release-check.sh` after publish | `3.37.0 is tagged, released and on crates.io` |
+| `scripts/dogfood-published.sh 3.37.0` (AD-02) | GO — 13 checks, 0 failures; `docs/audits/release-3.37.0-dogfood-published.md` |
+
+## Jidoka log
+
+- `git fetch origin master --tags` exits 1 on a `nightly` tag clobber; the publish chain now fetches tags separately and reports.
+- A leftover `.cargo/config.toml` from a failed verify redirected a worktree's target dir; the mutation chain asserts binary freshness (`-nt` the mutated file).
+- The PMAT-669 roadmap row had been dropped by a cascade on its branch; restored in the release cut from the branch's first commit.
+
+## Verdict
+
+DONE.

--- a/docs/audits/quorum-PMAT-671-receipts.json
+++ b/docs/audits/quorum-PMAT-671-receipts.json
@@ -1,0 +1,34 @@
+{
+ "ticket": "PMAT-671",
+ "base": "origin/master",
+ "head": "dae3603f8071272ce706c04fac80d0f3efe4feeb",
+ "diff_sha256": "6d747500e745dbf001272529d350475c093e76c74de96ac5e4066f388a39345a",
+ "width": 3,
+ "executor": "agy",
+ "prompt_mode": "inline",
+ "prompt_bytes": 9540,
+ "agreed": true,
+ "lanes": [
+  {
+   "lane": 1,
+   "verdict": "PASS",
+   "summary": "The diff correctly implements the requested document changes for the PMAT-671 release receipt. The diff accurately matches the receipt's own claims about its scope: it adds the main receipt, the dogfood receipt, and flips the three relevant roadmap rows (for PMAT-669, PMAT-670, and PMAT-671) from in_progress to completed. The issue and PR numbers referenced (PRs 1187 and 1188 carrying issues 1185 and 1186) align perfectly with the titles in the roadmap. No gates are weakened and the changes introduce exactly what is stated without asserting undocumented modifications.",
+   "findings": [],
+   "raw_bytes": 2191
+  },
+  {
+   "lane": 2,
+   "verdict": "PASS",
+   "summary": "The diff correctly implements the ticket PMAT-671. It adds the release receipt (`docs/audits/impl-PMAT-671-receipt.md`), the post-publish dog-food receipt (`docs/audits/release-3.37.0-dogfood-published.md`), and flips the status to 'completed' for the three corresponding roadmap items. The receipt's stated scope exactly matches the diff's contents. The Jidoka logs show strict adherence to user rules (replacing python3 scripts with shell, adding --self-test to CI scripts). No contradictions or unauthorized changes were found.",
+   "findings": [],
+   "raw_bytes": 2112
+  },
+  {
+   "lane": 3,
+   "verdict": "PASS",
+   "summary": "The diff correctly adds the post-publish dog-food receipt, the release receipt, and marks the corresponding release and fix tasks as completed in the roadmap. All claims in the receipt regarding the scope of the diff are fully backed by the changes. The PR corresponds to the administrative wrap-up after a release cut and publish. No tests are broken, no gates are weakened, and no unrequested changes are introduced.",
+   "findings": [],
+   "raw_bytes": 1879
+  }
+ ]
+}

--- a/docs/audits/release-3.37.0-dogfood-published.md
+++ b/docs/audits/release-3.37.0-dogfood-published.md
@@ -1,0 +1,11 @@
+# Post-publish dog-food — pmat 3.37.0
+
+| leg | result |
+|---|---|
+| P7 registry | `pmat 3.37.0` on crates.io, not yanked; size 8978890 bytes, created 2026-09-04T11:27:33.110659Z |
+| P5 install | `cargo install pmat --version 3.37.0 --locked` into a throwaway root: executable present |
+| --version | `pmat 3.37.0` — no commit line (CRUX-21: the crates.io build carries no git metadata) |
+| --help | answered |
+| release gate | `scripts/dogfood-use.sh` against the INSTALLED binary: 13 checks, 0 failure(s) |
+
+Written by `scripts/dogfood-published.sh` (AD-02, docs/specifications/agentic-delivery-pmat.md section 3.6). The registry size and stamp pin the artifact; a local build cannot forge them.

--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -4155,7 +4155,7 @@ roadmap:
   github_issue: null
   item_type: task
   title: 'ci: container jobs restore the runner''s ownership of the _work tree so a poisoned runner cannot fail the next job (#1185)'
-  status: in_progress
+  status: completed
   priority: high
   assigned_to: null
   created: 2026-09-04T06:57:45Z
@@ -4172,7 +4172,7 @@ roadmap:
   github_issue: null
   item_type: task
   title: 'pmat work: a ticket claims the ladder level its bindings evidence; --level on add and edit, --implements on edit, ladder check before the quality gates (#1186)'
-  status: in_progress
+  status: completed
   priority: high
   assigned_to: null
   created: 2026-09-04T06:57:46Z
@@ -4189,7 +4189,7 @@ roadmap:
   github_issue: null
   item_type: task
   title: 'release 3.37.0: cut, publish and dog-food the two urgent fixes (#1185, #1186) with CRUX-07 and AD-01..AD-10'
-  status: in_progress
+  status: completed
   priority: high
   assigned_to: null
   created: 2026-09-04T09:33:49Z


### PR DESCRIPTION
Post-publish receipts for 3.37.0: `docs/audits/impl-PMAT-671-receipt.md` (the release chain, gates re-run, the three quorum runs) and `docs/audits/release-3.37.0-dogfood-published.md` (AD-02: the crate crates.io serves, installed into a throwaway root — GO, 13 checks, 0 failures). Roadmap: PMAT-669, PMAT-670, PMAT-671 → completed. Docs-only.

Pmat-Ticket: PMAT-671