### PR TITLE
fix(PMAT-688): flag-efficacy release gate green — 18 no-op flags wired or allow-listed as artifacts, 4 error-outs reclassified

### DIFF
--- a/contracts/work/PMAT-688.yaml
+++ b/contracts/work/PMAT-688.yaml
@@ -1,0 +1,58 @@
+# Hand-authored work contract for PMAT-688: `make gate-flag-efficacy-full` was
+# RED on the 3.39.0 tree — 18 flags parsed and changed nothing, 4 rows were the
+# ledger writers refusing a dirty tree. Every evidence_method below was run on
+# this tree by the orchestrator; the lib tests run under CI's `cargo test --lib`,
+# the harness tests under `cargo test --test all`, and the sweep itself is the
+# release gate (artifact-level, ignored in CI).
+name: "PMAT-688"
+metadata:
+  version: "1.0.0"
+  kind: pattern
+  description: "Every CLI flag the flag-efficacy sweep exercises changes observable output on the corpus or refuses honestly; the four ledger-writer rows are documented precondition refusals, not error-outs"
+  references:
+    - "tests/modules/quality_harness/flag_efficacy.rs"
+    - "tests/modules/quality_harness/mod.rs"
+    - "src/cli/handlers/popper_score_format_text.rs"
+    - "src/cli/handlers/demo_score_handlers.rs"
+    - "src/roadmap/commands/commands_todos.rs"
+    - "src/cli/handlers/cuda_tdg_handlers_gate_kaizen.rs"
+    - "src/cli/analysis_utilities/string_utils.rs"
+    - "src/cli/handlers/mcp_manifest.rs"
+    - "src/cli/handlers/quality_gates_handler_execution.rs"
+surface: work-contract
+verification_summary:
+  target_level: L1
+  current_level: L1
+  total_obligations: 5
+proof_obligations:
+- id: "PO-F1"
+  statement: "--failures-only on popper-score and demo-score is the display filter its sibling score commands implement: a category or subcategory at or above the 80% pass line is not rendered in text or markdown, everything below it is, and popper's recommendations stay whatever the gateway said"
+  evidence_method: "env -u RUST_MIN_STACK cargo test --lib -- failures_only_text_keeps_only_failing_checks failures_only_verbose_keeps_only_failing_sub_scores failures_only_markdown_keeps_only_failing_checks failures_only_hides_passing_subcategories_in_text failures_only_hides_passing_subcategories_in_markdown"
+- id: "PO-F2"
+  statement: "roadmap todos names the format it wrote and the todo count on its confirmation line, and cuda-tdg gate names the P0 policy in force in its text report, so --include-quality-gates and --fail-on-p0 are visible on stdout and not only in a file or a verdict that already fails"
+  evidence_method: "env -u RUST_MIN_STACK cargo test --lib -- todos_written_line_names_the_format_and_count gate_text_names_the_p0_policy_in_force"
+- id: "PO-F3"
+  statement: "With colours forced for the thread, the list table header, the mcp manifest notice, the quality-gates validate verdict and the cuda-tdg score, gate and kaizen text carry an ANSI escape, and with colours off they are byte-identical to the pre-fix output"
+  evidence_method: "env -u RUST_MIN_STACK cargo test --lib -- table_header_carries_colour_when_forced manifest_notice_carries_colour_when_forced manifest_notice_is_plain_when_colours_are_off validation_verdict_carries_colour_when_forced validation_verdict_is_plain_when_colours_are_off score_gate_and_kaizen_text_carry_colour_when_forced"
+- id: "PO-F4"
+  statement: "The sweep classifies a refusal that names its precondition (the ledger writers' dirty-tree refusal, clap's missing-companion-flag error) as Refuses, and the Large corpus carries a broken relative link, an ADR directory, a two-task current sprint and a seeded trend store with one rising and one falling series inside the 30-day window"
+  evidence_method: "env -u RUST_MIN_STACK cargo test --test all -- precondition_refusals_are_honest large_corpus_carries_the_flag_fixtures allowed_noops_name_a_real_effect"
+- id: "PO-F5"
+  statement: "make gate-flag-efficacy-full exits 0 on this tree with 0 no-op and 0 error-out rows in its summary line; the RED side is the same sweep on 62562ccd9 (v3.39.0): 18 no-op, 4 error-out, exit 1"
+  evidence_method: "make gate-flag-efficacy-full && grep -E '^summary: .* 0 no-op, 0 error-out' /tmp/pmat-flag-efficacy-report.txt"
+falsifiable_claims:
+- hypothesis: "--failures-only on popper-score and demo-score is the display filter its sibling score commands implement: a category or subcategory at or above the 80% pass line is not rendered in text or markdown, everything below it is, and popper's recommendations stay whatever the gateway said"
+  method: "env -u RUST_MIN_STACK cargo test --lib -- failures_only_text_keeps_only_failing_checks failures_only_verbose_keeps_only_failing_sub_scores failures_only_markdown_keeps_only_failing_checks failures_only_hides_passing_subcategories_in_text failures_only_hides_passing_subcategories_in_markdown"
+  from_step: "F1"
+- hypothesis: "roadmap todos names the format it wrote and the todo count on its confirmation line, and cuda-tdg gate names the P0 policy in force in its text report, so --include-quality-gates and --fail-on-p0 are visible on stdout and not only in a file or a verdict that already fails"
+  method: "env -u RUST_MIN_STACK cargo test --lib -- todos_written_line_names_the_format_and_count gate_text_names_the_p0_policy_in_force"
+  from_step: "F2"
+- hypothesis: "With colours forced for the thread, the list table header, the mcp manifest notice, the quality-gates validate verdict and the cuda-tdg score, gate and kaizen text carry an ANSI escape, and with colours off they are byte-identical to the pre-fix output"
+  method: "env -u RUST_MIN_STACK cargo test --lib -- table_header_carries_colour_when_forced manifest_notice_carries_colour_when_forced manifest_notice_is_plain_when_colours_are_off validation_verdict_carries_colour_when_forced validation_verdict_is_plain_when_colours_are_off score_gate_and_kaizen_text_carry_colour_when_forced"
+  from_step: "F3"
+- hypothesis: "The sweep classifies a refusal that names its precondition (the ledger writers' dirty-tree refusal, clap's missing-companion-flag error) as Refuses, and the Large corpus carries a broken relative link, an ADR directory, a two-task current sprint and a seeded trend store with one rising and one falling series inside the 30-day window"
+  method: "env -u RUST_MIN_STACK cargo test --test all -- precondition_refusals_are_honest large_corpus_carries_the_flag_fixtures allowed_noops_name_a_real_effect"
+  from_step: "F4"
+- hypothesis: "make gate-flag-efficacy-full exits 0 on this tree with 0 no-op and 0 error-out rows in its summary line; the RED side is the same sweep on 62562ccd9 (v3.39.0): 18 no-op, 4 error-out, exit 1"
+  method: "make gate-flag-efficacy-full && grep -E '^summary: .* 0 no-op, 0 error-out' /tmp/pmat-flag-efficacy-report.txt"
+  from_step: "F5"

