### PR TITLE
feat(PMAT-693): board-check — the falsifiable instrument for a cleared board

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -185,6 +185,14 @@ gate-differential: ## Every metric must differ between an empty and a large proj
 gate-artifact: gate-differential gate-flag-efficacy ## Both falsification gates
 	@echo "✅ artifact falsification gates passed"
 
+.PHONY: board-check board-check-selftest
+
+board-check: ## the board is cleared: every open PR/issue/ticket has an enacted disposition (exit 1 lists the gaps)
+	@bash scripts/board-check.sh
+
+board-check-selftest: ## Offline self-test for scripts/board-check.sh (planted-gap + covered fixtures)
+	@bash scripts/board-check-selftest.sh
+
 # ── Release gates the dogfood protocol looks for by name.
 #
 # All three were ABSENT, and their absence reported as WARN — which the protocol

--- a/contracts/work/PMAT-693.yaml
+++ b/contracts/work/PMAT-693.yaml
@@ -1,0 +1,46 @@
+# Hand-authored work contract for PMAT-693 ([train/BC]): the release train's
+# "cleared board" definition had no instrument — 3.39.0 produced a 104-row
+# disposition ledger and nothing enforced it. `make board-check` is that
+# instrument: read-only, run from the session (never as a PR check), exit 1
+# listing every gap. Every evidence_method below was run on this tree.
+name: "PMAT-693"
+metadata:
+  version: "1.0.0"
+  kind: pattern
+  description: "make board-check exits 1 naming every open PR without a disposition row, every open issue without exactly one milestone or an evidence closure, and every non-completed roadmap ticket absent from the newest dispositions ledger; exit 0 only when there are no gaps"
+  references:
+    - "scripts/board-check.sh"
+    - "scripts/board-check-selftest.sh"
+    - "Makefile"
+    - "docs/audits/dispositions-3.39.0.json"
+surface: work-contract
+verification_summary:
+  target_level: L1
+  current_level: L1
+  total_obligations: 4
+proof_obligations:
+- id: "PO-B1"
+  statement: "On a fixture roadmap with one completed ticket, one planned ticket covered by a fixture ledger (defer(3.41.0)) and one planted planned ticket absent from that ledger, board-check --offline exits 1 naming exactly the planted id and nothing else"
+  evidence_method: "make board-check-selftest"
+- id: "PO-B2"
+  statement: "On a fixture where every non-completed ticket is covered, board-check --offline exits 0 with 'board-check: 0 gap(s)'"
+  evidence_method: "make board-check-selftest"
+- id: "PO-B3"
+  statement: "On this repository's live board the three legs run (PRs, issues, tickets) and the summary line reports the gap count; the count is non-zero until Phase E of the release train enacts every disposition"
+  evidence_method: "make board-check; test $? -eq 1 && bash scripts/board-check.sh | grep -qE '^board-check: [0-9]+ gap\\(s\\)$'"
+- id: "PO-B4"
+  statement: "Both scripts are bashrs-clean (0 errors)"
+  evidence_method: "bashrs lint scripts/board-check.sh scripts/board-check-selftest.sh"
+falsifiable_claims:
+- hypothesis: "On a fixture roadmap with one completed ticket, one planned ticket covered by a fixture ledger (defer(3.41.0)) and one planted planned ticket absent from that ledger, board-check --offline exits 1 naming exactly the planted id and nothing else"
+  method: "make board-check-selftest"
+  from_step: "B1"
+- hypothesis: "On a fixture where every non-completed ticket is covered, board-check --offline exits 0 with 'board-check: 0 gap(s)'"
+  method: "make board-check-selftest"
+  from_step: "B2"
+- hypothesis: "On this repository's live board the three legs run (PRs, issues, tickets) and the summary line reports the gap count; the count is non-zero until Phase E of the release train enacts every disposition"
+  method: "make board-check; test $? -eq 1 && bash scripts/board-check.sh | grep -qE '^board-check: [0-9]+ gap\\(s\\)$'"
+  from_step: "B3"
+- hypothesis: "Both scripts are bashrs-clean (0 errors)"
+  method: "bashrs lint scripts/board-check.sh scripts/board-check-selftest.sh"
+  from_step: "B4"

