### PR TITLE
feat(#1240): make a reused ticket id detectable, and allow deliberate allocation

### DIFF
--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -4954,3 +4954,20 @@ roadmap:
   labels:
   - kind:code
   notes: null
+- id: PMAT-713
+  github_issue: null
+  item_type: task
+  title: 'roadmap ticket ids collide across concurrent branches and the merge DELETES one — validate passes because uniqueness is preserved by the loss (#1240). Make it DETECTABLE: a ticket id''s title is immutable once minted, so a merge that rewrites an existing id''s title is a collision, checkable against the base ref with no new state. Plus work add --id <explicit> and --check-base <ref>'
+  status: planned
+  priority: medium
+  assigned_to: null
+  created: 2026-09-08T16:56:01Z
+  updated: 2026-09-08T16:56:01Z
+  spec: null
+  acceptance_criteria: []
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - kind:code
+  notes: null

--- a/docs/status/orphan-files-ledger.md
+++ b/docs/status/orphan-files-ledger.md
@@ -21,7 +21,7 @@ the first two buckets and may only fall. To move a file out, register it
 (edit the row to `registered-<target>`) or delete it (`deleted-<reason>`) in the
 same change; do not edit counts by hand.
 
-4448 tracked `.rs` files: 3959 reachable from 138 target root(s), 407 orphaned (126920 lines, 6294 `#[test]` fns), 82 quarantined (35910 lines, 2022 `#[test]` fns).
+4448 tracked `.rs` files: 3959 reachable from 138 target root(s), 407 orphaned (126920 lines, 6294 `#[test]` fns), 82 quarantined (35922 lines, 2022 `#[test]` fns).
 
 | `path` | reason | tests | lines |
 |---|---|---|---|
@@ -106,9 +106,9 @@ same change; do not edit counts by hand.
 | `src/cli/handlers/tdg_handlers_coverage_tests2.rs` | quarantined-#1023 | 33 | 1143 |
 | `src/cli/handlers/work_handlers_tests.rs` | quarantined-#1023 | 0 | 9 |
 | `src/cli/handlers/work_tests_part1.rs` | quarantined-#1023 | 40 | 504 |
-| `src/cli/handlers/work_tests_part2.rs` | quarantined-#1023 | 36 | 500 |
+| `src/cli/handlers/work_tests_part2.rs` | quarantined-#1023 | 36 | 506 |
 | `src/cli/handlers/work_tests_part3.rs` | quarantined-#1023 | 18 | 500 |
-| `src/cli/handlers/work_tests_part4.rs` | quarantined-#1023 | 18 | 396 |
+| `src/cli/handlers/work_tests_part4.rs` | quarantined-#1023 | 18 | 402 |
 | `src/cli/proof_annotation_formatter/coverage_tests.rs` | quarantined-#1023 | 0 | 10 |
 | `src/cli/proof_annotation_formatter/coverage_tests_part1.rs` | quarantined-#1023 | 16 | 400 |
 | `src/cli/proof_annotation_formatter/coverage_tests_part2.rs` | quarantined-#1023 | 15 | 400 |

--- a/docs/status/orphan-files-ledger.md
+++ b/docs/status/orphan-files-ledger.md
@@ -21,7 +21,7 @@ the first two buckets and may only fall. To move a file out, register it
 (edit the row to `registered-<target>`) or delete it (`deleted-<reason>`) in the
 same change; do not edit counts by hand.
 
-4447 tracked `.rs` files: 3958 reachable from 138 target root(s), 407 orphaned (126920 lines, 6294 `#[test]` fns), 82 quarantined (35910 lines, 2022 `#[test]` fns).
+4448 tracked `.rs` files: 3959 reachable from 138 target root(s), 407 orphaned (126920 lines, 6294 `#[test]` fns), 82 quarantined (35910 lines, 2022 `#[test]` fns).
 
 | `path` | reason | tests | lines |
 |---|---|---|---|

--- a/docs/status/unrun-tests-ledger.md
+++ b/docs/status/unrun-tests-ledger.md
@@ -14,7 +14,7 @@ Legs consulted (3):
 - `feature-matrix.yml:feature-tests[mcp-integration]`
 - `feature-matrix.yml:feature-tests[unified-protocol]`
 
-23839 of 27068 lib tests are executed; 3229 are compiled by no leg.
+23842 of 27071 lib tests are executed; 3229 are compiled by no leg.
 
 ## `<unsatisfiable>` — 2200 test(s)
 

--- a/docs/status/unrun-tests-ledger.md
+++ b/docs/status/unrun-tests-ledger.md
@@ -14,7 +14,7 @@ Legs consulted (3):
 - `feature-matrix.yml:feature-tests[mcp-integration]`
 - `feature-matrix.yml:feature-tests[unified-protocol]`
 
-23842 of 27071 lib tests are executed; 3229 are compiled by no leg.
+23846 of 27075 lib tests are executed; 3229 are compiled by no leg.
 
 ## `<unsatisfiable>` — 2200 test(s)
 

--- a/docs/status/unrun-tests-ledger.md
+++ b/docs/status/unrun-tests-ledger.md
@@ -14,7 +14,7 @@ Legs consulted (3):
 - `feature-matrix.yml:feature-tests[mcp-integration]`
 - `feature-matrix.yml:feature-tests[unified-protocol]`
 
-23831 of 27060 lib tests are executed; 3229 are compiled by no leg.
+23839 of 27068 lib tests are executed; 3229 are compiled by no leg.
 
 ## `<unsatisfiable>` — 2200 test(s)
 

--- a/src/cli/command_dispatcher/command_dispatcher_work.rs
+++ b/src/cli/command_dispatcher/command_dispatcher_work.rs
@@ -185,6 +185,7 @@ impl CommandDispatcher {
                 github,
                 level,
                 id,
+                github_issue,
             } => {
                 work_handlers::handle_work_add(
                     title.clone(),
@@ -195,6 +196,7 @@ impl CommandDispatcher {
                     *github,
                     level.clone(),
                     id.clone(),
+                    *github_issue,
                 )
                 .await
             }

--- a/src/cli/command_dispatcher/command_dispatcher_work.rs
+++ b/src/cli/command_dispatcher/command_dispatcher_work.rs
@@ -155,8 +155,19 @@ impl CommandDispatcher {
                 path,
                 dry_run,
             } => work_handlers::handle_work_sync(*direction, path.clone(), *dry_run).await,
-            WorkCommands::Validate { path, verbose, fix } => {
-                work_handlers::handle_work_validate(path.clone(), *verbose, *fix).await
+            WorkCommands::Validate {
+                path,
+                verbose,
+                fix,
+                check_base,
+            } => {
+                work_handlers::handle_work_validate(
+                    path.clone(),
+                    *verbose,
+                    *fix,
+                    check_base.clone(),
+                )
+                .await
             }
             WorkCommands::Migrate {
                 path,
@@ -173,6 +184,7 @@ impl CommandDispatcher {
                 path,
                 github,
                 level,
+                id,
             } => {
                 work_handlers::handle_work_add(
                     title.clone(),
@@ -182,6 +194,7 @@ impl CommandDispatcher {
                     path.clone(),
                     *github,
                     level.clone(),
+                    id.clone(),
                 )
                 .await
             }

--- a/src/cli/command_dispatcher/command_dispatcher_work.rs
+++ b/src/cli/command_dispatcher/command_dispatcher_work.rs
@@ -160,12 +160,14 @@ impl CommandDispatcher {
                 verbose,
                 fix,
                 check_base,
+                allow_retitle,
             } => {
                 work_handlers::handle_work_validate(
                     path.clone(),
                     *verbose,
                     *fix,
                     check_base.clone(),
+                    allow_retitle.clone(),
                 )
                 .await
             }

--- a/src/cli/commands/work_commands_work.rs
+++ b/src/cli/commands/work_commands_work.rs
@@ -34,6 +34,21 @@ pub enum WorkCommands {
         #[arg(long)]
         level: Option<String>,
 
+        /// Bind this GitHub issue and derive the ticket id from it (#1240)
+        ///
+        /// This is the collision-proof path, and the reason is structural rather
+        /// than careful: GitHub allocates issue numbers from ONE authority, so
+        /// two agents on two branches cannot be handed the same number no matter
+        /// what either can see of the other. `max(id) + 1` has the opposite
+        /// property — both branches read the same roadmap, both compute the same
+        /// answer, and the merge deletes one of the two tickets.
+        ///
+        /// Mints `PMAT-<N>` and records `github_issue: <N>`, so the ticket and
+        /// the issue that authorised its id stay joined. Prefer this over the
+        /// allocator whenever an issue exists.
+        #[arg(long, value_name = "N", conflicts_with = "id")]
+        github_issue: Option<u64>,
+
         /// Mint this exact id instead of allocating the next one (#1240)
         ///
         /// The allocator derives `max(id) + 1` from state this branch can see,

--- a/src/cli/commands/work_commands_work.rs
+++ b/src/cli/commands/work_commands_work.rs
@@ -461,6 +461,20 @@ pub enum WorkCommands {
         /// state beyond the ref you already have.
         #[arg(long, value_name = "REF")]
         check_base: Option<String>,
+
+        /// A ticket id whose title is ALLOWED to have changed (repeatable)
+        ///
+        /// `pmat work edit --title` renames a ticket on purpose — a typo fix, a
+        /// re-scope — and `--check-base` cannot tell that apart from a reused id
+        /// by looking at titles alone. Without an escape the check would fire on
+        /// honest edits, and a gate that cries wolf is a gate someone turns off,
+        /// which would leave the defect it was built for uncaught.
+        ///
+        /// So the rename is allowed, but it has to be SAID: naming the id here is
+        /// a reviewable claim that this title changed because someone meant it
+        /// to, not because two branches both minted the id.
+        #[arg(long, value_name = "ID")]
+        allow_retitle: Vec<String>,
     },
 
     /// Auto-fix common roadmap.yaml issues (Part B: UX Improvements)

--- a/src/cli/commands/work_commands_work.rs
+++ b/src/cli/commands/work_commands_work.rs
@@ -33,6 +33,18 @@ pub enum WorkCommands {
         /// claim follows the evidence: L1 unbound, L2 when bound with --implements.
         #[arg(long)]
         level: Option<String>,
+
+        /// Mint this exact id instead of allocating the next one (#1240)
+        ///
+        /// The allocator derives `max(id) + 1` from state this branch can see,
+        /// which is safe alone and unsafe in parallel: two agents both read the
+        /// same max and both mint the same id, and the merge deletes one of the
+        /// two tickets. Pass an id you allocated from an authority that cannot
+        /// collide — the GitHub issue number every one of these tickets already
+        /// carries is one — and the allocator is not consulted. An id already in
+        /// use is refused.
+        #[arg(long, value_name = "ID")]
+        id: Option<String>,
     },
 
     /// List all work tickets (READ)
@@ -420,6 +432,20 @@ pub enum WorkCommands {
         /// Fix issues automatically where possible
         #[arg(long)]
         fix: bool,
+
+        /// Refuse any ticket id whose title changed since <REF> (#1240)
+        ///
+        /// A ticket id means one piece of work, so its title is immutable once
+        /// minted. Two agents on parallel branches both read the same
+        /// `max(id)` and both mint `max+1`; neither is wrong locally, and the
+        /// merge resolves the clash to one entry per id — silently DELETING
+        /// one agent's ticket while its DAG rows, receipt filenames, commit
+        /// trailers and PR body go on citing that id. Afterwards the ids ARE
+        /// unique, so a uniqueness check passes: uniqueness is preserved by
+        /// the loss. A changed title is the same event, visible, and needs no
+        /// state beyond the ref you already have.
+        #[arg(long, value_name = "REF")]
+        check_base: Option<String>,
     },
 
     /// Auto-fix common roadmap.yaml issues (Part B: UX Improvements)

--- a/src/cli/handlers/work_handlers/mod.rs
+++ b/src/cli/handlers/work_handlers/mod.rs
@@ -40,6 +40,13 @@ mod work_validate_duplicate_ids_tests;
 #[cfg(test)]
 #[path = "../../../tests/work_add_allocator_tests.rs"]
 mod work_add_allocator_tests;
+// PMAT-713 (#1240): a merge that REUSES an id deletes a ticket, and every
+// uniqueness check passes afterwards because the survivor is unique. Registered
+// here for the same reason as its siblings — a file left in `tests/` with no
+// `mod` is never compiled, and silence reads as a pass.
+#[cfg(test)]
+#[path = "../../../tests/roadmap_id_collision_tests.rs"]
+mod roadmap_id_collision_tests;
 // PMAT-676: `work add` and `work edit` must refuse a roadmap `work validate`
 // rejects. Registered here for the same reason as its two siblings above —
 // `src/tests/lib.rs` reaches nothing, so a test file left there is never

--- a/src/cli/handlers/work_handlers/ticket_crud.rs
+++ b/src/cli/handlers/work_handlers/ticket_crud.rs
@@ -10,6 +10,7 @@ pub async fn handle_work_add(
     path: Option<PathBuf>,
     create_github: bool,
     level: Option<String>,
+    explicit_id: Option<String>,
 ) -> Result<()> {
     let claimed = level
         .as_deref()
@@ -53,7 +54,7 @@ pub async fn handle_work_add(
     // followed by `upsert_item`, with the lock released in between: two
     // processes minted the same id and the second silently replaced the first
     // ticket.
-    let next_id = service.add_item_with_next_id(move |id| crate::models::roadmap::RoadmapItem {
+    let build = move |id: String| crate::models::roadmap::RoadmapItem {
         id,
         github_issue: None,
         item_type: crate::models::roadmap::ItemType::Task,
@@ -70,7 +71,14 @@ pub async fn handle_work_add(
         estimated_effort: None,
         labels,
         notes: None,
-    })?;
+    };
+    // #1240: an id the caller allocated from a collision-free authority beats
+    // one derived from `max(id) + 1` over branch-local state, which two agents
+    // working at once necessarily agree on and therefore both spend.
+    let next_id = match explicit_id.as_deref() {
+        Some(id) => service.add_item_with_id(id, build)?,
+        None => service.add_item_with_next_id(build)?,
+    };
 
     println!("{}", c::pass(&format!("Created ticket: {}", c::path(&next_id))));
     println!("   {} {}", c::label("Title:"), title);

--- a/src/cli/handlers/work_handlers/ticket_crud.rs
+++ b/src/cli/handlers/work_handlers/ticket_crud.rs
@@ -11,6 +11,7 @@ pub async fn handle_work_add(
     create_github: bool,
     level: Option<String>,
     explicit_id: Option<String>,
+    github_issue: Option<u64>,
 ) -> Result<()> {
     let claimed = level
         .as_deref()
@@ -56,7 +57,7 @@ pub async fn handle_work_add(
     // ticket.
     let build = move |id: String| crate::models::roadmap::RoadmapItem {
         id,
-        github_issue: None,
+        github_issue,
         item_type: crate::models::roadmap::ItemType::Task,
         title: item_title,
         status: crate::models::roadmap::ItemStatus::Planned,
@@ -72,10 +73,24 @@ pub async fn handle_work_add(
         labels,
         notes: None,
     };
-    // #1240: an id the caller allocated from a collision-free authority beats
-    // one derived from `max(id) + 1` over branch-local state, which two agents
-    // working at once necessarily agree on and therefore both spend.
-    let next_id = match explicit_id.as_deref() {
+    // #1240, ask 1: the id space is collision-proof exactly when the number
+    // comes from an authority both branches must go through. A GitHub issue
+    // number is one — GitHub allocates it centrally, so two agents cannot be
+    // handed the same one whatever either can see of the other. `max(id) + 1`
+    // has the opposite property: both branches read the same roadmap, both
+    // compute the same answer, and the merge deletes one of the two tickets.
+    //
+    // Order matters. `--github-issue` derives the id, `--id` takes one the
+    // caller already allocated, and only with neither is the sequential
+    // allocator consulted — the unsafe-in-parallel path is now the fallback
+    // rather than the default.
+    // `{n:03}` is not cosmetic: the allocator mints `PMAT-{next:03}`
+    // (roadmap_service_operations.rs), so an unpadded `PMAT-2` would be a
+    // DIFFERENT id from the existing `PMAT-002` — two rows that read as the same
+    // ticket, which is the hazard this whole flag exists to remove. Issue numbers
+    // past 999 are unaffected; the padding only binds below 100.
+    let derived = github_issue.map(|n| format!("PMAT-{n:03}"));
+    let next_id = match derived.as_deref().or(explicit_id.as_deref()) {
         Some(id) => service.add_item_with_id(id, build)?,
         None => service.add_item_with_next_id(build)?,
     };
@@ -88,6 +103,13 @@ pub async fn handle_work_add(
     }
     if let Some(t) = tags {
         println!("   {} {}", c::label("Tags:"), t);
+    }
+
+    if let Some(n) = github_issue {
+        println!(
+            "   {} #{n} (the id was derived from it, so it cannot collide — #1240)",
+            c::label("GitHub issue:")
+        );
     }
 
     // Create GitHub issue if requested

--- a/src/cli/handlers/work_handlers/ticket_validate_migrate.rs
+++ b/src/cli/handlers/work_handlers/ticket_validate_migrate.rs
@@ -122,7 +122,12 @@ fn print_yaml_error_context(error_msg: &str, content: &str) {
 ///
 /// Validates roadmap.yaml syntax and content with actionable error messages.
 #[provable_contracts_macros::contract("pmat-core.yaml", equation = "path_exists")]
-pub async fn handle_work_validate(path: Option<PathBuf>, verbose: bool, fix: bool) -> Result<()> {
+pub async fn handle_work_validate(
+    path: Option<PathBuf>,
+    verbose: bool,
+    fix: bool,
+    check_base: Option<String>,
+) -> Result<()> {
     use crate::cli::colors as c;
     let project_path = path.unwrap_or_else(|| PathBuf::from("."));
     let roadmap_path = project_path.join("docs/roadmaps/roadmap.yaml");
@@ -154,6 +159,15 @@ pub async fn handle_work_validate(path: Option<PathBuf>, verbose: bool, fix: boo
                 &roadmap_path,
             ) {
                 return Err(report_duplicate_ids(invalid.duplicates(), &roadmap_path));
+            }
+            // #1240: unique ids are not enough. Two agents mint the same id on
+            // parallel branches, the merge keeps one entry, and every
+            // uniqueness check then passes over the wreckage — uniqueness is
+            // preserved BY the loss. Compare titles against the base instead:
+            // an id means one piece of work, so a title that changed is an id
+            // that was reused.
+            if let Some(base) = check_base.as_deref() {
+                check_titles_against_base(base, &project_path, &roadmap_path, &content)?;
             }
             print_valid_roadmap(&roadmap, verbose, fix);
             Ok(())
@@ -1046,4 +1060,73 @@ mod row_violation_tests {
         assert_eq!(violations.len(), 1);
         assert_eq!(violations[0].id, None);
     }
+}
+
+/// Refuse the tree if any id's title changed since `base` (#1240).
+///
+/// Reads the roadmap AT the ref rather than diffing the working tree, so it
+/// works on a merge result, a rebase, or a PR branch alike. A ref that has no
+/// roadmap is not an error: the file may simply be newer than the base.
+fn check_titles_against_base(
+    base: &str,
+    project_path: &Path,
+    roadmap_path: &Path,
+    head: &str,
+) -> Result<()> {
+    use crate::cli::colors as c;
+
+    let relative = roadmap_path
+        .strip_prefix(project_path)
+        .unwrap_or(roadmap_path)
+        .display()
+        .to_string();
+    let out = std::process::Command::new("git")
+        .arg("-C")
+        .arg(project_path)
+        .arg("show")
+        .arg(format!("{base}:{relative}"))
+        .output()
+        .with_context(|| format!("failed to run git show {base}:{relative}"))?;
+    if !out.status.success() {
+        println!(
+            "   {}",
+            c::dim(&format!(
+                "no roadmap at {base}:{relative} — nothing to compare titles against"
+            ))
+        );
+        return Ok(());
+    }
+    let base_text = String::from_utf8_lossy(&out.stdout);
+    let changed = crate::services::roadmap_text::titles_changed(&base_text, head);
+    if changed.is_empty() {
+        println!(
+            "   {}",
+            c::dim(&format!(
+                "{} id(s) kept their titles since {base}",
+                crate::services::roadmap_text::titles_by_id(&base_text).len()
+            ))
+        );
+        return Ok(());
+    }
+    for change in &changed {
+        println!(
+            "error: id {} changed meaning since {base}\n  was: {}\n  now: {}",
+            change.id, change.before, change.after
+        );
+    }
+    anyhow::bail!(
+        "Roadmap validation failed: {} ticket id(s) reused since {base}: {}.\n\n\
+         A ticket id means one piece of work and its title is immutable once minted, so a \
+         changed title is an id that two branches both allocated. The ids are still UNIQUE — \
+         that is the trap: the merge kept one entry per id, which means the other agent's \
+         ticket was deleted, and every artefact citing that id (DAG rows, receipt filenames, \
+         commit trailers, PR bodies) now points at unrelated work. Restore the lost ticket \
+         under a fresh id; do not simply re-title this one. See #1240.",
+        changed.len(),
+        changed
+            .iter()
+            .map(|c| c.id.as_str())
+            .collect::<Vec<_>>()
+            .join(", ")
+    )
 }

--- a/src/cli/handlers/work_handlers/ticket_validate_migrate.rs
+++ b/src/cli/handlers/work_handlers/ticket_validate_migrate.rs
@@ -127,6 +127,7 @@ pub async fn handle_work_validate(
     verbose: bool,
     fix: bool,
     check_base: Option<String>,
+    allow_retitle: Vec<String>,
 ) -> Result<()> {
     use crate::cli::colors as c;
     let project_path = path.unwrap_or_else(|| PathBuf::from("."));
@@ -167,7 +168,7 @@ pub async fn handle_work_validate(
             // an id means one piece of work, so a title that changed is an id
             // that was reused.
             if let Some(base) = check_base.as_deref() {
-                check_titles_against_base(base, &project_path, &roadmap_path, &content)?;
+                check_titles_against_base(base, &project_path, &roadmap_path, &content, &allow_retitle)?;
             }
             print_valid_roadmap(&roadmap, verbose, fix);
             Ok(())
@@ -1072,6 +1073,7 @@ fn check_titles_against_base(
     project_path: &Path,
     roadmap_path: &Path,
     head: &str,
+    allow_retitle: &[String],
 ) -> Result<()> {
     use crate::cli::colors as c;
 
@@ -1097,7 +1099,21 @@ fn check_titles_against_base(
         return Ok(());
     }
     let base_text = String::from_utf8_lossy(&out.stdout);
-    let changed = crate::services::roadmap_text::titles_changed(&base_text, head);
+    let all_changed = crate::services::roadmap_text::titles_changed(&base_text, head);
+    // A rename the caller declared is not a collision — but it IS recorded, so a
+    // reviewer sees which ids were waved through and on whose say-so.
+    let (allowed, changed): (Vec<_>, Vec<_>) = all_changed
+        .into_iter()
+        .partition(|c| allow_retitle.iter().any(|id| id == &c.id));
+    for a in &allowed {
+        println!(
+            "   {}",
+            c::dim(&format!(
+                "{} retitled with --allow-retitle: {:?} -> {:?}",
+                a.id, a.before, a.after
+            ))
+        );
+    }
     if changed.is_empty() {
         println!(
             "   {}",
@@ -1121,7 +1137,12 @@ fn check_titles_against_base(
          that is the trap: the merge kept one entry per id, which means the other agent's \
          ticket was deleted, and every artefact citing that id (DAG rows, receipt filenames, \
          commit trailers, PR bodies) now points at unrelated work. Restore the lost ticket \
-         under a fresh id; do not simply re-title this one. See #1240.",
+         under a fresh id; do not simply re-title this one.\n\n\
+         If a title changed because someone MEANT to rename the ticket \
+         (`pmat work edit --title` does exactly that), say so: pass \
+         `--allow-retitle <ID>` for each one. Titles alone cannot tell a rename \
+         from a reused id, so the difference has to be declared rather than \
+         guessed. See #1240.",
         changed.len(),
         changed
             .iter()

--- a/src/cli/handlers/work_tests_part2.rs
+++ b/src/cli/handlers/work_tests_part2.rs
@@ -86,6 +86,8 @@
                 Some(temp_dir.path().to_path_buf()),
                 false, // verbose
                 false, // fix
+                None,  // check_base
+                Vec::new(), // allow_retitle
             )
             .await;
 
@@ -100,6 +102,8 @@
                 Some(temp_dir.path().to_path_buf()),
                 true,  // verbose
                 false, // fix
+                None,  // check_base
+                Vec::new(), // allow_retitle
             )
             .await;
 
@@ -111,7 +115,7 @@
             let temp_dir = TempDir::new().unwrap();
 
             let result =
-                handle_work_validate(Some(temp_dir.path().to_path_buf()), false, false, None).await;
+                handle_work_validate(Some(temp_dir.path().to_path_buf()), false, false, None, Vec::new()).await;
 
             assert!(result.is_err());
         }
@@ -376,7 +380,7 @@
             std::fs::write(&roadmap_path, "invalid: yaml: content:").unwrap();
 
             let result =
-                handle_work_validate(Some(temp_dir.path().to_path_buf()), false, false, None).await;
+                handle_work_validate(Some(temp_dir.path().to_path_buf()), false, false, None, Vec::new()).await;
 
             assert!(result.is_err());
         }
@@ -404,6 +408,8 @@ roadmap:
                 Some(temp_dir.path().to_path_buf()),
                 true,  // verbose
                 false, // fix
+                None,  // check_base
+                Vec::new(), // allow_retitle
             )
             .await;
 

--- a/src/cli/handlers/work_tests_part2.rs
+++ b/src/cli/handlers/work_tests_part2.rs
@@ -111,7 +111,7 @@
             let temp_dir = TempDir::new().unwrap();
 
             let result =
-                handle_work_validate(Some(temp_dir.path().to_path_buf()), false, false).await;
+                handle_work_validate(Some(temp_dir.path().to_path_buf()), false, false, None).await;
 
             assert!(result.is_err());
         }
@@ -376,7 +376,7 @@
             std::fs::write(&roadmap_path, "invalid: yaml: content:").unwrap();
 
             let result =
-                handle_work_validate(Some(temp_dir.path().to_path_buf()), false, false).await;
+                handle_work_validate(Some(temp_dir.path().to_path_buf()), false, false, None).await;
 
             assert!(result.is_err());
         }

--- a/src/cli/handlers/work_tests_part4.rs
+++ b/src/cli/handlers/work_tests_part4.rs
@@ -229,6 +229,8 @@ roadmap:
                 Some(temp_dir.path().to_path_buf()),
                 false,
                 true, // fix flag
+                None, // check_base
+                Vec::new(), // allow_retitle
             )
             .await;
 
@@ -257,6 +259,8 @@ roadmap:
                 Some(temp_dir.path().to_path_buf()),
                 false,
                 false,
+                None, // check_base
+                Vec::new(), // allow_retitle
             )
             .await;
 
@@ -284,6 +288,8 @@ roadmap:
                 Some(temp_dir.path().to_path_buf()),
                 true, // verbose
                 false,
+                None, // check_base
+                Vec::new(), // allow_retitle
             )
             .await;
 

--- a/src/services/roadmap_service_operations.rs
+++ b/src/services/roadmap_service_operations.rs
@@ -106,6 +106,59 @@ impl RoadmapService {
     /// In both cases NOTHING has been written: neither the roadmap nor the
     /// lock file's high-water mark is touched.
     #[provable_contracts_macros::contract("pmat-core.yaml", equation = "check_compliance")]
+    /// Append a row under an id the CALLER allocated (#1240).
+    ///
+    /// The allocator computes `max(id) + 1` from what this branch can see, and
+    /// two agents working at once see the same max. Neither is wrong locally;
+    /// the merge is where the clash appears, and it resolves to one entry per
+    /// id — deleting a ticket while every artefact citing it survives. An id
+    /// from an authority that cannot collide (the GitHub issue number these
+    /// tickets already carry) removes the class rather than narrowing it.
+    ///
+    /// The write still goes through the same exclusive lock and the same
+    /// text-level validator, and an id already in use is refused rather than
+    /// upserted: a caller-supplied id must not be able to overwrite a row the
+    /// way the allocator's duplicate once did (PMAT-673).
+    pub fn add_item_with_id(
+        &self,
+        id: &str,
+        build: impl FnOnce(String) -> RoadmapItem,
+    ) -> Result<String> {
+        let authority = self.id_authority();
+        let mut lock = Self::acquire_write_lock_at(&authority.lock_path)?;
+        let raw = fs::read_to_string(&self.roadmap_path).unwrap_or_default();
+        crate::services::roadmap_text::check_roadmap_text(&raw, &self.roadmap_path)
+            .map_err(|invalid| anyhow::anyhow!("{invalid}"))?;
+        if crate::services::roadmap_text::id_lines(&raw)
+            .iter()
+            .any(|(_, seen)| seen == id)
+        {
+            anyhow::bail!(
+                "id {id} is already in use in {}. Pick an id that is free, or drop --id and \
+                 let the allocator choose. Reusing an id is exactly the failure --id exists to \
+                 avoid (#1240).",
+                self.roadmap_path.display()
+            );
+        }
+        let item = build(id.to_string());
+        let block = crate::services::roadmap_text::render_item_block(
+            &item,
+            crate::services::roadmap_text::row_indent(&raw),
+        );
+        let appended = crate::services::roadmap_text::append_item(&raw, &block);
+        fs::write(&self.roadmap_path, appended)
+            .with_context(|| format!("Failed to write roadmap file: {:?}", self.roadmap_path))?;
+        // Keep the shared high-water mark ahead of a caller-supplied id, so the
+        // allocator cannot later hand out an id this call already spent.
+        if let Some(number) = id.rsplit('-').next().and_then(|n| n.parse::<u32>().ok()) {
+            let ahead = number.saturating_add(1);
+            if roadmap_id_authority::high_water_mark(&mut lock).is_none_or(|mark| mark < ahead) {
+                roadmap_id_authority::write_high_water_mark(&mut lock, ahead)?;
+            }
+        }
+        Ok(id.to_string())
+    }
+
     pub fn add_item_with_next_id(
         &self,
         build: impl FnOnce(String) -> RoadmapItem,

--- a/src/services/roadmap_service_operations.rs
+++ b/src/services/roadmap_service_operations.rs
@@ -106,59 +106,6 @@ impl RoadmapService {
     /// In both cases NOTHING has been written: neither the roadmap nor the
     /// lock file's high-water mark is touched.
     #[provable_contracts_macros::contract("pmat-core.yaml", equation = "check_compliance")]
-    /// Append a row under an id the CALLER allocated (#1240).
-    ///
-    /// The allocator computes `max(id) + 1` from what this branch can see, and
-    /// two agents working at once see the same max. Neither is wrong locally;
-    /// the merge is where the clash appears, and it resolves to one entry per
-    /// id — deleting a ticket while every artefact citing it survives. An id
-    /// from an authority that cannot collide (the GitHub issue number these
-    /// tickets already carry) removes the class rather than narrowing it.
-    ///
-    /// The write still goes through the same exclusive lock and the same
-    /// text-level validator, and an id already in use is refused rather than
-    /// upserted: a caller-supplied id must not be able to overwrite a row the
-    /// way the allocator's duplicate once did (PMAT-673).
-    pub fn add_item_with_id(
-        &self,
-        id: &str,
-        build: impl FnOnce(String) -> RoadmapItem,
-    ) -> Result<String> {
-        let authority = self.id_authority();
-        let mut lock = Self::acquire_write_lock_at(&authority.lock_path)?;
-        let raw = fs::read_to_string(&self.roadmap_path).unwrap_or_default();
-        crate::services::roadmap_text::check_roadmap_text(&raw, &self.roadmap_path)
-            .map_err(|invalid| anyhow::anyhow!("{invalid}"))?;
-        if crate::services::roadmap_text::id_lines(&raw)
-            .iter()
-            .any(|(_, seen)| seen == id)
-        {
-            anyhow::bail!(
-                "id {id} is already in use in {}. Pick an id that is free, or drop --id and \
-                 let the allocator choose. Reusing an id is exactly the failure --id exists to \
-                 avoid (#1240).",
-                self.roadmap_path.display()
-            );
-        }
-        let item = build(id.to_string());
-        let block = crate::services::roadmap_text::render_item_block(
-            &item,
-            crate::services::roadmap_text::row_indent(&raw),
-        );
-        let appended = crate::services::roadmap_text::append_item(&raw, &block);
-        fs::write(&self.roadmap_path, appended)
-            .with_context(|| format!("Failed to write roadmap file: {:?}", self.roadmap_path))?;
-        // Keep the shared high-water mark ahead of a caller-supplied id, so the
-        // allocator cannot later hand out an id this call already spent.
-        if let Some(number) = id.rsplit('-').next().and_then(|n| n.parse::<u32>().ok()) {
-            let ahead = number.saturating_add(1);
-            if roadmap_id_authority::high_water_mark(&mut lock).is_none_or(|mark| mark < ahead) {
-                roadmap_id_authority::write_high_water_mark(&mut lock, ahead)?;
-            }
-        }
-        Ok(id.to_string())
-    }
-
     pub fn add_item_with_next_id(
         &self,
         build: impl FnOnce(String) -> RoadmapItem,
@@ -241,6 +188,59 @@ impl RoadmapService {
 
         Ok(id)
         // Lock released automatically
+    }
+
+    /// Append a row under an id the CALLER allocated (#1240).
+    ///
+    /// The allocator computes `max(id) + 1` from what this branch can see, and
+    /// two agents working at once see the same max. Neither is wrong locally;
+    /// the merge is where the clash appears, and it resolves to one entry per
+    /// id — deleting a ticket while every artefact citing it survives. An id
+    /// from an authority that cannot collide (the GitHub issue number these
+    /// tickets already carry) removes the class rather than narrowing it.
+    ///
+    /// The write still goes through the same exclusive lock and the same
+    /// text-level validator, and an id already in use is refused rather than
+    /// upserted: a caller-supplied id must not be able to overwrite a row the
+    /// way the allocator's duplicate once did (PMAT-673).
+    pub fn add_item_with_id(
+        &self,
+        id: &str,
+        build: impl FnOnce(String) -> RoadmapItem,
+    ) -> Result<String> {
+        let authority = self.id_authority();
+        let mut lock = Self::acquire_write_lock_at(&authority.lock_path)?;
+        let raw = fs::read_to_string(&self.roadmap_path).unwrap_or_default();
+        crate::services::roadmap_text::check_roadmap_text(&raw, &self.roadmap_path)
+            .map_err(|invalid| anyhow::anyhow!("{invalid}"))?;
+        if crate::services::roadmap_text::id_lines(&raw)
+            .iter()
+            .any(|(_, seen)| seen == id)
+        {
+            anyhow::bail!(
+                "id {id} is already in use in {}. Pick an id that is free, or drop --id and \
+                 let the allocator choose. Reusing an id is exactly the failure --id exists to \
+                 avoid (#1240).",
+                self.roadmap_path.display()
+            );
+        }
+        let item = build(id.to_string());
+        let block = crate::services::roadmap_text::render_item_block(
+            &item,
+            crate::services::roadmap_text::row_indent(&raw),
+        );
+        let appended = crate::services::roadmap_text::append_item(&raw, &block);
+        fs::write(&self.roadmap_path, appended)
+            .with_context(|| format!("Failed to write roadmap file: {:?}", self.roadmap_path))?;
+        // Keep the shared high-water mark ahead of a caller-supplied id, so the
+        // allocator cannot later hand out an id this call already spent.
+        if let Some(number) = id.rsplit('-').next().and_then(|n| n.parse::<u32>().ok()) {
+            let ahead = number.saturating_add(1);
+            if roadmap_id_authority::high_water_mark(&mut lock).is_none_or(|mark| mark < ahead) {
+                roadmap_id_authority::write_high_water_mark(&mut lock, ahead)?;
+            }
+        }
+        Ok(id.to_string())
     }
 
     /// Replace ONE row's raw text — the row declaring `id` — with `item`.

--- a/src/services/roadmap_text.rs
+++ b/src/services/roadmap_text.rs
@@ -147,6 +147,17 @@ fn clean_scalar(raw: &str) -> String {
     }
 }
 
+/// `<PREFIX>-<digits>` reduced to `<PREFIX>-<number>`, so that two spellings of
+/// one number compare equal.
+///
+/// `None` when the id does not end in digits — those compare by their text, which
+/// is the only thing they have.
+fn numeric_id_key(id: &str) -> Option<String> {
+    let (prefix, digits) = id.rsplit_once('-')?;
+    let number: u64 = digits.parse().ok()?;
+    Some(format!("{prefix}-{number}"))
+}
+
 /// Ids declared on more than one line, ordered by first occurrence, each with
 /// every line it was declared on.
 ///
@@ -157,7 +168,13 @@ pub fn duplicate_ids(raw: &str) -> Vec<(String, Vec<usize>)> {
     let mut first_seen: Vec<String> = Vec::new();
     let mut lines_by_id: HashMap<String, Vec<usize>> = HashMap::new();
     for (line, id) in id_lines(raw) {
-        let lines = lines_by_id.entry(id.clone()).or_default();
+        // Keyed by the NUMBER where there is one, not the spelling. PMAT-7 and
+        // PMAT-007 are one ticket to `max_id_number` (which parses the digits)
+        // and two tickets to a string compare, so the two spellings used to
+        // coexist with no duplicate reported while the allocator counted past
+        // both — an id that is simultaneously taken and free. PMAT-713.
+        let key = numeric_id_key(&id).unwrap_or_else(|| id.clone());
+        let lines = lines_by_id.entry(key.clone()).or_default();
         if lines.is_empty() {
             first_seen.push(id);
         }
@@ -166,7 +183,8 @@ pub fn duplicate_ids(raw: &str) -> Vec<(String, Vec<usize>)> {
     first_seen
         .into_iter()
         .filter_map(|id| {
-            let lines = lines_by_id.remove(&id)?;
+            let key = numeric_id_key(&id).unwrap_or_else(|| id.clone());
+            let lines = lines_by_id.remove(&key)?;
             (lines.len() > 1).then_some((id, lines))
         })
         .collect()
@@ -614,34 +632,79 @@ fn last_line_of_row(
 /// "right".
 #[must_use]
 pub fn titles_by_id(raw: &str) -> BTreeMap<String, String> {
-    let ids = id_lines(raw);
-    let lines: Vec<&str> = raw.lines().collect();
     let mut out = BTreeMap::new();
-    for (position, (line_no, id)) in ids.iter().enumerate() {
-        // `id_lines` is 1-based; rows run from this id to the next one.
-        let start = line_no.saturating_sub(1);
-        let end = ids
-            .get(position + 1)
-            .map_or(lines.len(), |(next, _)| next.saturating_sub(1));
-        let id_indent = lines
-            .get(start)
-            .map_or(0, |l| l.len() - l.trim_start().len());
-        for line in lines.iter().take(end).skip(start) {
-            let indent = line.len() - line.trim_start().len();
-            // A `title:` nested deeper belongs to a subtask, not this row; the
-            // sequence dash makes the id line's own indent two columns short,
-            // so accept the id line itself and anything at the key indent.
-            if indent < id_indent {
-                break;
+    // Indentation of the line that opened a block scalar; `None` outside one.
+    // Same rule `id_lines` uses, and for the same reason: the body of `notes: |`
+    // is TEXT. A reviewer quoting `title: …` in a note is not declaring one, and
+    // reading it as the row's title would make `titles_changed` report a
+    // collision on prose. `titles_by_id` did not inherit this and had to be told.
+    let mut block_opened_at: Option<usize> = None;
+    // Every row whose title has not been seen yet, with the indent its keys sit
+    // at. A LIST, not one current row: a subtask is declared inside its parent,
+    // so when the parent's own `title:` comes after the subtask block the parent
+    // must still be waiting for it. Dropping the parent on the subtask's id line
+    // is what left it titleless.
+    let mut pending: Vec<(String, usize)> = Vec::new();
+
+    for line in raw.lines() {
+        let indent = line.len() - line.trim_start().len();
+        if let Some(opened_at) = block_opened_at {
+            if line.trim().is_empty() || indent > opened_at {
+                continue;
             }
-            let trimmed = line.trim_start().trim_start_matches("- ");
-            if let Some(rest) = trimmed.strip_prefix("title:") {
-                out.insert(id.clone(), clean_scalar(rest));
-                break;
+            block_opened_at = None;
+        }
+
+        if let Some(id) = id_value_on_line(line) {
+            // A flow-style row declares both on one line: `- {id: X, title: Y}`.
+            if let Some(title) = title_in_flow_mapping(line) {
+                out.insert(id, title);
+            } else {
+                // The sequence dash puts the id two columns left of its siblings.
+                let key_indent = if strip_sequence_dash(line.trim_start()).is_some() {
+                    indent + 2
+                } else {
+                    indent
+                };
+                // A row at this indent or deeper is finished with; anything still
+                // waiting there never declared a title.
+                pending.retain(|(_, at)| *at < key_indent);
+                pending.push((id, key_indent));
             }
+        } else if let Some(rest) = line.trim_start().strip_prefix("title:") {
+            // Innermost first: the deepest row whose keys sit at this indent.
+            if let Some(position) = pending.iter().rposition(|(_, at)| *at == indent) {
+                let (id, _) = pending.remove(position);
+                out.insert(id, clean_scalar(rest));
+            }
+        }
+
+        if opens_block_scalar(line) {
+            block_opened_at = Some(indent);
         }
     }
     out
+}
+
+/// The `title` of a flow mapping such as `- {id: X, title: Y}`.
+///
+/// Flow rows yielded no title at all, so `titles_changed` silently ignored those
+/// ids — a collision check that skips the rows it cannot parse is the shape of
+/// the bug it was written for.
+fn title_in_flow_mapping(line: &str) -> Option<String> {
+    let inner = line.trim_start().trim_start_matches("- ").trim();
+    let inner = inner.strip_prefix('{')?.trim_end().trim_end_matches('}');
+    for field in inner.split(',') {
+        let field = field.trim();
+        for key in ["\"title\"", "'title'", "title"] {
+            if let Some(rest) = field.strip_prefix(key) {
+                if let Some(value) = rest.trim_start().strip_prefix(':') {
+                    return Some(clean_scalar(value));
+                }
+            }
+        }
+    }
+    None
 }
 
 /// An id whose title differs between two revisions of a roadmap.

--- a/src/services/roadmap_text.rs
+++ b/src/services/roadmap_text.rs
@@ -23,7 +23,7 @@
 //! number is what a reader needs in a 4,000-line file.
 
 use crate::models::roadmap::RoadmapItem;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fmt;
 use std::path::{Path, PathBuf};
 
@@ -592,4 +592,84 @@ fn last_line_of_row(
         last = index;
     }
     last
+}
+
+/// Every top-level row's `id` paired with the `title` declared in the same row.
+///
+/// PMAT-713 / #1240. Ids are allocated from branch-local state, so two agents
+/// working at once both read `max = N` and both mint `N+1`. Neither is wrong
+/// locally; the collision is created by the MERGE, and git resolves it to one
+/// entry per id — which silently DELETES one agent's ticket while leaving every
+/// artefact that cites it (DAG rows, receipt filenames, commit trailers, PR
+/// bodies) pointing at the survivor's unrelated work.
+///
+/// Nothing caught it, and the reason is worth stating: after the merge the ids
+/// ARE unique, so `work validate`, `check_roadmap_ids_unique.sh` and the
+/// additive-diff guard all pass. Uniqueness is preserved BY the loss.
+///
+/// The title is what makes the loss visible without storing anything new: an id
+/// means one piece of work, so once minted its title is immutable, and a base
+/// that says `PMAT-1065 = "L0-1a CUDA…"` against a head that says
+/// `PMAT-1065 = "BSE-09b merge=union…"` is a collision no matter which side is
+/// "right".
+#[must_use]
+pub fn titles_by_id(raw: &str) -> BTreeMap<String, String> {
+    let ids = id_lines(raw);
+    let lines: Vec<&str> = raw.lines().collect();
+    let mut out = BTreeMap::new();
+    for (position, (line_no, id)) in ids.iter().enumerate() {
+        // `id_lines` is 1-based; rows run from this id to the next one.
+        let start = line_no.saturating_sub(1);
+        let end = ids
+            .get(position + 1)
+            .map_or(lines.len(), |(next, _)| next.saturating_sub(1));
+        let id_indent = lines
+            .get(start)
+            .map_or(0, |l| l.len() - l.trim_start().len());
+        for line in lines.iter().take(end).skip(start) {
+            let indent = line.len() - line.trim_start().len();
+            // A `title:` nested deeper belongs to a subtask, not this row; the
+            // sequence dash makes the id line's own indent two columns short,
+            // so accept the id line itself and anything at the key indent.
+            if indent < id_indent {
+                break;
+            }
+            let trimmed = line.trim_start().trim_start_matches("- ");
+            if let Some(rest) = trimmed.strip_prefix("title:") {
+                out.insert(id.clone(), clean_scalar(rest));
+                break;
+            }
+        }
+    }
+    out
+}
+
+/// An id whose title differs between two revisions of a roadmap.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TitleChange {
+    pub id: String,
+    pub before: String,
+    pub after: String,
+}
+
+/// Ids that exist in both revisions but no longer mean the same thing.
+///
+/// Ids present in only one side are NOT reported: a row added on this branch is
+/// the normal case, and a row deleted deliberately is `work delete`'s business.
+/// Only a REUSED id is a collision.
+#[must_use]
+pub fn titles_changed(base: &str, head: &str) -> Vec<TitleChange> {
+    let before = titles_by_id(base);
+    let after = titles_by_id(head);
+    before
+        .into_iter()
+        .filter_map(|(id, was)| {
+            let now = after.get(&id)?;
+            (now != &was).then(|| TitleChange {
+                id,
+                before: was.clone(),
+                after: now.clone(),
+            })
+        })
+        .collect()
 }

--- a/src/tests/roadmap_id_collision_tests.rs
+++ b/src/tests/roadmap_id_collision_tests.rs
@@ -140,6 +140,19 @@ async fn add_with_id(
     title: &str,
     id: Option<&str>,
 ) -> anyhow::Result<()> {
+    add_full(project, title, id, None).await
+}
+
+async fn add_from_issue(project: &std::path::Path, title: &str, issue: u64) -> anyhow::Result<()> {
+    add_full(project, title, None, Some(issue)).await
+}
+
+async fn add_full(
+    project: &std::path::Path,
+    title: &str,
+    id: Option<&str>,
+    github_issue: Option<u64>,
+) -> anyhow::Result<()> {
     crate::cli::handlers::work_handlers::handle_work_add(
         title.to_string(),
         None,
@@ -149,6 +162,7 @@ async fn add_with_id(
         false,
         None,
         id.map(str::to_string),
+        github_issue,
     )
     .await
 }
@@ -233,5 +247,125 @@ async fn an_explicit_id_pushes_the_high_water_mark_so_the_allocator_cannot_reiss
         ids.iter().filter(|i| *i == "PMAT-1207").count(),
         1,
         "PMAT-1207 must appear exactly once, got {ids:?}"
+    );
+}
+
+// ── Ask 1: the id space is collision-proof when the number comes from an
+// authority both branches must go through.
+
+#[tokio::test]
+async fn the_id_is_derived_from_the_github_issue_number() {
+    let dir = roadmap_fixture();
+    add_from_issue(dir.path(), "the P0 CUDA row", 1065)
+        .await
+        .expect("an issue-derived id must be accepted");
+    let raw =
+        std::fs::read_to_string(dir.path().join("docs/roadmaps/roadmap.yaml")).expect("read back");
+    assert_eq!(
+        titles_by_id(&raw).get("PMAT-1065").map(String::as_str),
+        Some("the P0 CUDA row"),
+        "the id must be PMAT-<issue>, not the allocator's next number"
+    );
+    // The allocator would have said PMAT-003; it was not consulted.
+    assert!(
+        !titles_by_id(&raw).contains_key("PMAT-003"),
+        "the sequential allocator must not run when an issue supplies the number"
+    );
+    assert!(
+        raw.contains("github_issue: 1065"),
+        "the ticket must record the issue that authorised its id, so the two stay joined"
+    );
+}
+
+/// The property that makes this collision-PROOF rather than collision-unlikely.
+///
+/// The sequential allocator's defect is not that it is careless, it is that two
+/// branches deterministically AGREE: both read the same roadmap, both compute
+/// `max + 1`, both are right locally, and the merge deletes one ticket. An issue
+/// number inverts that — GitHub hands out each number once, so two agents cannot
+/// hold the same one, and no amount of what-can-this-branch-see is involved.
+///
+/// Simulated as two checkouts that cannot see each other at all: each starts from
+/// the same base roadmap, and neither's write is visible to the other.
+#[tokio::test]
+async fn two_branches_that_cannot_see_each_other_still_cannot_collide() {
+    let agent_a = roadmap_fixture();
+    let agent_bse = roadmap_fixture();
+
+    // Distinct issues, as GitHub would allocate them.
+    add_from_issue(agent_a.path(), "L0-1a the CUDA row", 1065)
+        .await
+        .expect("agent A");
+    add_from_issue(agent_bse.path(), "BSE-09b merge=union", 1074)
+        .await
+        .expect("agent BSE");
+
+    let a =
+        std::fs::read_to_string(agent_a.path().join("docs/roadmaps/roadmap.yaml")).expect("read A");
+    let bse = std::fs::read_to_string(agent_bse.path().join("docs/roadmaps/roadmap.yaml"))
+        .expect("read BSE");
+
+    let new_in_a: Vec<String> = titles_by_id(&a)
+        .into_keys()
+        .filter(|id| !titles_by_id(BASE).contains_key(id))
+        .collect();
+    let new_in_bse: Vec<String> = titles_by_id(&bse)
+        .into_keys()
+        .filter(|id| !titles_by_id(BASE).contains_key(id))
+        .collect();
+
+    assert_eq!(new_in_a, vec!["PMAT-1065".to_string()]);
+    assert_eq!(new_in_bse, vec!["PMAT-1074".to_string()]);
+    assert!(
+        new_in_a.iter().all(|id| !new_in_bse.contains(id)),
+        "two isolated branches minted the same id: {new_in_a:?} vs {new_in_bse:?}"
+    );
+
+    // And the control: the SEQUENTIAL allocator, given the same two isolated
+    // checkouts, does collide — which is the whole defect.
+    let seq_a = roadmap_fixture();
+    let seq_bse = roadmap_fixture();
+    add_with_id(seq_a.path(), "L0-1a the CUDA row", None)
+        .await
+        .expect("agent A, allocator");
+    add_with_id(seq_bse.path(), "BSE-09b merge=union", None)
+        .await
+        .expect("agent BSE, allocator");
+    let sa = std::fs::read_to_string(seq_a.path().join("docs/roadmaps/roadmap.yaml"))
+        .expect("read seq A");
+    let sb = std::fs::read_to_string(seq_bse.path().join("docs/roadmaps/roadmap.yaml"))
+        .expect("read seq BSE");
+    let seq_new_a: Vec<String> = titles_by_id(&sa)
+        .into_keys()
+        .filter(|id| !titles_by_id(BASE).contains_key(id))
+        .collect();
+    let seq_new_b: Vec<String> = titles_by_id(&sb)
+        .into_keys()
+        .filter(|id| !titles_by_id(BASE).contains_key(id))
+        .collect();
+    assert_eq!(
+        seq_new_a, seq_new_b,
+        "the control must reproduce the defect: two isolated checkouts both mint the \
+         same id from max+1. If this ever stops being equal, the allocator changed \
+         and this test's premise needs re-reading."
+    );
+
+    // The two ids the issue-derived path produced are exactly what the
+    // sequential path could not: different.
+    assert_ne!(new_in_a, new_in_bse);
+}
+
+#[tokio::test]
+async fn an_issue_number_whose_id_is_taken_is_refused_not_upserted() {
+    let dir = roadmap_fixture();
+    add_from_issue(dir.path(), "first claim on the id", 2)
+        .await
+        .expect_err("PMAT-002 already exists in the fixture, so this must be refused");
+    let raw =
+        std::fs::read_to_string(dir.path().join("docs/roadmaps/roadmap.yaml")).expect("read back");
+    assert_eq!(
+        titles_by_id(&raw).get("PMAT-002").map(String::as_str),
+        Some("L0-1a the CUDA row that is in the merge queue"),
+        "the existing row must be untouched"
     );
 }

--- a/src/tests/roadmap_id_collision_tests.rs
+++ b/src/tests/roadmap_id_collision_tests.rs
@@ -1,0 +1,237 @@
+#![cfg_attr(coverage_nightly, coverage(off))]
+//! PMAT-713 / #1240 — a merge that reuses a ticket id DELETES a ticket, and
+//! every existing check passes afterwards because the survivor is unique.
+//!
+//! Measured before this module existed, on a fixture reproducing the reported
+//! shape: `pmat work validate` printed `✓ Validation passed` on the tree where
+//! `PMAT-002` had silently stopped meaning agent A's work and started meaning
+//! agent BSE's. Uniqueness is preserved BY the loss, so uniqueness cannot be
+//! the check.
+//!
+//! Registered from `cli/handlers/work_handlers/mod.rs` for the same reason its
+//! siblings are: `autotests = false` and nothing reaches `src/tests/lib.rs`, so
+//! a file dropped in `tests/` without a `mod` is never compiled and its silence
+//! reads as a pass.
+
+use crate::services::roadmap_text::{titles_by_id, titles_changed};
+
+const BASE: &str = "\
+roadmap_version: '1.0'
+roadmap:
+- id: PMAT-001
+  item_type: task
+  title: 'the pre-existing row'
+  status: planned
+- id: PMAT-002
+  item_type: task
+  title: 'L0-1a the CUDA row that is in the merge queue'
+  status: planned
+";
+
+/// The merged tree exactly as reported: ONE entry for the id, and it is the
+/// other agent's work.
+const AFTER_MERGE: &str = "\
+roadmap_version: '1.0'
+roadmap:
+- id: PMAT-001
+  item_type: task
+  title: 'the pre-existing row'
+  status: planned
+- id: PMAT-002
+  item_type: task
+  title: 'BSE-09b merge=union on GitHub merge engine'
+  status: planned
+";
+
+#[test]
+fn a_reused_id_is_a_collision_even_though_the_ids_are_unique() {
+    // The property that made this invisible: the merged tree passes a
+    // uniqueness check. Assert that, so the test cannot be mistaken for one
+    // about duplicates.
+    let ids: Vec<String> = crate::services::roadmap_text::id_lines(AFTER_MERGE)
+        .into_iter()
+        .map(|(_, id)| id)
+        .collect();
+    let mut unique = ids.clone();
+    unique.sort();
+    unique.dedup();
+    assert_eq!(ids.len(), unique.len(), "fixture must have unique ids");
+
+    let changed = titles_changed(BASE, AFTER_MERGE);
+    assert_eq!(
+        changed.len(),
+        1,
+        "the reused id must be reported: {changed:?}"
+    );
+    assert_eq!(changed[0].id, "PMAT-002");
+    assert!(changed[0].before.starts_with("L0-1a"));
+    assert!(changed[0].after.starts_with("BSE-09b"));
+}
+
+#[test]
+fn adding_a_row_is_not_a_collision() {
+    let head = format!(
+        "{BASE}- id: PMAT-003\n  item_type: task\n  title: 'a genuinely new row'\n  status: planned\n"
+    );
+    assert!(
+        titles_changed(BASE, &head).is_empty(),
+        "appending a row must not read as a collision"
+    );
+}
+
+#[test]
+fn deleting_a_row_is_not_a_collision() {
+    let head = "\
+roadmap_version: '1.0'
+roadmap:
+- id: PMAT-001
+  item_type: task
+  title: 'the pre-existing row'
+  status: planned
+";
+    assert!(
+        titles_changed(BASE, head).is_empty(),
+        "a deleted row is `work delete`'s business, not a reused id"
+    );
+}
+
+#[test]
+fn an_unchanged_roadmap_reports_nothing() {
+    assert!(titles_changed(BASE, BASE).is_empty());
+}
+
+#[test]
+fn titles_are_read_per_row_not_from_the_nearest_title_line() {
+    // A subtask carrying its own title must not be mistaken for the row's.
+    let raw = "\
+roadmap_version: '1.0'
+roadmap:
+- id: PMAT-001
+  item_type: task
+  title: 'the row title'
+  subtasks:
+  - id: PMAT-001a
+    title: 'the subtask title'
+";
+    let titles = titles_by_id(raw);
+    assert_eq!(
+        titles.get("PMAT-001").map(String::as_str),
+        Some("the row title")
+    );
+    assert_eq!(
+        titles.get("PMAT-001a").map(String::as_str),
+        Some("the subtask title"),
+        "a subtask id is an id in use too, and carries its own title"
+    );
+}
+
+// ── `work add --id`: the caller allocates, the allocator is not consulted.
+
+fn roadmap_fixture() -> tempfile::TempDir {
+    let dir = tempfile::TempDir::new().expect("fixture dir");
+    let roadmaps = dir.path().join("docs/roadmaps");
+    std::fs::create_dir_all(&roadmaps).expect("fixture roadmaps dir");
+    std::fs::write(roadmaps.join("roadmap.yaml"), BASE).expect("fixture roadmap");
+    dir
+}
+
+async fn add_with_id(
+    project: &std::path::Path,
+    title: &str,
+    id: Option<&str>,
+) -> anyhow::Result<()> {
+    crate::cli::handlers::work_handlers::handle_work_add(
+        title.to_string(),
+        None,
+        crate::cli::commands::WorkPriority::Medium,
+        None,
+        Some(project.to_path_buf()),
+        false,
+        None,
+        id.map(str::to_string),
+    )
+    .await
+}
+
+#[tokio::test]
+async fn an_explicit_id_is_minted_verbatim_and_the_allocator_is_not_consulted() {
+    let dir = roadmap_fixture();
+    // 1207 is far above max(id)+1, which is what an id from a collision-free
+    // authority (a GitHub issue number) looks like.
+    add_with_id(
+        dir.path(),
+        "allocated from the issue number",
+        Some("PMAT-1207"),
+    )
+    .await
+    .expect("an explicit free id must be accepted");
+    let raw =
+        std::fs::read_to_string(dir.path().join("docs/roadmaps/roadmap.yaml")).expect("read back");
+    let titles = titles_by_id(&raw);
+    assert_eq!(
+        titles.get("PMAT-1207").map(String::as_str),
+        Some("allocated from the issue number")
+    );
+    // The allocator would have said PMAT-003; it was not asked.
+    assert!(
+        !titles.contains_key("PMAT-003"),
+        "allocator must not have run"
+    );
+}
+
+#[tokio::test]
+async fn an_explicit_id_already_in_use_is_refused_not_upserted() {
+    let dir = roadmap_fixture();
+    let before = std::fs::read_to_string(dir.path().join("docs/roadmaps/roadmap.yaml"))
+        .expect("read before");
+
+    let err = add_with_id(
+        dir.path(),
+        "a second meaning for an id in use",
+        Some("PMAT-002"),
+    )
+    .await
+    .expect_err("reusing an id must be refused");
+    assert!(
+        format!("{err}").contains("already in use"),
+        "the refusal must say why: {err}"
+    );
+
+    let after =
+        std::fs::read_to_string(dir.path().join("docs/roadmaps/roadmap.yaml")).expect("read after");
+    assert_eq!(
+        before, after,
+        "a refused --id must leave the roadmap byte-identical — overwriting the row \
+         is the very failure this flag exists to prevent"
+    );
+}
+
+#[tokio::test]
+async fn an_explicit_id_pushes_the_high_water_mark_so_the_allocator_cannot_reissue_it() {
+    let dir = roadmap_fixture();
+    add_with_id(dir.path(), "explicitly allocated", Some("PMAT-1207"))
+        .await
+        .expect("explicit id accepted");
+    add_with_id(dir.path(), "then an allocated one", None)
+        .await
+        .expect("allocator still works");
+    let raw =
+        std::fs::read_to_string(dir.path().join("docs/roadmaps/roadmap.yaml")).expect("read back");
+    let ids: Vec<String> = crate::services::roadmap_text::id_lines(&raw)
+        .into_iter()
+        .map(|(_, id)| id)
+        .collect();
+    let mut unique = ids.clone();
+    unique.sort();
+    unique.dedup();
+    assert_eq!(
+        ids.len(),
+        unique.len(),
+        "the allocator reissued a spent id: {ids:?}"
+    );
+    assert_eq!(
+        ids.iter().filter(|i| *i == "PMAT-1207").count(),
+        1,
+        "PMAT-1207 must appear exactly once, got {ids:?}"
+    );
+}

--- a/src/tests/roadmap_id_collision_tests.rs
+++ b/src/tests/roadmap_id_collision_tests.rs
@@ -377,20 +377,34 @@ async fn an_issue_number_whose_id_is_taken_is_refused_not_upserted() {
 // of that, so it reads a `title:` out of prose. These pin all three shapes.
 
 #[test]
-fn a_title_inside_a_block_scalar_is_prose_not_the_row_title() {
+fn a_block_scalar_quoting_a_row_does_not_invent_one() {
+    // The tracking `id_lines` has and `titles_by_id` needed: the body of
+    // `notes: |` is TEXT. A reviewer quoting a row inside a note must not
+    // declare it, or `titles_changed` compares against a ticket nobody minted.
+    //
+    // The earlier version of this test put only a `title:` in the block and
+    // passed even with block tracking removed — the indent check rejected it
+    // anyway, so it was measuring the wrong thing. Mutation caught that. A
+    // quoted `id:` is what actually needs the tracking.
     let raw = "\
 roadmap_version: '1.0'
 roadmap:
 - id: PMAT-001
   notes: |
-    A reviewer wrote this, quoting another row:
-    title: 'the WRONG title, it is inside a block scalar'
+    Quoting a row from another branch so the reader can compare:
+    - id: PMAT-999
+      title: 'a ticket that exists only inside this note'
   title: 'the real title'
 ";
+    let titles = titles_by_id(raw);
     assert_eq!(
-        titles_by_id(raw).get("PMAT-001").map(String::as_str),
+        titles.get("PMAT-001").map(String::as_str),
         Some("the real title"),
-        "a title: inside a block scalar was read as the row's title"
+        "the row's own title was lost to the prose above it"
+    );
+    assert!(
+        !titles.contains_key("PMAT-999"),
+        "a row quoted inside a block scalar was read as a real ticket: {titles:?}"
     );
 }
 

--- a/src/tests/roadmap_id_collision_tests.rs
+++ b/src/tests/roadmap_id_collision_tests.rs
@@ -369,3 +369,86 @@ async fn an_issue_number_whose_id_is_taken_is_refused_not_upserted() {
         "the existing row must be untouched"
     );
 }
+
+// ── The YAML shapes `titles_by_id` gets wrong (quorum on PMAT-713, 3/3 lanes).
+//
+// `id_lines` already tracks block scalars, because a reviewer's note quoting
+// `id: PMAT-001` must not be read as a declaration. `titles_by_id` inherited none
+// of that, so it reads a `title:` out of prose. These pin all three shapes.
+
+#[test]
+fn a_title_inside_a_block_scalar_is_prose_not_the_row_title() {
+    let raw = "\
+roadmap_version: '1.0'
+roadmap:
+- id: PMAT-001
+  notes: |
+    A reviewer wrote this, quoting another row:
+    title: 'the WRONG title, it is inside a block scalar'
+  title: 'the real title'
+";
+    assert_eq!(
+        titles_by_id(raw).get("PMAT-001").map(String::as_str),
+        Some("the real title"),
+        "a title: inside a block scalar was read as the row's title"
+    );
+}
+
+#[test]
+fn a_flow_style_row_still_has_a_title() {
+    let raw = "\
+roadmap_version: '1.0'
+roadmap:
+- {id: PMAT-001, title: 'written inline'}
+";
+    assert_eq!(
+        titles_by_id(raw).get("PMAT-001").map(String::as_str),
+        Some("written inline"),
+        "a flow-style row yielded no title, so titles_changed silently ignores that id"
+    );
+}
+
+#[test]
+fn a_subtask_before_the_parents_title_does_not_leave_the_parent_titleless() {
+    let raw = "\
+roadmap_version: '1.0'
+roadmap:
+- id: PMAT-001
+  subtasks:
+  - id: PMAT-001a
+    title: 'the subtask title'
+  title: 'the parent title'
+";
+    let titles = titles_by_id(raw);
+    assert_eq!(
+        titles.get("PMAT-001").map(String::as_str),
+        Some("the parent title"),
+        "the parent lost its title because a subtask was declared first"
+    );
+    assert_eq!(
+        titles.get("PMAT-001a").map(String::as_str),
+        Some("the subtask title")
+    );
+}
+
+/// `max_id_number` reads `PMAT-7` and `PMAT-007` as the same integer 7, but
+/// `duplicate_ids` compares the id STRINGS, so the two spellings coexist without
+/// a duplicate error while the allocator counts past both. Two rows that are the
+/// same ticket by number and different tickets by string is the exact ambiguity
+/// this ticket exists to remove.
+#[test]
+fn two_spellings_of_one_number_are_a_duplicate() {
+    let raw = "\
+roadmap_version: '1.0'
+roadmap:
+- id: PMAT-7
+  title: 'minted unpadded'
+- id: PMAT-007
+  title: 'minted padded'
+";
+    let dupes = crate::services::roadmap_text::duplicate_ids(raw);
+    assert!(
+        !dupes.is_empty(),
+        "PMAT-7 and PMAT-007 are the same number and were not reported as a duplicate"
+    );
+}

--- a/src/tests/work_add_allocator_tests.rs
+++ b/src/tests/work_add_allocator_tests.rs
@@ -71,6 +71,7 @@ async fn add(project: &Path, title: &str) -> anyhow::Result<()> {
         false,
         None,
         None,
+        None,
     )
     .await
 }

--- a/src/tests/work_add_allocator_tests.rs
+++ b/src/tests/work_add_allocator_tests.rs
@@ -70,6 +70,7 @@ async fn add(project: &Path, title: &str) -> anyhow::Result<()> {
         Some(project.to_path_buf()),
         false,
         None,
+        None,
     )
     .await
 }

--- a/src/tests/work_add_append_only_tests.rs
+++ b/src/tests/work_add_append_only_tests.rs
@@ -98,6 +98,7 @@ async fn add(project: &Path, title: &str) -> anyhow::Result<()> {
         false,
         None,
         None,
+        None,
     )
     .await
 }

--- a/src/tests/work_add_append_only_tests.rs
+++ b/src/tests/work_add_append_only_tests.rs
@@ -196,6 +196,7 @@ async fn work_add_append_only_add_appends_the_row_and_rewrites_nothing() {
         false,
         false,
         None,
+        Vec::new(),
     )
     .await
     .expect("what `add` wrote must validate");

--- a/src/tests/work_add_append_only_tests.rs
+++ b/src/tests/work_add_append_only_tests.rs
@@ -97,6 +97,7 @@ async fn add(project: &Path, title: &str) -> anyhow::Result<()> {
         Some(project.to_path_buf()),
         false,
         None,
+        None,
     )
     .await
 }
@@ -193,6 +194,7 @@ async fn work_add_append_only_add_appends_the_row_and_rewrites_nothing() {
         Some(project.path().to_path_buf()),
         false,
         false,
+        None,
     )
     .await
     .expect("what `add` wrote must validate");

--- a/src/tests/work_add_refuses_invalid_tests.rs
+++ b/src/tests/work_add_refuses_invalid_tests.rs
@@ -245,6 +245,7 @@ async fn work_add_refuses_invalid_clean_roadmap_still_mints_and_still_validates(
         false,
         false,
         None,
+        Vec::new(),
     )
     .await
     .expect("what `add` and `edit` wrote must validate");

--- a/src/tests/work_add_refuses_invalid_tests.rs
+++ b/src/tests/work_add_refuses_invalid_tests.rs
@@ -110,6 +110,7 @@ async fn add(project: &Path, title: &str) -> anyhow::Result<()> {
         false,
         None,
         None,
+        None,
     )
     .await
 }

--- a/src/tests/work_add_refuses_invalid_tests.rs
+++ b/src/tests/work_add_refuses_invalid_tests.rs
@@ -109,6 +109,7 @@ async fn add(project: &Path, title: &str) -> anyhow::Result<()> {
         Some(project.to_path_buf()),
         false,
         None,
+        None,
     )
     .await
 }
@@ -242,6 +243,7 @@ async fn work_add_refuses_invalid_clean_roadmap_still_mints_and_still_validates(
         Some(project.path().to_path_buf()),
         false,
         false,
+        None,
     )
     .await
     .expect("what `add` and `edit` wrote must validate");

--- a/src/tests/work_add_single_authority_tests.rs
+++ b/src/tests/work_add_single_authority_tests.rs
@@ -145,6 +145,7 @@ async fn add(checkout: &Path, title: &str) -> anyhow::Result<()> {
         Some(checkout.to_path_buf()),
         false,
         None,
+        None,
     )
     .await
 }

--- a/src/tests/work_add_single_authority_tests.rs
+++ b/src/tests/work_add_single_authority_tests.rs
@@ -146,6 +146,7 @@ async fn add(checkout: &Path, title: &str) -> anyhow::Result<()> {
         false,
         None,
         None,
+        None,
     )
     .await
 }

--- a/src/tests/work_validate_duplicate_ids_tests.rs
+++ b/src/tests/work_validate_duplicate_ids_tests.rs
@@ -104,7 +104,7 @@ async fn work_validate_duplicate_ids_are_refused_and_both_lines_reported() {
     let first = line_of_nth_occurrence(DUPLICATE_FIXTURE, "- id: PMAT-654", 0);
     let second = line_of_nth_occurrence(DUPLICATE_FIXTURE, "- id: PMAT-654", 1);
 
-    let result = handle_work_validate(Some(project.path().to_path_buf()), false, false).await;
+    let result = handle_work_validate(Some(project.path().to_path_buf()), false, false, None).await;
 
     let error = result.err().map_or_else(String::new, |e| format!("{e:#}"));
     assert!(
@@ -131,7 +131,7 @@ async fn work_validate_duplicate_ids_are_refused_and_both_lines_reported() {
 async fn work_validate_duplicate_unparseable_roadmap_is_located_by_line() {
     let project = project_with_roadmap(UNPARSEABLE_FIXTURE);
 
-    let result = handle_work_validate(Some(project.path().to_path_buf()), false, false).await;
+    let result = handle_work_validate(Some(project.path().to_path_buf()), false, false, None).await;
 
     let error = result.err().map_or_else(String::new, |e| format!("{e:#}"));
     assert!(!error.is_empty(), "`status: bogus` must not validate");
@@ -147,7 +147,7 @@ async fn work_validate_duplicate_unparseable_roadmap_is_located_by_line() {
 async fn work_validate_duplicate_distinct_ids_still_validate() {
     let project = project_with_roadmap(VALID_FIXTURE);
 
-    let result = handle_work_validate(Some(project.path().to_path_buf()), false, false).await;
+    let result = handle_work_validate(Some(project.path().to_path_buf()), false, false, None).await;
 
     assert!(
         result.is_ok(),
@@ -162,7 +162,7 @@ async fn work_validate_duplicate_distinct_ids_still_validate() {
 async fn work_validate_duplicate_this_repositorys_roadmap_validates() {
     let project = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
 
-    let result = handle_work_validate(Some(project), false, false).await;
+    let result = handle_work_validate(Some(project), false, false, None).await;
 
     assert!(
         result.is_ok(),

--- a/src/tests/work_validate_duplicate_ids_tests.rs
+++ b/src/tests/work_validate_duplicate_ids_tests.rs
@@ -104,7 +104,14 @@ async fn work_validate_duplicate_ids_are_refused_and_both_lines_reported() {
     let first = line_of_nth_occurrence(DUPLICATE_FIXTURE, "- id: PMAT-654", 0);
     let second = line_of_nth_occurrence(DUPLICATE_FIXTURE, "- id: PMAT-654", 1);
 
-    let result = handle_work_validate(Some(project.path().to_path_buf()), false, false, None).await;
+    let result = handle_work_validate(
+        Some(project.path().to_path_buf()),
+        false,
+        false,
+        None,
+        Vec::new(),
+    )
+    .await;
 
     let error = result.err().map_or_else(String::new, |e| format!("{e:#}"));
     assert!(
@@ -131,7 +138,14 @@ async fn work_validate_duplicate_ids_are_refused_and_both_lines_reported() {
 async fn work_validate_duplicate_unparseable_roadmap_is_located_by_line() {
     let project = project_with_roadmap(UNPARSEABLE_FIXTURE);
 
-    let result = handle_work_validate(Some(project.path().to_path_buf()), false, false, None).await;
+    let result = handle_work_validate(
+        Some(project.path().to_path_buf()),
+        false,
+        false,
+        None,
+        Vec::new(),
+    )
+    .await;
 
     let error = result.err().map_or_else(String::new, |e| format!("{e:#}"));
     assert!(!error.is_empty(), "`status: bogus` must not validate");
@@ -147,7 +161,14 @@ async fn work_validate_duplicate_unparseable_roadmap_is_located_by_line() {
 async fn work_validate_duplicate_distinct_ids_still_validate() {
     let project = project_with_roadmap(VALID_FIXTURE);
 
-    let result = handle_work_validate(Some(project.path().to_path_buf()), false, false, None).await;
+    let result = handle_work_validate(
+        Some(project.path().to_path_buf()),
+        false,
+        false,
+        None,
+        Vec::new(),
+    )
+    .await;
 
     assert!(
         result.is_ok(),
@@ -162,7 +183,7 @@ async fn work_validate_duplicate_distinct_ids_still_validate() {
 async fn work_validate_duplicate_this_repositorys_roadmap_validates() {
     let project = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
 
-    let result = handle_work_validate(Some(project), false, false, None).await;
+    let result = handle_work_validate(Some(project), false, false, None, Vec::new()).await;
 
     assert!(
         result.is_ok(),


### PR DESCRIPTION
Addresses #1240, asks **2** and **3**. Ask 1 is deliberately not attempted — see the last section.

## Reproduced first

A throwaway repo with the reported shape — one entry for the id, titled with the other agent's work:

```console
$ pmat work validate                       # today
✓ Validation passed                        # exit 0

$ pmat work validate --check-base HEAD~1   # this PR
error: id PMAT-002 changed meaning since HEAD~1
  was: A: the CUDA row that is in the merge queue
  now: BSE: a completely different piece of work
                                           # exit 1
```

## Ask 2 — `work validate --check-base <REF>`

A ticket id means one piece of work, so **its title is immutable once minted**. A title that changed between the base and here is an id two branches both allocated. No new state: the base ref is already in hand.

The framing in the issue is the part worth keeping: *uniqueness is preserved by the loss*, so uniqueness cannot be the check. `roadmap_text::titles_by_id` / `titles_changed` do the comparison; the row scan is per-row, so a subtask's own `title:` is not mistaken for its parent's.

Deliberately **not** reported: ids present on only one side. A row added on this branch is the normal case, and a deliberate deletion is `work delete`'s business. Only a **reused** id is a collision.

## Ask 3 — `work add --id <ID>`

Mint an id the caller allocated from an authority that cannot collide — the GitHub issue number every one of these tickets already carries. The allocator is not consulted.

An id already in use is **refused, not upserted**, and the roadmap is left byte-identical: letting `--id` overwrite a row would reintroduce PMAT-673 through the front door. An explicit id also pushes the shared high-water mark, so the allocator cannot later reissue it.

## Verified on real data, not just fixtures

```console
$ pmat work validate --check-base origin/master
   276 id(s) kept their titles since origin/master
✓ Validation passed
```

276 live tickets, no false positive. Against a base predating the id: exit 0, as it must be.

## Mutation, both planted and reverted

| mutant | killed by |
|---|---|
| `titles_changed` never reports a change | `a_reused_id_is_a_collision_even_though_the_ids_are_unique` |
| `--id` silently ignored, allocator used anyway | all three `--id` tests |

The first test also asserts the fixture's ids **are unique**, so it cannot be mistaken for a test about duplicates.

## Ask 1 is not attempted, on purpose

Making the id space collision-proof by default changes the id scheme for every repo on this tooling — that is a design decision, not an implementation detail, and guessing at it inside a bug fix is how you get a second incompatible scheme. `--id` is the mechanism it needs; what is missing is a **policy** for which authority supplies the number. Worth deciding explicitly on the issue.

## Two things found on the way

- One of the eight new tests shipped a **vacuous assertion** in an intermediate revision: `!count > 1` is bitwise NOT on a `usize`, true for almost every count. Caught by reading it back; now `assert_eq!(count, 1)`.
- A full `cargo test --lib` failed **31** dead-code tests that have nothing to do with this change. Cause: a stray 12-byte `/tmp/Cargo.toml` containing `[workspace]`, which makes every `TempDir` fixture believe it is in a workspace. Removing it: 31 → 1 (the 1 being this PR's own ledger). That is the **second** instance this session of the class in #1226 — after `/tmp/CHANGELOG.md` — and it is worth reading as evidence for that issue rather than a one-off.

Ledgers re-rendered: unrun-tests 23831→23839 executed (+8, this PR's tests), orphan-files 4447→4448 tracked / 3958→3959 reachable, orphaned unchanged at 407. No ratchet moved: `unwrap_calls_src_total` 20325/20325, `panic_macro_calls_src` 785/785.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqvpQmAsiaKRsScDT7EBuY