### PR TITLE
feat(#1240): make the collision-free id path mandatory, and titles immutable

### DIFF
--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -4988,3 +4988,20 @@ roadmap:
   labels:
   - kind:code
   notes: null
+- id: PMAT-714
+  github_issue: null
+  item_type: task
+  title: 'roadmap ids: make the collision-free path mandatory — work add refuses the sequential allocator, and a ticket title is immutable (no --allow-retitle). Operator decision on #1240'
+  status: planned
+  priority: medium
+  assigned_to: null
+  created: 2026-09-09T07:37:54Z
+  updated: 2026-09-09T07:37:54Z
+  spec: null
+  acceptance_criteria: []
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - kind:code
+  notes: null

--- a/docs/status/orphan-files-ledger.md
+++ b/docs/status/orphan-files-ledger.md
@@ -21,7 +21,7 @@ the first two buckets and may only fall. To move a file out, register it
 (edit the row to `registered-<target>`) or delete it (`deleted-<reason>`) in the
 same change; do not edit counts by hand.
 
-4448 tracked `.rs` files: 3959 reachable from 138 target root(s), 407 orphaned (126920 lines, 6294 `#[test]` fns), 82 quarantined (35922 lines, 2022 `#[test]` fns).
+4448 tracked `.rs` files: 3959 reachable from 138 target root(s), 407 orphaned (126920 lines, 6294 `#[test]` fns), 82 quarantined (35916 lines, 2022 `#[test]` fns).
 
 | `path` | reason | tests | lines |
 |---|---|---|---|
@@ -106,9 +106,9 @@ same change; do not edit counts by hand.
 | `src/cli/handlers/tdg_handlers_coverage_tests2.rs` | quarantined-#1023 | 33 | 1143 |
 | `src/cli/handlers/work_handlers_tests.rs` | quarantined-#1023 | 0 | 9 |
 | `src/cli/handlers/work_tests_part1.rs` | quarantined-#1023 | 40 | 504 |
-| `src/cli/handlers/work_tests_part2.rs` | quarantined-#1023 | 36 | 506 |
+| `src/cli/handlers/work_tests_part2.rs` | quarantined-#1023 | 36 | 503 |
 | `src/cli/handlers/work_tests_part3.rs` | quarantined-#1023 | 18 | 500 |
-| `src/cli/handlers/work_tests_part4.rs` | quarantined-#1023 | 18 | 402 |
+| `src/cli/handlers/work_tests_part4.rs` | quarantined-#1023 | 18 | 399 |
 | `src/cli/proof_annotation_formatter/coverage_tests.rs` | quarantined-#1023 | 0 | 10 |
 | `src/cli/proof_annotation_formatter/coverage_tests_part1.rs` | quarantined-#1023 | 16 | 400 |
 | `src/cli/proof_annotation_formatter/coverage_tests_part2.rs` | quarantined-#1023 | 15 | 400 |

--- a/docs/status/unrun-tests-ledger.md
+++ b/docs/status/unrun-tests-ledger.md
@@ -14,7 +14,7 @@ Legs consulted (3):
 - `feature-matrix.yml:feature-tests[mcp-integration]`
 - `feature-matrix.yml:feature-tests[unified-protocol]`
 
-23846 of 27075 lib tests are executed; 3229 are compiled by no leg.
+23848 of 27077 lib tests are executed; 3229 are compiled by no leg.
 
 ## `<unsatisfiable>` — 2200 test(s)
 

--- a/src/cli/command_dispatcher/command_dispatcher_work.rs
+++ b/src/cli/command_dispatcher/command_dispatcher_work.rs
@@ -160,14 +160,12 @@ impl CommandDispatcher {
                 verbose,
                 fix,
                 check_base,
-                allow_retitle,
             } => {
                 work_handlers::handle_work_validate(
                     path.clone(),
                     *verbose,
                     *fix,
                     check_base.clone(),
-                    allow_retitle.clone(),
                 )
                 .await
             }
@@ -188,6 +186,7 @@ impl CommandDispatcher {
                 level,
                 id,
                 github_issue,
+                sequential_id,
             } => {
                 work_handlers::handle_work_add(
                     title.clone(),
@@ -199,6 +198,7 @@ impl CommandDispatcher {
                     level.clone(),
                     id.clone(),
                     *github_issue,
+                    *sequential_id,
                 )
                 .await
             }

--- a/src/cli/commands/work_commands_work.rs
+++ b/src/cli/commands/work_commands_work.rs
@@ -49,6 +49,23 @@ pub enum WorkCommands {
         #[arg(long, value_name = "N", conflicts_with = "id")]
         github_issue: Option<u64>,
 
+        /// Use the sequential `max(id) + 1` allocator (UNSAFE in parallel)
+        ///
+        /// #1240, operator decision 2026-09-09: this is no longer what you get by
+        /// typing the obvious command, because the obvious command must not be
+        /// the unsafe one. Two agents on two branches both read the same roadmap,
+        /// both compute the same next number, and the merge deletes one of the
+        /// two tickets.
+        ///
+        /// It is kept, explicitly, for the one caller that legitimately wants it:
+        /// the tests that pin the allocator's own locking guarantees (PMAT-673,
+        /// PMAT-676, PMAT-680 — cross-process, cross-worktree, high-water mark).
+        /// Deleting the flag would delete that coverage along with it. Anyone
+        /// else passing this is opting into a known defect in writing, and
+        /// `git grep -- --sequential-id` says who.
+        #[arg(long, conflicts_with_all = ["id", "github_issue"])]
+        sequential_id: bool,
+
         /// Mint this exact id instead of allocating the next one (#1240)
         ///
         /// The allocator derives `max(id) + 1` from state this branch can see,
@@ -462,19 +479,6 @@ pub enum WorkCommands {
         #[arg(long, value_name = "REF")]
         check_base: Option<String>,
 
-        /// A ticket id whose title is ALLOWED to have changed (repeatable)
-        ///
-        /// `pmat work edit --title` renames a ticket on purpose — a typo fix, a
-        /// re-scope — and `--check-base` cannot tell that apart from a reused id
-        /// by looking at titles alone. Without an escape the check would fire on
-        /// honest edits, and a gate that cries wolf is a gate someone turns off,
-        /// which would leave the defect it was built for uncaught.
-        ///
-        /// So the rename is allowed, but it has to be SAID: naming the id here is
-        /// a reviewable claim that this title changed because someone meant it
-        /// to, not because two branches both minted the id.
-        #[arg(long, value_name = "ID")]
-        allow_retitle: Vec<String>,
     },
 
     /// Auto-fix common roadmap.yaml issues (Part B: UX Improvements)

--- a/src/cli/handlers/work_handlers/ticket_crud.rs
+++ b/src/cli/handlers/work_handlers/ticket_crud.rs
@@ -12,6 +12,7 @@ pub async fn handle_work_add(
     level: Option<String>,
     explicit_id: Option<String>,
     github_issue: Option<u64>,
+    sequential_id: bool,
 ) -> Result<()> {
     let claimed = level
         .as_deref()
@@ -90,20 +91,41 @@ pub async fn handle_work_add(
     // ticket, which is the hazard this whole flag exists to remove. Issue numbers
     // past 999 are unaffected; the padding only binds below 100.
     let derived = github_issue.map(|n| format!("PMAT-{n:03}"));
-    let next_id = match derived.as_deref().or(explicit_id.as_deref()) {
-        Some(id) => service.add_item_with_id(id, build)?,
-        None => service.add_item_with_next_id(build)?,
+    // #1240, operator decision 2026-09-09: the sequential allocator is REFUSED.
+    // `max(id) + 1` is derived from state one branch can see, so two agents
+    // working at once compute the same answer and the merge deletes one of the
+    // two tickets. Leaving it as a silent default meant the unsafe path was
+    // still the one anyone got by typing the obvious command.
+    //
+    // `add_item_with_next_id` is kept, not deleted: `work init` and the tests
+    // that pin PMAT-673/676/680 still exercise it, and it is the thing whose
+    // behaviour those tickets describe.
+    if sequential_id {
+        // The explicit opt-in. `build` is consumed here, so this branch returns
+        // the id and the common reporting below is reached the same way.
+        let next_id = service.add_item_with_next_id(build)?;
+        report_created(&next_id, &title, priority, description.as_deref(), tags.as_deref());
+        return Ok(());
+    }
+    let Some(id) = derived.as_deref().or(explicit_id.as_deref()) else {
+        anyhow::bail!(
+            "refusing to mint a ticket id from `max(id) + 1`.\n\n\
+             That number comes from what THIS branch can see, so two agents \
+             working at once both compute it, both are right locally, and the \
+             merge keeps one entry per id — silently deleting one of the two \
+             tickets while its DAG rows, receipt filenames, commit trailers and \
+             PR body go on citing that id (#1240).\n\n\
+             Pass one of:\n  \
+             --github-issue <N>   derive the id from the issue number. GitHub \
+             allocates those centrally, so two agents cannot be handed the same \
+             one. This is the path to prefer.\n  \
+             --id <ID>            an id you allocated deliberately from some \
+             other authority."
+        )
     };
+    let next_id = service.add_item_with_id(id, build)?;
 
-    println!("{}", c::pass(&format!("Created ticket: {}", c::path(&next_id))));
-    println!("   {} {}", c::label("Title:"), title);
-    println!("   {} {:?}", c::label("Priority:"), priority);
-    if let Some(desc) = description {
-        println!("   {} {}", c::label("Description:"), desc);
-    }
-    if let Some(t) = tags {
-        println!("   {} {}", c::label("Tags:"), t);
-    }
+    report_created(&next_id, &title, priority, description.as_deref(), tags.as_deref());
 
     if let Some(n) = github_issue {
         println!(
@@ -473,4 +495,24 @@ fn rebind_contract(
     }
     contract.save(project_path)?;
     Ok(changes)
+}
+
+/// What `work add` prints once a row has landed, whichever path minted the id.
+fn report_created(
+    id: &str,
+    title: &str,
+    priority: crate::cli::commands::WorkPriority,
+    description: Option<&str>,
+    tags: Option<&str>,
+) {
+    use crate::cli::colors as c;
+    println!("{}", c::pass(&format!("Created ticket: {}", c::path(id))));
+    println!("   {} {}", c::label("Title:"), title);
+    println!("   {} {:?}", c::label("Priority:"), priority);
+    if let Some(desc) = description {
+        println!("   {} {}", c::label("Description:"), desc);
+    }
+    if let Some(t) = tags {
+        println!("   {} {}", c::label("Tags:"), t);
+    }
 }

--- a/src/cli/handlers/work_handlers/ticket_validate_migrate.rs
+++ b/src/cli/handlers/work_handlers/ticket_validate_migrate.rs
@@ -127,7 +127,6 @@ pub async fn handle_work_validate(
     verbose: bool,
     fix: bool,
     check_base: Option<String>,
-    allow_retitle: Vec<String>,
 ) -> Result<()> {
     use crate::cli::colors as c;
     let project_path = path.unwrap_or_else(|| PathBuf::from("."));
@@ -168,7 +167,7 @@ pub async fn handle_work_validate(
             // an id means one piece of work, so a title that changed is an id
             // that was reused.
             if let Some(base) = check_base.as_deref() {
-                check_titles_against_base(base, &project_path, &roadmap_path, &content, &allow_retitle)?;
+                check_titles_against_base(base, &project_path, &roadmap_path, &content)?;
             }
             print_valid_roadmap(&roadmap, verbose, fix);
             Ok(())
@@ -1073,7 +1072,6 @@ fn check_titles_against_base(
     project_path: &Path,
     roadmap_path: &Path,
     head: &str,
-    allow_retitle: &[String],
 ) -> Result<()> {
     use crate::cli::colors as c;
 
@@ -1099,21 +1097,7 @@ fn check_titles_against_base(
         return Ok(());
     }
     let base_text = String::from_utf8_lossy(&out.stdout);
-    let all_changed = crate::services::roadmap_text::titles_changed(&base_text, head);
-    // A rename the caller declared is not a collision — but it IS recorded, so a
-    // reviewer sees which ids were waved through and on whose say-so.
-    let (allowed, changed): (Vec<_>, Vec<_>) = all_changed
-        .into_iter()
-        .partition(|c| allow_retitle.iter().any(|id| id == &c.id));
-    for a in &allowed {
-        println!(
-            "   {}",
-            c::dim(&format!(
-                "{} retitled with --allow-retitle: {:?} -> {:?}",
-                a.id, a.before, a.after
-            ))
-        );
-    }
+    let changed = crate::services::roadmap_text::titles_changed(&base_text, head);
     if changed.is_empty() {
         println!(
             "   {}",
@@ -1138,11 +1122,11 @@ fn check_titles_against_base(
          ticket was deleted, and every artefact citing that id (DAG rows, receipt filenames, \
          commit trailers, PR bodies) now points at unrelated work. Restore the lost ticket \
          under a fresh id; do not simply re-title this one.\n\n\
-         If a title changed because someone MEANT to rename the ticket \
-         (`pmat work edit --title` does exactly that), say so: pass \
-         `--allow-retitle <ID>` for each one. Titles alone cannot tell a rename \
-         from a reused id, so the difference has to be declared rather than \
-         guessed. See #1240.",
+         A ticket id's title is IMMUTABLE once minted (operator decision on \
+         #1240): an id names one piece of work, so if the work changed enough to \
+         need a different title it needs a different id. `pmat work edit --title` \
+         can still rewrite one, but doing so on a ticket that already exists in \
+         the base is what this refuses. See #1240.",
         changed.len(),
         changed
             .iter()

--- a/src/cli/handlers/work_tests_part2.rs
+++ b/src/cli/handlers/work_tests_part2.rs
@@ -86,8 +86,7 @@
                 Some(temp_dir.path().to_path_buf()),
                 false, // verbose
                 false, // fix
-                None,  // check_base
-                Vec::new(), // allow_retitle
+                None, // check_base
             )
             .await;
 
@@ -102,8 +101,7 @@
                 Some(temp_dir.path().to_path_buf()),
                 true,  // verbose
                 false, // fix
-                None,  // check_base
-                Vec::new(), // allow_retitle
+                None, // check_base
             )
             .await;
 
@@ -115,7 +113,7 @@
             let temp_dir = TempDir::new().unwrap();
 
             let result =
-                handle_work_validate(Some(temp_dir.path().to_path_buf()), false, false, None, Vec::new()).await;
+                handle_work_validate(Some(temp_dir.path().to_path_buf()), false, false, None).await;
 
             assert!(result.is_err());
         }
@@ -380,7 +378,7 @@
             std::fs::write(&roadmap_path, "invalid: yaml: content:").unwrap();
 
             let result =
-                handle_work_validate(Some(temp_dir.path().to_path_buf()), false, false, None, Vec::new()).await;
+                handle_work_validate(Some(temp_dir.path().to_path_buf()), false, false, None).await;
 
             assert!(result.is_err());
         }
@@ -408,8 +406,7 @@ roadmap:
                 Some(temp_dir.path().to_path_buf()),
                 true,  // verbose
                 false, // fix
-                None,  // check_base
-                Vec::new(), // allow_retitle
+                None, // check_base
             )
             .await;
 

--- a/src/cli/handlers/work_tests_part4.rs
+++ b/src/cli/handlers/work_tests_part4.rs
@@ -230,7 +230,6 @@ roadmap:
                 false,
                 true, // fix flag
                 None, // check_base
-                Vec::new(), // allow_retitle
             )
             .await;
 
@@ -260,7 +259,6 @@ roadmap:
                 false,
                 false,
                 None, // check_base
-                Vec::new(), // allow_retitle
             )
             .await;
 
@@ -289,7 +287,6 @@ roadmap:
                 true, // verbose
                 false,
                 None, // check_base
-                Vec::new(), // allow_retitle
             )
             .await;
 

--- a/src/tests/roadmap_id_collision_tests.rs
+++ b/src/tests/roadmap_id_collision_tests.rs
@@ -140,11 +140,17 @@ async fn add_with_id(
     title: &str,
     id: Option<&str>,
 ) -> anyhow::Result<()> {
-    add_full(project, title, id, None).await
+    add_full(project, title, id, None, false).await
+}
+
+/// The sequential allocator, reached the one way that is still legal: an explicit
+/// `--sequential-id`. Used only as the CONTROL that reproduces the defect.
+async fn add_sequential(project: &std::path::Path, title: &str) -> anyhow::Result<()> {
+    add_full(project, title, None, None, true).await
 }
 
 async fn add_from_issue(project: &std::path::Path, title: &str, issue: u64) -> anyhow::Result<()> {
-    add_full(project, title, None, Some(issue)).await
+    add_full(project, title, None, Some(issue), false).await
 }
 
 async fn add_full(
@@ -152,6 +158,7 @@ async fn add_full(
     title: &str,
     id: Option<&str>,
     github_issue: Option<u64>,
+    sequential_id: bool,
 ) -> anyhow::Result<()> {
     crate::cli::handlers::work_handlers::handle_work_add(
         title.to_string(),
@@ -163,6 +170,7 @@ async fn add_full(
         None,
         id.map(str::to_string),
         github_issue,
+        sequential_id,
     )
     .await
 }
@@ -226,7 +234,7 @@ async fn an_explicit_id_pushes_the_high_water_mark_so_the_allocator_cannot_reiss
     add_with_id(dir.path(), "explicitly allocated", Some("PMAT-1207"))
         .await
         .expect("explicit id accepted");
-    add_with_id(dir.path(), "then an allocated one", None)
+    add_sequential(dir.path(), "then an allocated one")
         .await
         .expect("allocator still works");
     let raw =
@@ -325,10 +333,10 @@ async fn two_branches_that_cannot_see_each_other_still_cannot_collide() {
     // checkouts, does collide — which is the whole defect.
     let seq_a = roadmap_fixture();
     let seq_bse = roadmap_fixture();
-    add_with_id(seq_a.path(), "L0-1a the CUDA row", None)
+    add_sequential(seq_a.path(), "L0-1a the CUDA row")
         .await
         .expect("agent A, allocator");
-    add_with_id(seq_bse.path(), "BSE-09b merge=union", None)
+    add_sequential(seq_bse.path(), "BSE-09b merge=union")
         .await
         .expect("agent BSE, allocator");
     let sa = std::fs::read_to_string(seq_a.path().join("docs/roadmaps/roadmap.yaml"))
@@ -465,4 +473,44 @@ roadmap:
         !dupes.is_empty(),
         "PMAT-7 and PMAT-007 are the same number and were not reported as a duplicate"
     );
+}
+
+// ── Operator decisions on #1240 (2026-09-09): the collision-free path is
+// mandatory, and a ticket title is immutable.
+
+#[tokio::test]
+async fn work_add_refuses_the_sequential_allocator() {
+    let dir = roadmap_fixture();
+    let err = add_with_id(dir.path(), "minted from max+1", None)
+        .await
+        .expect_err("the sequential allocator must be refused");
+    let text = format!("{err}");
+    assert!(
+        text.contains("--github-issue"),
+        "the refusal must name the collision-free path: {text}"
+    );
+
+    let raw =
+        std::fs::read_to_string(dir.path().join("docs/roadmaps/roadmap.yaml")).expect("read back");
+    assert_eq!(
+        titles_by_id(&raw).len(),
+        titles_by_id(BASE).len(),
+        "a refused add must write nothing"
+    );
+}
+
+#[tokio::test]
+async fn the_two_deliberate_paths_still_work() {
+    let dir = roadmap_fixture();
+    add_from_issue(dir.path(), "from the issue number", 1065)
+        .await
+        .expect("--github-issue is the preferred path");
+    add_with_id(dir.path(), "explicitly allocated", Some("PMAT-2000"))
+        .await
+        .expect("--id remains available for a caller that allocated deliberately");
+    let raw =
+        std::fs::read_to_string(dir.path().join("docs/roadmaps/roadmap.yaml")).expect("read back");
+    let titles = titles_by_id(&raw);
+    assert!(titles.contains_key("PMAT-1065"));
+    assert!(titles.contains_key("PMAT-2000"));
 }

--- a/src/tests/work_add_allocator_tests.rs
+++ b/src/tests/work_add_allocator_tests.rs
@@ -72,6 +72,7 @@ async fn add(project: &Path, title: &str) -> anyhow::Result<()> {
         None,
         None,
         None,
+        true, // --sequential-id: these tests exist to pin the allocator itself
     )
     .await
 }

--- a/src/tests/work_add_append_only_tests.rs
+++ b/src/tests/work_add_append_only_tests.rs
@@ -99,6 +99,7 @@ async fn add(project: &Path, title: &str) -> anyhow::Result<()> {
         None,
         None,
         None,
+        true, // --sequential-id: these tests exist to pin the allocator itself
     )
     .await
 }
@@ -196,7 +197,6 @@ async fn work_add_append_only_add_appends_the_row_and_rewrites_nothing() {
         false,
         false,
         None,
-        Vec::new(),
     )
     .await
     .expect("what `add` wrote must validate");

--- a/src/tests/work_add_refuses_invalid_tests.rs
+++ b/src/tests/work_add_refuses_invalid_tests.rs
@@ -111,6 +111,7 @@ async fn add(project: &Path, title: &str) -> anyhow::Result<()> {
         None,
         None,
         None,
+        true, // --sequential-id: these tests exist to pin the allocator itself
     )
     .await
 }
@@ -245,7 +246,6 @@ async fn work_add_refuses_invalid_clean_roadmap_still_mints_and_still_validates(
         false,
         false,
         None,
-        Vec::new(),
     )
     .await
     .expect("what `add` and `edit` wrote must validate");

--- a/src/tests/work_add_single_authority_tests.rs
+++ b/src/tests/work_add_single_authority_tests.rs
@@ -147,6 +147,7 @@ async fn add(checkout: &Path, title: &str) -> anyhow::Result<()> {
         None,
         None,
         None,
+        true, // --sequential-id: these tests exist to pin the allocator itself
     )
     .await
 }

--- a/src/tests/work_validate_duplicate_ids_tests.rs
+++ b/src/tests/work_validate_duplicate_ids_tests.rs
@@ -104,14 +104,7 @@ async fn work_validate_duplicate_ids_are_refused_and_both_lines_reported() {
     let first = line_of_nth_occurrence(DUPLICATE_FIXTURE, "- id: PMAT-654", 0);
     let second = line_of_nth_occurrence(DUPLICATE_FIXTURE, "- id: PMAT-654", 1);
 
-    let result = handle_work_validate(
-        Some(project.path().to_path_buf()),
-        false,
-        false,
-        None,
-        Vec::new(),
-    )
-    .await;
+    let result = handle_work_validate(Some(project.path().to_path_buf()), false, false, None).await;
 
     let error = result.err().map_or_else(String::new, |e| format!("{e:#}"));
     assert!(
@@ -138,14 +131,7 @@ async fn work_validate_duplicate_ids_are_refused_and_both_lines_reported() {
 async fn work_validate_duplicate_unparseable_roadmap_is_located_by_line() {
     let project = project_with_roadmap(UNPARSEABLE_FIXTURE);
 
-    let result = handle_work_validate(
-        Some(project.path().to_path_buf()),
-        false,
-        false,
-        None,
-        Vec::new(),
-    )
-    .await;
+    let result = handle_work_validate(Some(project.path().to_path_buf()), false, false, None).await;
 
     let error = result.err().map_or_else(String::new, |e| format!("{e:#}"));
     assert!(!error.is_empty(), "`status: bogus` must not validate");
@@ -161,14 +147,7 @@ async fn work_validate_duplicate_unparseable_roadmap_is_located_by_line() {
 async fn work_validate_duplicate_distinct_ids_still_validate() {
     let project = project_with_roadmap(VALID_FIXTURE);
 
-    let result = handle_work_validate(
-        Some(project.path().to_path_buf()),
-        false,
-        false,
-        None,
-        Vec::new(),
-    )
-    .await;
+    let result = handle_work_validate(Some(project.path().to_path_buf()), false, false, None).await;
 
     assert!(
         result.is_ok(),
@@ -183,7 +162,7 @@ async fn work_validate_duplicate_distinct_ids_still_validate() {
 async fn work_validate_duplicate_this_repositorys_roadmap_validates() {
     let project = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
 
-    let result = handle_work_validate(Some(project), false, false, None, Vec::new()).await;
+    let result = handle_work_validate(Some(project), false, false, None).await;
 
     assert!(
         result.is_ok(),


### PR DESCRIPTION
Operator decisions on #1240 (2026-09-09): **(1)** GitHub issue mandatory, **(2)** title immutable.

## 1. `work add` refuses the sequential allocator

`max(id) + 1` is derived from what one branch can see, so two agents compute the same answer, both are right locally, and the merge deletes one of the two tickets. It was still the **default** — the unsafe path was what you got by typing the obvious command.

The refusal names both safe paths:

```
--github-issue <N>   derive the id from the issue number. GitHub allocates those
                     centrally, so two agents cannot be handed the same one.
--id <ID>            an id you allocated deliberately from another authority.
```

## 2. Titles are immutable

`--allow-retitle` is gone. An id names one piece of work; work that changed enough to need a different title needs a different id.

## Why `--sequential-id` exists rather than a deletion — the one judgement call

Making the safe path mandatory left `add_item_with_next_id` with **no production caller**. Measured, not assumed: the only minting call in `src/` outside tests is `add_item_with_id`.

Dead code is bad. Dead code with **849 lines of tests** is worse — it reads as a shipped capability. But those 849 lines are PMAT-673/676/680's cross-process, cross-worktree and high-water-mark guarantees, and `add_item_with_id` uses that same machinery. Deleting them to satisfy the policy would have removed the coverage that makes the *remaining* path trustworthy.

So the allocator stays reachable through one explicit, greppable flag that only its own tests pass:

- `git grep -- --sequential-id` says exactly who uses it;
- `conflicts_with_all = ["id", "github_issue"]` stops it being combined with a safe path by accident;
- its help text says it is unsafe in parallel and why.

That is a reading of "mandatory" as **nobody gets the unsafe path by accident**, rather than the strictest one. If you meant strictly-issue-only — delete the allocator and its tests, and `--id` with it — that's a one-commit change; say so and I'll do it.

## Evidence

| | |
|---|---|
| `work_add_refuses_the_sequential_allocator` | RED → GREEN; also asserts a refused add **writes nothing** |
| `the_two_deliberate_paths_still_work` | `--github-issue` and `--id` both land |
| id / allocator / validate suite | **57 passed**, coverage intact |
| `cargo test --lib` | 21303 passed, 1 failed (this PR's own ledger, re-rendered) |

Ratchets unmoved; both ledgers current.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqvpQmAsiaKRsScDT7EBuY