### PR TITLE
fix(PMAT-687): a pmat tag can pass the fleet gate — analyzer debt paid, fixtures rebuilt, nothing excluded

### DIFF
--- a/contracts/work/PMAT-687.yaml
+++ b/contracts/work/PMAT-687.yaml
@@ -1,19 +1,20 @@
 # Hand-authored work contract for PMAT-687 ([train/FG]): the fleet clean-room
 # gate (paiml/.github unified-gate.yml "Banned path scan") failed on every pmat
-# tag because the banned-path analyzer's own source names the strings it bans,
-# so 3.39.0 shipped clean_room=local-modeA with a hand-made prerelease. The
-# fleet gate now excludes exactly that one file (paiml/.github#65) and the last
-# other line (a comment in check.rs) is scrubbed. Evidence methods were run on
-# this tree; the workflow probe runs after both PRs merge.
+# tag because the banned-path analyzer's own comments and fixtures named the
+# strings it bans, so 3.39.0 shipped clean_room=local-modeA with a hand-made
+# prerelease. The honest fix (quorum): pay the analyzer's complexity debt so its
+# fixtures could be rebuilt, scrub the last comment in check.rs, exclude nothing
+# fleet-side. Evidence methods were run on this tree; the workflow probe runs
+# on the first tag that carries this change.
 name: "PMAT-687"
 metadata:
   version: "1.0.0"
   kind: pattern
-  description: "A pmat tag passes the fleet gate's banned-path scan: the in-repo mirror of the scan is clean with zero pinned debt and exactly one fleet-side exclusion (the analyzer's own source)"
+  description: "A pmat tag passes the fleet gate's banned-path scan: every tracked .rs/.toml/.sh is clean, nothing is excluded fleet-side and nothing is pinned; the analyzer's fixtures no longer name this workstation"
   references:
     - "src/tests/fleet_banned_paths_tests.rs"
     - "src/cli/handlers/comply_handlers/check_handlers/check.rs"
-    - "https://github.com/paiml/.github/pull/65"
+    - "src/services/hardcoded_paths.rs"
     - ".github/workflows/release.yml"
 surface: work-contract
 verification_summary:
@@ -22,21 +23,21 @@ verification_summary:
   total_obligations: 3
 proof_obligations:
 - id: "PO-G1"
-  statement: "The in-repo mirror of the fleet scan (every tracked .rs/.toml/.sh except src/services/hardcoded_paths.rs) finds zero banned-path lines and pins no debt; at the RED commit it named exactly check.rs:693"
+  statement: "The in-repo mirror of the fleet scan (every tracked .rs/.toml/.sh, nothing excluded) finds zero banned-path lines and pins no debt; at the RED commit it named exactly check.rs:693"
   evidence_method: "env -u RUST_MIN_STACK cargo test --lib -- fleet_banned_path_scan_is_clean"
 - id: "PO-G2"
-  statement: "The fleet-side exclusion is exactly one file and still tracked: the mirror asserts the excluded file exists (an exclusion for a vanished file is dead)"
-  evidence_method: "env -u RUST_MIN_STACK cargo test --lib -- fleet_banned_path_scan_is_clean && git ls-files --error-unmatch src/services/hardcoded_paths.rs"
+  statement: "The fleet gate's own grep, reproduced locally with the EXCLUDE from unified-gate.yml, finds zero lines for each of the four banned prefixes; the analyzer's 23 behaviour tests pass unchanged after the refactor, and pmat verify measures its complexity green"
+  evidence_method: "for p in /mnt/nvme-raid0 /home/noah /home/ubuntu /tmp/clean-room; do git grep -nE \"$p\" -- '*.rs' '*.toml' '*.sh' ':!CLAUDE.md' | grep -vcE '(^|/)(examples|tests|benches|fuzz|state|docs|machines)/|pmat\\.toml|scripts/'; done | grep -qv '^0$' && exit 1; env -u RUST_MIN_STACK cargo test --lib -- hardcoded_paths && pmat verify --skip tests"
 - id: "PO-G3"
-  statement: "With paiml/.github#65 merged, a workflow_dispatch probe of release.yml on tag v3.39.0 with probe_fail_verify=true reaches verify: gate / lint-gate is green, verify is red, and no release is created for the probe (clean_room=fleet is admissible)"
-  evidence_method: "gh workflow run release.yml -f tag=v3.39.0 -f probe_fail_verify=true && gh run watch <id>; gh api repos/paiml/paiml-mcp-agent-toolkit/actions/runs/<id>/jobs -q '.jobs[]|\"\\(.name)=\\(.conclusion)\"'"
+  statement: "On the first tag that carries this change (v3.40.0), release.yml's gate / lint-gate is green on the banned-path scan and the run proceeds to verify (clean_room=fleet); a probe on an older tag cannot show this because the older tree still carries the literals"
+  evidence_method: "gh run list --workflow release.yml --event push --limit 1 --json databaseId -q '.[0].databaseId' | xargs -I{} gh api repos/paiml/paiml-mcp-agent-toolkit/actions/runs/{}/jobs -q '.jobs[]|\"\\(.name)=\\(.conclusion)\"' | grep -E '^gate / lint-gate=success'"
 falsifiable_claims:
-- hypothesis: "The in-repo mirror of the fleet scan (every tracked .rs/.toml/.sh except src/services/hardcoded_paths.rs) finds zero banned-path lines and pins no debt; at the RED commit it named exactly check.rs:693"
+- hypothesis: "The in-repo mirror of the fleet scan (every tracked .rs/.toml/.sh, nothing excluded) finds zero banned-path lines and pins no debt; at the RED commit it named exactly check.rs:693"
   method: "env -u RUST_MIN_STACK cargo test --lib -- fleet_banned_path_scan_is_clean"
   from_step: "G1"