--- a/docs/audits/impl-PMAT-688-receipt.md
+++ b/docs/audits/impl-PMAT-688-receipt.md
@@ -1,0 +1,80 @@
+# impl receipt — PMAT-688: flag-efficacy release gate RED on the 3.39.0 tree
+
+**Ticket:** PMAT-688 (kind:code, p=high, deferred:3.40.0) · **Branch:** `PMAT-688-flag-efficacy` cut from origin/master d90a3c901 · **Orchestrator:** Fable (paiml-implement, direct routing; 1 agy teamwork lane on the plan, 3 quorum lanes on the diff) · **gate_cmd_fallback=true** (discovery: `cargo test --workspace`; `pmat verify` used as the real gate).
+
+## What was red
+
+`make gate-flag-efficacy-full` on 62562ccd9 (v3.39.0), report `/tmp/pmat-flag-efficacy-report.txt`:
+
+```
+summary: 584 effective, 4 refuses-honestly, 18 no-op, 4 error-out, 369 skipped
+```
+
+The gate asserts `noops.is_empty()` (flag_efficacy.rs) — 18 rows failed it. Error-outs are listed, never asserted; the ticket asked for them to be reclassified anyway because a dirty-tree refusal is documented behaviour.
+
+## Root causes, each reproduced by hand
+
+Every row below was reproduced on a dumped Large corpus (`PMAT_CORPUS_OUT=… cargo test --test all -- --ignored dump_corpus`) with the installed 3.39.0 binary, `--color auto` vs `--color always` for the colour rows (stdout/stderr md5 + exit), before any code was touched.
+
+| flag | measured cause | fix |
+|---|---|---|
+| `list --color` | box table, no colourable element | header cells through `colors::label`, padded before colouring so the box does not move (`render_table`, extracted from `print_table`) |
+| `mcp manifest --color` | two plain `println!`s | notice extracted to `manifest_notice`; hint dimmed, success green |
+| `prompt comply/book/repo-image --color` | stdout IS the YAML prompt (21,724 / 25,057 / 14,166 B) | ALLOWED_NOOPS with the measured reason — an escape would corrupt the artifact |
+| `roadmap todos --color`, `--include-quality-gates` | baseline failed on the corpus (no `docs/execution/roadmap.md`) with the 🔄 banner already on stdout, so the harness's "not a control" guard never fired; the flag only changed the written file (222 B vs 3,651 B) | corpus roadmap (2-task current sprint); confirmation line names the format and count, ✅ coloured |
+| `validate-docs --fail-on-error` | wired (exit 1 iff broken_links > 0), corpus had no broken link | `docs/links.md` with one broken relative link |
+| `popper-score --failures-only` | read only as `verbose && !failures_only` and `failures_only && gateway_passed` | the sibling display filter (repo-score `keep_category`, infra-score, rust-project-score): rows ≥ 80% hidden, text + markdown, verbose sub-scores too; recommendations stay. Corpus gains `docs/adr/` (transparency C3, +4) so one category sits above the line |
+| `demo-score --failures-only` | only filtered findings, only under `--verbose` | subcategories ≥ 80% hidden in text and markdown |
+| `show-metrics --failures-only` | wired, corpus had no trend store | corpus seeds `.pmat-metrics/trends/{lint,test-fast}.json` (8 daily points, rising / falling, p < 0.05) |
+| `quality-gates validate --color` | plain `println!` | verdict extracted to `validation_verdict`, coloured |
+| `quality-gates show --color` | prints the config as TOML/JSON | ALLOWED_NOOPS (artifact) |
+| `cuda-tdg score --color` | plain one-liner | grade through the existing `grade_color`, gateway coloured |
+| `cuda-tdg report --color` | default `--format markdown` renders a document | ALLOWED_NOOPS (artifact) |
+| `cuda-tdg gate --color`, `--fail-on-p0` | plain text; the corpus gate already fails (gateway FAILED, 0 P0) so the policy could change nothing visible | `P0 policy:` line (and `fail_on_p0` in JSON), PASSED/FAILED coloured |
+| `cuda-tdg kaizen --color` | plain text | header through `colors::header` |
+| `analyze reachability/unrun-tests --write-ledger`, `--allow-dirty` (error-out ×4) | "refusing to write … from a dirty git tree … or pass --allow-dirty" (exit 1); clap "the following required arguments were not provided: --write-ledger" (exit 2, the flag `requires` it) | `is_honest_refusal` accepts a refusal that names its precondition ⇒ `Verdict::Refuses` |
+
+Also: four ALLOWED_NOOPS entries the report listed as "not exercised" were verified **effective** by hand and deleted (`analyze proof-annotations --color`, `analyze deep-context --quiet`, `comply report --quiet`, `comply check --strict`); the other 13 still reproduce as no-ops and stay.
+
+## RED → GREEN
+
+- RED commit 27ef50ee3: 13 lib tests + 2 harness tests, all failing at that commit (`cargo test --lib -- failures_only_ gate_text_names_the_p0 … table_header_carries`: 10 FAILED; `cargo test --test all -- precondition_refusals_are_honest large_corpus_carries_the_flag_fixtures`: 2 FAILED). The four confirmation lines were extracted into pure fns in the same commit, behaviour-preserving, so the bytes could be asserted on.
+- GREEN commit e7e36afcf: the same tests: `test result: ok. 20 passed` (lib, incl. 7 pre-existing `failures_only` tests of the sibling commands) and 3/3 harness.
+- Discrimination beyond assertion: the popper verbose test first failed against the *fixture* (`add_sub_score` adds the sub-score's points to the category and pushed B onto the pass line); the fixture, not the filter, was corrected.
+
+## The sweep found two more
+
+First full sweep on e7e36afcf (`make gate-flag-efficacy-full`, 17:56–18:15Z):
+
+```
+summary: 593 effective, 8 refuses-honestly, 2 no-op, 0 error-out, 369 skipped
+```
+
+- The four deleted allow-list entries did not come back as no-ops (they were effective, as measured).
+- `validate-docs --fail-on-error` stayed a no-op: the arg was `bool` with `default_value = "true"`, a switch that can never change anything; the branch binary already exited 1 on the corpus's broken link without it. Fixed as a real switch (`ArgAction::Set`, `num_args = 0..=1`, default true, `--fail-on-error false` opts out); the help advertises `[possible values: true, false]` so the sweep probes both. Verified with the freshly built binary on the dumped corpus: bare / `true` → exit 1, `false` → exit 0.
+- `roadmap status --color` appeared: once the corpus carried a roadmap the command became reachable and its table went through no colour helper. Sprint and task headers now go through `colors::header`; json/csv/markdown are asserted escape-free.
+- RED df0daad38 (both tests failing), GREEN 64257712a.
+
+## Acceptance (Fable re-ran every command)
+
+Second full sweep on 64257712a (`make gate-flag-efficacy-full`, 18:26–18:44Z, 659 s, exit 0):
+
+```
+summary: 612 effective, 8 refuses-honestly, 0 no-op, 0 error-out, 373 skipped
+```
+
+against the 3.39.0 baseline `584 effective, 4 refuses-honestly, 18 no-op, 4 error-out, 369 skipped`. The four ledger-writer rows now sit under REFUSES HONESTLY. Skips moved 369 → 373 because two commands the first sweep skipped whole as "nondeterministic baseline" (`comply report *`, `show-metrics *`) became checkable — the seeded trend store made `show-metrics` deterministic — and each now carries three per-flag "needs a value" skips while its other flags are measured. 13 allow-list entries are still "not exercised" (their commands are skipped in the sweep); each was re-verified by hand on the corpus and still reproduces as a no-op, so they stay.
+
+Reports kept: sweep 1 and sweep 2 under the session scratchpad (`report-sweep1.txt`, `report-sweep2.txt`); the RED baseline is the report the ticket cites.
+
+`make gate-differential` (the other gate sharing `build_corpus`): `test result: ok` (57 s, 18:45–18:53Z) — the seeded fixtures did not move any constant-leaf classification.
+
+## Quorum
+
+QUORUM_PLACEHOLDER
+
+## Gate
+
+GATE_PLACEHOLDER
+
+IMPL-PMAT-688-RECEIPT-END

--- a/docs/audits/impl-PMAT-688-receipt.md
+++ b/docs/audits/impl-PMAT-688-receipt.md
@@ -69,12 +69,32 @@ Reports kept: sweep 1 and sweep 2 under the session scratchpad (`report-sweep1.t
 
 `make gate-differential` (the other gate sharing `build_corpus`): `test result: ok` (57 s, 18:45–18:53Z) — the seeded fixtures did not move any constant-leaf classification.
 
-## Quorum
+## Quorum (agy, `--mode plan`, width 3, review-only) on 4be6be1e8
 
-QUORUM_PLACEHOLDER
+Lanes 5a29c43b-abc7-4c34-9d44-162a797f260a, 4260e6cf-4562-4ca2-b37b-f9a8bd9eaae0, 7e26446c-345f-476f-a979-7bc5871801a9 — **3/3 needs-changes**, no lane said merge-as-is. Findings and what happened to each:
+
+| # | finding | lanes | disposition |
+|---|---|---|---|
+| 1 | **BLOCKER** — the `_` arms of cuda-tdg score, gate and kaizen were now coloured, so `--format markdown` and `--format sarif` gained ANSI escapes whenever colour was on (`cuda_tdg_handlers_format_score.rs`, `cuda_tdg_handlers_gate_kaizen.rs`); the receipt's own "no machine format gained an escape" row was false | 2 + delegate's own check | **fixed fffcc8845**: colour scoped to `CudaTdgOutputFormat::Terminal`; the test asserts a Sarif config never carries an escape |
+| 2 | **MAJOR** — classifying clap's "required arguments were not provided" as an honest refusal converts a sweep that never supplied the `requires` companion into a PASS | 2 of 3 (lane 1 dissented: `baseline.succeeded()` is the control) | **fixed fffcc8845**: phrase dropped; `--allow-dirty` on both ledger writers gets a `PROBE_CONTEXT` of `--write-ledger`, so the flag is probed in context (dirty tree ⇒ the control refuses ⇒ an honest skip; clean ⇒ both write); "refusing to" stays, the ledger writers name `--allow-dirty` in it |
+| 3 | "a new `unwrap()` at commands_status_tests.rs:166" | 2 | **refuted by the delegate**: an unchanged context line; 0 added `unwrap(`/`panic!(` under src/ |
+| 4 | the `P0 policy:` line and the todos format line are "echoes" that exist to satisfy the sweep | 2 of 3 on the P0 line | kept: `fail_on_p0` does change `passes_quality_gate` (scoring_calculation.rs:172-188); on a tree that already fails the only honest observable is to say which policy was applied, exactly as `Minimum Required` is printed. The todos line is the one place the terminal can show which document was written |
+| 5 | Q4(b): no lane opened the trend-store *reader* | delegate | measured before the quorum: `metric_trends_io.rs::load` parses `Vec<MetricObservation>` from `<metric>.json`, and `show-metrics --failures-only` on the seeded corpus copy dropped the improving series by hand |
+
+Agreed sound across all three lanes: the `--failures-only` display-filter semantics match `keep_category`; `--fail-on-error false` is a backwards-compatible `ArgAction::Set` switch with no positional to swallow; the five allow-list entries are artifact outputs; `render_table` pads before colouring; the corpus fixtures are gated to `CorpusSize::Large`. The delegate also verified every changed test file is compiled (no orphan risk).
+
+Third full sweep after the fixes (18503f90f): `make gate-flag-efficacy-full` 19:27–19:44Z, 637 s, exit 0:
+
+```
+summary: 595 effective, 6 refuses-honestly, 0 no-op, 0 error-out, 371 skipped
+```
+
+Row for row against sweep 2: the two `--allow-dirty` flags moved from REFUSES HONESTLY to SKIPPED with the reason the probe context predicts (`probe context ["--write-ledger"]: baseline exited 1 with empty stdout; the command failed before any flag was read, so it is not a control` — the tree is dirty by then, so the control refuses), and `comply report *` / `show-metrics *` flipped back to whole-command `[nondeterministic baseline]` skips, exactly as in the 3.39.0 sweep; that removes their 21 per-flag rows (hence 612 → 595 effective) and means `show-metrics --failures-only` was measured Effective in sweep 2 only. By hand two consecutive `show-metrics` runs on the dumped corpus are byte-identical, so the flip is between the harness's two baseline runs, not in the command; filed as **PMAT-690**. No sweep since the fix has booked a no-op or an error-out.
 
 ## Gate
 
-GATE_PLACEHOLDER
+`pmat verify --format json` on 4be6be1e8 read `ok: false`: the `tests` stage failed on three `documentation_scorer` tests and the unrun-tests ledger drift. The ledger was regenerated with the branch binary (18503f90f; the first regeneration used the installed 3.39.0 before two tests were added). The three scorer tests fail on **every** tree right now: `score_changelog` also reads `project_path.parent()/CHANGELOG.md`, and another session left a 216 KB `/tmp/CHANGELOG.md` at 19:17 local, so a `TempDir` under `/tmp` scores it. Not this branch's file to delete; filed as **PMAT-689** (test isolation). The gate below was re-run with `TMPDIR` pointed at an empty directory so the tests measure their own fixture.
+
+`TMPDIR=/tmp/tmpx pmat verify --format json` on 18503f90f: `ok: null` (no verdict — complexity declined: "no Rust files changed vs HEAD, so nothing was measured" on a clean tree), `stages_measured: 4`, format ✓ satd ✓ clippy ✓ tests ✓ (`cargo test --lib`: 21,255 passed, 0 failed, 154 ignored, 359 s). The same gate with the session scratchpad as TMPDIR failed two other tests on the path alone (`comprehensive_refusal_names_the_quality_score` sees digits in the temp path as a score; `test_collect_files_with_include_filter` matches a path component) — both pass under the neutral directory and neither is touched by this branch. Complexity for the branch is CI's `pmat score` / `ci / gate` to judge; PR #1209.
 
 IMPL-PMAT-688-RECEIPT-END

--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -4501,11 +4501,11 @@ roadmap:
   github_issue: null
   item_type: task
   title: 'flag-efficacy release gate is RED on the 3.39.0 tree: 18 no-op flags (14x --color on report commands, --fail-on-error, --failures-only x3, --include-quality-gates, --fail-on-p0) and 4 ''error-out'' entries that are the ledger writers refusing the sweep''s dirty corpus'
-  status: inprogress
+  status: completed
   priority: high
   assigned_to: null
   created: 2026-09-06T14:59:43Z
-  updated: 2026-09-06T17:09:57.540360852+00:00
+  updated: 2026-09-06T20:14:38Z
   spec: null
   acceptance_criteria:
   - 'make gate-flag-efficacy-full on 62562ccd9: summary 584 effective, 4 refuses-honestly, 18 no-op, 4 error-out, 369 skipped; report /tmp/pmat-flag-efficacy-report.txt. None of the 22 flags was touched by 3.39.0 (verify: the same gate on v3.38.0 in a detached worktree, log gate-fe-3380). Falsifier: each no-op flag changes observable output on the corpus or refuses honestly; the two --write-ledger/--allow-dirty pairs are re-classified by the harness (a refusal on a dirty tree is the documented behaviour, not an error-out); the sweep then exits 0.'

--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -4549,3 +4549,19 @@ roadmap:
   estimated_effort: null
   labels: []
   notes: null
+- id: PMAT-690
+  github_issue: null
+  item_type: task
+  title: 'flag-efficacy sweep: show-metrics and comply report baselines are intermittently nondeterministic — skipped whole as [nondeterministic baseline] in the 3.39.0 sweep and in PMAT-688 sweep 3, but checked flag-by-flag in PMAT-688 sweep 2 (show-metrics --failures-only Effective there); by hand two consecutive show-metrics runs on the dumped corpus are byte-identical. Find what changes between the harness''s two baseline runs (a concurrent writer to .pmat-metrics/trends, or PageRank hotness) and pin it, so the two commands'' 21 flags are measured every sweep'
+  status: planned
+  priority: low
+  assigned_to: null
+  created: 2026-09-06T19:45:30Z
+  updated: 2026-09-06T19:45:30Z
+  spec: null
+  acceptance_criteria: []
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels: []
+  notes: null

--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -4501,11 +4501,11 @@ roadmap:
   github_issue: null
   item_type: task
   title: 'flag-efficacy release gate is RED on the 3.39.0 tree: 18 no-op flags (14x --color on report commands, --fail-on-error, --failures-only x3, --include-quality-gates, --fail-on-p0) and 4 ''error-out'' entries that are the ledger writers refusing the sweep''s dirty corpus'
-  status: planned
+  status: inprogress
   priority: high
   assigned_to: null
   created: 2026-09-06T14:59:43Z
-  updated: 2026-09-06T14:59:43Z
+  updated: 2026-09-06T17:09:57.540360852+00:00
   spec: null
   acceptance_criteria:
   - 'make gate-flag-efficacy-full on 62562ccd9: summary 584 effective, 4 refuses-honestly, 18 no-op, 4 error-out, 369 skipped; report /tmp/pmat-flag-efficacy-report.txt. None of the 22 flags was touched by 3.39.0 (verify: the same gate on v3.38.0 in a detached worktree, log gate-fe-3380). Falsifier: each no-op flag changes observable output on the corpus or refuses honestly; the two --write-ledger/--allow-dirty pairs are re-classified by the harness (a refusal on a dirty tree is the documented behaviour, not an error-out); the sweep then exits 0.'

--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -4533,3 +4533,19 @@ roadmap:
   estimated_effort: null
   labels: []
   notes: null
+- id: PMAT-689
+  github_issue: null
+  item_type: task
+  title: 'documentation_scorer tests score the temp dir''s PARENT: score_changelog looks at project_path.parent()/CHANGELOG.md, so a stray /tmp/CHANGELOG.md (216 KB, left by another session 2026-09-06 19:17 local) fails test_changelog_missing, test_changelog_minimal and test_recommendations_empty_project on every tree; isolate the tests (TMPDIR-independent fixture root) or scope the workspace lookup to a real Cargo workspace'
+  status: planned
+  priority: low
+  assigned_to: null
+  created: 2026-09-06T19:21:25Z
+  updated: 2026-09-06T19:21:25Z
+  spec: null
+  acceptance_criteria: []
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels: []
+  notes: null

--- a/docs/status/orphan-files-ledger.md
+++ b/docs/status/orphan-files-ledger.md
@@ -21,7 +21,7 @@ the first two buckets and may only fall. To move a file out, register it
 (edit the row to `registered-<target>`) or delete it (`deleted-<reason>`) in the
 same change; do not edit counts by hand.
 
-4444 tracked `.rs` files: 3955 reachable from 137 target root(s), 407 orphaned (126920 lines, 6294 `#[test]` fns), 82 quarantined (35891 lines, 2021 `#[test]` fns).
+4444 tracked `.rs` files: 3955 reachable from 137 target root(s), 407 orphaned (126920 lines, 6294 `#[test]` fns), 82 quarantined (35910 lines, 2022 `#[test]` fns).
 
 | `path` | reason | tests | lines |
 |---|---|---|---|
@@ -149,7 +149,7 @@ same change; do not edit counts by hand.
 | `src/qdd/generator_core.rs` | pending-#1017 | 2 | 343 |
 | `src/qdd/generator_doc.rs` | pending-#1017 | 0 | 123 |
 | `src/qdd/generator_tests.rs` | pending-#1017 | 33 | 819 |
-| `src/roadmap/commands/tests.rs` | quarantined-#1023 | 9 | 178 |
+| `src/roadmap/commands/tests.rs` | quarantined-#1023 | 10 | 197 |
 | `src/roadmap/commands/tests_basic.rs` | pending-#1017 | 9 | 170 |
 | `src/roadmap/commands/tests_part2.rs` | quarantined-#1023 | 22 | 470 |
 | `src/roadmap/commands/tests_part3.rs` | quarantined-#1023 | 19 | 490 |

--- a/docs/status/unrun-tests-ledger.md
+++ b/docs/status/unrun-tests-ledger.md
@@ -14,9 +14,9 @@ Legs consulted (3):
 - `feature-matrix.yml:feature-tests[mcp-integration]`
 - `feature-matrix.yml:feature-tests[unified-protocol]`
 
-23784 of 27012 lib tests are executed; 3228 are compiled by no leg.
+23797 of 27026 lib tests are executed; 3229 are compiled by no leg.
 
-## `<unsatisfiable>` — 2199 test(s)
+## `<unsatisfiable>` — 2200 test(s)
 
 NOT a clean bill of health — the strongest finding in this ledger, and it grew from 18 to 2199 without a single test changing. #1023 moved the `broken-tests` quarantine from a Cargo FEATURE to the cfg flag `pmat_broken_tests`, and that reclassified 2181 tests out of five `broken-tests,*` buckets into this one. The old buckets read as 'enable this feature and they run', which was never true — the bodies do not compile. `<unsatisfiable>` says what is actually the case. Of the original 18: 14 are `#[cfg(all(feature = "F", not(feature = "F")))]` — a `test_..._without_feature` body written to cover the feature-OFF branch, placed inside a module already gated ON that feature — and 4 are `#[cfg(any())]`, which is `false` by definition. No `--features` invocation can compile any of these; only moving the bodies out of the gated module can. The 2181 quarantined ones need their tests repaired or deleted, which is #1023's remaining work.
 
@@ -1426,6 +1426,7 @@ crate::roadmap::commands::tests::tests::test_priority_from_str
 crate::roadmap::commands::tests::tests::test_roadmap_command_parsing
 crate::roadmap::commands::tests::tests::test_start_subcommand_parsing
 crate::roadmap::commands::tests::tests::test_todos_subcommand_parsing
+crate::roadmap::commands::tests::tests::todos_written_line_names_the_format_and_count
 crate::roadmap::commands::tests_part2::coverage_tests_part1::test_complete_subcommand_defaults
 crate::roadmap::commands::tests_part2::coverage_tests_part1::test_complete_task_with_skip_quality_check
 crate::roadmap::commands::tests_part2::coverage_tests_part1::test_init_sprint_adds_to_existing_roadmap

--- a/docs/status/unrun-tests-ledger.md
+++ b/docs/status/unrun-tests-ledger.md
@@ -14,7 +14,7 @@ Legs consulted (3):
 - `feature-matrix.yml:feature-tests[mcp-integration]`
 - `feature-matrix.yml:feature-tests[unified-protocol]`
 
-23797 of 27026 lib tests are executed; 3229 are compiled by no leg.
+23799 of 27028 lib tests are executed; 3229 are compiled by no leg.
 
 ## `<unsatisfiable>` — 2200 test(s)
 

--- a/src/cli/analysis_utilities/string_utils.rs
+++ b/src/cli/analysis_utilities/string_utils.rs
@@ -272,9 +272,16 @@ pub fn params_to_json(
 #[provable_contracts_macros::contract("pmat-core.yaml", equation = "check_compliance")]
 /// Print table.
 pub fn print_table(items: &[std::sync::Arc<crate::models::template::TemplateResource>]) {
+    print!("{}", render_table(items));
+}
+
+/// Render the `pmat list` table exactly as `print_table` prints it (every
+/// line newline-terminated), so the bytes can be asserted on.
+pub fn render_table(items: &[std::sync::Arc<crate::models::template::TemplateResource>]) -> String {
+    use std::fmt::Write as _;
+
     if items.is_empty() {
-        println!("No templates found.");
-        return;
+        return "No templates found.\n".to_string();
     }
 
     // Calculate column widths
@@ -296,16 +303,18 @@ pub fn print_table(items: &[std::sync::Arc<crate::models::template::TemplateReso
     category_width += 2;
     desc_width += 2;
 
-    // Print header
-    println!(
+    let mut out = String::new();
+    // Header
+    let _ = writeln!(
+        out,
         "┌{}┬{}┬{}┬{}┐",
         "─".repeat(name_width),
         "─".repeat(toolchain_width),
         "─".repeat(category_width),
         "─".repeat(desc_width)
     );
-
-    println!(
+    let _ = writeln!(
+        out,
         "│{:^name_width$}│{:^toolchain_width$}│{:^category_width$}│{:^desc_width$}│",
         "Name",
         "Toolchain",
@@ -316,8 +325,8 @@ pub fn print_table(items: &[std::sync::Arc<crate::models::template::TemplateReso
         category_width = category_width,
         desc_width = desc_width
     );
-
-    println!(
+    let _ = writeln!(
+        out,
         "├{}┼{}┼{}┼{}┤",
         "─".repeat(name_width),
         "─".repeat(toolchain_width),
@@ -325,7 +334,7 @@ pub fn print_table(items: &[std::sync::Arc<crate::models::template::TemplateReso
         "─".repeat(desc_width)
     );
 
-    // Print rows
+    // Rows
     for item in items {
         let toolchain = item.toolchain.as_str();
         let category = format!("{:?}", item.category);
@@ -336,7 +345,8 @@ pub fn print_table(items: &[std::sync::Arc<crate::models::template::TemplateReso
             description
         };
 
-        println!(
+        let _ = writeln!(
+            out,
             "│{:<name_width$}│{:<toolchain_width$}│{:<category_width$}│{:<desc_width$}│",
             format!(" {} ", item.name),
             format!(" {} ", toolchain),
@@ -349,14 +359,80 @@ pub fn print_table(items: &[std::sync::Arc<crate::models::template::TemplateReso
         );
     }
 
-    // Print footer
-    println!(
+    // Footer
+    let _ = writeln!(
+        out,
         "└{}┴{}┴{}┴{}┘",
         "─".repeat(name_width),
         "─".repeat(toolchain_width),
         "─".repeat(category_width),
         "─".repeat(desc_width)
     );
+    out
+}
+
+#[cfg(test)]
+mod render_table_tests {
+    use super::render_table;
+    use crate::models::template::{
+        ParameterSpec, ParameterType, TemplateCategory, TemplateResource, Toolchain,
+    };
+    use std::sync::Arc;
+
+    fn template() -> Arc<TemplateResource> {
+        Arc::new(TemplateResource {
+            uri: "template://makefile/rust/cli".to_string(),
+            category: TemplateCategory::Makefile,
+            toolchain: Toolchain::RustCli {
+                cargo_features: vec![],
+            },
+            name: "Rust CLI Binary Makefile".to_string(),
+            description: "Makefile for Rust CLI applications".to_string(),
+            parameters: vec![ParameterSpec {
+                name: "project_name".to_string(),
+                param_type: ParameterType::String,
+                required: true,
+                default_value: None,
+                description: "Project name".to_string(),
+                validation_pattern: None,
+            }],
+            content_hash: "hash123".to_string(),
+            semantic_version: semver::Version::new(1, 0, 0),
+            dependency_graph: vec![],
+            s3_object_key: "templates/makefile/rust/cli.hbs".to_string(),
+        })
+    }
+
+    /// PMAT-688: `pmat list --color always` emitted the same bytes as
+    /// `--color auto` — the box table had no colourable element. The header
+    /// cells are the colourable element; the box characters and the cell
+    /// widths must not move when colour is on.
+    #[test]
+    fn table_header_carries_colour_when_forced() {
+        let items = [template()];
+        let plain = {
+            let _off = crate::cli::colors::ForcedColor::off();
+            render_table(&items)
+        };
+        let coloured = {
+            let _on = crate::cli::colors::ForcedColor::on();
+            render_table(&items)
+        };
+        assert!(!plain.contains("\x1b["), "{plain}");
+        assert!(coloured.contains("\x1b["), "{coloured}");
+        let header = coloured.lines().nth(1).expect("header row");
+        assert!(header.contains("Name") && header.contains("\x1b["), "{header:?}");
+        // Strip the escapes and the two renderings must agree byte for byte.
+        let stripped = regex::Regex::new("\x1b\\[[0-9;]*m")
+            .expect("static regex must compile")
+            .replace_all(&coloured, "");
+        assert_eq!(stripped, plain, "colour must add escapes only");
+    }
+
+    #[test]
+    fn empty_table_says_so() {
+        assert_eq!(render_table(&[]), "No templates found.\n");
+    }
 }
 
 // Deleted estimate_cyclomatic_complexity - using proper AST analysis instead

--- a/src/cli/analysis_utilities/string_utils.rs
+++ b/src/cli/analysis_utilities/string_utils.rs
@@ -313,17 +313,16 @@ pub fn render_table(items: &[std::sync::Arc<crate::models::template::TemplateRes
         "─".repeat(category_width),
         "─".repeat(desc_width)
     );
+    // Pad first, then colour: an escape inside the `{:^width$}` cell would
+    // count against the width and move the box (PMAT-688).
+    let cell = |text: &str, width: usize| crate::cli::colors::label(&format!("{text:^width$}"));
     let _ = writeln!(
         out,
-        "│{:^name_width$}│{:^toolchain_width$}│{:^category_width$}│{:^desc_width$}│",
-        "Name",
-        "Toolchain",
-        "Category",
-        "Description",
-        name_width = name_width,
-        toolchain_width = toolchain_width,
-        category_width = category_width,
-        desc_width = desc_width
+        "│{}│{}│{}│{}│",
+        cell("Name", name_width),
+        cell("Toolchain", toolchain_width),
+        cell("Category", category_width),
+        cell("Description", desc_width)
     );
     let _ = writeln!(
         out,

--- a/src/cli/handlers/cuda_tdg_handlers_format_score.rs
+++ b/src/cli/handlers/cuda_tdg_handlers_format_score.rs
@@ -58,16 +58,19 @@ fn format_analysis(result: &CudaSimdTdgResult, config: &CudaTdgCommandConfig) ->
 fn format_score_summary(score: &PopperScore, config: &CudaTdgCommandConfig) -> Result<String> {
     match config.format {
         CudaTdgOutputFormat::Json => Ok(serde_json::to_string_pretty(score)?),
-        _ => Ok(format!(
-            "{:.1}/100 (Grade: {}, Gateway: {})",
-            score.total,
-            score.grade,
-            if score.gateway_passed {
-                "PASSED"
-            } else {
-                "FAILED"
-            }
-        )),
+        _ => {
+            use crate::cli::colors as c;
+            Ok(format!(
+                "{:.1}/100 (Grade: {}, Gateway: {})",
+                score.total,
+                c::colored(grade_color(&score.grade), &score.grade.to_string()),
+                if score.gateway_passed {
+                    c::colored(c::GREEN, "PASSED")
+                } else {
+                    c::colored(c::RED, "FAILED")
+                }
+            ))
+        }
     }
 }
 

--- a/src/cli/handlers/cuda_tdg_handlers_format_score.rs
+++ b/src/cli/handlers/cuda_tdg_handlers_format_score.rs
@@ -58,7 +58,9 @@ fn format_analysis(result: &CudaSimdTdgResult, config: &CudaTdgCommandConfig) ->
 fn format_score_summary(score: &PopperScore, config: &CudaTdgCommandConfig) -> Result<String> {
     match config.format {
         CudaTdgOutputFormat::Json => Ok(serde_json::to_string_pretty(score)?),
-        _ => {
+        // Only the terminal format may carry colour; markdown and sarif are
+        // documents and stay plain whatever `--color` says (PMAT-688 quorum).
+        CudaTdgOutputFormat::Terminal => {
             use crate::cli::colors as c;
             Ok(format!(
                 "{:.1}/100 (Grade: {}, Gateway: {})",
@@ -71,6 +73,16 @@ fn format_score_summary(score: &PopperScore, config: &CudaTdgCommandConfig) -> R
                 }
             ))
         }
+        _ => Ok(format!(
+            "{:.1}/100 (Grade: {}, Gateway: {})",
+            score.total,
+            score.grade,
+            if score.gateway_passed {
+                "PASSED"
+            } else {
+                "FAILED"
+            }
+        )),
     }
 }
 

--- a/src/cli/handlers/cuda_tdg_handlers_gate_kaizen.rs
+++ b/src/cli/handlers/cuda_tdg_handlers_gate_kaizen.rs
@@ -35,8 +35,9 @@ async fn handle_gate(
             "p0_defects": result.defects.iter()
                 .filter(|d| d.defect_class.severity == DefectSeverity::P0Critical)
                 .count(),
+            "fail_on_p0": fail_on_p0,
         }))?,
-        _ => format_gate_text(&result, passes, min_score),
+        _ => format_gate_text(&result, passes, min_score, fail_on_p0),
     };
 
     write_output(&output, config)?;
@@ -48,7 +49,24 @@ async fn handle_gate(
     Ok(())
 }
 
-fn format_gate_text(result: &CudaSimdTdgResult, passes: bool, min_score: f64) -> String {
+/// The P0 policy the gate applied, named so the report explains its own
+/// verdict (PMAT-688): on a tree that already fails, `--fail-on-p0` changes
+/// nothing else the reader can see.
+fn p0_policy_line(fail_on_p0: bool) -> &'static str {
+    if fail_on_p0 {
+        "P0 policy: fail on any P0 defect (--fail-on-p0)"
+    } else {
+        "P0 policy: advisory (P0 defects are reported, not gated)"
+    }
+}
+
+fn format_gate_text(
+    result: &CudaSimdTdgResult,
+    passes: bool,
+    min_score: f64,
+    fail_on_p0: bool,
+) -> String {
+    use crate::cli::colors as c;
     let mut output = String::new();
     output.push_str("CUDA-TDG Quality Gate\n");
     output.push_str("=====================\n\n");
@@ -57,12 +75,14 @@ fn format_gate_text(result: &CudaSimdTdgResult, passes: bool, min_score: f64) ->
         result.score.total, result.score.grade
     ));
     output.push_str(&format!("Minimum Required: {:.1}\n", min_score));
+    output.push_str(p0_policy_line(fail_on_p0));
+    output.push('\n');
     output.push_str(&format!(
         "Gateway (Falsifiability): {}\n",
         if result.score.gateway_passed {
-            "PASSED"
+            c::colored(c::GREEN, "PASSED")
         } else {
-            "FAILED"
+            c::colored(c::RED, "FAILED")
         }
     ));
 
@@ -74,7 +94,7 @@ fn format_gate_text(result: &CudaSimdTdgResult, passes: bool, min_score: f64) ->
     output.push_str(&format!("P0 Critical Defects: {}\n\n", p0_count));
     output.push_str(&format!(
         "Result: {}\n",
-        if passes { "PASSED" } else { "FAILED" }
+        if passes { c::colored(c::GREEN, "PASSED") } else { c::colored(c::RED, "FAILED") }
     ));
     output
 }
@@ -161,7 +181,10 @@ fn format_kaizen_markdown(result: &CudaSimdTdgResult) -> String {
 
 fn format_kaizen_text(result: &CudaSimdTdgResult) -> String {
     let mut output = String::new();
-    output.push_str("Kaizen Continuous Improvement Report\n");
+    output.push_str(&crate::cli::colors::header(
+        "Kaizen Continuous Improvement Report",
+    ));
+    output.push('\n');
     output.push_str("====================================\n\n");
     output.push_str(&format!(
         "Tickets Resolved: {}\n",

--- a/src/cli/handlers/cuda_tdg_handlers_gate_kaizen.rs
+++ b/src/cli/handlers/cuda_tdg_handlers_gate_kaizen.rs
@@ -37,7 +37,12 @@ async fn handle_gate(
                 .count(),
             "fail_on_p0": fail_on_p0,
         }))?,
-        _ => format_gate_text(&result, passes, min_score, fail_on_p0),
+        // Only the terminal format may carry colour; markdown and sarif stay
+        // plain whatever `--color` says (PMAT-688 quorum).
+        CudaTdgOutputFormat::Terminal => {
+            format_gate_text(&result, passes, min_score, fail_on_p0, true)
+        }
+        _ => format_gate_text(&result, passes, min_score, fail_on_p0, false),
     };
 
     write_output(&output, config)?;
@@ -65,8 +70,18 @@ fn format_gate_text(
     passes: bool,
     min_score: f64,
     fail_on_p0: bool,
+    colour: bool,
 ) -> String {
     use crate::cli::colors as c;
+    // `colour` is the format's say (terminal only); the helpers still defer
+    // to `--color` / NO_COLOR / the tty through `colors_enabled()`.
+    let paint = |sgr: c::Sgr, text: &str| {
+        if colour {
+            c::colored(sgr, text)
+        } else {
+            text.to_string()
+        }
+    };
     let mut output = String::new();
     output.push_str("CUDA-TDG Quality Gate\n");
     output.push_str("=====================\n\n");
@@ -80,9 +95,9 @@ fn format_gate_text(
     output.push_str(&format!(
         "Gateway (Falsifiability): {}\n",
         if result.score.gateway_passed {
-            c::colored(c::GREEN, "PASSED")
+            paint(c::GREEN, "PASSED")
         } else {
-            c::colored(c::RED, "FAILED")
+            paint(c::RED, "FAILED")
         }
     ));
 
@@ -94,7 +109,11 @@ fn format_gate_text(
     output.push_str(&format!("P0 Critical Defects: {}\n\n", p0_count));
     output.push_str(&format!(
         "Result: {}\n",
-        if passes { c::colored(c::GREEN, "PASSED") } else { c::colored(c::RED, "FAILED") }
+        if passes {
+            paint(c::GREEN, "PASSED")
+        } else {
+            paint(c::RED, "FAILED")
+        }
     ));
     output
 }
@@ -137,7 +156,8 @@ async fn handle_kaizen(
     let output = match config.format {
         CudaTdgOutputFormat::Json => serde_json::to_string_pretty(&result.kaizen)?,
         CudaTdgOutputFormat::Markdown => format_kaizen_markdown(&result),
-        _ => format_kaizen_text(&result),
+        CudaTdgOutputFormat::Terminal => format_kaizen_text(&result, true),
+        _ => format_kaizen_text(&result, false),
     };
 
     write_output(&output, config)?;
@@ -179,11 +199,14 @@ fn format_kaizen_markdown(result: &CudaSimdTdgResult) -> String {
     md
 }
 
-fn format_kaizen_text(result: &CudaSimdTdgResult) -> String {
+fn format_kaizen_text(result: &CudaSimdTdgResult, colour: bool) -> String {
     let mut output = String::new();
-    output.push_str(&crate::cli::colors::header(
-        "Kaizen Continuous Improvement Report",
-    ));
+    let title = "Kaizen Continuous Improvement Report";
+    if colour {
+        output.push_str(&crate::cli::colors::header(title));
+    } else {
+        output.push_str(title);
+    }
     output.push('\n');
     output.push_str("====================================\n\n");
     output.push_str(&format!(
@@ -229,7 +252,7 @@ mod kaizen_honesty_tests {
         std::fs::write(dir.path().join("lib.rs"), "pub fn f() {}\n").unwrap();
 
         let result = CudaSimdAnalyzer::new().analyze(dir.path()).unwrap();
-        let text = format_kaizen_text(&result);
+        let text = format_kaizen_text(&result, false);
 
         assert!(
             text.contains("Mean Time to Detect: not measured"),

--- a/src/cli/handlers/cuda_tdg_handlers_tests.rs
+++ b/src/cli/handlers/cuda_tdg_handlers_tests.rs
@@ -175,11 +175,14 @@ mod coverage_tests {
     fn gate_text_names_the_p0_policy_in_force() {
         let temp_dir = TempDir::new().expect("tempdir");
         let result = create_mock_result(temp_dir.path());
-        let text = format_gate_text(&result, true, 85.0);
+        let strict = format_gate_text(&result, true, 85.0, true);
+        let advisory = format_gate_text(&result, true, 85.0, false);
         assert!(
-            text.contains("P0 policy"),
-            "the gate report must say which P0 policy was applied:\n{text}"
+            strict.contains("P0 policy") && strict.contains("--fail-on-p0"),
+            "the gate report must say which P0 policy was applied:\n{strict}"
         );
+        assert!(advisory.contains("P0 policy"), "{advisory}");
+        assert_ne!(strict, advisory, "the policy line must reflect the flag");
     }
 
     /// PMAT-688: `cuda-tdg score|gate|kaizen --color always` emitted the same
@@ -195,7 +198,7 @@ mod coverage_tests {
             let _on = crate::cli::colors::ForcedColor::on();
             let summary = format_score_summary(&result.score, &config).expect("summary");
             assert!(summary.contains("\x1b["), "score summary: {summary:?}");
-            let gate = format_gate_text(&result, true, 85.0);
+            let gate = format_gate_text(&result, true, 85.0, false);
             assert!(gate.contains("\x1b["), "gate: {gate:?}");
             let kaizen = format_kaizen_text(&result);
             assert!(kaizen.contains("\x1b["), "kaizen: {kaizen:?}");
@@ -206,7 +209,7 @@ mod coverage_tests {
             !summary.contains("\x1b["),
             "plain when colours are off: {summary:?}"
         );
-        assert!(!format_gate_text(&result, true, 85.0).contains("\x1b["));
+        assert!(!format_gate_text(&result, true, 85.0, false).contains("\x1b["));
         assert!(!format_kaizen_text(&result).contains("\x1b["));
     }
 

--- a/src/cli/handlers/cuda_tdg_handlers_tests.rs
+++ b/src/cli/handlers/cuda_tdg_handlers_tests.rs
@@ -175,8 +175,8 @@ mod coverage_tests {
     fn gate_text_names_the_p0_policy_in_force() {
         let temp_dir = TempDir::new().expect("tempdir");
         let result = create_mock_result(temp_dir.path());
-        let strict = format_gate_text(&result, true, 85.0, true);
-        let advisory = format_gate_text(&result, true, 85.0, false);
+        let strict = format_gate_text(&result, true, 85.0, true, false);
+        let advisory = format_gate_text(&result, true, 85.0, false, false);
         assert!(
             strict.contains("P0 policy") && strict.contains("--fail-on-p0"),
             "the gate report must say which P0 policy was applied:\n{strict}"
@@ -198,10 +198,17 @@ mod coverage_tests {
             let _on = crate::cli::colors::ForcedColor::on();
             let summary = format_score_summary(&result.score, &config).expect("summary");
             assert!(summary.contains("\x1b["), "score summary: {summary:?}");
-            let gate = format_gate_text(&result, true, 85.0, false);
+            let gate = format_gate_text(&result, true, 85.0, false, true);
             assert!(gate.contains("\x1b["), "gate: {gate:?}");
-            let kaizen = format_kaizen_text(&result);
+            let kaizen = format_kaizen_text(&result, true);
             assert!(kaizen.contains("\x1b["), "kaizen: {kaizen:?}");
+            // A document format never carries an escape, colours forced or not.
+            let sarif = create_config_with_format(CudaTdgOutputFormat::Sarif);
+            assert!(!format_score_summary(&result.score, &sarif)
+                .expect("summary")
+                .contains("\x1b["));
+            assert!(!format_gate_text(&result, true, 85.0, false, false).contains("\x1b["));
+            assert!(!format_kaizen_text(&result, false).contains("\x1b["));
         }
         let _off = crate::cli::colors::ForcedColor::off();
         let summary = format_score_summary(&result.score, &config).expect("summary");
@@ -209,8 +216,8 @@ mod coverage_tests {
             !summary.contains("\x1b["),
             "plain when colours are off: {summary:?}"
         );
-        assert!(!format_gate_text(&result, true, 85.0, false).contains("\x1b["));
-        assert!(!format_kaizen_text(&result).contains("\x1b["));
+        assert!(!format_gate_text(&result, true, 85.0, false, true).contains("\x1b["));
+        assert!(!format_kaizen_text(&result, true).contains("\x1b["));
     }
 
     // Tests for format_result

--- a/src/cli/handlers/cuda_tdg_handlers_tests.rs
+++ b/src/cli/handlers/cuda_tdg_handlers_tests.rs
@@ -166,6 +166,50 @@ mod coverage_tests {
         }
     }
 
+    /// PMAT-688: on the sweep corpus the gate already fails (gateway FAILED,
+    /// zero P0 defects), so `--fail-on-p0` could change neither the verdict
+    /// nor a byte of the report and was booked as a no-op. A CI gate report
+    /// must name the policy that produced its verdict, exactly as it already
+    /// names `Minimum Required`.
+    #[test]
+    fn gate_text_names_the_p0_policy_in_force() {
+        let temp_dir = TempDir::new().expect("tempdir");
+        let result = create_mock_result(temp_dir.path());
+        let text = format_gate_text(&result, true, 85.0);
+        assert!(
+            text.contains("P0 policy"),
+            "the gate report must say which P0 policy was applied:\n{text}"
+        );
+    }
+
+    /// PMAT-688: `cuda-tdg score|gate|kaizen --color always` emitted the same
+    /// bytes as `--color auto` — none of the three text formatters went
+    /// through crate::cli::colors. With colours forced for this thread each
+    /// must carry an escape sequence, and none may when colours are off.
+    #[test]
+    fn score_gate_and_kaizen_text_carry_colour_when_forced() {
+        let temp_dir = TempDir::new().expect("tempdir");
+        let result = create_mock_result(temp_dir.path());
+        let config = create_config_with_format(CudaTdgOutputFormat::Terminal);
+        {
+            let _on = crate::cli::colors::ForcedColor::on();
+            let summary = format_score_summary(&result.score, &config).expect("summary");
+            assert!(summary.contains("\x1b["), "score summary: {summary:?}");
+            let gate = format_gate_text(&result, true, 85.0);
+            assert!(gate.contains("\x1b["), "gate: {gate:?}");
+            let kaizen = format_kaizen_text(&result);
+            assert!(kaizen.contains("\x1b["), "kaizen: {kaizen:?}");
+        }
+        let _off = crate::cli::colors::ForcedColor::off();
+        let summary = format_score_summary(&result.score, &config).expect("summary");
+        assert!(
+            !summary.contains("\x1b["),
+            "plain when colours are off: {summary:?}"
+        );
+        assert!(!format_gate_text(&result, true, 85.0).contains("\x1b["));
+        assert!(!format_kaizen_text(&result).contains("\x1b["));
+    }
+
     // Tests for format_result
 
     #[test]

--- a/src/cli/handlers/demo_score_handlers.rs
+++ b/src/cli/handlers/demo_score_handlers.rs
@@ -375,4 +375,74 @@ mod tests {
         assert_eq!(grade_from_percentage(55.0), "C");
         assert_eq!(grade_from_percentage(30.0), "F");
     }
+
+    fn mixed_category() -> CategoryScore {
+        use crate::services::repo_score::models::{
+            Finding, ScoreStatus, Severity, SubcategoryScore,
+        };
+        let sub = |id: &str, name: &str, score: f64, max: f64, severity: Severity, msg: &str| {
+            SubcategoryScore {
+                id: id.to_string(),
+                name: name.to_string(),
+                score,
+                max_score: max,
+                findings: vec![Finding {
+                    severity,
+                    category: "G".to_string(),
+                    message: msg.to_string(),
+                    location: None,
+                    impact_points: 0.0,
+                }],
+            }
+        };
+        CategoryScore {
+            score: 4.0,
+            max_score: 6.0,
+            percentage: 66.7,
+            status: ScoreStatus::Fail,
+            subcategories: vec![
+                sub(
+                    "G1",
+                    "Time-to-Interaction",
+                    1.0,
+                    3.0,
+                    Severity::Error,
+                    "no quick start",
+                ),
+                sub(
+                    "G2",
+                    "Error Gracefulness",
+                    3.0,
+                    3.0,
+                    Severity::Success,
+                    "errors are handled",
+                ),
+            ],
+            findings: Vec::new(),
+        }
+    }
+
+    /// PMAT-688: `--failures-only` only filtered findings, and only under
+    /// `--verbose`, so the swept `demo-score --failures-only` reproduced the
+    /// baseline. A subcategory at or above the 80% pass line is not a failure
+    /// and must not be listed.
+    #[test]
+    fn failures_only_hides_passing_subcategories_in_text() {
+        let score = mixed_category();
+        let all = format_text(&score, false, false);
+        let failing = format_text(&score, false, true);
+        assert!(all.contains("Error Gracefulness"), "{all}");
+        assert!(!failing.contains("Error Gracefulness"), "{failing}");
+        assert!(failing.contains("Time-to-Interaction"), "{failing}");
+    }
+
+    #[test]
+    fn failures_only_hides_passing_subcategories_in_markdown() {
+        let score = mixed_category();
+        let all = format_markdown(&score, false, false);
+        let failing = format_markdown(&score, false, true);
+        assert!(all.contains("Error Gracefulness"), "{all}");
+        assert!(!failing.contains("Error Gracefulness"), "{failing}");
+        assert!(failing.contains("Time-to-Interaction"), "{failing}");
+    }
 }

--- a/src/cli/handlers/demo_score_handlers.rs
+++ b/src/cli/handlers/demo_score_handlers.rs
@@ -140,6 +140,11 @@ fn format_text_subcategory(
     use crate::cli::colors as c;
 
     let (icon, pct, is_na) = subcategory_status(sub);
+    // PMAT-688: `--failures-only` is a display filter — a subcategory at or
+    // above the 80% pass line is not shown, in text and markdown alike.
+    if failures_only && !is_na && pct >= 80.0 {
+        return;
+    }
     if is_na {
         output.push_str(&format!("  {} {}: {}\n", icon, sub.name, c::dim("N/A")));
     } else {
@@ -189,6 +194,9 @@ fn format_markdown(score: &CategoryScore, verbose: bool, failures_only: bool) ->
     output.push_str("|----------|-------|-----|------------|\n");
     for sub in &score.subcategories {
         let (icon, pct, is_na) = subcategory_status(sub);
+        if failures_only && !is_na && pct >= 80.0 {
+            continue;
+        }
         if is_na {
             output.push_str(&format!("| {} {} | N/A | N/A | N/A |\n", icon, sub.name));
         } else {
@@ -431,9 +439,17 @@ mod tests {
         let score = mixed_category();
         let all = format_text(&score, false, false);
         let failing = format_text(&score, false, true);
-        assert!(all.contains("Error Gracefulness"), "{all}");
-        assert!(!failing.contains("Error Gracefulness"), "{failing}");
-        assert!(failing.contains("Time-to-Interaction"), "{failing}");
+        // The static "Category Breakdown" legend names every category; the
+        // row is what the filter removes.
+        assert!(all.contains("Error Gracefulness: 3.0/3.0"), "{all}");
+        assert!(
+            !failing.contains("Error Gracefulness: 3.0/3.0"),
+            "{failing}"
+        );
+        assert!(
+            failing.contains("Time-to-Interaction: 1.0/3.0"),
+            "{failing}"
+        );
     }
 
     #[test]

--- a/src/cli/handlers/doc_validate_handlers.rs
+++ b/src/cli/handlers/doc_validate_handlers.rs
@@ -19,8 +19,20 @@ pub struct ValidateDocsCmd {
     #[arg(short, long)]
     pub config: Option<PathBuf>,
 
-    /// Fail on broken links
-    #[arg(short, long, default_value = "true")]
+    /// Exit non-zero when a broken link is found (the default; bare
+    /// `--fail-on-error` says so explicitly). Pass `--fail-on-error false`
+    /// to report the links without failing the run.
+    ///
+    /// PMAT-688: this was a `bool` with `default_value = "true"`, a switch
+    /// that could never change anything.
+    #[arg(
+        short,
+        long,
+        action = clap::ArgAction::Set,
+        num_args = 0..=1,
+        default_value_t = true,
+        default_missing_value = "true"
+    )]
     pub fail_on_error: bool,
 
     /// Output format (text, json, junit)

--- a/src/cli/handlers/doc_validate_handlers.rs
+++ b/src/cli/handlers/doc_validate_handlers.rs
@@ -507,4 +507,21 @@ mod tests {
             ]
         );
     }
+
+    /// PMAT-688: `--fail-on-error` was a `bool` with `default_value = "true"`,
+    /// so the switch could never change anything — the flag-efficacy sweep
+    /// booked it as a no-op on a corpus with a broken link. It is a real
+    /// switch now: bare `--fail-on-error` and its absence both mean fail
+    /// (the safe default), and `--fail-on-error false` opts out.
+    #[test]
+    fn fail_on_error_is_a_switch_that_can_be_turned_off() {
+        let absent = ValidateDocsCmd::try_parse_from(["validate-docs"]).expect("parses");
+        assert!(absent.fail_on_error, "fail by default");
+        let bare = ValidateDocsCmd::try_parse_from(["validate-docs", "--fail-on-error"])
+            .expect("bare switch parses");
+        assert!(bare.fail_on_error);
+        let off = ValidateDocsCmd::try_parse_from(["validate-docs", "--fail-on-error", "false"])
+            .expect("`--fail-on-error false` parses");
+        assert!(!off.fail_on_error, "the explicit value turns the gate off");
+    }
 }

--- a/src/cli/handlers/mcp_manifest.rs
+++ b/src/cli/handlers/mcp_manifest.rs
@@ -73,9 +73,10 @@ mod manifest {
 /// #1029: the tool count alone reads as a complete surface, which is how
 /// three analyzers shipped CLI-only without anyone noticing.
 fn manifest_notice(written: Option<usize>) -> String {
+    use crate::cli::colors as c;
     let first = match written {
-        Some(tools) => format!("Generated mcp.json with {tools} tools"),
-        None => "Run with --write to generate the manifest".to_string(),
+        Some(tools) => c::colored(c::GREEN, &format!("Generated mcp.json with {tools} tools")),
+        None => c::dim("Run with --write to generate the manifest"),
     };
     format!(
         "{first}\n{}",

--- a/src/cli/handlers/mcp_manifest.rs
+++ b/src/cli/handlers/mcp_manifest.rs
@@ -16,14 +16,9 @@ pub async fn handle_mcp_command(cmd: McpCommands, project_path: &Path) -> Result
                 let manifest =
                     crate::mcp_pmcp::tool_manifest::render_manifest(env!("CARGO_PKG_VERSION"));
                 std::fs::write(&manifest_path, manifest)?;
-                println!("Generated mcp.json with {} tools", canonical_tools.len());
-                // #1029: say what the manifest does NOT cover. The tool count
-                // alone reads as a complete surface, which is how three
-                // analyzers shipped CLI-only without anyone noticing.
-                println!("{}", crate::cli::analyze_mcp_exposure::parity_summary());
+                println!("{}", manifest_notice(Some(canonical_tools.len())));
             } else {
-                println!("Run with --write to generate the manifest");
-                println!("{}", crate::cli::analyze_mcp_exposure::parity_summary());
+                println!("{}", manifest_notice(None));
             }
         }
         McpCommands::Connect => crate::cli::handlers::mcp_onboarding::handle_mcp(false)?,
@@ -69,5 +64,54 @@ mod manifest {
                 expected_string
             );
         }
+    }
+}
+
+/// The two lines `mcp manifest` prints: what happened (or how to make it
+/// happen), then what the manifest does NOT cover.
+///
+/// #1029: the tool count alone reads as a complete surface, which is how
+/// three analyzers shipped CLI-only without anyone noticing.
+fn manifest_notice(written: Option<usize>) -> String {
+    let first = match written {
+        Some(tools) => format!("Generated mcp.json with {tools} tools"),
+        None => "Run with --write to generate the manifest".to_string(),
+    };
+    format!(
+        "{first}\n{}",
+        crate::cli::analyze_mcp_exposure::parity_summary()
+    )
+}
+
+#[cfg(test)]
+mod notice_tests {
+    use super::manifest_notice;
+
+    /// PMAT-688: `mcp manifest --color always` emitted the same bytes as
+    /// `--color auto`; both lines were plain `println!`s.
+    #[test]
+    fn manifest_notice_carries_colour_when_forced() {
+        let _on = crate::cli::colors::ForcedColor::on();
+        let hint = manifest_notice(None);
+        assert!(
+            hint.contains("--write") && hint.contains("\x1b["),
+            "{hint:?}"
+        );
+        let written = manifest_notice(Some(12));
+        assert!(
+            written.contains("12 tools") && written.contains("\x1b["),
+            "{written:?}"
+        );
+    }
+
+    #[test]
+    fn manifest_notice_is_plain_when_colours_are_off() {
+        let _off = crate::cli::colors::ForcedColor::off();
+        let hint = manifest_notice(None);
+        assert!(!hint.contains("\x1b["), "{hint:?}");
+        assert!(
+            hint.lines().count() >= 2,
+            "hint, then the parity summary:\n{hint}"
+        );
     }
 }

--- a/src/cli/handlers/popper_score_format_markdown.rs
+++ b/src/cli/handlers/popper_score_format_markdown.rs
@@ -71,7 +71,7 @@ fn format_markdown_recommendations(output: &mut String, score: &PopperScore) {
 }
 
 /// Format score as Markdown
-fn format_markdown(score: &PopperScore, verbose: bool, _failures_only: bool) -> String {
+fn format_markdown(score: &PopperScore, verbose: bool, failures_only: bool) -> String {
     let mut output = String::new();
 
     // Header
@@ -106,6 +106,10 @@ fn format_markdown(score: &PopperScore, verbose: bool, _failures_only: bool) -> 
     output.push_str("|----------|-------|------------|--------|\n");
 
     for (name, category, is_gateway) in popper_category_entries(score) {
+        // PMAT-688: the same display filter as the text formatter.
+        if failures_only && !category.is_not_applicable && category.percentage() >= 80.0 {
+            continue;
+        }
         format_markdown_category_row(&mut output, name, category, is_gateway);
     }
     output.push('\n');

--- a/src/cli/handlers/popper_score_format_text.rs
+++ b/src/cli/handlers/popper_score_format_text.rs
@@ -18,6 +18,11 @@ fn format_text_category(
     }
 
     let percentage = category.percentage();
+    // PMAT-688: `--failures-only` is the display filter its sibling score
+    // commands implement — a row at or above the pass line is not shown.
+    if failures_only && percentage >= 80.0 {
+        return;
+    }
     let icon = percentage_icon(percentage);
     let gateway_marker = if is_gateway {
         format!(" {}[GATEWAY]{}", c::seq(c::BOLD_YELLOW), c::seq(c::RESET))
@@ -34,8 +39,11 @@ fn format_text_category(
         gateway_marker
     ));
 
-    if verbose && !failures_only {
+    if verbose {
         for sub in &category.sub_scores {
+            if failures_only && sub.earned >= sub.max * 0.8 {
+                continue;
+            }
             let sub_icon = if sub.earned >= sub.max * 0.8 {
                 format!("  {}✓{}", c::seq(c::GREEN), c::seq(c::RESET))
             } else if sub.earned >= sub.max * 0.5 {
@@ -55,10 +63,12 @@ fn format_text_category(
 }
 
 /// Append text-formatted recommendations to the output
-fn format_text_recommendations(output: &mut String, score: &PopperScore, failures_only: bool) {
+/// The recommendations are the actionable failures: they stay under
+/// `--failures-only` whatever the gateway said (PMAT-688).
+fn format_text_recommendations(output: &mut String, score: &PopperScore) {
     use crate::cli::colors as c;
 
-    if score.recommendations.is_empty() || (failures_only && score.gateway_passed) {
+    if score.recommendations.is_empty() {
         return;
     }
     output.push_str(&format!("{}\n", c::label("Recommendations")));
@@ -149,7 +159,7 @@ fn format_text(score: &PopperScore, verbose: bool, failures_only: bool) -> Strin
     output.push('\n');
 
     // Recommendations
-    format_text_recommendations(&mut output, score, failures_only);
+    format_text_recommendations(&mut output, score);
 
     // Footer
     output.push_str(&format!("{}\n", c::rule()));

--- a/src/cli/handlers/popper_score_tests.rs
+++ b/src/cli/handlers/popper_score_tests.rs
@@ -284,4 +284,55 @@ mod tests {
 
     // Include format-specific tests
     include!("popper_score_tests_format.rs");
+
+    /// PMAT-688: on the 3.39.0 tree `--failures-only` was read in two places
+    /// only (`verbose && !failures_only` and `failures_only && gateway_passed`),
+    /// so the swept `popper-score --failures-only` reproduced the baseline byte
+    /// for byte. The flag is the same display filter its siblings implement
+    /// (`repo-score`, `infra-score`, `rust-project-score`): a row at or above
+    /// the pass line is not shown, everything else is untouched, and the
+    /// recommendations — the actionable failures — stay even when the gateway
+    /// passed.
+    #[test]
+    fn failures_only_text_keeps_only_failing_checks() {
+        // Falsifiability 20/25 sits on the 80% pass line; the other four are below it.
+        let score = create_test_score_passed();
+        let all = format_text(&score, false, false);
+        let failing = format_text(&score, false, true);
+        assert!(all.contains("Falsifiability & Testability"), "{all}");
+        assert!(
+            !failing.contains("Falsifiability & Testability"),
+            "a category at the pass line is not a failing check:\n{failing}"
+        );
+        for kept in ["Reproducibility Infrastructure", "Summary", "Verdict", "Recommendations"] {
+            assert!(failing.contains(kept), "{kept} must survive the filter:\n{failing}");
+        }
+    }
+
+    #[test]
+    fn failures_only_verbose_keeps_only_failing_sub_scores() {
+        // A1 8/10 and A2 12/15 both sit on the pass line inside a passing category;
+        // B has no sub-scores, so add one that fails.
+        let mut score = create_test_score_passed();
+        score
+            .categories
+            .reproducibility
+            .add_sub_score(PopperSubScore::new("B1", "Lockfile", 2.0, 10.0, "no lockfile"));
+        let all = format_text(&score, true, false);
+        let failing = format_text(&score, true, true);
+        assert!(all.contains("A1") && all.contains("B1"), "{all}");
+        assert!(!failing.contains("A1"), "a passing sub-score is not a failure:\n{failing}");
+        assert!(failing.contains("B1"), "a failing sub-score stays:\n{failing}");
+    }
+
+    #[test]
+    fn failures_only_markdown_keeps_only_failing_checks() {
+        let score = create_test_score_passed();
+        let all = format_markdown(&score, false, false);
+        let failing = format_markdown(&score, false, true);
+        assert!(all.contains("Falsifiability & Testability"), "{all}");
+        assert!(!failing.contains("Falsifiability & Testability"), "{failing}");
+        assert!(failing.contains("Reproducibility Infrastructure"), "{failing}");
+        assert!(failing.contains("Verdict"), "{failing}");
+    }
 }

--- a/src/cli/handlers/popper_score_tests.rs
+++ b/src/cli/handlers/popper_score_tests.rs
@@ -312,12 +312,14 @@ mod tests {
     #[test]
     fn failures_only_verbose_keeps_only_failing_sub_scores() {
         // A1 8/10 and A2 12/15 both sit on the pass line inside a passing category;
-        // B has no sub-scores, so add one that fails.
+        // B (18/25) has no sub-scores, so add one that fails. `add_sub_score`
+        // adds the sub-score's points to the category, so it must earn 0 for
+        // B to stay below the line.
         let mut score = create_test_score_passed();
         score
             .categories
             .reproducibility
-            .add_sub_score(PopperSubScore::new("B1", "Lockfile", 2.0, 10.0, "no lockfile"));
+            .add_sub_score(PopperSubScore::new("B1", "Lockfile", 0.0, 10.0, "no lockfile"));
         let all = format_text(&score, true, false);
         let failing = format_text(&score, true, true);
         assert!(all.contains("A1") && all.contains("B1"), "{all}");

--- a/src/cli/handlers/quality_gates_handler_execution.rs
+++ b/src/cli/handlers/quality_gates_handler_execution.rs
@@ -98,18 +98,54 @@ fn handle_validate_config(path: &Path) -> Result<()> {
 
     match validate_config(&config) {
         Ok(()) => {
-            println!("✅ Configuration is valid");
+            println!("{}", validation_verdict(&[]));
             Ok(())
         }
         Err(errors) => {
-            println!("❌ Configuration has {} error(s):", errors.len());
-            for error in errors {
-                println!("  - {}", error);
-            }
+            println!("{}", validation_verdict(&errors));
             std::process::exit(1);
         }
     }
 }
+
+/// The verdict `quality-gates validate` prints: one line when the file is
+/// valid, a headline plus one line per error otherwise.
+fn validation_verdict(errors: &[String]) -> String {
+    if errors.is_empty() {
+        return "✅ Configuration is valid".to_string();
+    }
+    let mut out = format!("❌ Configuration has {} error(s):", errors.len());
+    for error in errors {
+        out.push_str(&format!("\n  - {error}"));
+    }
+    out
+}
+
+#[cfg(test)]
+mod verdict_tests {
+    use super::validation_verdict;
+
+    /// PMAT-688: `quality-gates validate --color always` emitted the same
+    /// bytes as `--color auto`; the verdict was a plain `println!`.
+    #[test]
+    fn validation_verdict_carries_colour_when_forced() {
+        let _on = crate::cli::colors::ForcedColor::on();
+        let ok = validation_verdict(&[]);
+        assert!(ok.contains("Configuration is valid") && ok.contains("\x1b["), "{ok:?}");
+        let bad = validation_verdict(&["gates.max_complexity must be positive".to_string()]);
+        assert!(bad.contains("1 error(s)") && bad.contains("\x1b["), "{bad:?}");
+        assert!(bad.contains("  - gates.max_complexity must be positive"), "{bad}");
+    }
+
+    #[test]
+    fn validation_verdict_is_plain_when_colours_are_off() {
+        let _off = crate::cli::colors::ForcedColor::off();
+        assert_eq!(validation_verdict(&[]), "✅ Configuration is valid");
+        let bad = validation_verdict(&["a".to_string(), "b".to_string()]);
+        assert_eq!(bad, "❌ Configuration has 2 error(s):\n  - a\n  - b");
+    }
+}
+
 
 /// Show configuration (TICKET-PMAT-5024)
 ///

--- a/src/cli/handlers/quality_gates_handler_execution.rs
+++ b/src/cli/handlers/quality_gates_handler_execution.rs
@@ -111,10 +111,11 @@ fn handle_validate_config(path: &Path) -> Result<()> {
 /// The verdict `quality-gates validate` prints: one line when the file is
 /// valid, a headline plus one line per error otherwise.
 fn validation_verdict(errors: &[String]) -> String {
+    use crate::cli::colors as c;
     if errors.is_empty() {
-        return "✅ Configuration is valid".to_string();
+        return c::colored(c::GREEN, "✅ Configuration is valid");
     }
-    let mut out = format!("❌ Configuration has {} error(s):", errors.len());
+    let mut out = c::colored(c::RED, &format!("❌ Configuration has {} error(s):", errors.len()));
     for error in errors {
         out.push_str(&format!("\n  - {error}"));
     }

--- a/src/roadmap/commands/commands_status.rs
+++ b/src/roadmap/commands/commands_status.rs
@@ -116,7 +116,11 @@ fn render_task_details(task: &Task) -> String {
     use std::fmt::Write as _;
 
     let mut out = String::new();
-    let _ = writeln!(out, "Task {}: {}", task.id, task.status.to_emoji());
+    let _ = writeln!(
+        out,
+        "{}",
+        crate::cli::colors::header(&format!("Task {}: {}", task.id, task.status.to_emoji()))
+    );
     let _ = writeln!(out, "  Description: {}", task.description);
     let _ = writeln!(out, "  Complexity: {:?}", task.complexity);
     let _ = write!(out, "  Priority: {:?}", task.priority);
@@ -215,7 +219,14 @@ fn render_sprint_details(sprint: &Sprint) -> String {
     let (completed, in_progress, total) = calculate_sprint_progress(sprint);
 
     let mut out = String::new();
-    let _ = writeln!(out, "Sprint {}: {}", sprint.version, sprint.title);
+    // PMAT-688: the human table is the one format that may carry colour;
+    // the header goes through the env-aware helper so `--color always`
+    // is observable and `--color never` leaves the bytes untouched.
+    let _ = writeln!(
+        out,
+        "{}",
+        crate::cli::colors::header(&format!("Sprint {}: {}", sprint.version, sprint.title))
+    );
     let _ = writeln!(
         out,
         "  Duration: {} to {}",

--- a/src/roadmap/commands/commands_status_tests.rs
+++ b/src/roadmap/commands/commands_status_tests.rs
@@ -166,4 +166,31 @@ mod status_format_tests {
         let csv = format_task_status(&t, OutputFormat::Csv).unwrap();
         assert!(csv.contains("\"fix a, b and \"\"c\"\"\""), "{csv}");
     }
+
+    /// PMAT-688: once the sweep corpus carried a roadmap, `roadmap status
+    /// --color always` became reachable and emitted the same bytes as
+    /// `--color auto` — the human table went through no colour helper. The
+    /// table (the default and `text` format) must carry an escape when
+    /// colours are forced, and none when they are off; machine formats stay
+    /// untouched either way.
+    #[test]
+    fn sprint_table_carries_colour_when_forced() {
+        let sprint = sprint();
+        let plain = {
+            let _off = crate::cli::colors::ForcedColor::off();
+            format_sprint_status(&sprint, OutputFormat::Table).expect("table")
+        };
+        let _on = crate::cli::colors::ForcedColor::on();
+        let coloured = format_sprint_status(&sprint, OutputFormat::Table).expect("table");
+        assert!(!plain.contains("\x1b["), "{plain}");
+        assert!(coloured.contains("\x1b["), "{coloured}");
+        let stripped = regex::Regex::new("\x1b\\[[0-9;]*m")
+            .expect("static regex must compile")
+            .replace_all(&coloured, "");
+        assert_eq!(stripped, plain, "colour must add escapes only");
+        for machine in [OutputFormat::Json, OutputFormat::Csv, OutputFormat::Markdown] {
+            let out = format_sprint_status(&sprint, machine).expect("machine format");
+            assert!(!out.contains("\x1b["), "{machine:?} must never carry an escape");
+        }
+    }
 }

--- a/src/roadmap/commands/commands_todos.rs
+++ b/src/roadmap/commands/commands_todos.rs
@@ -50,7 +50,19 @@ async fn generate_todos(
 }
 
 /// The confirmation line `roadmap todos` prints after writing its file.
+///
+/// Names the format and the count (PMAT-688): `--include-quality-gates`
+/// changes the file, and the terminal must show which document was written.
 fn todos_written_line(output_path: &Path, count: usize, include_quality_gates: bool) -> String {
-    let _ = (count, include_quality_gates);
-    format!("✅ Todos written to: {}", output_path.display())
+    use crate::cli::colors as c;
+    let format = if include_quality_gates {
+        "PDMT with quality gates"
+    } else {
+        "simple checklist"
+    };
+    format!(
+        "{} Todos written to: {} ({format}, {count} todos)",
+        c::colored(c::GREEN, "✅"),
+        output_path.display()
+    )
 }

--- a/src/roadmap/commands/commands_todos.rs
+++ b/src/roadmap/commands/commands_todos.rs
@@ -41,7 +41,16 @@ async fn generate_todos(
     };
 
     std::fs::write(output_path, output)?;
-    println!("✅ Todos written to: {}", output_path.display());
+    println!(
+        "{}",
+        todos_written_line(output_path, todos.len(), include_quality_gates)
+    );
 
     Ok(())
+}
+
+/// The confirmation line `roadmap todos` prints after writing its file.
+fn todos_written_line(output_path: &Path, count: usize, include_quality_gates: bool) -> String {
+    let _ = (count, include_quality_gates);
+    format!("✅ Todos written to: {}", output_path.display())
 }

--- a/src/roadmap/commands/tests.rs
+++ b/src/roadmap/commands/tests.rs
@@ -175,4 +175,23 @@ mod tests {
         // This tests the branch creation code path
         assert!(result.is_ok() || result.is_err()); // Either outcome acceptable in test
     }
+
+    /// PMAT-688: `roadmap todos --include-quality-gates` changed the file it
+    /// wrote (a 222 B checklist became a 3.6 KB PDMT document on the sweep
+    /// corpus) and nothing on stdout, so the flag-efficacy sweep booked it as
+    /// a no-op. The confirmation line names the format and the count, so the
+    /// terminal shows what the flag did.
+    #[test]
+    fn todos_written_line_names_the_format_and_count() {
+        let path = std::path::Path::new("todos.md");
+        let simple = todos_written_line(path, 4, false);
+        let pdmt = todos_written_line(path, 4, true);
+        assert!(
+            simple.contains("todos.md") && simple.contains("4 todos"),
+            "{simple}"
+        );
+        assert!(simple.to_lowercase().contains("checklist"), "{simple}");
+        assert!(pdmt.to_lowercase().contains("quality gates"), "{pdmt}");
+        assert_ne!(simple, pdmt);
+    }
 }

--- a/tests/modules/quality_harness/flag_efficacy.rs
+++ b/tests/modules/quality_harness/flag_efficacy.rs
@@ -185,11 +185,6 @@ const ALLOWED_NOOPS: &[(&str, &str, &str)] = &[
         "colours the clean-result confirmation (lint_hotspot_handlers/mod.rs:206-220 report_measured_clean -> c::pass); on a clean crate `--color always` emits an ANSI-green tick and `--color auto` does not — the corpus is dirty by construction so that branch is unreachable",
     ),
     (
-        "analyze proof-annotations",
-        "--color",
-        "sets CLICOLOR_FORCE/NO_COLOR; proof_annotation_helpers_format.rs emits no colour in any of its five formats (summary/full/json/markdown/sarif all verified at 0 escape bytes)",
-    ),
-    (
         "comply cross-crate",
         "--color",
         "sets CLICOLOR_FORCE/NO_COLOR; nothing under cross_crate_handlers/ references crate::cli::colors, and the reachable output here is the plain single-crate discovery notice (handler.rs:81)",
@@ -250,11 +245,6 @@ const ALLOWED_NOOPS: &[(&str, &str, &str)] = &[
         "emits only the Known Defects Report on stdout (3661B, exit 1) and nothing on stderr; src/cli/handlers/analyze_defects_handler/ contains no stderr macro at all",
     ),
     (
-        "analyze deep-context",
-        "--quiet",
-        "the swept default format uses SimpleDeepContext, which prints no progress — stdout report only, stderr 0B. The flag's effect is demonstrable one format over: `--format sarif` runs the full DeepContextAnalyzer and emitted 62B of spinner text, now 62B -> 0B under --quiet with this round's progress-primitive fix",
-    ),
-    (
         "analyze entropy",
         "--quiet",
         "emits only the Entropy Analysis Summary on stdout (571B), stderr 0B. The four progress banners in its file (entropy_semantic.rs) belong to `analyze semantic`'s route, not to route_entropy_analysis",
@@ -288,11 +278,6 @@ const ALLOWED_NOOPS: &[(&str, &str, &str)] = &[
         "comply init",
         "--quiet",
         "on the corpus the command has already been initialised by an earlier sweep invocation and prints its 'Project already initialized at ./.pmat/project.toml' refusal on stdout, which is the result. On a fresh directory the banner and next-steps block are status_println! and --quiet takes stdout 378B -> 101B (measured), leaving only the created-artifact lines",
-    ),
-    (
-        "comply report",
-        "--quiet",
-        "the swept invocation writes the compliance report itself to stdout (511B), and a report is a result. The flag's effect is on the --output branch: `comply report --output F` prints '✓ Compliance report written to F' via status_println! (43B), and --quiet suppresses it (measured: 43B -> 0B, file still written)",
     ),
     (
         "comply asset-validate",
@@ -373,10 +358,33 @@ const ALLOWED_NOOPS: &[(&str, &str, &str)] = &[
         "--stack",
         "appends the 'Stack Quality (CB-150)' block listing sovereign dependencies found in Cargo.toml (score_handler_display.rs:5-31); adding `aprender`/`trueno` to the fixture's Cargo.toml makes it appear. The corpus has an empty [dependencies] section, and the function early-returns when none are found",
     ),
+    // PMAT-688: five commands whose stdout IS the artifact. Verified on the
+    // dumped Large corpus with 3.39.0 (`--color auto` vs `--color always`):
+    // byte-identical, and there is no human-facing line to colour.
     (
-        "comply check",
-        "--strict",
-        "escalates warnings to a failing exit and nothing else — exit_policy (comply_handlers/check_handlers/check.rs:229-256) returns code 2 only when `is_compliant && warn > 0 && fail == 0`; a report with failures already exits 1 and the flag has nothing left to escalate. Demonstrated on this corpus: give it a `deny.toml` naming all four families and a `.github/workflows/ci.yml` whose `gate` job runs the CB-reaching commands, then `PMAT_REQUIRED_STATUS_CHECKS=gate pmat comply check` exits 0 and the same run with --strict exits 2 with 'the report is COMPLIANT (0 failures), but --strict treats warnings as errors: 9 warning(s)'. The swept corpus fails CB-1701 and CB-2100, so both runs exit 1 with byte-identical stdout (15,773B). Pinned as a tri-state by check_readonly_and_exemption_tests.rs::strict_exit_codes_are_a_documented_tri_state",
+        "prompt comply",
+        "--color",
+        "stdout is the generated YAML prompt itself (prompt_handlers_generators.rs write_prompt_output; 21,724 B on the corpus with no --output) for an LLM to consume — an ANSI escape inside it would corrupt the prompt, and there is no status line to colour",
+    ),
+    (
+        "prompt book",
+        "--color",
+        "stdout is the generated YAML prompt itself (prompt_handlers_generators.rs write_prompt_output; 25,057 B on the corpus with no --output) for an LLM to consume — an ANSI escape inside it would corrupt the prompt, and there is no status line to colour",
+    ),
+    (
+        "prompt repo-image",
+        "--color",
+        "stdout is the generated YAML prompt itself (prompt_handlers_generators.rs write_prompt_output; 14,166 B on the corpus with no --output) for an LLM to consume — an ANSI escape inside it would corrupt the prompt, and there is no status line to colour",
+    ),
+    (
+        "quality-gates show",
+        "--color",
+        "prints the gate config verbatim as TOML (misc_commands_spec_debug.rs:221 default) or JSON through quality_gates_handler_execution.rs handle_show_config — a config artifact meant to be redirected into .pmat-gates.toml, which an escape would corrupt",
+    ),
+    (
+        "cuda-tdg report",
+        "--color",
+        "default `--format markdown` (misc_commands_cuda_oracle.rs:47) renders a Markdown document through format_markdown_report, and html/json are documents too; colour is live only in the terminal formatter reached by `score --breakdown`, `gate` and `kaizen`, which the sweep checks separately",
     ),
 ];
 
@@ -541,7 +549,9 @@ enum Verdict {
     /// not silently do nothing, and exiting non-zero with "--ml is not
     /// implemented ... this flag would relabel them without changing them" is
     /// the honest alternative. Classifying it as a failure penalised precisely
-    /// the fix that earlier rounds landed.
+    /// the fix that earlier rounds landed. A refusal that names an unmet
+    /// precondition — a dirty tree, a missing companion flag — is the same
+    /// class (PMAT-688): the flag did not silently do nothing.
     Refuses,
     /// The flag turned a working command into a failing one.
     Errors { code: Option<i32> },
@@ -830,6 +840,13 @@ fn is_honest_refusal(stderr: &str) -> bool {
         || s.contains("does not implement")
         || s.contains("would be accepted and ignored")
         || s.contains("no longer supported")
+        // PMAT-688: a documented precondition, named in the refusal — the
+        // ledger writers' "refusing to write … from a dirty git tree … or pass
+        // --allow-dirty", and clap's "the following required arguments were
+        // not provided" for a flag that `requires` a companion. Both say what
+        // the flag needs; neither is a flag breaking a working command.
+        || s.contains("refusing to")
+        || s.contains("required arguments were not provided")
 }
 
 #[test]

--- a/tests/modules/quality_harness/flag_efficacy.rs
+++ b/tests/modules/quality_harness/flag_efficacy.rs
@@ -466,6 +466,13 @@ const PROBE_CONTEXT: &[(&str, &str, &[&str])] = &[
         "--convergence-threshold",
         &["--format", "json"],
     ),
+    // PMAT-688: `--allow-dirty` has clap `requires = "write_ledger"` on both
+    // ledger writers; probed alone it is a usage error, which is the sweep's
+    // omission, not the flag's. With the companion the probe is real: on a
+    // dirty tree the control refuses (exit 1, empty stdout ⇒ "not a control",
+    // an honest skip) and on a clean one both write the ledger.
+    ("analyze reachability", "--allow-dirty", &["--write-ledger"]),
+    ("analyze unrun-tests", "--allow-dirty", &["--write-ledger"]),
 ];
 
 /// Probe values that must straddle the fixture for a specific option.
@@ -842,11 +849,12 @@ fn is_honest_refusal(stderr: &str) -> bool {
         || s.contains("no longer supported")
         // PMAT-688: a documented precondition, named in the refusal — the
         // ledger writers' "refusing to write … from a dirty git tree … or pass
-        // --allow-dirty", and clap's "the following required arguments were
-        // not provided" for a flag that `requires` a companion. Both say what
-        // the flag needs; neither is a flag breaking a working command.
+        // --allow-dirty". The flag did not silently do nothing; it said what
+        // it needs. Clap's "required arguments were not provided" is NOT in
+        // this list (quorum, 2 of 3 lanes): that is the sweep failing to
+        // supply a `requires` companion, and PROBE_CONTEXT is where the
+        // companion belongs — a harness omission must never read as a pass.
         || s.contains("refusing to")
-        || s.contains("required arguments were not provided")
 }
 
 #[test]
@@ -2183,12 +2191,13 @@ fn small_corpora_stay_poor_so_the_contrast_survives() {
     );
 }
 
-/// PMAT-688: the 3.39.0 sweep booked four "errors out" rows that were the
-/// ledger writers refusing a dirty tree (documented: "Commit or stash first,
-/// or pass --allow-dirty") and clap refusing `--allow-dirty` without the
-/// `--write-ledger` it `requires`. A refusal that names its precondition is
-/// the honest alternative to silently doing nothing — the same class as
-/// "--ml is not implemented", not the "flag broke a working command" class.
+/// PMAT-688: the 3.39.0 sweep booked four "errors out" rows: the ledger
+/// writers refusing a dirty tree (documented: "Commit or stash first, or pass
+/// --allow-dirty") and clap refusing `--allow-dirty` without the
+/// `--write-ledger` it `requires`. The first is a refusal that names its
+/// precondition — the honest alternative to silently doing nothing, the same
+/// class as "--ml is not implemented". The second is the sweep's own
+/// omission and is answered with a probe context, never with a pass.
 #[test]
 fn precondition_refusals_are_honest() {
     let dirty = "Error: refusing to write .pmat/reachability-ledger.json from a dirty git \
@@ -2203,8 +2212,17 @@ fn precondition_refusals_are_honest() {
         "a documented precondition refusal is honest"
     );
     assert!(
-        is_honest_refusal(requires),
-        "clap naming the missing companion flag is honest"
+        !is_honest_refusal(requires),
+        "clap naming a missing companion flag is the sweep's omission, not a refusal: \
+         PROBE_CONTEXT must supply the companion so the flag is actually exercised"
+    );
+    assert_eq!(
+        probe_context("analyze reachability", "--allow-dirty"),
+        ["--write-ledger"]
+    );
+    assert_eq!(
+        probe_context("analyze unrun-tests", "--allow-dirty"),
+        ["--write-ledger"]
     );
     assert!(
         !is_honest_refusal("Error: called `Option::unwrap()` on a `None` value"),

--- a/tests/modules/quality_harness/flag_efficacy.rs
+++ b/tests/modules/quality_harness/flag_efficacy.rs
@@ -2165,3 +2165,109 @@ fn small_corpora_stay_poor_so_the_contrast_survives() {
         "tiny must stay reportless, or the not-measured branch is never exercised"
     );
 }
+
+/// PMAT-688: the 3.39.0 sweep booked four "errors out" rows that were the
+/// ledger writers refusing a dirty tree (documented: "Commit or stash first,
+/// or pass --allow-dirty") and clap refusing `--allow-dirty` without the
+/// `--write-ledger` it `requires`. A refusal that names its precondition is
+/// the honest alternative to silently doing nothing — the same class as
+/// "--ml is not implemented", not the "flag broke a working command" class.
+#[test]
+fn precondition_refusals_are_honest() {
+    let dirty = "Error: refusing to write .pmat/reachability-ledger.json from a dirty git \
+                 tree: it would record whatever these uncommitted, possibly-unrelated changes \
+                 happen to add or remove, not the tree at HEAD. Commit or stash first, or pass \
+                 --allow-dirty.\n M src/lib.rs\n";
+    let requires = "error: the following required arguments were not provided:\n  \
+                    --write-ledger\n\nUsage: pmat analyze reachability --write-ledger \
+                    --allow-dirty\n";
+    assert!(
+        is_honest_refusal(dirty),
+        "a documented precondition refusal is honest"
+    );
+    assert!(
+        is_honest_refusal(requires),
+        "clap naming the missing companion flag is honest"
+    );
+    assert!(
+        !is_honest_refusal("Error: called `Option::unwrap()` on a `None` value"),
+        "a crash is not a refusal"
+    );
+    assert!(
+        !is_honest_refusal("error: failed to parse config: missing field `gates`"),
+        "an unrelated error: line is not a refusal"
+    );
+}
+
+/// PMAT-688: three flags were booked as no-ops because the corpus carried
+/// nothing for them to act on. `validate-docs --fail-on-error` needs a broken
+/// link; `roadmap todos` needs a roadmap with a current sprint (its baseline
+/// failed on the corpus with the 🔄 banner already on stdout, so the
+/// "not a control" guard never fired and both `--color` and
+/// `--include-quality-gates` were booked against a failing command);
+/// `show-metrics --failures-only` needs a trend store holding one regressing
+/// and one improving series inside its 30-day window.
+#[test]
+fn large_corpus_carries_the_flag_fixtures() {
+    let corpus = build_corpus(CorpusSize::Large);
+    let root = corpus.path();
+
+    let links = std::fs::read_to_string(root.join("docs/links.md")).expect("docs/links.md");
+    assert!(
+        links.contains("](design-notes.md)") && !root.join("docs/design-notes.md").exists(),
+        "one relative link to a file that does not exist:\n{links}"
+    );
+
+    // `popper-score --failures-only` hides a category at or above its 80% pass
+    // line; the corpus had none (best: Transparency at 70%). An ADR directory
+    // is the scorer's 4-point lever (transparency.rs C3) and lifts it to 90%.
+    let adr = root.join("docs/adr");
+    assert!(
+        adr.is_dir() && std::fs::read_dir(&adr).expect("docs/adr").next().is_some(),
+        "docs/adr/ with at least one decision record"
+    );
+
+    let roadmap = std::fs::read_to_string(root.join("docs/execution/roadmap.md"))
+        .expect("docs/execution/roadmap.md");
+    assert!(
+        roadmap.contains("## Current Sprint:") && roadmap.contains("| ID | Description |"),
+        "a current sprint with the task table the parser reads:\n{roadmap}"
+    );
+    assert_eq!(
+        roadmap.matches("| PMAT-").count(),
+        2,
+        "two sprint tasks:\n{roadmap}"
+    );
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("clock")
+        .as_secs() as i64;
+    for (metric, rising) in [("lint", true), ("test-fast", false)] {
+        let raw = std::fs::read_to_string(root.join(format!(".pmat-metrics/trends/{metric}.json")))
+            .unwrap_or_else(|e| panic!(".pmat-metrics/trends/{metric}.json: {e}"));
+        let obs: Vec<serde_json::Value> = serde_json::from_str(&raw).expect("observations");
+        assert!(obs.len() >= 6, "{metric}: {} observations", obs.len());
+        let vals: Vec<f64> = obs
+            .iter()
+            .map(|o| o["value"].as_f64().expect("value"))
+            .collect();
+        let monotone = vals
+            .windows(2)
+            .all(|w| if rising { w[1] > w[0] } else { w[1] < w[0] });
+        assert!(
+            monotone,
+            "{metric} must be strictly {}: {vals:?}",
+            if rising { "rising" } else { "falling" }
+        );
+        let newest = obs
+            .iter()
+            .map(|o| o["timestamp"].as_i64().expect("timestamp"))
+            .max()
+            .expect("at least one observation");
+        assert!(
+            now - newest < 86_400 * 30,
+            "{metric}: the newest observation must fall inside show-metrics' 30-day window"
+        );
+    }
+}

--- a/tests/modules/quality_harness/mod.rs
+++ b/tests/modules/quality_harness/mod.rs
@@ -524,6 +524,86 @@ jobs:
     .expect("write docs");
 
     write_hygiene_debt(root);
+    write_flag_fixtures(root);
+}
+
+/// PMAT-688: inputs the flag-efficacy sweep needs so that four flags have
+/// something to act on. Each block names the flag it unsticks.
+fn write_flag_fixtures(root: &Path) {
+    // `validate-docs --fail-on-error`: exit 1 needs a broken link. The
+    // validator resolves a relative link against the file and asks
+    // `normalized_path.exists()` (doc_validator_validation.rs).
+    std::fs::write(
+        root.join("docs/links.md"),
+        "# Links\n\nSee the [architecture](architecture.md) and the [design notes](design-notes.md).\n",
+    )
+    .expect("write docs/links.md");
+
+    // `popper-score --failures-only` hides a category at or above its 80%
+    // pass line; Transparency sat at 70% and an ADR directory is the
+    // scorer's 4-point lever (popper_score/scorers/transparency.rs, C3).
+    std::fs::create_dir_all(root.join("docs/adr")).expect("mkdir docs/adr");
+    std::fs::write(
+        root.join("docs/adr/0001-record-architecture-decisions.md"),
+        "# 1. Record architecture decisions\n\nStatus: accepted\n\nWe keep ADRs in this directory.\n",
+    )
+    .expect("write docs/adr");
+
+    // `roadmap todos`: the command failed on the corpus before reading any
+    // flag (no docs/execution/roadmap.md) with its 🔄 banner already on
+    // stdout, so every flag on it was booked against a failing command.
+    std::fs::create_dir_all(root.join("docs/execution")).expect("mkdir docs/execution");
+    std::fs::write(
+        root.join("docs/execution/roadmap.md"),
+        "# Corpus Roadmap\n\n## Current Sprint: v0.1.0 Corpus Sprint\n\
+         - **Priority**: P0 - HIGH PRIORITY\n\
+         - **Duration**: 2026-09-01 to 2026-09-08\n\
+         - **Status**: Active\n\n\
+         ### Tasks\n\
+         | ID | Description | Priority | Status | Estimate |\n\
+         |----|-------------|----------|--------|----------|\n\
+         | PMAT-0001 | Wire the flag | High | Open | 2h |\n\
+         | PMAT-0002 | Cover the branch | Medium | In Progress | 4h |\n",
+    )
+    .expect("write docs/execution/roadmap.md");
+
+    // `show-metrics --failures-only` drops every trend that is not
+    // Regressing (metric_trends_core.rs: p < 0.05 and a positive slope).
+    // Eight daily observations, strictly rising for `lint` and strictly
+    // falling for `test-fast`, inside the 30-day window the command reads.
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("clock")
+        .as_secs() as i64;
+    std::fs::create_dir_all(root.join(".pmat-metrics/trends")).expect("mkdir trends");
+    let series: [(&str, [f64; 8]); 2] = [
+        (
+            "lint",
+            [100.0, 130.0, 160.0, 190.0, 220.0, 250.0, 280.0, 310.0],
+        ),
+        (
+            "test-fast",
+            [800.0, 760.0, 720.0, 680.0, 640.0, 600.0, 560.0, 520.0],
+        ),
+    ];
+    for (metric, values) in series {
+        let observations: Vec<String> = values
+            .iter()
+            .enumerate()
+            .map(|(i, v)| {
+                let age_days = values.len() as i64 - i as i64;
+                format!(
+                    "{{\"metric\":\"{metric}\",\"value\":{v:.1},\"timestamp\":{}}}",
+                    now - 86_400 * age_days
+                )
+            })
+            .collect();
+        std::fs::write(
+            root.join(format!(".pmat-metrics/trends/{metric}.json")),
+            format!("[{}]\n", observations.join(",")),
+        )
+        .expect("write trend series");
+    }
 }
 
 /// The *repository-level* defects, as distinct from the source-level ones.


### PR DESCRIPTION
## PMAT-688 — flag-efficacy release gate was RED on the 3.39.0 tree

`make gate-flag-efficacy-full` on v3.39.0: `584 effective, 4 refuses-honestly, 18 no-op, 4 error-out, 369 skipped` → exit 1.
On this branch (18503f90f): `595 effective, 6 refuses-honestly, 0 no-op, 0 error-out, 371 skipped` → **exit 0** (three full sweeps run; the last two both 0/0).

Every one of the 18 no-ops was reproduced by hand on a dumped corpus with the installed 3.39.0 binary before any code changed, then fixed at the cause — receipt: `docs/audits/impl-PMAT-688-receipt.md`, contract: `contracts/work/PMAT-688.yaml` (pv validate + lint clean).

**Behaviour changes (user-visible)**
- `popper-score --failures-only`, `demo-score --failures-only`: the same display filter as `repo-score` / `infra-score` / `rust-project-score` — rows at or above the pass line are hidden; popper's recommendations stay whatever the gateway said.
- `roadmap todos`: the confirmation line names the document written and the count (`simple checklist` vs `PDMT with quality gates`).
- `cuda-tdg gate`: reports the P0 policy in force (`P0 policy: …`; JSON gains `fail_on_p0`).
- `validate-docs --fail-on-error`: was a `bool` with `default_value = "true"` (a switch that could never change anything); now a real switch — default and bare form still fail, `--fail-on-error false` opts out.
- `--color always` now colours something on `list`, `mcp manifest`, `roadmap todos`, `roadmap status`, `quality-gates validate`, `cuda-tdg score/gate/kaizen` (terminal format only; markdown/sarif/json/csv/toml stay plain). Plain bytes are unchanged when colours are off.

**Harness / corpus**
- A refusal that names its precondition (the ledger writers' dirty-tree refusal) is `Verdict::Refuses`; `--allow-dirty` gets a `PROBE_CONTEXT` of `--write-ledger` instead of a clap-error pass (quorum finding).
- Large corpus gains `docs/links.md` (broken relative link), `docs/adr/`, `docs/execution/roadmap.md`, `.pmat-metrics/trends/{lint,test-fast}.json`. `make gate-differential` re-run green.
- 4 stale ALLOWED_NOOPS entries deleted (verified effective by hand), 5 artifact outputs allow-listed with measured reasons (prompt comply/book/repo-image, quality-gates show, cuda-tdg report).

**RED → GREEN**: 27ef50ee3 (RED, 15 tests failing) → e7e36afcf; df0daad38 (RED) → 64257712a; quorum fixes fffcc8845. 3-lane agy quorum on the diff: 3/3 needs-changes → both confirmed findings fixed (Markdown/Sarif colour leak; clap-error classification); one lane claim refuted (no new `unwrap` in src/).

**Filed, not fixed here**: PMAT-689 (documentation_scorer tests read the temp dir's parent — a stray `/tmp/CHANGELOG.md` from another session fails three tests on every tree), PMAT-690 (show-metrics / comply report baselines intermittently nondeterministic in the sweep).

Pmat-Ticket: PMAT-688

🤖 Generated with [Claude Code](https://claude.com/claude-code)
