### PR TITLE
chore(release): bump to 3.38.0 (work add id allocator, work validate as a required gate)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.38.0] - 2026-09-05
+
+### Fixed
+
+- `pmat work add` minted colliding ids (#1193, #1169; PMAT-673, PR #1195). The
+  allocator ran outside the write lock over the parsed model: two processes both
+  read `max = N`, both minted `N+1`, and the second silently overwrote the first
+  ticket. The id is now minted under ONE exclusive lock from every `id:` line of
+  the raw roadmap text (subtask ids and every YAML spelling of the key included)
+  plus a high-water mark persisted in `docs/roadmaps/roadmap.yaml.lock`; an
+  unparseable roadmap is refused with `file:line` and writes nothing. 13 lib
+  tests including a 12-process contention test; the planted pre-fix allocator
+  was observed RED in CI and reverted.
+- `pmat work validate` printed "Validation passed" on a roadmap carrying the
+  same id twice (PMAT-674, PR #1196; this repo's own roadmap carried `PMAT-654`
+  twice, removed in #1194). A duplicated id is now an error naming the id and
+  every `file:line`; an unparseable roadmap fails with `file:line:column` in the
+  error itself; `--help` documents the exit codes (0 valid, 1 invalid or
+  unreadable). The raw-text scanner skips block-scalar bodies and reads
+  flow-style rows (agy quorum findings, both reproduced RED before the fix).
+
+### Added
+
+- CI job `roadmap validates` (`.github/workflows/ci.yml`): builds pmat from the
+  tree, first proves the validator can fail on a duplicated-id fixture, then
+  validates `docs/roadmaps/roadmap.yaml`. It is in the required `gate`'s `needs`
+  and result loop, so a red roadmap fails `ci / gate` instead of printing a
+  warning. Its own control step went RED on the planted mutation.
+- pv work contracts `contracts/work/PMAT-673.yaml` and `contracts/work/PMAT-674.yaml`;
+  receipts `docs/audits/impl-PMAT-673-receipt.md` and `impl-PMAT-674-receipt.md`.
+
+### Known, not fixed
+
+- The whole-file re-serialisation of `roadmap.yaml` on every `work add` / `work
+  edit` (the other half of #1193 / #1169) and cross-checkout id collisions (the
+  lock file is per checkout) are follow-ups.
+- The infra pin bump 3.37.0 → 3.38.0 in the org workflows is a named follow-up.
+
 ## [3.37.0] - 2026-09-04
 
 Agentic delivery (spec: `docs/specifications/agentic-delivery-pmat.md`) and two

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4986,7 +4986,7 @@ dependencies = [
 
 [[package]]
 name = "pmat"
-version = "3.37.0"
+version = "3.38.0"
 dependencies = [
  "actix",
  "actix-rt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pmat"
 default-run = "pmat"
-version = "3.37.0"
+version = "3.38.0"
 edition = "2021"
 rust-version = "1.91.0"
 authors = ["Pragmatic AI Labs"]

--- a/README.md
+++ b/README.md
@@ -625,7 +625,7 @@ PMAT is built on the PAIML Sovereign Stack - pure-Rust, SIMD-accelerated librari
 | [aprender-zram-core](https://crates.io/crates/aprender-zram-core) | SIMD LZ4/ZSTD compression (optional) | 0.64 |
 | [aprender-contracts](https://crates.io/crates/aprender-contracts) | Provable contracts (with `aprender-contracts-macros`) | 0.64 |
 | [pmcp](https://crates.io/crates/pmcp) | MCP protocol SDK (streamable HTTP transport) | 2.17 |
-| **pmat** | Code analysis toolkit | 3.37.0 |
+| **pmat** | Code analysis toolkit | 3.38.0 |
 
 **Key Benefits:**
 - Pure Rust (no C dependencies, no FFI)

--- a/docs/audits/release-3.38.0-receipt.md
+++ b/docs/audits/release-3.38.0-receipt.md
@@ -1,0 +1,40 @@
+# release receipt — 3.38.0 (cut on master 5a9a82bf4; STOPPED before merge/tag/publish)
+
+| field | value |
+|---|---|
+| base | `master` 5a9a82bf4 = #1196 merge (PMAT-674) on top of 97e826ae8 = #1195 merge (PMAT-673) on top of 7aff1179d = #1194 (roadmap dedupe + tickets) |
+| branch / PR | `release/3.38.0` · PR #1197 · **draft, no auto-merge, no tag** |
+| bump | Cargo.toml:4, Cargo.lock (pmat entry), README.md:628, mcp.json:3, CHANGELOG.md (section from the three PR bodies); PMAT-673 and PMAT-674 marked `completed` |
+| tickets merged | #1195 head 1ce01bc1a: check-runs success=42 skipped=5 failure=0, merged 2026-09-05T20:58:47Z; #1196 head d9180f92e: success=43 skipped=5 failure=0, merged 2026-09-05T21:51:58Z; no reruns on either |
+| gate_cmd_fallback | `true` in discover.json (`cargo test --workspace`) — recorded, not fixed, not run; `pmat verify` was the gate on both tickets |
+| infra pin bump 3.37.0 → 3.38.0 | named follow-up, not done here |
+
+## Pre-merge gates run on this branch (b233e7911)
+
+| gate | result |
+|---|---|
+| `make validate-book` | PASS — 4 critical chapters (05, 07, 13, 14), Ch13 control "1 of 1 script(s) fail without a working pmat" OK; wall 0.7 s, which means it exercised an already-built pmat, not a fresh build of this tree — the book at `/home/noah/src/pmat-book` was present |
+| fixture dogfood of the built tree (`cargo metadata` target dir, `pmat 3.38.0`) | `work add first` exit 0 → `PMAT-011`, lock file `11`; `work add second` exit 0 → `PMAT-012`, lock file `12` (distinct, sequential, high-water mark advanced); append a second `- id: PMAT-011` row → `work validate` exit 1: `error: duplicate id PMAT-011 at …/roadmap.yaml:21, …/roadmap.yaml:53`; an unparseable roadmap: `work validate` exit 1 and `work add` exit 1 (nothing written) |
+| trap on the way | `./target/debug/pmat` inside the repo is a stale Sep-2 binary; the real target directory is off-site (`cargo metadata --format-version 1 | jq -r .target_directory`). The first fixture pass used the stale one and read "Validation passed" on a duplicated id — the evidence above is from the real one |
+
+## Why this stops here
+
+The instruction: the release workflow publishes; if it lacks a clean-room hard gate or has `continue-on-error` on publish, STOP and report; never `cargo publish` by hand, no `--allow-dirty`, no `--skip`.
+
+- The only workflow that runs `cargo publish` is `.github/workflows/release.yml.disabled` (publish behind `gate` and `verify` on `[self-hosted, clean-room]`) — disabled since #382, "manual publish only". `automated-release.yml.disabled` and `auto-tag-release.yml.disabled` likewise. Nothing enabled publishes the crate.
+- A `v3.38.0` tag today would trigger `docker-publish.yml` (an image of a version that is not on crates.io) and nothing else; `post-release.yml` runs only on a published GitHub release.
+- Every earlier release (3.34.0 → 3.37.0) was published by hand after the tag (`env -u CARGO_REGISTRY_TOKEN cargo publish --locked`), which this run was told not to do.
+
+Not done, deliberately: merge of #1197, tag `v3.38.0`, `gh release create`, `cargo publish`, and therefore the post-publish `cargo install pmat --version 3.38.0 --locked` dogfood (the fixture run above is on the tree's own build, not on the published crate).
+
+## Follow-ups named
+
+1. Re-enable `release.yml` (it carries the clean-room gates) or decide the manual path; then merge #1197, tag on the merge commit, publish, dog-food the installed crate.
+2. Whole-file re-serialisation of `roadmap.yaml` on every `work add` / `work edit` (#1193 / #1169, second half).
+3. Cross-checkout id collisions: the lock file is per checkout; a union-across-refs mint is not in PMAT-673.
+4. One raw-text id scanner instead of two (`roadmap_service_operations.rs::id_key_value` vs `ticket_validate_migrate.rs::collect_id_lines`).
+5. Infra pin bump 3.37.0 → 3.38.0.
+
+## Verdict
+
+**STOPPED(publish-path-absent)** — release cut prepared on PR #1197 as a draft; nothing published, nothing tagged. — RELEASE-3.38.0-RECEIPT-END

--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -4205,11 +4205,11 @@ roadmap:
   github_issue: null
   item_type: task
   title: 'work add: id allocator collides (pmat#1193/#1169)'
-  status: inprogress
+  status: completed
   priority: high
   assigned_to: null
   created: 2026-09-05T17:58:14Z
-  updated: 2026-09-05T18:05:10.828438430+00:00
+  updated: 2026-09-05T21:53:04Z
   spec: null
   acceptance_criteria:
   - 'generate_next_id (src/cli/handlers/work_handlers/ticket_handlers.rs) takes max over the PARSED items of one load() under a SHARED lock that is released before upsert_item takes the EXCLUSIVE lock; two processes both read max=N and both mint N+1, and the second upsert_item finds the id present and OVERWRITES the first ticket (find_item_mut). Fix: allocate under the exclusive lock as max over every ''- id:'' line of the raw roadmap text (not the parsed model, which drops rows serde rejects) plus the id recorded in docs/roadmaps/roadmap.yaml.lock, write the roadmap and the lock''s high-water mark under the same lock. Acceptance: sequential adds mint distinct ids; two concurrent processes mint distinct ids; an unparseable roadmap is refused with file:line and mints nothing (no roadmap write, no lock bump); a mutation that restores the old allocator turns the concurrent test RED once in CI, then reverted. Contract: pv contract in the same PR, or pv_lane=NotRun named in the receipt.'
@@ -4224,11 +4224,11 @@ roadmap:
   github_issue: null
   item_type: task
   title: 'work validate: duplicate ids RED, unparseable RED with file:line, wired into ci / gate'
-  status: inprogress
+  status: completed
   priority: high
   assigned_to: null
   created: 2026-09-05T17:58:14Z
-  updated: 2026-09-05T19:14:04.031896401+00:00
+  updated: 2026-09-05T21:53:04Z
   spec: null
   acceptance_criteria:
   - 'handle_work_validate (src/cli/handlers/work_handlers/ticket_validate_migrate.rs) printed ''Validation passed'' on a roadmap carrying PMAT-654 twice (master 914fe6246, docs/roadmaps/roadmap.yaml:4001 and :4035). Fix: (1) a duplicated ''- id:'' is an ERROR, exit non-zero, naming the id and both file:line positions; (2) an unparseable roadmap exits non-zero and names file:line of the first parse error; (3) exit codes are documented in the command''s --help (0 valid, 1 invalid or unreadable); (4) a job that runs ''pmat work validate'' from the tree is added to .github/workflows/ci.yml and to the gate job''s needs list AND to its result loop, so a red roadmap fails the required check ''ci / gate'' rather than printing a warning. Acceptance: fixture with a duplicate id exits 1 and prints both lines; fixture with a YAML error exits 1 and prints file:line; the current roadmap exits 0; the gate loop names the new job.'

--- a/mcp.json
+++ b/mcp.json
@@ -1,6 +1,6 @@
 {
   "name": "pmat",
-  "version": "3.37.0",
+  "version": "3.38.0",
   "description": "Project Analysis and Intelligence Modeling Toolkit",
   "main": "pmat",
   "bin": {


### PR DESCRIPTION
Release cut for **3.38.0** on master `5a9a82bf4`: PMAT-673 (#1195) and PMAT-674 (#1196), both merged on their required checks with no reruns; the roadmap fix and the two tickets (#1194).

Bumps the five version carriers (`Cargo.toml`, `Cargo.lock`, `README.md:628`, `mcp.json:3`, `CHANGELOG.md`) and marks PMAT-673/PMAT-674 completed in the roadmap. The CHANGELOG section is written from the three PR bodies.

## STOPPED before merge — the publish path does not exist

The instruction for this release was: *the release workflow publishes; if it lacks a clean-room hard gate or has `continue-on-error` on publish, STOP and report; never `cargo publish` by hand.*

- `.github/workflows/release.yml` — the only workflow that runs `cargo publish` (behind `gate` + `verify` on `[self-hosted, clean-room]`) — is **`release.yml.disabled`** since #382 ("manual publish only"). `automated-release.yml.disabled` and `auto-tag-release.yml.disabled` likewise.
- What a `v3.38.0` tag would trigger today: `docker-publish.yml` (a Docker image of a version that is not on crates.io) and nothing that publishes the crate. `post-release.yml` runs only on a published GitHub release.
- Every previous release (3.34.0 → 3.37.0) was published by hand with `env -u CARGO_REGISTRY_TOKEN cargo publish` after the tag and `gh release create`.

So this PR is a **draft with no auto-merge and no tag**: merging a version bump that cannot ship leaves master claiming 3.38.0 while crates.io serves 3.37.0. Decide one of: (a) re-enable `release.yml` (it has the clean-room gates) and then merge + tag; (b) merge, tag, and publish by hand as before; (c) hold.

`make validate-book` and the fixture dogfood of the built tree are recorded in the session's release receipt (`docs/audits/release-3.38.0-receipt.md`, added on this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Zq45QNXY3PPkuYauyMhRr