-- hypothesis: "The fleet-side exclusion is exactly one file and still tracked: the mirror asserts the excluded file exists (an exclusion for a vanished file is dead)"
-  method: "env -u RUST_MIN_STACK cargo test --lib -- fleet_banned_path_scan_is_clean && git ls-files --error-unmatch src/services/hardcoded_paths.rs"
+- hypothesis: "The fleet gate's own grep, reproduced locally with the EXCLUDE from unified-gate.yml, finds zero lines for each of the four banned prefixes; the analyzer's 23 behaviour tests pass unchanged after the refactor, and pmat verify measures its complexity green"
+  method: "for p in /mnt/nvme-raid0 /home/noah /home/ubuntu /tmp/clean-room; do git grep -nE \"$p\" -- '*.rs' '*.toml' '*.sh' ':!CLAUDE.md' | grep -vcE '(^|/)(examples|tests|benches|fuzz|state|docs|machines)/|pmat\\.toml|scripts/'; done | grep -qv '^0$' && exit 1; env -u RUST_MIN_STACK cargo test --lib -- hardcoded_paths && pmat verify --skip tests"
   from_step: "G2"
-- hypothesis: "With paiml/.github#65 merged, a workflow_dispatch probe of release.yml on tag v3.39.0 with probe_fail_verify=true reaches verify: gate / lint-gate is green, verify is red, and no release is created for the probe (clean_room=fleet is admissible)"
-  method: "gh workflow run release.yml -f tag=v3.39.0 -f probe_fail_verify=true && gh run watch <id>; gh api repos/paiml/paiml-mcp-agent-toolkit/actions/runs/<id>/jobs -q '.jobs[]|\"\\(.name)=\\(.conclusion)\"'"
+- hypothesis: "On the first tag that carries this change (v3.40.0), release.yml's gate / lint-gate is green on the banned-path scan and the run proceeds to verify (clean_room=fleet); a probe on an older tag cannot show this because the older tree still carries the literals"
+  method: "gh run list --workflow release.yml --event push --limit 1 --json databaseId -q '.[0].databaseId' | xargs -I{} gh api repos/paiml/paiml-mcp-agent-toolkit/actions/runs/{}/jobs -q '.jobs[]|\"\\(.name)=\\(.conclusion)\"' | grep -E '^gate / lint-gate=success'"
   from_step: "G3"

--- a/contracts/work/PMAT-687.yaml
+++ b/contracts/work/PMAT-687.yaml
@@ -1,0 +1,42 @@
+# Hand-authored work contract for PMAT-687 ([train/FG]): the fleet clean-room
+# gate (paiml/.github unified-gate.yml "Banned path scan") failed on every pmat
+# tag because the banned-path analyzer's own source names the strings it bans,
+# so 3.39.0 shipped clean_room=local-modeA with a hand-made prerelease. The
+# fleet gate now excludes exactly that one file (paiml/.github#65) and the last
+# other line (a comment in check.rs) is scrubbed. Evidence methods were run on
+# this tree; the workflow probe runs after both PRs merge.
+name: "PMAT-687"
+metadata:
+  version: "1.0.0"
+  kind: pattern
+  description: "A pmat tag passes the fleet gate's banned-path scan: the in-repo mirror of the scan is clean with zero pinned debt and exactly one fleet-side exclusion (the analyzer's own source)"
+  references:
+    - "src/tests/fleet_banned_paths_tests.rs"
+    - "src/cli/handlers/comply_handlers/check_handlers/check.rs"
+    - "https://github.com/paiml/.github/pull/65"
+    - ".github/workflows/release.yml"
+surface: work-contract
+verification_summary:
+  target_level: L1
+  current_level: L1
+  total_obligations: 3
+proof_obligations:
+- id: "PO-G1"
+  statement: "The in-repo mirror of the fleet scan (every tracked .rs/.toml/.sh except src/services/hardcoded_paths.rs) finds zero banned-path lines and pins no debt; at the RED commit it named exactly check.rs:693"
+  evidence_method: "env -u RUST_MIN_STACK cargo test --lib -- fleet_banned_path_scan_is_clean"
+- id: "PO-G2"
+  statement: "The fleet-side exclusion is exactly one file and still tracked: the mirror asserts the excluded file exists (an exclusion for a vanished file is dead)"
+  evidence_method: "env -u RUST_MIN_STACK cargo test --lib -- fleet_banned_path_scan_is_clean && git ls-files --error-unmatch src/services/hardcoded_paths.rs"
+- id: "PO-G3"
+  statement: "With paiml/.github#65 merged, a workflow_dispatch probe of release.yml on tag v3.39.0 with probe_fail_verify=true reaches verify: gate / lint-gate is green, verify is red, and no release is created for the probe (clean_room=fleet is admissible)"
+  evidence_method: "gh workflow run release.yml -f tag=v3.39.0 -f probe_fail_verify=true && gh run watch <id>; gh api repos/paiml/paiml-mcp-agent-toolkit/actions/runs/<id>/jobs -q '.jobs[]|\"\\(.name)=\\(.conclusion)\"'"
+falsifiable_claims:
+- hypothesis: "The in-repo mirror of the fleet scan (every tracked .rs/.toml/.sh except src/services/hardcoded_paths.rs) finds zero banned-path lines and pins no debt; at the RED commit it named exactly check.rs:693"
+  method: "env -u RUST_MIN_STACK cargo test --lib -- fleet_banned_path_scan_is_clean"
+  from_step: "G1"
+- hypothesis: "The fleet-side exclusion is exactly one file and still tracked: the mirror asserts the excluded file exists (an exclusion for a vanished file is dead)"
+  method: "env -u RUST_MIN_STACK cargo test --lib -- fleet_banned_path_scan_is_clean && git ls-files --error-unmatch src/services/hardcoded_paths.rs"
+  from_step: "G2"
+- hypothesis: "With paiml/.github#65 merged, a workflow_dispatch probe of release.yml on tag v3.39.0 with probe_fail_verify=true reaches verify: gate / lint-gate is green, verify is red, and no release is created for the probe (clean_room=fleet is admissible)"
+  method: "gh workflow run release.yml -f tag=v3.39.0 -f probe_fail_verify=true && gh run watch <id>; gh api repos/paiml/paiml-mcp-agent-toolkit/actions/runs/<id>/jobs -q '.jobs[]|\"\\(.name)=\\(.conclusion)\"'"
+  from_step: "G3"

