### PR TITLE
chore(release): bump to 3.39.0 (cot derive hollow obligations, roadmap writer and id authority, release path, fleet-gate scrub)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,55 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.39.0] - 2026-09-06
+
+### Fixed
+
+- `pmat work cot derive` wrote hollow obligations (`statement: ""`, `hypothesis: ""`)
+  for `version: "5.0"` contracts whose steps carry `falsifiable_claim` instead of
+  `implication`; `pv` refused the artifact (SCHEMA-005) while CB-1658 passed it
+  (#1200, PMAT-685, PR #1201). The claim — or the top-level
+  `falsifiable_claims[]` entry the step discharges — is now the obligation; a step
+  that is still hollow is refused by name before any write; `cot check` warns;
+  CB-1658 fails an empty statement or hypothesis; the CoT digest covers borrowed
+  top-level claims (pre-existing digests unchanged). Pinned by aprender's ten real
+  `GH-663..672` contracts as fixtures.
+- `pmat work add` and `pmat work edit` accepted — and rewrote — a roadmap that
+  `pmat work validate` rejects (PMAT-676, PR #1201). One raw-text scanner and one
+  validator (`services::roadmap_text`) now serve `add`, `edit` and `validate`,
+  under the write lock, before any write.
+- `pmat work add` re-serialised the whole roadmap on every call (the 2,532-line
+  class; #1193 / #1169, aprender #2874; PMAT-679, PR #1201). `add` now appends
+  the raw row and `edit` replaces exactly one row's block; every untouched entry
+  stays byte-identical, including comments, flow-style rows, block scalars and
+  unknown keys. Rows start at every dash line, and the sequence ends at the next
+  top-level key.
+- Two checkouts of one repository minted the same id (#1193, PMAT-680, PR #1201).
+  Ids are minted from one authority per repository: a lock and high-water mark in
+  the git common dir (shared by every worktree) plus every ref's roadmap; outside
+  git the sibling lock still works.
+
+### Added
+
+- `.github/workflows/release.yml` restored (PMAT-675, PR #1203): a `v*` tag runs
+  the fleet clean-room gate and `cargo package --verify --locked`, then creates a
+  GitHub **prerelease**; binary-release and post-release are dispatched explicitly.
+  No workflow publishes the crate; no registry token; no `continue-on-error`. A
+  `workflow_dispatch` probe (`probe_fail_verify`) proves a red verify creates no
+  release. `docker-publish.yml` is dispatch-only with a secret preflight.
+- AD-09: one orchestrator per repository per host (PMAT-663, PR #1181).
+- pv work contracts `contracts/work/PMAT-{675,676,679,680,685}.yaml`; receipts under
+  `docs/audits/impl-PMAT-*-receipt.md`.
+
+### Known, not fixed
+
+- `work start` / `work complete` / `work sync` still round-trip the whole roadmap
+  through serde (`upsert_item`, `save`).
+- Two separate clones still race between fetches; the id authority is the union
+  of refs the clone knows (no server-side counter).
+- `ci / coverage` can kill lib tests that shell out to `cargo` under load
+  (#1202): two flake classes recorded; each job was rerun once.
+
 ## [3.38.0] - 2026-09-05
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4986,7 +4986,7 @@ dependencies = [
 
 [[package]]
 name = "pmat"
-version = "3.38.0"
+version = "3.39.0"
 dependencies = [
  "actix",
  "actix-rt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pmat"
 default-run = "pmat"
-version = "3.38.0"
+version = "3.39.0"
 edition = "2021"
 rust-version = "1.91.0"
 authors = ["Pragmatic AI Labs"]

--- a/README.md
+++ b/README.md
@@ -625,7 +625,7 @@ PMAT is built on the PAIML Sovereign Stack - pure-Rust, SIMD-accelerated librari
 | [aprender-zram-core](https://crates.io/crates/aprender-zram-core) | SIMD LZ4/ZSTD compression (optional) | 0.64 |
 | [aprender-contracts](https://crates.io/crates/aprender-contracts) | Provable contracts (with `aprender-contracts-macros`) | 0.64 |
 | [pmcp](https://crates.io/crates/pmcp) | MCP protocol SDK (streamable HTTP transport) | 2.17 |
-| **pmat** | Code analysis toolkit | 3.38.0 |
+| **pmat** | Code analysis toolkit | 3.39.0 |
 
 **Key Benefits:**
 - Pure Rust (no C dependencies, no FFI)

--- a/docs/audits/2026-09-crux/build.sh
+++ b/docs/audits/2026-09-crux/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 S=/tmp/claude-1000/-home-noah-src-paiml-mcp-agent-toolkit/e1ae0d23-4b84-4273-be07-926cd668e2d3/scratchpad/research
-cd /home/noah/src/paiml-mcp-agent-toolkit || exit 99
+cd "${REPO:-$HOME/src/paiml-mcp-agent-toolkit}" || exit 99
 { date -Is; uptime; } > "$S/build1.start"
 /usr/bin/time -v -o "$S/build1.time" cargo build --release --message-format=json > "$S/build1.json" 2> "$S/build1.stderr"
 { echo "exit=$?"; date -Is; uptime; } > "$S/build1.exit"

--- a/docs/audits/2026-09-crux/build3.sh
+++ b/docs/audits/2026-09-crux/build3.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 S=/tmp/claude-1000/-home-noah-src-paiml-mcp-agent-toolkit/e1ae0d23-4b84-4273-be07-926cd668e2d3/scratchpad/research
-cd /home/noah/src/paiml-mcp-agent-toolkit || exit 99
+cd "${REPO:-$HOME/src/paiml-mcp-agent-toolkit}" || exit 99
 stat -c '%y %n' .git/index .git/HEAD > "$S/build3.gitstat.before"
 { date -Is; uptime; } > "$S/build3.start"
 CARGO_LOG=cargo::core::compiler::fingerprint=info /usr/bin/time -v -o "$S/build3.time" cargo build --release --message-format=json > "$S/build3.json" 2> "$S/build3.stderr"

--- a/docs/audits/2026-09-crux/measure.sh
+++ b/docs/audits/2026-09-crux/measure.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 S=/tmp/claude-1000/-home-noah-src-paiml-mcp-agent-toolkit/e1ae0d23-4b84-4273-be07-926cd668e2d3/scratchpad/research
 M=$S/m
-BIN=/mnt/nvme-raid0/coverage/paiml-mcp-agent-toolkit/release/pmat
-REPO=/home/noah/src/paiml-mcp-agent-toolkit
+BIN="${PMAT_BIN:-$(cargo metadata --format-version 1 --no-deps | jq -r .target_directory)/release/pmat}"
+REPO="${REPO:-$HOME/src/paiml-mcp-agent-toolkit}"
 FIX=$S/fixture-small
 run() { # name dir cmd...
   local name=$1; shift; local dir=$1; shift

--- a/docs/audits/2026-09-crux/measure2.sh
+++ b/docs/audits/2026-09-crux/measure2.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 S=/tmp/claude-1000/-home-noah-src-paiml-mcp-agent-toolkit/e1ae0d23-4b84-4273-be07-926cd668e2d3/scratchpad/research
 M=$S/m
-BIN=/mnt/nvme-raid0/coverage/paiml-mcp-agent-toolkit/release/pmat
-REPO=/home/noah/src/paiml-mcp-agent-toolkit
+BIN="${PMAT_BIN:-$(cargo metadata --format-version 1 --no-deps | jq -r .target_directory)/release/pmat}"
+REPO="${REPO:-$HOME/src/paiml-mcp-agent-toolkit}"
 run() {
   local name=$1; shift; local dir=$1; shift
   cd "$dir" || return

--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -4243,11 +4243,11 @@ roadmap:
   github_issue: null
   item_type: task
   title: 'release path: restore release.yml (clean-room gate+verify → GitHub prerelease), demote docker-publish to workflow_dispatch with a secret preflight'
-  status: planned
+  status: completed
   priority: high
   assigned_to: null
   created: 2026-09-06T07:56:01Z
-  updated: 2026-09-06T07:56:01Z
+  updated: 2026-09-06T13:29:01Z
   spec: null
   acceptance_criteria:
   - 'A pmat tag runs no clean-room gate and creates no release. Restore .github/workflows/release.yml from release.yml.disabled keeping create-release → gate → verify on [self-hosted, clean-room] and creating a GitHub prerelease (prerelease: true); delete the publish, build-binaries and publish-release jobs (binary-release.yml on release: published supersedes them). No cargo publish, no CARGO_REGISTRY_TOKEN, no continue-on-error. docker-publish.yml: red on every tag since v3.32.0 (6 consecutive), hard-codes image tag 2.10.0, but docs/DOCKER.md documents paiml/pmat:2.12.0 (#1122) — a doc consumer exists, so it is demoted to workflow_dispatch with a secret-presence preflight that exits 1 with a named reason, not deleted; HRQ. Falsifier: a workflow_dispatch probe run with an injected failing verify step creates no release; the failure names verify, not create-release.'
@@ -4262,11 +4262,11 @@ roadmap:
   github_issue: null
   item_type: task
   title: 'work add refuses what validate rejects: one raw-text id scanner, one validator, called by add/edit/validate inside the write lock'
-  status: inprogress
+  status: completed
   priority: high
   assigned_to: null
   created: 2026-09-06T07:56:01Z
-  updated: 2026-09-06T09:54:47.374929312+00:00
+  updated: 2026-09-06T13:27:03Z
   spec: null
   acceptance_criteria:
   - '3.38.0: work add refuses only unparseable roadmaps; a duplicated-id roadmap (validate exit 1) is accepted and written. Root: two scanners (roadmap_service_operations.rs::id_key_value vs ticket_validate_migrate.rs::collect_id_lines) and no shared validator. Fix: one scanner, one validator used by add, edit and validate, before any write, under the lock. Falsifier: fixture with PMAT-011 twice → work add exit 1 naming both file:line, roadmap.yaml byte-identical, lock unchanged; mutation removing the validator call in add → the new lib test RED while the validate test stays GREEN.'
@@ -4316,11 +4316,11 @@ roadmap:
   github_issue: null
   item_type: task
   title: 'roadmap re-serialisation (#1193/#1169 second half): work add appends and work edit patches the raw text; untouched rows are never re-emitted'
-  status: planned
+  status: completed
   priority: high
   assigned_to: null
   created: 2026-09-06T07:56:01Z
-  updated: 2026-09-06T07:56:01Z
+  updated: 2026-09-06T13:29:02Z
   spec: null
   acceptance_criteria:
   - 'Every work add/edit round-trips docs/roadmaps/roadmap.yaml through serde and rewrites the whole file (order, quoting, comments, unknown keys), which is why every concurrent branch conflicts on the roadmap (all five open PRs at 3.38.0 conflict there). Fix at the writer: append the raw row for add; targeted row edit for edit. Falsifier: byte-diff of work add on a fixture with comments, flow-style rows, a block scalar and an unknown key is exactly the appended row (+ lock); routing add through the serde writer → RED.'
@@ -4334,11 +4334,11 @@ roadmap:
   github_issue: null
   item_type: task
   title: 'cross-checkout id union: mint max(lock, HEAD roadmap, roadmap blobs of every local ref)'
-  status: planned
+  status: completed
   priority: medium
   assigned_to: null
   created: 2026-09-06T07:56:01Z
-  updated: 2026-09-06T07:56:01Z
+  updated: 2026-09-06T13:29:02Z
   spec: null
   acceptance_criteria:
   - 'The lock file is per checkout; two worktrees mint the same id (3.38.0 receipt follow-up). Design: next = max(lock high-water, ids in the working roadmap, ids in git show <sha>:docs/roadmaps/roadmap.yaml for every ref from git for-each-ref refs/heads refs/remotes) + 1. Falsifier: two worktrees on different branches each work add → distinct ids; dropping the ref scan → collision RED. Implement only if the 3.39.0 budget allows; else deferred to 3.40.0 with this design.'
@@ -4427,11 +4427,11 @@ roadmap:
   github_issue: null
   item_type: task
   title: 'work cot derive: read falsifiable_claim (v5.0 steps) or refuse a hollow obligation; CB-1658 refuses empty statement/hypothesis (#1200)'
-  status: inprogress
+  status: completed
   priority: critical
   assigned_to: null
   created: 2026-09-06T08:03:59Z
-  updated: 2026-09-06T08:04:39.626986847+00:00
+  updated: 2026-09-06T13:27:04Z
   spec: null
   acceptance_criteria:
   - 'pmat 3.37/3.38: for a version 5.0 contract.json whose chain_of_thought[] steps carry falsifiable_claim (not assumption/implication), parse_step treats the step as structured, both texts come out empty, and render_derivation writes statement: '''' / hypothesis: '''' verbatim; pv refuses the artifact (SCHEMA-005) and CB-1658 passes it because it only compares counts and verbatim equality ('''' == ''''). Blocks aprender PP-066 row C0-3 (#2892). Fix: parse_steps reads falsifiable_claim (string or {claim|text}) and the top-level falsifiable_claims[] entry the step discharges when implication is absent; handle_work_cot_derive refuses with the step id and the missing field instead of writing a hollow artifact; CB-1658 fails an obligation with an empty statement or a claim with an empty hypothesis. Falsifier: the issue''s exact step JSON derives a non-empty statement equal to the claim; a step with neither field → derive exit 1, no artifact, no digest; a hand-written hollow .cot.yaml → CB-1658 Fail naming the ticket and obligation id; mutation restoring the old parse_step → RED.'
@@ -4446,11 +4446,11 @@ roadmap:
   github_issue: null
   item_type: task
   title: 'AD-09: one orchestrator per repository per host'
-  status: in_progress
+  status: completed
   priority: medium
   assigned_to: null
   created: 2026-09-04T02:20:10Z
-  updated: 2026-09-04T02:20:10Z
+  updated: 2026-09-06T13:27:03Z
   spec: null
   acceptance_criteria:
   - 'agentic-delivery-pmat.md section 6 / 9.9. Bundle: discover.sh takes an orchestrator lock per repository in the runtime dir; the hook refuses a second session''s first Agent spawn in the same repository naming the holder; stale locks (session gone, or older than 12h) are taken over; hooks/orchestrator-lock-selftest.sh drives the real hook. The xhigh assertion is not machine-checkable from a hook and stays [U]. pmat side: spec note and receipt. Controls: second orchestrator refused naming the first; holder may spawn; stale lock taken over.'
@@ -4463,11 +4463,11 @@ roadmap:
   github_issue: null
   item_type: task
   title: 'fleet lint-gate: scrub the banned-path literals the unified-gate greps for (/home/noah, /mnt/nvme-raid0) from *.rs *.toml *.sh; in-repo scan test'
-  status: planned
+  status: completed
   priority: high
   assigned_to: null
   created: 2026-09-06T13:26:04Z
-  updated: 2026-09-06T13:26:04Z
+  updated: 2026-09-06T13:29:03Z
   spec: null
   acceptance_criteria:
   - The v3.38.0 release-path probe failed at the fleet gate's Banned path scan (40 lines of pmat's own tree). Scrubbed in 4211f0bf7 except two files pinned for PMAT-687; src/tests/fleet_banned_paths_tests.rs mirrors the fleet scan over tracked *.rs *.toml *.sh.

--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -4459,3 +4459,41 @@ roadmap:
   estimated_effort: null
   labels: []
   notes: null
+- id: PMAT-686
+  github_issue: null
+  item_type: task
+  title: 'fleet lint-gate: scrub the banned-path literals the unified-gate greps for (/home/noah, /mnt/nvme-raid0) from *.rs *.toml *.sh; in-repo scan test'
+  status: planned
+  priority: high
+  assigned_to: null
+  created: 2026-09-06T13:26:04Z
+  updated: 2026-09-06T13:26:04Z
+  spec: null
+  acceptance_criteria:
+  - The v3.38.0 release-path probe failed at the fleet gate's Banned path scan (40 lines of pmat's own tree). Scrubbed in 4211f0bf7 except two files pinned for PMAT-687; src/tests/fleet_banned_paths_tests.rs mirrors the fleet scan over tracked *.rs *.toml *.sh.
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - kind:code
+  - release
+  notes: null
+- id: PMAT-687
+  github_issue: null
+  item_type: task
+  title: 'fleet lint-gate: hardcoded_paths.rs fixtures and check.rs comment still carry /home/noah; pay the complexity debt (classify cognitive 33, check.rs helpers 25 fns) or land a per-repo EXCLUDE in paiml/.github unified-gate.yml'
+  status: planned
+  priority: medium
+  assigned_to: null
+  created: 2026-09-06T13:26:05Z
+  updated: 2026-09-06T13:26:05Z
+  spec: null
+  acceptance_criteria:
+  - 'Until one of the two lands, a pmat tag fails the fleet gate at lint-gate (probe run 34034967876) and the prerelease is created by hand. Also: pmat analyze hardcoded-paths reports 45 machine-specific paths in shipped code on this tree — audit them in the same ticket.'
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - kind:code
+  - deferred:3.40.0
+  notes: null

--- a/docs/status/orphan-files-ledger.md
+++ b/docs/status/orphan-files-ledger.md
@@ -21,7 +21,7 @@ the first two buckets and may only fall. To move a file out, register it
 (edit the row to `registered-<target>`) or delete it (`deleted-<reason>`) in the
 same change; do not edit counts by hand.
 
-4443 tracked `.rs` files: 3954 reachable from 137 target root(s), 407 orphaned (126922 lines, 6294 `#[test]` fns), 82 quarantined (35891 lines, 2021 `#[test]` fns).
+4444 tracked `.rs` files: 3955 reachable from 137 target root(s), 407 orphaned (126922 lines, 6294 `#[test]` fns), 82 quarantined (35891 lines, 2021 `#[test]` fns).
 
 | `path` | reason | tests | lines |
 |---|---|---|---|

--- a/docs/status/unrun-tests-ledger.md
+++ b/docs/status/unrun-tests-ledger.md
@@ -14,7 +14,7 @@ Legs consulted (3):
 - `feature-matrix.yml:feature-tests[mcp-integration]`
 - `feature-matrix.yml:feature-tests[unified-protocol]`
 
-23783 of 27011 lib tests are executed; 3228 are compiled by no leg.
+23784 of 27012 lib tests are executed; 3228 are compiled by no leg.
 
 ## `<unsatisfiable>` — 2199 test(s)
 

--- a/mcp.json
+++ b/mcp.json
@@ -1,6 +1,6 @@
 {
   "name": "pmat",
-  "version": "3.38.0",
+  "version": "3.39.0",
   "description": "Project Analysis and Intelligence Modeling Toolkit",
   "main": "pmat",
   "bin": {

--- a/pmat.toml
+++ b/pmat.toml
@@ -1,6 +1,6 @@
 [system]
 project_name = "pmat"
-project_path = "/home/noah/src/paiml-mcp-agent-toolkit"
+project_path = "."
 output_dir = "target/pmat"
 max_concurrent_operations = 48
 verbose = false

--- a/scripts/dogfood/pmat-dogfood_surfaces.sh
+++ b/scripts/dogfood/pmat-dogfood_surfaces.sh
@@ -335,7 +335,7 @@ surface_cli() {
     # ASK CARGO which executables it produced. Do NOT build a path from
     # `cargo metadata`'s target_directory: measured in a worktree of this repo,
     # metadata reports
-    #     /mnt/nvme-raid0/targets/aprender
+    #     <target-dir>/aprender
     # while the executables cargo actually wrote were at
     #     <worktree>/target/debug/
     # because .cargo/config.toml carries the target-dir redirect and is

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -185,7 +185,7 @@ fi
 
 # === 2. pmat-book Sync Status ===
 # Check pmat-book sync status
-BOOK_DIR="${PMAT_BOOK_DIR:-/home/noah/src/pmat-book}"
+BOOK_DIR="${PMAT_BOOK_DIR:-$HOME/src/pmat-book}"
 if [[ "${BOOK_DIR}" == *".."* ]] || [ ! -d "${BOOK_DIR}/.git" ]; then
     BOOK_DIR=""  # unusable or traversal-bearing: skip the book check entirely
 fi
@@ -316,7 +316,7 @@ CYAN='\033[0;36m'
 BOLD='\033[1m'
 NC='\033[0m' # No Color
 
-BOOK_DIR="${PMAT_BOOK_DIR:-/home/noah/src/pmat-book}"
+BOOK_DIR="${PMAT_BOOK_DIR:-$HOME/src/pmat-book}"
 
 echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
 echo -e "${CYAN}📚 Checking pmat-book sync status...${NC}"

--- a/scripts/validate-pmat-book.sh
+++ b/scripts/validate-pmat-book.sh
@@ -24,7 +24,7 @@ GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m'
 
-BOOK_DIR="${PMAT_BOOK_DIR:-/home/noah/src/pmat-book}"
+BOOK_DIR="${PMAT_BOOK_DIR:-$HOME/src/pmat-book}"
 PARALLEL_JOBS="${PMAT_BOOK_JOBS:-4}"
 
 # Per-script wall-clock budget, applied to both the control run and the real

--- a/src/cli/commands/analyze_commands/mod.rs
+++ b/src/cli/commands/analyze_commands/mod.rs
@@ -387,7 +387,7 @@ pub enum AnalyzeCommands {
 
     /// Find machine-specific absolute paths baked into source
     ///
-    /// aprender shipped binaries containing `/home/noah/…`: correct on the
+    /// aprender shipped binaries containing `/home/alice/…`: correct on the
     /// machine that built them, inert everywhere else, and invisible to every
     /// gate — the code compiled, clippy was clean, and the path was just a
     /// string literal. Flags a path only when it names a specific user, nix

--- a/src/cli/handlers/tdg_handlers/formatting.rs
+++ b/src/cli/handlers/tdg_handlers/formatting.rs
@@ -670,7 +670,7 @@ mod cap_disclosure_tests {
         let mut project = ProjectScore::aggregate(vec![file_at(100.0)]);
         for name in ["arxiv_entries.rs", "coursera_entries.rs"] {
             project.ungraded_files.push(crate::tdg::UngradedFile {
-                path: format!("/home/noah/src/aprender/crates/aprender-core/src/oracle/{name}"),
+                path: format!("/home/alice/src/aprender/crates/aprender-core/src/oracle/{name}"),
                 reason: "expected `;`".to_string(),
             });
         }

--- a/src/cli/handlers/work_handlers/mod.rs
+++ b/src/cli/handlers/work_handlers/mod.rs
@@ -70,3 +70,8 @@ mod work_add_single_authority_tests;
 #[cfg(test)]
 #[path = "../../../tests/release_workflow_tests.rs"]
 mod release_workflow_tests;
+
+// PMAT-686: the fleet gate's banned-path scan, in-repo.
+#[cfg(test)]
+#[path = "../../../tests/fleet_banned_paths_tests.rs"]
+mod fleet_banned_paths_tests;

--- a/src/handlers/tools_advanced.rs
+++ b/src/handlers/tools_advanced.rs
@@ -466,14 +466,14 @@ mod part1_pure_helpers_tests {
 
     #[test]
     fn test_get_relative_path_strips_prefix() {
-        let base = std::path::Path::new("/home/noah/project");
-        let file = std::path::Path::new("/home/noah/project/src/main.rs");
+        let base = std::path::Path::new("/home/alice/project");
+        let file = std::path::Path::new("/home/alice/project/src/main.rs");
         assert_eq!(get_relative_path(file, base), "src/main.rs");
     }
 
     #[test]
     fn test_get_relative_path_no_prefix_match_returns_original() {
-        let base = std::path::Path::new("/home/noah/project");
+        let base = std::path::Path::new("/home/alice/project");
         let file = std::path::Path::new("/tmp/other.rs");
         // strip_prefix returns Err → unwrap_or(path) → original.
         assert_eq!(get_relative_path(file, base), "/tmp/other.rs");

--- a/src/tdg/formatters/project.rs
+++ b/src/tdg/formatters/project.rs
@@ -165,7 +165,7 @@ fn percent_of(count: usize, total: usize) -> f32 {
 mod ungraded_disclosure_tests {
     //! REGRESSION (#983): the table named the unmeasured files by pasting the
     //! raw path into a 47-column row, so every entry was clipped to the prefix
-    //! the paths share — `/home/noah/src/aprender/crates/aprender-…` for all of
+    //! the paths share — `/home/alice/src/aprender/crates/aprender-…` for all of
     //! them. Naming a file with a string that cannot identify it is the same
     //! defect as not naming it.
     use super::*;
@@ -186,8 +186,8 @@ mod ungraded_disclosure_tests {
     #[test]
     fn long_paths_are_named_by_their_tail_and_stay_distinct() {
         let rendered = format_project(&project_with(&[
-            "/home/noah/src/aprender/crates/aprender-core/src/oracle/arxiv_entries.rs",
-            "/home/noah/src/aprender/crates/aprender-core/src/oracle/coursera_entries.rs",
+            "/home/alice/src/aprender/crates/aprender-core/src/oracle/arxiv_entries.rs",
+            "/home/alice/src/aprender/crates/aprender-core/src/oracle/coursera_entries.rs",
         ]));
         assert!(rendered.contains("Not Graded: 2 file(s)"), "{rendered}");
         assert!(rendered.contains("arxiv_entries.rs"), "got:\n{rendered}");
@@ -198,7 +198,7 @@ mod ungraded_disclosure_tests {
     #[test]
     fn named_rows_stay_inside_the_frame() {
         let rendered = format_project(&project_with(&[
-            "/home/noah/src/aprender/crates/aprender-core/src/oracle/coursera/arxiv_entries.rs",
+            "/home/alice/src/aprender/crates/aprender-core/src/oracle/coursera/arxiv_entries.rs",
         ]));
         let widths: Vec<usize> = rendered
             .lines()

--- a/src/tdg/formatters/ungraded.rs
+++ b/src/tdg/formatters/ungraded.rs
@@ -365,7 +365,7 @@ mod tests {
     fn a_long_path_keeps_its_tail() {
         let rows = ungraded_rows(
             &[f(
-                "/home/noah/src/aprender/crates/aprender-core/src/oracle/coursera/arxiv_entries.rs",
+                "/home/alice/src/aprender/crates/aprender-core/src/oracle/coursera/arxiv_entries.rs",
                 "expected `;`",
             )],
             Some(ENTRY_BUDGET),
@@ -451,7 +451,7 @@ mod tests {
     #[test]
     fn unbudgeted_rows_are_not_elided() {
         let long =
-            "/home/noah/src/aprender/crates/aprender-core/src/oracle/coursera/arxiv_entries.rs";
+            "/home/alice/src/aprender/crates/aprender-core/src/oracle/coursera/arxiv_entries.rs";
         let rows = ungraded_rows(&[f(long, "expected `;`")], None);
         assert!(rows[1].contains(long), "got: {rows:?}");
         assert!(rows[1].contains("expected `;`"), "got: {rows:?}");

--- a/src/tests/fleet_banned_paths_tests.rs
+++ b/src/tests/fleet_banned_paths_tests.rs
@@ -1,0 +1,103 @@
+//! PMAT-686 — the fleet clean-room gate (paiml/.github unified-gate.yml,
+//! "Banned path scan") greps every `*.rs`, `*.toml` and `*.sh` in the tree for
+//! four machine-specific prefixes and fails the release gate on a hit. On the
+//! v3.38.0 tag it hit 40 lines of pmat's own tree — mostly the hardcoded-path
+//! analyzer's fixtures, plus script defaults pointing at one workstation — so
+//! no pmat tag could ever pass the fleet gate. This test is that scan, in-repo,
+//! so the tree cannot drift back.
+//!
+//! Registered from `cli/handlers/work_handlers/mod.rs` with `#[path]`.
+
+use std::path::{Path, PathBuf};
+
+// Built with `concat!` so this file carries none of the literals itself —
+// the fleet gate would flag the test that mirrors it.
+const BANNED: [&str; 4] = [
+    concat!("/mnt/", "nvme-raid0"),
+    concat!("/home/", "noah"),
+    concat!("/home/", "ubuntu"),
+    concat!("/tmp/", "clean-room"),
+];
+
+/// The files the fleet gate scans: every TRACKED `*.rs`, `*.toml`, `*.sh`
+/// (`git grep … -- '*.rs' '*.toml' '*.sh' ':!CLAUDE.md'`). Tracked, not on
+/// disk: a gitignored `.cargo/config.toml` or a scratch script is not shipped
+/// and the gate never sees it.
+fn scanned_files(root: &Path) -> Vec<PathBuf> {
+    let listed = std::process::Command::new("git")
+        .args([
+            "-C",
+            &root.display().to_string(),
+            "ls-files",
+            "-z",
+            "--",
+            "*.rs",
+            "*.toml",
+            "*.sh",
+            ":!CLAUDE.md",
+        ])
+        .output();
+    let listed = listed.expect("git ls-files runs (the fleet gate runs on a git checkout too)");
+    assert!(
+        listed.status.success(),
+        "git ls-files failed: {}",
+        String::from_utf8_lossy(&listed.stderr)
+    );
+    String::from_utf8_lossy(&listed.stdout)
+        .split('\0')
+        .filter(|s| !s.is_empty())
+        .map(|s| root.join(s))
+        .collect()
+}
+
+#[test]
+fn fleet_banned_path_scan_is_clean() {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    // PMAT-687: two files still carry the literals — the hardcoded-path
+    // analyzer's own fixtures (src/services/hardcoded_paths.rs, 15 lines) and
+    // one comment in check.rs. Both files owe complexity debt that `pmat
+    // verify` measures the moment a line in them changes (classify: cognitive
+    // 33 > 25; check.rs's included helpers: 25 functions over), so their scrub
+    // rides with that refactor. Until then the fleet gate fails on them and the
+    // tag's prerelease is created by hand; the exception is pinned here so it
+    // cannot grow.
+    const PINNED_DEBT: [&str; 2] = [
+        "src/services/hardcoded_paths.rs",
+        "src/cli/handlers/comply_handlers/check_handlers/check.rs",
+    ];
+    let files: Vec<PathBuf> = scanned_files(&root)
+        .into_iter()
+        .filter(|f| {
+            let rel = f.strip_prefix(&root).unwrap_or(f).display().to_string();
+            !PINNED_DEBT.contains(&rel.as_str())
+        })
+        .collect();
+    assert!(
+        files.len() > 100,
+        "the walk must see the tree, saw {}",
+        files.len()
+    );
+    let mut hits = Vec::new();
+    for file in &files {
+        let Ok(text) = std::fs::read_to_string(file) else {
+            continue;
+        };
+        for (n, line) in text.lines().enumerate() {
+            for banned in BANNED {
+                if line.contains(banned) {
+                    hits.push(format!(
+                        "{}:{}: {banned}",
+                        file.strip_prefix(&root).unwrap_or(file).display(),
+                        n + 1
+                    ));
+                }
+            }
+        }
+    }
+    assert!(
+        hits.is_empty(),
+        "the fleet gate would fail on {} line(s):\n{}",
+        hits.len(),
+        hits.join("\n")
+    );
+}

--- a/src/tests/unified_go_analyzer_tests.rs
+++ b/src/tests/unified_go_analyzer_tests.rs
@@ -184,7 +184,7 @@ mod property_tests {
 async fn red_test_unified_go_on_real_file() {
     use crate::services::unified_go_analyzer::UnifiedGoAnalyzer;
 
-    let real_file = PathBuf::from("/home/noah/src/agentic-ai/go-actors/simple.go");
+    let real_file = PathBuf::from("/home/alice/src/agentic-ai/go-actors/simple.go");
     if !real_file.exists() {
         return;
     }

--- a/src/tests/unified_typescript_analyzer_tests.rs
+++ b/src/tests/unified_typescript_analyzer_tests.rs
@@ -182,7 +182,7 @@ async fn red_test_unified_typescript_on_real_file() {
     use crate::services::unified_typescript_analyzer::UnifiedTypeScriptAnalyzer;
 
     // Use actual file from agentic-ai project
-    let real_file = PathBuf::from("/home/noah/src/agentic-ai/deno-actors/simple.ts");
+    let real_file = PathBuf::from("/home/alice/src/agentic-ai/deno-actors/simple.ts");
 
     if !real_file.exists() {
         // Skip if file doesn't exist

--- a/tests/perf_falsification.sh
+++ b/tests/perf_falsification.sh
@@ -31,7 +31,7 @@ if [ -z "${EPOCHREALTIME:-}" ]; then
 fi
 
 PMAT="pmat"
-PROJECT="/home/noah/src/paiml-mcp-agent-toolkit"
+PROJECT="$HOME/src/paiml-mcp-agent-toolkit"
 cd "$PROJECT"
 
 PASS=0


### PR DESCRIPTION
Release cut for **3.39.0** on master `6b5697153` (#1201 merged: #1200 fix + PMAT-676/679/680; #1203 release path; #1181 AD-09). Ticket PMAT-682.

- Bumps the five version carriers (`Cargo.toml`, `Cargo.lock`, `README.md:628`, `mcp.json:3`, `CHANGELOG.md` `[3.39.0]` from the merged PR bodies).
- Marks PMAT-663, 675, 676, 679, 680, 685, 686 completed — through the tree's own binary, so the roadmap diff is exactly the edited rows (the append-only writer at work).
- **PMAT-686** (same PR): scrubs the banned-path literals the fleet clean-room gate greps for (`/home/noah`, `/mnt/nvme-raid0`) from 17 `*.rs`/`*.toml`/`*.sh` files (analyzer fixtures → a neutral home, script defaults → `$HOME`, `pmat.toml` `project_path` → `.`), with an in-repo test mirroring the fleet scan over tracked files. Two files stay pinned as `PINNED_DEBT` for **PMAT-687** (their pre-existing complexity debt trips `pmat verify` on any edit): `src/services/hardcoded_paths.rs` and `check.rs`. Until PMAT-687 lands, the fleet lint-gate fails on a pmat tag (probe run 34034967876 on `v3.38.0`: `create-release` ✓, `gate / lint-gate` ✗ at "Banned path scan", no release created) and the `v3.39.0` prerelease is created by hand.

After merge: tag `v3.39.0` on the merge commit → GitHub prerelease → `cargo publish --dry-run --locked` from a detached worktree of the tag → **stop at PUBLISH-READY** (Noah publishes) → promote the prerelease → paiml/infra#458 pins the four hosts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)