--- a/docs/audits/impl-PMAT-693-receipt.md
+++ b/docs/audits/impl-PMAT-693-receipt.md
@@ -13,10 +13,27 @@
 ## Live board
 `bash scripts/board-check.sh` on this repository before Phase E of the 3.40.0 train: `board-check: 45 gap(s)` (issues without a milestone, the train's freshly minted tickets not yet in a ledger, and `#1029` "ledger says complete but the issue is still open"). The offline leg alone: 13 ticket gaps. Phase E enacts them and re-runs this command; the release receipt records the after count.
 
+## Quorum (agy `--mode plan`, width 3, review-only) on 09ec0880e
+
+Lanes 86c6118c-1828-4cf8-a71e-82b36244cfb7, 50aa693e-be2e-43d2-b4a3-097d47755871, fb64e5a1-aef4-4373-bc02-b47d7c64ac12 — 3/3 needs-changes. Every finding re-verified by the orchestrator and fixed in the commit that carries this section:
+
+| # | finding | lanes | fix |
+|---|---|---|---|
+| 1 | `--offline` printed a clean summary and exited 0 having run one leg of three | 3/3 | a clean partial run exits **3**; 1 with gaps; documented in `--help` |
+| 2 | a roadmap that parses to zero `- id:` rows was silently zero gaps | 3/3 | exit **2** "parsed to zero tickets — refusing to report a board it could not read" |
+| 3 | the evidence-closure arm still emitted a gap, worded "no evidence-closure" exactly when there was one | lane 3 (verified) | the rule is now stated as it is meant: an OPEN issue whose row carries evidence is a gap in its own words ("close it") — evidence is how a `complete` row gets closed, never an exemption |
+| 4 | the self-test drove only the ticket leg (`--offline`), so the issue leg was never exercised, and there was no injection seam | delegate | `--prs-json` / `--issues-json` seams; fixture 2 now runs all three legs (HRQ reject covered, milestoned issue covered); fixture 3 drives the issue leg (unmilestoned → gap, open-but-complete → gap, HRQ reject → not named, exactly 2 gaps); fixture 4 zero-ticket roadmap → exit 2; fixture 5 clean `--offline` → exit 3 |
+| 5 | `gh pr list` took gh's default page (30) and `gh issue list --limit 200` could truncate silently | delegate | both legs ask for 200 and refuse a page that is exactly full (exit 2) |
+| 6 | `sort` not `sort -V` for the newest ledger (`3.9.0` would beat `3.39.0`) | delegate | `sort -V` |
+
+Agreed sound across all lanes: the RED commit is real (the script absent), fixture 1 discriminates (exit code, exact planted id, count, absence of the other ids), the HRQ-reject exemption needs the ledger row AND the label, the enactable set is a positive allowlist, the jq `($name | .[])` rewrites are identical to `$name[]` on jq 1.6.
+
+After the fixes: `make board-check-selftest` → PASSED (5 fixtures); `bashrs lint` 0 errors; live board against `dispositions-3.40.0.json` → `board-check: 7 gap(s)` exit 1 — the seven tickets this train's Phase 2 / RC / IP complete (PMAT-687, 691, 693, 694, 695, 700, 701), which is E1's exit predicate.
+
 ## Gate
 `bashrs lint scripts/board-check.sh scripts/board-check-selftest.sh`: 0 errors. `pmat verify --skip clippy,tests --format json`: ok=None measured=2 not_measured=['complexity']. `pv validate` + `pv lint contracts/work/PMAT-693.yaml`: PASS.
 
-Orchestrator turns: 6 (footprint, worker dispatch, one resume, takeover, contract/receipt)
+Orchestrator turns: 9 (footprint, worker dispatch, one resume, takeover, contract/receipt, quorum fixes)
 
 verdict: GREEN
 

--- a/docs/audits/impl-PMAT-693-receipt.md
+++ b/docs/audits/impl-PMAT-693-receipt.md
@@ -1,0 +1,23 @@
+# impl receipt — PMAT-693 [train/BC]: board-check, the cleared-board instrument
+
+**Ticket:** PMAT-693 (kind:code) · **Branch:** `PMAT-693-board-check` · **Orchestrator:** Fable (paiml-implement). Worker: paiml-impl-worker (sonnet) wrote the self-test, the RED commit and the first draft of `board-check.sh`, then hit its 40-turn cap twice on bashrs findings (one resume used); the orchestrator finished the lint fix (three jq `$name[` expansions rewritten as `($name | .[])`, a bashrs SC1087 false positive on jq syntax), the contract and this receipt. `gate_cmd_fallback=true` (discovery); `pmat verify --skip clippy,tests` used (no Rust changed).
+
+## What
+`scripts/board-check.sh` + `make board-check` (read-only; `gh` for PRs and issues, a raw-text scan of `docs/roadmaps/roadmap.yaml` for tickets, the lexically newest `docs/audits/dispositions-*.json` as the ledger). Gap rules: an open PR without a `pr` ledger row; an open issue without exactly one milestone (a `complete` row on an open issue is a gap — complete means closed); a non-completed ticket absent from the ledger or with a non-enactable disposition. Flags: `--ledger`, `--repo`, `--roadmap`, `--offline`. Summary line `board-check: <n> gap(s)`, exit 1 iff n > 0. `scripts/board-check-selftest.sh` + `make board-check-selftest` is the acceptance arm.
+
+## RED → GREEN
+- RED 122571090 ( 2 files changed, 191 insertions(+)): `make board-check-selftest` failed — `scripts/board-check.sh` did not exist.
+- GREEN (this commit): `board-check-selftest: PASSED` — fixture 1 exits 1 naming exactly the planted id (`board-check: 1 gap(s)`), fixture 2 exits 0 (`board-check: 0 gap(s)`).
+- Discrimination: the self-test's first fixture has three tickets and the gap list names one; a script that flagged every planned ticket would name two.
+
+## Live board
+`bash scripts/board-check.sh` on this repository before Phase E of the 3.40.0 train: `board-check: 45 gap(s)` (issues without a milestone, the train's freshly minted tickets not yet in a ledger, and `#1029` "ledger says complete but the issue is still open"). The offline leg alone: 13 ticket gaps. Phase E enacts them and re-runs this command; the release receipt records the after count.
+
+## Gate
+`bashrs lint scripts/board-check.sh scripts/board-check-selftest.sh`: 0 errors. `pmat verify --skip clippy,tests --format json`: ok=None measured=2 not_measured=['complexity']. `pv validate` + `pv lint contracts/work/PMAT-693.yaml`: PASS.
+
+Orchestrator turns: 6 (footprint, worker dispatch, one resume, takeover, contract/receipt)
+
+verdict: GREEN
+
+IMPL-PMAT-693-RECEIPT-END

--- a/scripts/board-check-selftest.sh
+++ b/scripts/board-check-selftest.sh
@@ -7,8 +7,12 @@
 #                         board-check.sh --offline must exit 1 and name
 #                         exactly that ticket id, nothing else.
 #   Fixture 2 (covered):  every non-completed ticket has an enactable
-#                         disposition in the ledger. board-check.sh --offline
-#                         must exit 0.
+#                         disposition in the ledger; every leg runs through the
+#                         --prs-json / --issues-json seams and must exit 0.
+#   fixture 3 (issue leg)  an unmilestoned issue and an open-but-complete issue
+#                         are named, an HRQ reject is not; exit 1.
+#   fixture 4 (vacuity)    a zero-ticket roadmap exits 2.
+#   fixture 5 (partial)    a clean --offline run exits 3, never 0.
 #
 # This script never touches the real repo's roadmap.yaml or ledger, and never
 # calls gh (--offline skips the PR/issue legs entirely).
@@ -160,7 +164,17 @@ rm -f "${gap_out}"
 echo "board-check-selftest: fixture 2 (fully covered)"
 covered_out="$(mktemp "${TMPDIR:-/tmp}/board-check-selftest-covered-out.XXXXXX")"
 covered_exit=0
-"${board_check}" --offline --ledger "${covered_ledger}" --roadmap "${covered_roadmap}" >"${covered_out}" 2>&1 || covered_exit=$?
+# Fixture 2 drives every leg: no open PRs, two open issues — one milestoned,
+# one an HRQ reject (ledger row reject+hrq AND the disposition:reject label).
+prs_json="${work_dir}/prs.json"
+issues_json="${work_dir}/issues.json"
+printf '[]\n' >"${prs_json}"
+cat >"${issues_json}" <<'JSON'
+[{"number":9001,"title":"deferred","milestone":{"title":"3.41.0"},"labels":[{"name":"disposition:defer"}],"state":"OPEN"},
+ {"number":9002,"title":"hrq reject","milestone":null,"labels":[{"name":"disposition:reject"}],"state":"OPEN"}]
+JSON
+jq '. + [{"id":"#9001","kind":"issue","disposition":"defer(3.41.0)","hrq":false},{"id":"#9002","kind":"issue","disposition":"reject","hrq":true}]' "${covered_ledger}" >"${covered_ledger}.tmp" && mv "${covered_ledger}.tmp" "${covered_ledger}"
+"${board_check}" --prs-json "${prs_json}" --issues-json "${issues_json}" --ledger "${covered_ledger}" --roadmap "${covered_roadmap}" >"${covered_out}" 2>&1 || covered_exit=$?
 cat "${covered_out}"
 
 if [ "${covered_exit}" -ne 0 ]; then
@@ -177,6 +191,61 @@ rm -f "${covered_out}"
 
 if [ "${fail}" -ne 0 ]; then
   echo "board-check-selftest: FAILED"
+  exit 1
+fi
+
+# Fixture 3: the issue leg must fire — an open issue with no milestone whose
+# ledger row is a plain defer (label present, but no milestone) is a gap, and an
+# open issue whose row says complete is a gap; nothing else may be named.
+issues3_json="${work_dir}/issues3.json"
+cat >"${issues3_json}" <<'JSON'
+[{"number":9003,"title":"unmilestoned","milestone":null,"labels":[{"name":"disposition:defer"}],"state":"OPEN"},
+ {"number":9004,"title":"still open","milestone":{"title":"3.41.0"},"labels":[],"state":"OPEN"},
+ {"number":9002,"title":"hrq reject","milestone":null,"labels":[{"name":"disposition:reject"}],"state":"OPEN"}]
+JSON
+ledger3="${work_dir}/ledger3.json"
+jq '. + [{"id":"#9003","kind":"issue","disposition":"defer(3.41.0)","hrq":false},{"id":"#9004","kind":"issue","disposition":"complete","hrq":false,"evidence":"fixture"},{"id":"#9002","kind":"issue","disposition":"reject","hrq":true}]' "${covered_ledger}" >"${ledger3}"
+issue_out="${work_dir}/issue.out"
+issue_exit=0
+"${board_check}" --prs-json "${prs_json}" --issues-json "${issues3_json}" --ledger "${ledger3}" --roadmap "${covered_roadmap}" >"${issue_out}" 2>&1 || issue_exit=$?
+echo "board-check-selftest: fixture 3 (issue leg)"
+cat "${issue_out}"
+if [ "${issue_exit}" -ne 1 ]; then
+  echo "board-check-selftest: FAIL — expected exit 1 on the issue fixture, got ${issue_exit}" >&2
+  exit 1
+fi
+if ! grep -q '^GAP issue #9003 no milestone$' "${issue_out}"; then
+  echo "board-check-selftest: FAIL — the unmilestoned issue was not named" >&2
+  exit 1
+fi
+if ! grep -q '^GAP issue #9004 ledger says complete but the issue is still open$' "${issue_out}"; then
+  echo "board-check-selftest: FAIL — the open-but-complete issue was not named" >&2
+  exit 1
+fi
+if grep -q '#9002' "${issue_out}"; then
+  echo "board-check-selftest: FAIL — the HRQ reject was named as a gap" >&2
+  exit 1
+fi
+if [ "$(grep -c '^GAP ' "${issue_out}")" -ne 2 ]; then
+  echo "board-check-selftest: FAIL — expected exactly 2 gaps on the issue fixture" >&2
+  exit 1
+fi
+
+# Fixture 4: a roadmap that parses to zero tickets is not a clean board.
+empty_roadmap="${work_dir}/empty-roadmap.yaml"
+printf 'items: []\n' >"${empty_roadmap}"
+empty_exit=0
+"${board_check}" --offline --ledger "${covered_ledger}" --roadmap "${empty_roadmap}" >/dev/null 2>&1 || empty_exit=$?
+if [ "${empty_exit}" -ne 2 ]; then
+  echo "board-check-selftest: FAIL — expected exit 2 on a zero-ticket roadmap, got ${empty_exit}" >&2
+  exit 1
+fi
+
+# Fixture 5: --offline on a clean fixture is partial, never 0.
+partial_exit=0
+"${board_check}" --offline --ledger "${covered_ledger}" --roadmap "${covered_roadmap}" >/dev/null 2>&1 || partial_exit=$?
+if [ "${partial_exit}" -ne 3 ]; then
+  echo "board-check-selftest: FAIL — expected exit 3 on a clean --offline run, got ${partial_exit}" >&2
   exit 1
 fi
 

--- a/scripts/board-check-selftest.sh
+++ b/scripts/board-check-selftest.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# board-check-selftest.sh — offline self-test for scripts/board-check.sh (PMAT-693).
+#
+# Builds two fixtures in a temp dir: a roadmap.yaml with 3 tickets plus a
+# matching dispositions ledger.
+#   Fixture 1 (gap):     one ticket is planned and absent from the ledger.
+#                         board-check.sh --offline must exit 1 and name
+#                         exactly that ticket id, nothing else.
+#   Fixture 2 (covered):  every non-completed ticket has an enactable
+#                         disposition in the ledger. board-check.sh --offline
+#                         must exit 0.
+#
+# This script never touches the real repo's roadmap.yaml or ledger, and never
+# calls gh (--offline skips the PR/issue legs entirely).
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+board_check="${script_dir}/board-check.sh"
+
+if [ ! -x "${board_check}" ]; then
+  echo "board-check-selftest: ${board_check} not found or not executable" >&2
+  exit 1
+fi
+
+work_dir="$(mktemp -d "${TMPDIR:-/tmp}/board-check-selftest.XXXXXX")"
+trap 'rm -rf "${work_dir}"' EXIT
+
+write_roadmap() {
+  local path="$1"
+  cat >"${path}" <<'EOF'
+roadmap_version: '1.0'
+github_enabled: true
+github_repo: paiml/paiml-mcp-agent-toolkit
+roadmap:
+- id: PMAT-9901
+  github_issue: null
+  item_type: task
+  title: 'fixture: completed ticket'
+  status: completed
+  priority: medium
+  assigned_to: null
+  created: 2026-01-01T00:00:00Z
+  updated: 2026-01-01T00:00:00Z
+  spec: null
+  acceptance_criteria: []
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels: []
+  notes: null
+- id: PMAT-9902
+  github_issue: null
+  item_type: task
+  title: 'fixture: planned ticket, covered by the ledger'
+  status: planned
+  priority: medium
+  assigned_to: null
+  created: 2026-01-01T00:00:00Z
+  updated: 2026-01-01T00:00:00Z
+  spec: null
+  acceptance_criteria: []
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels: []
+  notes: null
+- id: PMAT-9903
+  github_issue: null
+  item_type: task
+  title: 'fixture: planned ticket, planted gap (absent from the ledger)'
+  status: planned
+  priority: medium
+  assigned_to: null
+  created: 2026-01-01T00:00:00Z
+  updated: 2026-01-01T00:00:00Z
+  spec: null
+  acceptance_criteria: []
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels: []
+  notes: null
+EOF
+}
+
+gap_roadmap="${work_dir}/roadmap-gap.yaml"
+gap_ledger="${work_dir}/dispositions-gap.json"
+write_roadmap "${gap_roadmap}"
+cat >"${gap_ledger}" <<'EOF'
+[
+  {
+    "kind": "ticket",
+    "id": "PMAT-9902",
+    "title": "fixture: planned ticket, covered by the ledger",
+    "disposition": "defer(3.41.0)",
+    "rationale": "fixture row",
+    "hrq": false,
+    "links": []
+  }
+]
+EOF
+
+covered_roadmap="${work_dir}/roadmap-covered.yaml"
+covered_ledger="${work_dir}/dispositions-covered.json"
+write_roadmap "${covered_roadmap}"
+cat >"${covered_ledger}" <<'EOF'
+[
+  {
+    "kind": "ticket",
+    "id": "PMAT-9902",
+    "title": "fixture: planned ticket, covered by the ledger",
+    "disposition": "defer(3.41.0)",
+    "rationale": "fixture row",
+    "hrq": false,
+    "links": []
+  },
+  {
+    "kind": "ticket",
+    "id": "PMAT-9903",
+    "title": "fixture: planned ticket, planted gap (absent from the ledger)",
+    "disposition": "defer(3.41.0)",
+    "rationale": "fixture row",
+    "hrq": false,
+    "links": []
+  }
+]
+EOF
+
+fail=0
+
+echo "board-check-selftest: fixture 1 (planted gap: PMAT-9903 not in ledger)"
+gap_out="$(mktemp "${TMPDIR:-/tmp}/board-check-selftest-gap-out.XXXXXX")"
+gap_exit=0
+"${board_check}" --offline --ledger "${gap_ledger}" --roadmap "${gap_roadmap}" >"${gap_out}" 2>&1 || gap_exit=$?
+cat "${gap_out}"
+
+if [ "${gap_exit}" -ne 1 ]; then
+  echo "board-check-selftest: FAIL — expected exit 1 on the gap fixture, got ${gap_exit}" >&2
+  fail=1
+fi
+
+gap_lines="$(grep -c '^GAP ' "${gap_out}" || true)"
+if [ "${gap_lines}" -ne 1 ]; then
+  echo "board-check-selftest: FAIL — expected exactly 1 GAP line on the gap fixture, got ${gap_lines}" >&2
+  fail=1
+fi
+
+if ! grep -qF 'GAP ticket PMAT-9903 not in ledger' "${gap_out}"; then
+  echo "board-check-selftest: FAIL — expected 'GAP ticket PMAT-9903 not in ledger', not found" >&2
+  fail=1
+fi
+
+if grep -q 'PMAT-9901\|PMAT-9902' "${gap_out}"; then
+  echo "board-check-selftest: FAIL — output named a ticket other than the planted gap" >&2
+  fail=1
+fi
+
+rm -f "${gap_out}"
+
+echo "board-check-selftest: fixture 2 (fully covered)"
+covered_out="$(mktemp "${TMPDIR:-/tmp}/board-check-selftest-covered-out.XXXXXX")"
+covered_exit=0
+"${board_check}" --offline --ledger "${covered_ledger}" --roadmap "${covered_roadmap}" >"${covered_out}" 2>&1 || covered_exit=$?
+cat "${covered_out}"
+
+if [ "${covered_exit}" -ne 0 ]; then
+  echo "board-check-selftest: FAIL — expected exit 0 on the covered fixture, got ${covered_exit}" >&2
+  fail=1
+fi
+
+if grep -q '^GAP ' "${covered_out}"; then
+  echo "board-check-selftest: FAIL — covered fixture reported a GAP" >&2
+  fail=1
+fi
+
+rm -f "${covered_out}"
+
+if [ "${fail}" -ne 0 ]; then
+  echo "board-check-selftest: FAILED"
+  exit 1
+fi
+
+echo "board-check-selftest: PASSED"

--- a/scripts/board-check.sh
+++ b/scripts/board-check.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+# board-check.sh — the board is cleared: every open PR/issue/ticket has an
+# enacted disposition. READ-ONLY: never mutates GitHub or the roadmap.
+# Prints one `GAP <kind> <id> <reason>` line per gap found, then a summary
+# line `board-check: <n> gap(s)`. Exits 1 iff n>0, 0 otherwise. (PMAT-693)
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: board-check.sh [--ledger PATH] [--repo OWNER/NAME] [--roadmap PATH] [--offline]
+
+  --ledger PATH      use this dispositions ledger instead of the lexically
+                      newest ledger under docs/audits
+  --repo OWNER/NAME  GitHub repo to query (default: taken from `gh repo view`)
+  --roadmap PATH     roadmap.yaml to read tickets from (default:
+                      docs/roadmaps/roadmap.yaml)
+  --offline          skip every `gh` call; only the ticket leg runs
+USAGE
+}
+
+ledger_path=""
+repo=""
+roadmap_path="docs/roadmaps/roadmap.yaml"
+offline=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --ledger)
+      ledger_path="$2"
+      shift 2
+      ;;
+    --repo)
+      repo="$2"
+      shift 2
+      ;;
+    --roadmap)
+      roadmap_path="$2"
+      shift 2
+      ;;
+    --offline)
+      offline=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "board-check: unrecognized argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+# ── Find the newest ledger (lexically-last dispositions ledger under
+# docs/audits), unless one was given explicitly. No `ls` parsing: a glob
+# array, sorted.
+find_newest_ledger() {
+  local -a candidates=()
+  shopt -s nullglob
+  candidates=(docs/audits/dispositions-*.json)
+  shopt -u nullglob
+  if [ "${#candidates[@]}" -eq 0 ]; then
+    return 1
+  fi
+  printf '%s\n' "${candidates[@]}" | sort | tail -n 1
+}
+
+if [ -z "${ledger_path}" ]; then
+  if ! ledger_path="$(find_newest_ledger)"; then
+    echo "board-check: no ledger found under docs/audits and none given via --ledger" >&2
+    exit 2
+  fi
+fi
+
+if [ ! -f "${ledger_path}" ]; then
+  echo "board-check: ledger file does not exist: ${ledger_path}" >&2
+  exit 2
+fi
+
+if [ ! -f "${roadmap_path}" ]; then
+  echo "board-check: roadmap file does not exist: ${roadmap_path}" >&2
+  exit 2
+fi
+
+if [[ "${offline}" -eq 0 && -z "${repo}" ]]; then
+  repo="$(gh repo view --json nameWithOwner --jq '.nameWithOwner')"
+fi
+
+gap_count=0
+
+# report_gap: print one GAP line and bump the running total.
+# $1=kind $2=id $3=reason
+report_gap() {
+  echo "GAP $1 $2 $3"
+  ((gap_count++)) || true
+}
+
+# report_gap_lines: print every non-empty line of $1 (one GAP line per line)
+# and bump the running total by however many lines were printed.
+report_gap_lines() {
+  local text="$1"
+  [ -n "${text}" ] || return 0
+  printf '%s\n' "${text}"
+  local n
+  n="$(printf '%s\n' "${text}" | grep -c '^GAP ')"
+  ((gap_count += n)) || true
+}
+
+# ── Ticket leg: raw-text parse of roadmap.yaml. Every top-level `- id: PMAT-N`
+# row, paired with the first `status:` line that follows it (before the next
+# top-level `- id:` row). Never shells out to `pmat`.
+ticket_table="$(awk '
+  /^- id: PMAT-[0-9]+/ {
+    current_id = $3
+    capturing = 1
+    next
+  }
+  /^- id:/ {
+    capturing = 0
+    next
+  }
+  capturing && /^  status:/ {
+    print current_id "\t" $2
+    capturing = 0
+  }
+' "${roadmap_path}")"
+
+# One ledger read for every ticket row, keyed by ticket id, built once so the
+# per-ticket loop below never forks a subprocess.
+declare -A ledger_ticket_disposition=()
+while IFS=$'\t' read -r row_id row_disposition; do
+  [ -n "${row_id}" ] || continue
+  ledger_ticket_disposition["${row_id}"]="${row_disposition}"
+done < <(jq -r '.[] | select(.kind == "ticket") | "\(.id)\t\(.disposition)"' "${ledger_path}")
+
+is_completed_status() {
+  case "$1" in
+    completed|cancelled|rejected) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+is_enactable_disposition() {
+  case "$1" in
+    complete|reject) return 0 ;;
+    defer\(*\)) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+if [ -n "${ticket_table}" ]; then
+  while IFS=$'\t' read -r ticket_id ticket_status; do
+    [ -n "${ticket_id}" ] || continue
+    if is_completed_status "${ticket_status}"; then
+      continue
+    fi
+    disposition="${ledger_ticket_disposition[${ticket_id}]:-}"
+    if [ -z "${disposition}" ]; then
+      report_gap ticket "${ticket_id}" "not in ledger"
+      continue
+    fi
+    if ! is_enactable_disposition "${disposition}"; then
+      report_gap ticket "${ticket_id}" "disposition ${disposition} is not enactable"
+      continue
+    fi
+    if [ "${disposition}" = "complete" ]; then
+      report_gap ticket "${ticket_id}" "marked complete in the ledger but roadmap status is still ${ticket_status}"
+    fi
+  done <<TICKETS
+${ticket_table}
+TICKETS
+fi
+
+if [ "${offline}" -eq 1 ]; then
+  echo "board-check: --offline set — PR and issue legs skipped, only the ticket leg ran"
+  echo "board-check: ${gap_count} gap(s)"
+  if [ "${gap_count}" -gt 0 ]; then
+    exit 1
+  fi
+  exit 0
+fi
+
+# ── PR leg: one jq pass over open PRs against the ledger's "pr" rows.
+open_pr_table="$(gh pr list --repo "${repo}" --state open --json number,title,headRefName)"
+pr_gap_text="$(jq -r \
+  --argjson prs "${open_pr_table}" \
+  --slurpfile ledger_rows "${ledger_path}" \
+  -n '
+    (($ledger_rows | .[0]) // []) as $rows
+    | ($rows | map(select(.kind == "pr")) | map(.id)) as $covered
+    | ($prs | .[])
+    | ("#" + (.number | tostring)) as $pr_id
+    | select(($covered | index($pr_id)) | not)
+    | "GAP pr " + $pr_id + " no disposition row"
+  ')"
+report_gap_lines "${pr_gap_text}"
+
+# ── Issue leg: one jq pass over open issues against the ledger's "issue" rows.
+# A newer ledger row may carry an `evidence` or `evidenced` key; a non-null
+# value there is treated as an evidence-closure that changes the missing-
+# milestone wording (see PMAT-693 brief).
+open_issue_table="$(gh issue list --repo "${repo}" --state open --limit 200 --json number,title,milestone,labels,state)"
+issue_gap_text="$(jq -r \
+  --argjson issues "${open_issue_table}" \
+  --slurpfile ledger_rows "${ledger_path}" \
+  -n '
+    (($ledger_rows | .[0]) // []) as $rows
+    | ($issues | .[])
+    | . as $issue
+    | ("#" + (.number | tostring)) as $issue_id
+    | ($rows | map(select(.kind == "issue" and .id == $issue_id)) | first) as $row
+    | (($row.evidence // $row.evidenced // null) != null) as $has_evidence
+    | (
+        if $issue.milestone == null then
+          if $has_evidence then
+            "GAP issue " + $issue_id + " milestone missing and no evidence-closure"
+          else
+            "GAP issue " + $issue_id + " no milestone"
+          end
+        else
+          empty
+        end
+      ),
+      (
+        if ($row.disposition // "") == "complete" then
+          "GAP issue " + $issue_id + " ledger says complete but the issue is still open"
+        else
+          empty
+        end
+      )
+  ')"
+report_gap_lines "${issue_gap_text}"
+
+echo "board-check: ${gap_count} gap(s)"
+if [ "${gap_count}" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/scripts/board-check.sh
+++ b/scripts/board-check.sh
@@ -2,19 +2,32 @@
 # board-check.sh — the board is cleared: every open PR/issue/ticket has an
 # enacted disposition. READ-ONLY: never mutates GitHub or the roadmap.
 # Prints one `GAP <kind> <id> <reason>` line per gap found, then a summary
-# line `board-check: <n> gap(s)`. Exits 1 iff n>0, 0 otherwise. (PMAT-693)
+# line `board-check: <n> gap(s)`. Exit 0 only when every leg ran and n=0;
+# 1 when n>0; 2 when the board could not be measured; 3 clean-but-partial.
+# (PMAT-693)
 set -euo pipefail
 
 usage() {
   cat <<'USAGE'
 Usage: board-check.sh [--ledger PATH] [--repo OWNER/NAME] [--roadmap PATH] [--offline]
+                      [--prs-json PATH] [--issues-json PATH]
 
   --ledger PATH      use this dispositions ledger instead of the lexically
                       newest ledger under docs/audits
   --repo OWNER/NAME  GitHub repo to query (default: taken from `gh repo view`)
   --roadmap PATH     roadmap.yaml to read tickets from (default:
                       docs/roadmaps/roadmap.yaml)
-  --offline          skip every `gh` call; only the ticket leg runs
+  --offline          skip every `gh` call; only the ticket leg runs. A clean
+                      partial run exits 3, never 0: one leg of three is not a
+                      cleared board
+  --prs-json PATH    read open PRs from this JSON file instead of `gh pr list`
+                      (the self-test's seam; same shape as gh's --json output)
+  --issues-json PATH read open issues from this JSON file instead of
+                      `gh issue list` (same shape as gh's --json output)
+
+Exit codes: 0 no gap and every leg ran · 1 at least one gap · 2 the run could
+not measure the board (a leg was truncated, the roadmap parsed to zero tickets,
+no ledger) · 3 clean but partial (--offline)
 USAGE
 }
 
@@ -22,6 +35,11 @@ ledger_path=""
 repo=""
 roadmap_path="docs/roadmaps/roadmap.yaml"
 offline=0
+prs_json=""
+issues_json=""
+# gh pages at 30 by default; a silently truncated listing reads as "no gap",
+# so both legs ask for this many and refuse a page that is exactly full.
+readonly GH_LIMIT=200
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -40,6 +58,14 @@ while [ $# -gt 0 ]; do
     --offline)
       offline=1
       shift
+      ;;
+    --prs-json)
+      prs_json="$2"
+      shift 2
+      ;;
+    --issues-json)
+      issues_json="$2"
+      shift 2
       ;;
     -h|--help)
       usage
@@ -64,7 +90,7 @@ find_newest_ledger() {
   if [ "${#candidates[@]}" -eq 0 ]; then
     return 1
   fi
-  printf '%s\n' "${candidates[@]}" | sort | tail -n 1
+  printf '%s\n' "${candidates[@]}" | sort -V | tail -n 1
 }
 
 if [ -z "${ledger_path}" ]; then
@@ -150,6 +176,10 @@ is_enactable_disposition() {
   esac
 }
 
+if [ -z "${ticket_table}" ]; then
+  echo "board-check: ${roadmap_path} parsed to zero tickets — refusing to report a board it could not read" >&2
+  exit 2
+fi
 if [ -n "${ticket_table}" ]; then
   while IFS=$'\t' read -r ticket_id ticket_status; do
     [ -n "${ticket_id}" ] || continue
@@ -175,15 +205,23 @@ fi
 
 if [ "${offline}" -eq 1 ]; then
   echo "board-check: --offline set — PR and issue legs skipped, only the ticket leg ran"
-  echo "board-check: ${gap_count} gap(s)"
+  echo "board-check: ${gap_count} gap(s) (partial: 1 of 3 legs)"
   if [ "${gap_count}" -gt 0 ]; then
     exit 1
   fi
-  exit 0
+  exit 3
 fi
 
 # ── PR leg: one jq pass over open PRs against the ledger's "pr" rows.
-open_pr_table="$(gh pr list --repo "${repo}" --state open --json number,title,headRefName)"
+if [ -n "${prs_json}" ]; then
+  open_pr_table="$(cat "${prs_json}")"
+else
+  open_pr_table="$(gh pr list --repo "${repo}" --state open --limit "${GH_LIMIT}" --json number,title,headRefName)"
+fi
+if [ "$(jq 'length' <<<"${open_pr_table}")" -ge "${GH_LIMIT}" ]; then
+  echo "board-check: the PR listing is exactly ${GH_LIMIT} long — truncated, not measured" >&2
+  exit 2
+fi
 pr_gap_text="$(jq -r \
   --argjson prs "${open_pr_table}" \
   --slurpfile ledger_rows "${ledger_path}" \
@@ -198,13 +236,23 @@ pr_gap_text="$(jq -r \
 report_gap_lines "${pr_gap_text}"
 
 # ── Issue leg: one jq pass over open issues against the ledger's "issue" rows.
-# A newer ledger row may carry an `evidence` or `evidenced` key; a non-null
-# value there is treated as an evidence-closure that changes the missing-
-# milestone wording (see PMAT-693 brief). A `reject` row with `hrq: true` whose
+# A newer ledger row may carry an `evidence` or `evidenced` key. Evidence is
+# how a `complete` row gets CLOSED (release brief §0.3); an open issue whose
+# row carries evidence is therefore a gap in its own words — close it — never
+# an exemption (quorum lane 3 on PMAT-693: the earlier wording said "no
+# evidence-closure" exactly when there was one). A `reject` row with `hrq: true` whose
 # issue carries the `disposition:reject` label is the human review queue — the
 # run never closes a human-authored item on a reject — and counts as enacted
 # without a milestone (release brief §0.3, §8).
-open_issue_table="$(gh issue list --repo "${repo}" --state open --limit 200 --json number,title,milestone,labels,state)"
+if [ -n "${issues_json}" ]; then
+  open_issue_table="$(cat "${issues_json}")"
+else
+  open_issue_table="$(gh issue list --repo "${repo}" --state open --limit "${GH_LIMIT}" --json number,title,milestone,labels,state)"
+fi
+if [ "$(jq 'length' <<<"${open_issue_table}")" -ge "${GH_LIMIT}" ]; then
+  echo "board-check: the issue listing is exactly ${GH_LIMIT} long — truncated, not measured" >&2
+  exit 2
+fi
 issue_gap_text="$(jq -r \
   --argjson issues "${open_issue_table}" \
   --slurpfile ledger_rows "${ledger_path}" \
@@ -221,7 +269,7 @@ issue_gap_text="$(jq -r \
     | (
         if $issue.milestone == null and ($hrq_reject | not) then
           if $has_evidence then
-            "GAP issue " + $issue_id + " milestone missing and no evidence-closure"
+            "GAP issue " + $issue_id + " ledger row carries an evidence closure but the issue is still open — close it"
           else
             "GAP issue " + $issue_id + " no milestone"
           end

--- a/scripts/board-check.sh
+++ b/scripts/board-check.sh
@@ -200,7 +200,10 @@ report_gap_lines "${pr_gap_text}"
 # ── Issue leg: one jq pass over open issues against the ledger's "issue" rows.
 # A newer ledger row may carry an `evidence` or `evidenced` key; a non-null
 # value there is treated as an evidence-closure that changes the missing-
-# milestone wording (see PMAT-693 brief).
+# milestone wording (see PMAT-693 brief). A `reject` row with `hrq: true` whose
+# issue carries the `disposition:reject` label is the human review queue — the
+# run never closes a human-authored item on a reject — and counts as enacted
+# without a milestone (release brief §0.3, §8).
 open_issue_table="$(gh issue list --repo "${repo}" --state open --limit 200 --json number,title,milestone,labels,state)"
 issue_gap_text="$(jq -r \
   --argjson issues "${open_issue_table}" \
@@ -212,8 +215,11 @@ issue_gap_text="$(jq -r \
     | ("#" + (.number | tostring)) as $issue_id
     | ($rows | map(select(.kind == "issue" and .id == $issue_id)) | first) as $row
     | (($row.evidence // $row.evidenced // null) != null) as $has_evidence
+    | (($row.disposition // "") == "reject"
+        and ($row.hrq // false) == true
+        and ([$issue.labels[].name] | index("disposition:reject")) != null) as $hrq_reject
     | (
-        if $issue.milestone == null then
+        if $issue.milestone == null and ($hrq_reject | not) then
           if $has_evidence then
             "GAP issue " + $issue_id + " milestone missing and no evidence-closure"
           else


### PR DESCRIPTION
`make board-check` (read-only, run from the session, never a PR check) exits 1 listing every gap: an open PR with no ledger row; an open issue without exactly one milestone, unless its ledger row is a `reject` in the human review queue (row `hrq: true` **and** the `disposition:reject` label) — the run never closes a human-authored item on a reject; a `complete` row on an open issue; a non-completed roadmap ticket absent from the newest `docs/audits/dispositions-*.json` or with a non-enactable disposition.

Why: 3.39.0 produced a 104-row disposition ledger and nothing enforced it — 47 issues stayed open, 0 milestoned. A ledger nobody reads is enforcement theater.

**RED → GREEN:** RED 122571090 (the self-test fails, the script absent) → GREEN. `make board-check-selftest` runs five fixtures: a planted ticket absent from a fixture ledger must be named and nothing else; a fully covered fixture through all three legs; the issue leg (unmilestoned → gap, open-but-complete → gap, HRQ reject → not a gap, exactly two gaps); a zero-ticket roadmap → exit 2; a clean `--offline` run → exit 3.

**Quorum (3 lanes, 3/3 needs-changes), all fixed:** `--offline` exited 0 having run one leg of three (now 3); a roadmap parsing to zero tickets read as clean (now exit 2); the evidence arm's message said "no evidence-closure" exactly when there was one; the self-test never drove the issue leg (added `--prs-json`/`--issues-json` seams and fixtures 3-5); both `gh` legs now refuse a listing that is exactly the page limit; `sort -V` for the newest ledger.

Exit codes: 0 clean and complete · 1 gaps · 2 could not measure · 3 clean but partial. `bashrs lint`: 0 errors. Contract `contracts/work/PMAT-693.yaml` (pv validate + lint pass); receipt `docs/audits/impl-PMAT-693-receipt.md`.

Pmat-Ticket: PMAT-693

🤖 Generated with [Claude Code](https://claude.com/claude-code)