--- a/docs/audits/impl-PMAT-687-receipt.md
+++ b/docs/audits/impl-PMAT-687-receipt.md
@@ -5,20 +5,20 @@
 ## Mechanism (five-whys terminal)
 `release.yml` could never go green on a pmat tag: `gate / lint-gate`'s "Banned path scan" greps every tracked `*.rs *.toml *.sh` for four workstation prefixes, and pmat's own banned-path analyzer (`src/services/hardcoded_paths.rs`) names those strings in its recognisers and test fixtures (14 lines), plus one comment in `check.rs` quoted an absolute checkout path. PMAT-686 scrubbed 17 other files at 3.39.0 and pinned these two as debt because editing the analyzer trips `pmat verify`'s complexity gate on its pre-existing `classify` (cognitive 33 > 25). So 3.39.0 shipped `clean_room=local-modeA` with a prerelease created by hand — a producer gating itself.
 
-## Fix
-- **Fleet side (paiml/.github#65):** the per-repo `EXCLUDE` for `paiml-mcp-agent-toolkit` gains exactly `src/services/hardcoded_paths\.rs` — the file whose purpose is recognising those strings. Every other shipped file is still scanned.
-- **Repo side (this branch):** `check.rs:693`'s comment no longer quotes a workstation path; the in-repo mirror of the scan (`src/tests/fleet_banned_paths_tests.rs`, PMAT-686) models the same one-file exclusion (`FLEET_EXCLUDED`) and pins **no** debt — the tree must be clean and the excluded file must still exist.
+## Fix (after the quorum)
+The first cut excluded the analyzer's file fleet-side (paiml/.github#65). The 3-lane quorum returned **do-not-merge** on that diff (lanes 4faaed6e-1f62-4323-902c-ce0b8db0c802, 963b24c9-66bc-4eeb-a3b2-c676d7fdb37c; one lane unparsed) with two findings the orchestrator verified: (1) `grep -vE "$EXCLUDE"` in the scan runs on `path:line:content`, so an unanchored fragment masks any line anywhere whose *content* contains it — an exclusion blinds more than one file; (2) the 14 hits were comments and `#[cfg(test)]` fixtures, so the honest fix the ticket named first (pay the complexity debt, rebuild the fixtures) was available. #65 was closed with that five-whys and the masking class was reported to the fleet as a follow-up.
+
+The landed fix: `classify` split into four helpers and `candidates` / `feed` / `braces_outside_literals` refactored below the cognitive-25 gate with no behaviour change (the file's 23 tests are the contract and pass unchanged; `pmat analyze complexity` errors `[]`, was 4); the fixtures name `/home/alice` (any named user is machine-specific to the analyzer — the fixture never needed this workstation) and the doc comments say `<user>`; `check.rs:693`'s comment scrubbed; the mirror test excludes nothing, pins nothing, and reads bytes lossily like `git grep` (a non-UTF-8 file is scanned, not skipped). The fleet's own grep, reproduced locally with `unified-gate.yml`'s EXCLUDE, finds 0 lines for each of the four prefixes.
 
 ## RED → GREEN
-- RED 039217d74: mirror test with the exclusion modelled and the pins removed fails on exactly one line: `src/cli/handlers/comply_handlers/check_handlers/check.rs:693: /home/<user>` (the literal, redacted here).
-- GREEN 75e2e128e: `cargo test --lib -- fleet_banned_path_scan_is_clean` → 1 passed. `TMPDIR=/tmp/tmpx pmat verify --skip tests --format json` → ok=true (format, complexity, satd, clippy all measured true; tests ran separately above).
-- Discrimination: the RED named the comment line only, not the analyzer file — the exclusion is doing exactly its one job.
-- Anti-vacuity (the exclusion must not blind the scan): PO-G1's mirror still scans every other tracked file; plant a banned prefix in any `src/*.rs` outside the excluded file and the test names it (the RED commit is that observation on check.rs).
+- RED 039217d74: mirror test with the pins removed fails on exactly one line: `check.rs:693` (the redacted literal). Discrimination: it did not name the analyzer file's 14 lines because that commit still modelled an exclusion; the final mirror models none and is green because the literals are gone, not hidden.
+- GREEN 75e2e128e (scrub) + the refactor commit: `cargo test --lib -- hardcoded_paths fleet_banned` → 23 passed; `TMPDIR=/tmp/tmpx pmat verify --skip tests --format json` → ok=true (format, complexity, satd, clippy all measured true).
+- Anti-vacuity: plant a banned prefix in any tracked `src/*.rs` and the mirror names it (the RED commit is that observation on check.rs).
 
 ## Workflow probe (PO-G3)
-Runs after both PRs merge: `gh workflow run release.yml -f tag=v3.39.0 -f probe_fail_verify=true` → expected `gate / lint-gate` green, `verify` red, no release for the probe. Recorded in the 3.40.0 release receipt (gate table, `clean_room=`).
+A probe on v3.39.0 cannot show this (that tree still carries the literals — quorum lane 1). The falsifier is the first tag carrying this change: on `v3.40.0`, `release.yml`'s `gate / lint-gate` must pass the banned-path scan and the run must reach `verify`. Recorded in the 3.40.0 release receipt (gate table, `clean_room=`).
 
-Orchestrator turns: 5
+Orchestrator turns: 11 (incl. the quorum, the closed fleet PR, and one worker cut off by the API limit whose green tree the orchestrator committed)
 
 verdict: GREEN
 

--- a/docs/audits/impl-PMAT-687-receipt.md
+++ b/docs/audits/impl-PMAT-687-receipt.md
@@ -1,0 +1,25 @@
+# impl receipt — PMAT-687 [train/FG]: fleet gate admissibility for a pmat tag
+
+**Ticket:** PMAT-687 (kind:code, carried from 3.39.0) · **Branch:** `PMAT-687-fleet-gate` · **Orchestrator:** Fable (direct; workflow edits are orchestrator-only). Paired change in the fleet: paiml/.github#65.
+
+## Mechanism (five-whys terminal)
+`release.yml` could never go green on a pmat tag: `gate / lint-gate`'s "Banned path scan" greps every tracked `*.rs *.toml *.sh` for four workstation prefixes, and pmat's own banned-path analyzer (`src/services/hardcoded_paths.rs`) names those strings in its recognisers and test fixtures (14 lines), plus one comment in `check.rs` quoted an absolute checkout path. PMAT-686 scrubbed 17 other files at 3.39.0 and pinned these two as debt because editing the analyzer trips `pmat verify`'s complexity gate on its pre-existing `classify` (cognitive 33 > 25). So 3.39.0 shipped `clean_room=local-modeA` with a prerelease created by hand — a producer gating itself.
+
+## Fix
+- **Fleet side (paiml/.github#65):** the per-repo `EXCLUDE` for `paiml-mcp-agent-toolkit` gains exactly `src/services/hardcoded_paths\.rs` — the file whose purpose is recognising those strings. Every other shipped file is still scanned.
+- **Repo side (this branch):** `check.rs:693`'s comment no longer quotes a workstation path; the in-repo mirror of the scan (`src/tests/fleet_banned_paths_tests.rs`, PMAT-686) models the same one-file exclusion (`FLEET_EXCLUDED`) and pins **no** debt — the tree must be clean and the excluded file must still exist.
+
+## RED → GREEN
+- RED 039217d74: mirror test with the exclusion modelled and the pins removed fails on exactly one line: `src/cli/handlers/comply_handlers/check_handlers/check.rs:693: /home/<user>` (the literal, redacted here).
+- GREEN 75e2e128e: `cargo test --lib -- fleet_banned_path_scan_is_clean` → 1 passed. `TMPDIR=/tmp/tmpx pmat verify --skip tests --format json` → ok=true (format, complexity, satd, clippy all measured true; tests ran separately above).
+- Discrimination: the RED named the comment line only, not the analyzer file — the exclusion is doing exactly its one job.
+- Anti-vacuity (the exclusion must not blind the scan): PO-G1's mirror still scans every other tracked file; plant a banned prefix in any `src/*.rs` outside the excluded file and the test names it (the RED commit is that observation on check.rs).
+
+## Workflow probe (PO-G3)
+Runs after both PRs merge: `gh workflow run release.yml -f tag=v3.39.0 -f probe_fail_verify=true` → expected `gate / lint-gate` green, `verify` red, no release for the probe. Recorded in the 3.40.0 release receipt (gate table, `clean_room=`).
+
+Orchestrator turns: 5
+
+verdict: GREEN
+
+IMPL-PMAT-687-RECEIPT-END

--- a/src/cli/handlers/comply_handlers/check_handlers/check.rs
+++ b/src/cli/handlers/comply_handlers/check_handlers/check.rs
@@ -690,7 +690,7 @@ fn build_sarif(report: &ComplianceReport, project_path: &Path) -> serde_json::Va
     // Every result is about the project as a whole: `ComplianceCheck` carries a
     // name, status, message and severity, and no file. This used to be encoded
     // as `project_path` verbatim, which put the ABSOLUTE path of whoever ran it
-    // into the document — "/home/noah/src/paiml-mcp-agent-toolkit". That output
+    // into the document — "/home/<user>/src/<checkout>". That output
     // is uploaded to code scanning, so it published a developer's home
     // directory, and it made the document differ between two checkouts of the
     // same commit. `%SRCROOT%` is the standard base id for repository-relative

--- a/src/services/hardcoded_paths.rs
+++ b/src/services/hardcoded_paths.rs
@@ -2,7 +2,7 @@
 //!
 //! # Why this exists
 //!
-//! aprender shipped binaries containing `/home/noah/...`. They worked perfectly
+//! aprender shipped binaries containing `/home/<user>/...`. They worked perfectly
 //! on the machine that built them and were inert everywhere else. Nothing in the
 //! quality gates saw it: the code compiled, the tests passed (on that machine),
 //! clippy was clean, and the path was just a string literal.
@@ -173,52 +173,74 @@ impl Report {
 /// each arm requires a *specific* identifier (a username, a store hash, a
 /// toolchain root), never merely a leading slash.
 fn classify(path: &str) -> Option<PathKind> {
-    // `/home/<user>/` and `/Users/<user>/` — the trailing slash matters. Bare
-    // `/home` or `/Users` is the mount point, which is portable and meaningless
-    // on its own; it is the *named user under it* that pins the machine.
+    if let Some(decided) = classify_user_home(path) {
+        return decided;
+    }
+    if let Some(kind) = classify_windows_home(path) {
+        return Some(kind);
+    }
+    if let Some(kind) = classify_nix_or_root(path) {
+        return Some(kind);
+    }
+    classify_toolchain_state(path)
+}
+
+/// `/home/<user>/` and `/Users/<user>/` — the trailing slash matters. Bare
+/// `/home` or `/Users` is the mount point, which is portable and meaningless
+/// on its own; it is the *named user under it* that pins the machine.
+///
+/// `Some(verdict)` when the path is under one of those roots (the verdict may
+/// itself be `None`: a placeholder home is portable all the way down, so the
+/// caller must stop here rather than fall through to the build-host rules —
+/// `/home/user/.cargo/registry/…` is a documentation example, not this
+/// machine's crate cache). `None` when the prefix does not apply.
+fn classify_user_home(path: &str) -> Option<Option<PathKind>> {
     for prefix in ["/home/", "/Users/"] {
         if let Some(rest) = path.strip_prefix(prefix) {
             let user = rest.split('/').next().unwrap_or("");
-            if is_username(user) {
-                return Some(PathKind::UserHome);
-            }
-            // A placeholder home is portable all the way down, so stop here
-            // rather than fall through to the build-host rules below —
-            // `/home/user/.cargo/registry/…` is a documentation example, not
-            // this machine's crate cache.
-            return None;
+            return Some(is_username(user).then_some(PathKind::UserHome));
         }
     }
-    // Windows: `C:\Users\<user>\` in any drive letter, either slash direction.
-    if let Some(rest) = windows_users_suffix(path) {
-        let user = rest.split(['/', '\\']).next().unwrap_or("");
-        if is_username(user) {
-            return Some(PathKind::UserHome);
-        }
-    }
+    None
+}
+
+/// Windows: `C:\Users\<user>\` in any drive letter, either slash direction.
+fn classify_windows_home(path: &str) -> Option<PathKind> {
+    let rest = windows_users_suffix(path)?;
+    let user = rest.split(['/', '\\']).next().unwrap_or("");
+    is_username(user).then_some(PathKind::UserHome)
+}
+
+/// The Nix store, and `/root/` with something under it. A bare `/root/` is a
+/// prefix, not a location: pmat's own hook checker lists
+/// `["/home/", "/Users/", "/root/"]` as the patterns it searches for, and
+/// flagging a detector's own pattern table is the noise that makes a detector
+/// unusable.
+fn classify_nix_or_root(path: &str) -> Option<PathKind> {
     if path
         .strip_prefix("/nix/store/")
         .is_some_and(|r| !r.is_empty())
     {
         return Some(PathKind::NixStore);
     }
-    // A bare `/root/` with nothing under it is a prefix, not a location. pmat's
-    // own hook checker lists `["/home/", "/Users/", "/root/"]` as the patterns
-    // it searches for; flagging a detector's own pattern table is the noise that
-    // makes a detector unusable.
     if path.strip_prefix("/root/").is_some_and(|r| !r.is_empty()) {
         return Some(PathKind::BuildHost);
     }
-    // Toolchain state, wherever it is rooted. The host root is what makes it
-    // machine-specific, so there must be something before `/.cargo/registry/`:
-    // `/home/x/.cargo/registry/` is a real location, while the bare
-    // `"/.cargo/registry/"` in `file_discovery.rs` is an ignore-glob fragment.
-    for marker in ["/.cargo/registry/", "/.rustup/toolchains/"] {
-        if path.starts_with('/') && path.find(marker).is_some_and(|at| at > 0) {
-            return Some(PathKind::BuildHost);
-        }
-    }
     None
+}
+
+/// Toolchain state, wherever it is rooted. The host root is what makes it
+/// machine-specific, so there must be something before `/.cargo/registry/`:
+/// `/home/x/.cargo/registry/` is a real location, while the bare
+/// `"/.cargo/registry/"` in `file_discovery.rs` is an ignore-glob fragment.
+fn classify_toolchain_state(path: &str) -> Option<PathKind> {
+    if !path.starts_with('/') {
+        return None;
+    }
+    ["/.cargo/registry/", "/.rustup/toolchains/"]
+        .iter()
+        .any(|marker| path.find(marker).is_some_and(|at| at > 0))
+        .then_some(PathKind::BuildHost)
 }
 
 /// `C:\Users\<user>` / `c:/users/<user>` — returns what follows `Users`, if the
@@ -310,34 +332,48 @@ fn is_boundary(prev: u8) -> bool {
     )
 }
 
+/// Does a Windows drive-letter path (`C:\\…` or `C:/…`) begin at `i`?
+fn is_windows_drive(b: &[u8], i: usize) -> bool {
+    i + 2 < b.len()
+        && b[i].is_ascii_alphabetic()
+        && b[i + 1] == b':'
+        && (b[i + 2] == b'\\' || b[i + 2] == b'/')
+}
+
+/// Does an absolute path — unix (`/…`) or Windows drive-letter — begin at `i`?
+fn path_starts_at(b: &[u8], i: usize) -> bool {
+    b[i] == b'/' || is_windows_drive(b, i)
+}
+
+/// Terminate on whitespace, quotes, and shell/format metacharacters.
+fn ends_candidate(c: u8) -> bool {
+    c.is_ascii_whitespace()
+        || matches!(
+            c,
+            b'"' | b'\'' | b'`' | b')' | b']' | b'}' | b',' | b';' | b'|' | b'>' | b'<'
+        )
+}
+
+/// Index one past the last byte of the candidate that begins at `start`.
+fn candidate_end(b: &[u8], start: usize) -> usize {
+    let mut i = start;
+    while i < b.len() && !ends_candidate(b[i]) {
+        i += 1;
+    }
+    i
+}
+
 fn candidates(line: &str) -> Vec<&str> {
     let mut out = Vec::new();
     let bytes = line.as_bytes();
     let mut i = 0;
     while i < bytes.len() {
-        let starts_path = bytes[i] == b'/'
-            || (i + 2 < bytes.len()
-                && bytes[i].is_ascii_alphabetic()
-                && bytes[i + 1] == b':'
-                && (bytes[i + 2] == b'\\' || bytes[i + 2] == b'/'));
-        if !starts_path || (i > 0 && !is_boundary(bytes[i - 1])) {
+        if !path_starts_at(bytes, i) || (i > 0 && !is_boundary(bytes[i - 1])) {
             i += 1;
             continue;
         }
         let start = i;
-        while i < bytes.len() {
-            let c = bytes[i];
-            // Terminate on whitespace, quotes, and shell/format metacharacters.
-            if c.is_ascii_whitespace()
-                || matches!(
-                    c,
-                    b'"' | b'\'' | b'`' | b')' | b']' | b'}' | b',' | b';' | b'|' | b'>' | b'<'
-                )
-            {
-                break;
-            }
-            i += 1;
-        }
+        i = candidate_end(bytes, start);
         if i > start {
             out.push(&line[start..i]);
         }
@@ -397,7 +433,7 @@ fn site_of(rel: &str) -> Site {
 }
 
 /// Is this line a comment? Comment hits are documentation-grade, not defects,
-/// so they are downgraded rather than dropped — a `/home/noah` in a comment is
+/// so they are downgraded rather than dropped — a `/home/<user>` in a comment is
 /// still a sign someone developed against one machine.
 fn is_comment(line: &str, ext: Option<&str>) -> bool {
     let t = line.trim_start();
@@ -434,75 +470,110 @@ fn is_comment(line: &str, ext: Option<&str>) -> bool {
 /// literals spanning multiple lines are not, because this reads line by line —
 /// that residual is why [`CfgTestTracker`] treats an early close as "leave the
 /// test region" (report as shipped) rather than the reverse.
+/// Skip a char literal that starts at the `'` at `quote`, returning the byte to
+/// resume scanning from.
+///
+/// Only a closing quote within a few bytes makes this a literal; a lifetime
+/// (`'a`) has none, so the scan rewinds to just past the quote and continues
+/// normally rather than swallowing the rest of the line.
+fn skip_char_literal(b: &[u8], quote: usize) -> usize {
+    let start = quote + 1;
+    let mut i = start;
+    while i < b.len() && i - start < 4 {
+        if b[i] == b'\\' {
+            i += 2;
+            continue;
+        }
+        if b[i] == b'\'' {
+            break;
+        }
+        i += 1;
+    }
+    if i >= b.len() || b[i] != b'\'' {
+        start // a lifetime; rewind and keep scanning normally
+    } else {
+        i + 1
+    }
+}
+
+/// Skip a raw string (`r"…"` or `r#"…"#` with any number of hashes) that starts
+/// at `r`, returning the byte to resume scanning from. An `r` that is not
+/// actually a raw string opener advances by one.
+fn skip_raw_string(b: &[u8], r: usize) -> usize {
+    let mut hashes = 0usize;
+    let mut j = r + 1;
+    while j < b.len() && b[j] == b'#' {
+        hashes += 1;
+        j += 1;
+    }
+    if j >= b.len() || b[j] != b'"' {
+        return r + 1;
+    }
+    j += 1;
+    // Scan to the terminator: `"` followed by `hashes` `#`s.
+    while j < b.len() {
+        if b[j] == b'"' && b[j + 1..].iter().take(hashes).all(|c| *c == b'#') {
+            j += 1 + hashes;
+            break;
+        }
+        j += 1;
+    }
+    j
+}
+
+/// Skip a normal string literal opening at `quote`, honouring backslash
+/// escapes, and return the byte to resume scanning from. An unterminated
+/// literal runs to the end of the line, which ends the scan.
+fn skip_string_literal(b: &[u8], quote: usize) -> usize {
+    let mut i = quote + 1;
+    while i < b.len() {
+        if b[i] == b'\\' {
+            i += 2;
+            continue;
+        }
+        if b[i] == b'"' {
+            break;
+        }
+        i += 1;
+    }
+    i + 1
+}
+
+/// Does a line comment (`//`) begin at `i`? Everything after it is skipped.
+fn is_line_comment(b: &[u8], i: usize) -> bool {
+    b[i] == b'/' && i + 1 < b.len() && b[i + 1] == b'/'
+}
+
+/// Does a raw string opener (`r"` or `r#`) begin at `i`?
+fn is_raw_string_open(b: &[u8], i: usize) -> bool {
+    b[i] == b'r' && i + 1 < b.len() && (b[i + 1] == b'"' || b[i + 1] == b'#')
+}
+
 fn braces_outside_literals(line: &str) -> (i32, i32) {
     let b = line.as_bytes();
     let (mut opens, mut closes) = (0i32, 0i32);
     let mut i = 0usize;
     while i < b.len() {
-        match b[i] {
-            b'/' if i + 1 < b.len() && b[i + 1] == b'/' => break, // line comment
-            b'{' => opens += 1,
-            b'}' => closes += 1,
-            b'\'' => {
-                // Char literal or a lifetime (`'a`). Only a closing quote within
-                // a few bytes makes it a literal; lifetimes have none.
-                i += 1;
-                let start = i;
-                while i < b.len() && i - start < 4 {
-                    if b[i] == b'\\' {
-                        i += 2;
-                        continue;
-                    }
-                    if b[i] == b'\'' {
-                        break;
-                    }
-                    i += 1;
-                }
-                if i >= b.len() || b[i] != b'\'' {
-                    i = start; // a lifetime; rewind and keep scanning normally
-                    continue;
-                }
-            }
-            b'r' if i + 1 < b.len() && (b[i + 1] == b'"' || b[i + 1] == b'#') => {
-                // Raw string: r"…" or r#"…"# with any number of hashes.
-                let mut hashes = 0usize;
-                let mut j = i + 1;
-                while j < b.len() && b[j] == b'#' {
-                    hashes += 1;
-                    j += 1;
-                }
-                if j >= b.len() || b[j] != b'"' {
-                    i += 1;
-                    continue;
-                }
-                j += 1;
-                // Scan to the terminator: `"` followed by `hashes` `#`s.
-                while j < b.len() {
-                    if b[j] == b'"' && b[j + 1..].iter().take(hashes).all(|c| *c == b'#') {
-                        j += 1 + hashes;
-                        break;
-                    }
-                    j += 1;
-                }
-                i = j;
-                continue;
-            }
-            b'"' => {
-                i += 1;
-                while i < b.len() {
-                    if b[i] == b'\\' {
-                        i += 2;
-                        continue;
-                    }
-                    if b[i] == b'"' {
-                        break;
-                    }
-                    i += 1;
-                }
-            }
-            _ => {}
+        if is_line_comment(b, i) {
+            break;
         }
-        i += 1;
+        i = if is_raw_string_open(b, i) {
+            skip_raw_string(b, i)
+        } else {
+            match b[i] {
+                b'{' => {
+                    opens += 1;
+                    i + 1
+                }
+                b'}' => {
+                    closes += 1;
+                    i + 1
+                }
+                b'\'' => skip_char_literal(b, i),
+                b'"' => skip_string_literal(b, i),
+                _ => i + 1,
+            }
+        };
     }
     (opens, closes)
 }
@@ -519,32 +590,43 @@ impl CfgTestTracker {
         if ext != Some("rs") {
             return false;
         }
-        let t = line.trim();
         if self.depth == 0 {
-            if t.starts_with("#[cfg(test)]") || t.starts_with("#[cfg(all(test") {
-                self.armed = true;
-                return false;
-            }
-            if self.armed {
-                // The `mod … {` that the attribute applies to. Attributes may
-                // stack, so tolerate intervening attribute lines.
-                if t.starts_with("#[") || t.is_empty() {
-                    return false;
-                }
-                self.armed = false;
-                if t.contains(" mod ") || t.starts_with("mod ") {
-                    self.depth = i32::from(t.contains('{'));
-                    return self.depth > 0;
-                }
-                return false;
-            }
+            return self.feed_outside(line.trim());
+        }
+        self.feed_inside(line)
+    }
+
+    /// At depth 0: arm on a `#[cfg(test)]` attribute, then look for the `mod … {`
+    /// it applies to. Always reports "not in a test module" except on the `mod`
+    /// line itself, which opens the region.
+    fn feed_outside(&mut self, t: &str) -> bool {
+        if t.starts_with("#[cfg(test)]") || t.starts_with("#[cfg(all(test") {
+            self.armed = true;
             return false;
         }
+        if !self.armed {
+            return false;
+        }
+        // The `mod … {` that the attribute applies to. Attributes may
+        // stack, so tolerate intervening attribute lines.
+        if t.starts_with("#[") || t.is_empty() {
+            return false;
+        }
+        self.armed = false;
+        if !t.contains(" mod ") && !t.starts_with("mod ") {
+            return false;
+        }
+        self.depth = i32::from(t.contains('{'));
+        self.depth > 0
+    }
+
+    /// Inside the module: track brace depth. Always reports "in a test module",
+    /// because the line that closes the module is still part of it.
+    fn feed_inside(&mut self, line: &str) -> bool {
         let (opens, closes) = braces_outside_literals(line);
         self.depth += opens - closes;
         if self.depth <= 0 {
             self.depth = 0;
-            return true; // the closing line is still part of the module
         }
         true
     }
@@ -667,7 +749,7 @@ mod tests {
 
     #[test]
     fn a_named_home_is_machine_specific() {
-        assert_eq!(classify("/home/noah/src/x"), Some(PathKind::UserHome));
+        assert_eq!(classify("/home/alice/src/x"), Some(PathKind::UserHome));
         assert_eq!(classify("/Users/alice/Code"), Some(PathKind::UserHome));
         assert_eq!(
             classify("C:\\Users\\bob\\AppData"),
@@ -738,15 +820,15 @@ mod tests {
     /// this, every docs link to a user page would be a finding.
     #[test]
     fn urls_are_not_paths() {
-        let (f, _) = scan_text("src/a.rs", r#"let u = "https://example.com/home/noah/x";"#);
+        let (f, _) = scan_text("src/a.rs", r#"let u = "https://example.com/home/alice/x";"#);
         assert!(f.is_empty(), "URL was flagged as a path: {f:?}");
     }
 
     #[test]
     fn shipped_code_is_ranked_above_tests_and_docs() {
-        let (shipped, _) = scan_text("src/main.rs", r#"let p = "/home/noah/data";"#);
-        let (test, _) = scan_text("tests/it.rs", r#"let p = "/home/noah/data";"#);
-        let (doc, _) = scan_text("docs/guide.md", "see /home/noah/data");
+        let (shipped, _) = scan_text("src/main.rs", r#"let p = "/home/alice/data";"#);
+        let (test, _) = scan_text("tests/it.rs", r#"let p = "/home/alice/data";"#);
+        let (doc, _) = scan_text("docs/guide.md", "see /home/alice/data");
         assert_eq!(shipped[0].site, Site::Shipped);
         assert_eq!(test[0].site, Site::Test);
         assert_eq!(doc[0].site, Site::Doc);
@@ -755,7 +837,7 @@ mod tests {
     /// A comment is a weaker signal than an executable literal, but not zero.
     #[test]
     fn a_comment_hit_is_downgraded_not_dropped() {
-        let (f, _) = scan_text("src/a.rs", "// built against /home/noah/src/x");
+        let (f, _) = scan_text("src/a.rs", "// built against /home/alice/src/x");
         assert_eq!(f.len(), 1, "comment hit was dropped entirely");
         assert_eq!(f[0].site, Site::Doc);
     }
@@ -829,13 +911,13 @@ mod tests {
     #[test]
     fn an_inline_cfg_test_module_is_test_site_not_shipped() {
         let src = r#"
-pub fn real() -> &'static str { "/home/noah/prod" }
+pub fn real() -> &'static str { "/home/alice/prod" }
 
 #[cfg(test)]
 mod tests {
     #[test]
     fn t() {
-        let fixture = "/home/noah/fixture";
+        let fixture = "/home/alice/fixture";
         assert!(fixture.len() > 0);
     }
 }
@@ -862,10 +944,10 @@ mod tests {
         let src = r#"
 #[cfg(test)]
 mod tests {
-    fn t() { let _ = "/home/noah/fixture"; }
+    fn t() { let _ = "/home/alice/fixture"; }
 }
 
-pub fn later() -> &'static str { "/home/noah/prod" }
+pub fn later() -> &'static str { "/home/alice/prod" }
 "#;
         let (f, _) = scan_text("src/lib.rs", src);
         let prod = f.iter().find(|x| x.path.contains("prod")).expect("prod");
@@ -890,7 +972,7 @@ mod tests {
         let _ = msg;
     }
     fn b() {
-        let p = \"/home/noah/fixture\";
+        let p = \"/home/alice/fixture\";
         let _ = p;
     }
 }
@@ -979,7 +1061,7 @@ mod tests {
         );
         // A real user under the same shape is still a finding.
         assert_eq!(
-            classify("/home/noah/.cargo/registry/src/x"),
+            classify("/home/alice/.cargo/registry/src/x"),
             Some(PathKind::UserHome)
         );
     }

--- a/src/tests/fleet_banned_paths_tests.rs
+++ b/src/tests/fleet_banned_paths_tests.rs
@@ -53,20 +53,12 @@ fn scanned_files(root: &Path) -> Vec<PathBuf> {
 #[test]
 fn fleet_banned_path_scan_is_clean() {
     let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    // PMAT-687: two files still carry the literals — the hardcoded-path
-    // analyzer's own fixtures and one comment in check.rs. Both owe complexity
-    // debt that `pmat verify` measures the moment a line in them changes
-    // (classify: cognitive 33 > 25; check.rs's included helpers: 25 functions
-    // over), so their scrub rides with that refactor. Until then the fleet
-    // gate fails on them and the tag's prerelease is created by hand. The
-    // debt is PINNED AS A COUNT (quorum lane 2 on #1204): it may only go down.
-    const PINNED_DEBT: [(&str, usize); 2] = [
-        ("src/services/hardcoded_paths.rs", 14),
-        (
-            "src/cli/handlers/comply_handlers/check_handlers/check.rs",
-            1,
-        ),
-    ];
+    // PMAT-687: the fleet scan excludes exactly one pmat file, the
+    // hardcoded-path analyzer's own source (paiml/.github#65 — its recognisers
+    // and fixtures name the strings the scan bans). Everything else is scanned,
+    // and the tree must be clean: the debt pinned here at 3.39.0 (14 lines in
+    // the analyzer, one comment in check.rs) is paid or excluded.
+    const FLEET_EXCLUDED: [&str; 1] = ["src/services/hardcoded_paths.rs"];
     let files = scanned_files(&root);
     assert!(
         files.len() > 100,
@@ -74,7 +66,7 @@ fn fleet_banned_path_scan_is_clean() {
         files.len()
     );
     let mut hits = Vec::new();
-    let mut pinned_seen = 0usize;
+    let mut excluded_seen = 0usize;
     for file in &files {
         let Ok(text) = std::fs::read_to_string(file) else {
             continue;
@@ -84,30 +76,22 @@ fn fleet_banned_path_scan_is_clean() {
             .unwrap_or(file)
             .display()
             .to_string();
-        let pin = PINNED_DEBT.iter().find(|(name, _)| *name == rel);
-        let mut count = 0usize;
+        if FLEET_EXCLUDED.contains(&rel.as_str()) {
+            excluded_seen += 1;
+            continue;
+        }
         for (n, line) in text.lines().enumerate() {
             for banned in BANNED {
                 if line.contains(banned) {
-                    count += 1;
-                    if pin.is_none() {
-                        hits.push(format!("{rel}:{}: {banned}", n + 1));
-                    }
+                    hits.push(format!("{rel}:{}: {banned}", n + 1));
                 }
             }
         }
-        if let Some((name, allowed)) = pin {
-            pinned_seen += 1;
-            assert!(
-                count <= *allowed,
-                "{name}: {count} banned-path line(s), pinned at {allowed} — the debt may only go down (PMAT-687)"
-            );
-        }
     }
     assert_eq!(
-        pinned_seen,
-        PINNED_DEBT.len(),
-        "every pinned file is still tracked"
+        excluded_seen,
+        FLEET_EXCLUDED.len(),
+        "every fleet-excluded file is still tracked (an exclusion for a file that no longer exists is dead)"
     );
     assert!(
         hits.is_empty(),

--- a/src/tests/fleet_banned_paths_tests.rs
+++ b/src/tests/fleet_banned_paths_tests.rs
@@ -53,12 +53,10 @@ fn scanned_files(root: &Path) -> Vec<PathBuf> {
 #[test]
 fn fleet_banned_path_scan_is_clean() {
     let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    // PMAT-687: the fleet scan excludes exactly one pmat file, the
-    // hardcoded-path analyzer's own source (paiml/.github#65 — its recognisers
-    // and fixtures name the strings the scan bans). Everything else is scanned,
-    // and the tree must be clean: the debt pinned here at 3.39.0 (14 lines in
-    // the analyzer, one comment in check.rs) is paid or excluded.
-    const FLEET_EXCLUDED: [&str; 1] = ["src/services/hardcoded_paths.rs"];
+    // PMAT-687: nothing is excluded and nothing is pinned. The analyzer's own
+    // source once carried 14 of the banned literals (comments and fixtures);
+    // its fixtures now name a user the fleet does not ban, and its doc comments
+    // say `<user>`. The fleet gate scans this file like any other.
     let files = scanned_files(&root);
     assert!(
         files.len() > 100,
@@ -66,20 +64,16 @@ fn fleet_banned_path_scan_is_clean() {
         files.len()
     );
     let mut hits = Vec::new();
-    let mut excluded_seen = 0usize;
     for file in &files {
-        let Ok(text) = std::fs::read_to_string(file) else {
-            continue;
-        };
+        // The fleet gate is `git grep`, which reads bytes; a file that is not
+        // UTF-8 must not be skipped silently (quorum lane 1 on PMAT-687).
+        let bytes = std::fs::read(file).expect("a tracked file is readable");
+        let text = String::from_utf8_lossy(&bytes).into_owned();
         let rel = file
             .strip_prefix(&root)
             .unwrap_or(file)
             .display()
             .to_string();
-        if FLEET_EXCLUDED.contains(&rel.as_str()) {
-            excluded_seen += 1;
-            continue;
-        }
         for (n, line) in text.lines().enumerate() {
             for banned in BANNED {
                 if line.contains(banned) {
@@ -88,11 +82,6 @@ fn fleet_banned_path_scan_is_clean() {
             }
         }
     }
-    assert_eq!(
-        excluded_seen,
-        FLEET_EXCLUDED.len(),
-        "every fleet-excluded file is still tracked (an exclusion for a file that no longer exists is dead)"
-    );
     assert!(
         hits.is_empty(),
         "the fleet gate would fail on {} line(s):\n{}",


### PR DESCRIPTION
The fleet clean-room gate (`paiml/.github` unified-gate.yml, "Banned path scan") failed on every pmat tag because the banned-path analyzer's own comments and `#[cfg(test)]` fixtures name the four strings the scan bans. 3.39.0 therefore shipped `clean_room=local-modeA` with a prerelease created by hand — a producer gating itself.

**The first cut was wrong and was withdrawn.** It excluded the analyzer's file fleet-side (paiml/.github#65). The 3-lane quorum returned do-not-merge, with two findings I verified: the scan's `grep -vE "$EXCLUDE"` runs on `path:line:content`, so an unanchored fragment masks any line anywhere whose *content* names it; and the 14 hits were comments and fixtures, so the honest fix was available. #65 is closed with that five-whys, and the masking class was reported to the fleet as a follow-up.

**This PR:** `classify` split into four helpers and `candidates` / `feed` / `braces_outside_literals` refactored below the cognitive-25 gate with no behaviour change — the file's 23 tests are the contract and pass unchanged, `pmat analyze complexity` errors go 4 → 0. The fixtures now name `/home/alice` (any named user is machine-specific to the analyzer; the fixture never needed this workstation) and the doc comments say `<user>`. One comment in `check.rs` scrubbed. The in-repo mirror of the fleet scan excludes nothing, pins nothing, and reads bytes lossily like `git grep`.

**Falsifier:** the fleet's own grep, reproduced locally with unified-gate's EXCLUDE, finds 0 lines for each of the four prefixes. RED 039217d74 named exactly `check.rs:693`. PO-G3 (the tag probe) is recorded as running on v3.40.0 — a probe on v3.39.0 cannot show this, since that tree still carries the literals.

Pmat-Ticket: PMAT-687

🤖 Generated with [Claude Code](https://claude.com/claude-code)