### PR TITLE
chore(release): bump to 3.40.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.40.0] - 2026-09-07
+
+### Added
+- `make board-check` — the falsifiable instrument for a cleared board (PMAT-693). Read-only; exits 1 listing every open PR without a disposition row, every open issue without exactly one milestone (a `reject` in the human review queue is exempt: it carries the ledger row and the label, and the run never closes a human-authored item on a reject), and every non-completed roadmap ticket absent from the newest disposition ledger. Exit codes: 0 clean and complete, 1 gaps, 2 could not measure, 3 clean but partial. `make board-check-selftest` drives five fixtures.
+
+### Fixed
+- A pmat tag can pass the fleet clean-room gate's banned-path scan (PMAT-687). The banned-path analyzer's own comments and test fixtures named the strings the scan bans, so every tag since the scan landed failed `gate / lint-gate` and 3.39.0 shipped with a hand-made prerelease. The analyzer's complexity debt is paid (`classify` split into four helpers; `candidates`, `feed` and `braces_outside_literals` refactored below the cognitive-25 gate, 23 behaviour tests unchanged), its fixtures no longer name a real workstation, and the last quoted path in a `comply check` comment is scrubbed. Nothing is excluded fleet-side: an `EXCLUDE` fragment there is matched against `path:line:content` and would mask any line whose content names it.
+- The dead-code outcome fixture gets a `Cargo.lock` (PMAT-705). The analyzer passes `--locked`, so a fixture crate without one was refused for the missing lockfile rather than for the syntax error each test plants — passing locally for the wrong reason and failing `ci / test`.
+
+### Changed
+- Dependencies: hyper 1.11.1, tower-http 0.7.1, ureq 3.4.0, arrow 59.3.0, minijinja 2.24.0. The `flate2` bump was declined: it adds a second `miniz_oxide` and a new `zlib-rs`, and `deny.toml` sets `multiple-versions = "warn"` so CI cannot refuse it (PMAT-692).
+
+
 ## [3.39.0] - 2026-09-06
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4986,7 +4986,7 @@ dependencies = [
 
 [[package]]
 name = "pmat"
-version = "3.39.0"
+version = "3.40.0"
 dependencies = [
  "actix",
  "actix-rt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pmat"
 default-run = "pmat"
-version = "3.39.0"
+version = "3.40.0"
 edition = "2021"
 rust-version = "1.91.0"
 authors = ["Pragmatic AI Labs"]

--- a/README.md
+++ b/README.md
@@ -625,7 +625,7 @@ PMAT is built on the PAIML Sovereign Stack - pure-Rust, SIMD-accelerated librari
 | [aprender-zram-core](https://crates.io/crates/aprender-zram-core) | SIMD LZ4/ZSTD compression (optional) | 0.64 |
 | [aprender-contracts](https://crates.io/crates/aprender-contracts) | Provable contracts (with `aprender-contracts-macros`) | 0.64 |
 | [pmcp](https://crates.io/crates/pmcp) | MCP protocol SDK (streamable HTTP transport) | 2.17 |
-| **pmat** | Code analysis toolkit | 3.39.0 |
+| **pmat** | Code analysis toolkit | 3.40.0 |
 
 **Key Benefits:**
 - Pure Rust (no C dependencies, no FFI)

--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -4502,11 +4502,11 @@ roadmap:
   github_issue: null
   item_type: task
   title: 'fleet lint-gate: hardcoded_paths.rs fixtures and check.rs comment still carry /home/noah; pay the complexity debt (classify cognitive 33, check.rs helpers 25 fns) or land a per-repo EXCLUDE in paiml/.github unified-gate.yml'
-  status: inprogress
+  status: completed
   priority: medium
   assigned_to: null
   created: 2026-09-06T13:26:05Z
-  updated: 2026-09-07T09:23:32.230419688+00:00
+  updated: 2026-09-07T17:11:38Z
   spec: null
   acceptance_criteria:
   - 'Until one of the two lands, a pmat tag fails the fleet gate at lint-gate (probe run 34034967876) and the prerelease is created by hand. Also: pmat analyze hardcoded-paths reports 45 machine-specific paths in shipped code on this tree — audit them in the same ticket.'
@@ -4591,11 +4591,11 @@ roadmap:
   github_issue: null
   item_type: task
   title: 'board post-3.39.0: disposition the five dependabot PRs opened 2026-09-07 (#1210-#1214) and reconcile PMAT-682''s roadmap status (recorded complete in dispositions-3.39.0.json, still planned in roadmap.yaml)'
-  status: inprogress
+  status: completed
   priority: medium
   assigned_to: null
   created: 2026-09-07T07:00:54Z
-  updated: 2026-09-07T07:01:13.407321051+00:00
+  updated: 2026-09-07T17:11:38Z
   spec: null
   acceptance_criteria: []
   phases: []
@@ -4626,11 +4626,11 @@ roadmap:
   github_issue: null
   item_type: task
   title: '[train/BC] board-check: scripts/board-check.sh + make board-check — read-only; exit 1 naming every open PR without a disposition row, every open issue without exactly one milestone or an evidence closure, every non-completed roadmap ticket absent from the newest docs/audits/dispositions-*.json or lacking defer/complete/reject; self-test arm on a planted id must fail'
-  status: inprogress
+  status: completed
   priority: high
   assigned_to: null
   created: 2026-09-07T07:56:24Z
-  updated: 2026-09-07T08:02:23.168389884+00:00
+  updated: 2026-09-07T17:11:38Z
   spec: null
   acceptance_criteria: []
   phases: []
@@ -4749,11 +4749,11 @@ roadmap:
   github_issue: null
   item_type: task
   title: '[train/RC] release cut 3.40.0: bump the six version carriers the 3.39.0 cut touched (Cargo.toml, Cargo.lock pmat entry, README.md, mcp.json, CHANGELOG.md [Unreleased] -> [3.40.0], roadmap statuses); tag v3.40.0; prerelease; publish --locked from a detached worktree of the tag; AD-01 + AD-02 exit 0'
-  status: planned
+  status: inprogress
   priority: high
   assigned_to: null
   created: 2026-09-07T07:56:32Z
-  updated: 2026-09-07T07:56:32Z
+  updated: 2026-09-07T17:10:01.693904154+00:00
   spec: null
   acceptance_criteria: []
   phases: []
@@ -4837,11 +4837,11 @@ roadmap:
   github_issue: null
   item_type: task
   title: 'dead-code outcome tests: crate_with() builds a fixture with no Cargo.lock, so check_dead_code_outcome refuses for the MISSING LOCKFILE, not the syntax error the test names — it passes locally for the wrong reason and fails in ci/test (run 34123854548, a_crate_that_does_not_compile_is_reported_as_not_measured: not_measured was None). Give the fixture a lockfile via write_fixture_lockfile so each of the three legs measures what it claims'
-  status: planned
+  status: completed
   priority: high
   assigned_to: null
   created: 2026-09-07T14:07:36Z
-  updated: 2026-09-07T14:07:36Z
+  updated: 2026-09-07T17:13:47Z
   spec: null
   acceptance_criteria: []
   phases: []

--- a/mcp.json
+++ b/mcp.json
@@ -1,6 +1,6 @@
 {
   "name": "pmat",
-  "version": "3.39.0",
+  "version": "3.40.0",
   "description": "Project Analysis and Intelligence Modeling Toolkit",
   "main": "pmat",
   "bin": {


### PR DESCRIPTION
Cuts 3.40.0. Contents: `make board-check` (PMAT-693), the fleet clean-room gate fix (PMAT-687), the dead-code fixture lockfile (PMAT-705), the board triage and disposition ledger (PMAT-691), and five dependency bumps.

Phase 3 gates on 56f86bbaf: `dogfood-use` 13 checks / 0 failures; `gate-artifact` passed; `make gate-flag-efficacy-full` **595 effective, 6 refuses-honestly, 0 no-op, 0 error-out** — the release gate that was red at 3.38.0 and 3.39.0 and published over twice is green (PMAT-688, shipped in 3.39.0's train). `validate-book` passes in 0.7 s, which proves an already-built binary was exercised, not a cold run — recorded as such.

Deferred to 3.41.0 with five-whys on their PRs: PMAT-694 (#1218; the wrapped child produces no clippy findings on a GitHub-hosted runner — its own control caught it) and PMAT-695 (#1219; the vendored assets take the package to 9.5 MiB against the repo's 9.0 MiB budget, blocked behind PMAT-702).

Pmat-Ticket: PMAT-700

🤖 Generated with [Claude Code](https://claude.com/claude-code)