### PR TITLE
feat(#1228): both CLI-doc ratchets become hard failures, and the debt is paid

### DIFF
--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -4988,3 +4988,20 @@ roadmap:
   labels:
   - kind:code
   notes: null
+- id: PMAT-715
+  github_issue: null
+  item_type: task
+  title: 'cli-reference: convert both ratchets to hard failures and clear the debt they recorded — document the 60 undocumented commands, fix or remove the 16 drifted examples (#1228 step 3, forced by the operator decision to make them hard failures)'
+  status: planned
+  priority: medium
+  assigned_to: null
+  created: 2026-09-09T08:05:16Z
+  updated: 2026-09-09T08:05:16Z
+  spec: null
+  acceptance_criteria: []
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - kind:code
+  notes: null

--- a/rust-docs/cli-reference.md
+++ b/rust-docs/cli-reference.md
@@ -126,15 +126,10 @@ paiml-mcp-agent-toolkit demo --protocol cli --show-api
 # Analyze GitHub repository with MCP protocol
 paiml-mcp-agent-toolkit demo --url https://github.com/user/repo --protocol mcp
 
-# Web-based interactive demo
-paiml-mcp-agent-toolkit demo --web --port 8080
 
 # Compare all protocols
 paiml-mcp-agent-toolkit demo --protocol all --format json
 
-# Export analysis results
-paiml-mcp-agent-toolkit demo --export markdown -o analysis.md
-paiml-mcp-agent-toolkit demo --export sarif -o results.sarif
 ```
 
 ### `generate` (aliases: `gen`, `g`)
@@ -225,12 +220,6 @@ pub fn scaffold_parallel(templates: Vec<TemplateRequest>) -> Result<Vec<Generate
 #### Examples
 
 ```bash
-# Scaffold complete Rust project
-paiml-mcp-agent-toolkit scaffold rust \
-  -t makefile,readme,gitignore \
-  -p project_name=my-cli \
-  -p author="Jane Doe" \
-  --parallel 4
 ```
 
 ### `list`
@@ -315,14 +304,7 @@ pub struct CacheHierarchy {
 #### Examples
 
 ```bash
-# Analyze current Rust project
-paiml-mcp-agent-toolkit context rust
 
-# Analyze specific project as JSON
-paiml-mcp-agent-toolkit context deno \
-  -p /path/to/project \
-  -o context.json \
-  --format json
 ```
 
 ### `analyze`
@@ -567,8 +549,6 @@ pmat analyze duplicates --detection-type exact
 # Comprehensive semantic duplicate detection
 pmat analyze duplicates --detection-type all --threshold 0.8
 
-# GPU-accelerated analysis with performance metrics
-pmat analyze duplicates --gpu --perf --format json
 ```
 
 ##### `analyze defect-prediction`
@@ -584,14 +564,8 @@ pmat analyze duplicates --gpu --perf --format json
 
 **Examples:**
 ```bash
-# High-confidence defect predictions
-pmat analyze defect-prediction --min-confidence 0.8
 
-# Detailed analysis with feature explanations
-pmat analyze defect-prediction --explain --format detailed
 
-# IDE integration with SARIF output
-pmat analyze defect-prediction --sarif -o defects.sarif
 ```
 
 ##### `analyze comprehensive`
@@ -699,8 +673,6 @@ pmat analyze name-similarity "proces" --phonetic --top-k 5
 # Basic Big-O analysis
 pmat analyze big-o
 
-# Find quadratic or worse complexity
-pmat analyze big-o --min-complexity "O(n^2)" --format json
 ```
 
 ##### `analyze makefile`
@@ -723,8 +695,6 @@ pmat analyze makefile
 # Fix issues automatically
 pmat analyze makefile --fix
 
-# CI/CD integration
-pmat analyze makefile --min-severity error --format sarif
 ```
 
 ##### `analyze proof-annotations`
@@ -763,8 +733,6 @@ pmat analyze proof-annotations --property-type nullability --high-confidence-onl
 # Check coverage for PR
 pmat analyze incremental-coverage --base-branch main
 
-# Enforce minimum coverage
-pmat analyze incremental-coverage --min-coverage 80.0 --fail-on-decrease
 ```
 
 ##### `analyze symbol-table`
@@ -783,8 +751,6 @@ pmat analyze incremental-coverage --min-coverage 80.0 --fail-on-decrease
 # Generate symbol table
 pmat analyze symbol-table --format json -o symbols.json
 
-# Generate ctags format
-pmat analyze symbol-table --format ctags --include-private
 ```
 
 ### `refactor`
@@ -879,8 +845,6 @@ Batch refactoring server for large-scale operations.
 # Batch refactoring
 pmat refactor serve --config refactor.json
 
-# Resume with auto-commit
-pmat refactor serve --resume --auto-commit "refactor: {file}"
 ```
 
 ##### `refactor status`
@@ -1033,8 +997,6 @@ pmat analyze assembly-script --format json -o analysis.json
 # Analyze all WebAssembly files
 pmat analyze web-assembly
 
-# Only analyze binary WASM files
-pmat analyze web-assembly --include-binary --no-include-text
 
 # Comprehensive analysis
 pmat analyze web-assembly --memory-analysis --security --complexity
@@ -1083,3 +1045,601 @@ pub fn expand_env_vars(template: &str) -> String {
 - **Parallel File I/O**: Bounded concurrent file operations
 - **Lock-Free Caching**: `DashMap` for thread-safe template access
 - **Work Stealing**: Rayon-based parallel iteration
+
+## Commands not yet hand-documented
+
+The sections below are generated from the CLI's own `--help`, one per command that
+this reference did not cover. They exist so the drift guard can be a HARD FAILURE
+rather than a ratchet: a new command with no entry here now fails
+`test_no_undocumented_commands` immediately, instead of being added to a list of
+60 exceptions that nobody was going to shrink (#1228).
+
+A generated stub is not a hand-written section and does not pretend to be. It
+carries the command's real name and its real summary, which is what the guard
+checks; the argument tables, examples and prose are still owed. #1228 step 3 —
+generating the WHOLE reference from the command registry and deleting the
+markdown-parsing test — is the proper end of this road.
+
+### `agent`
+
+[NOT AVAILABLE in the default build] Claude Code background agent — needs --features agent-daemon
+
+Aliases: `ag`
+
+```bash
+pmat agent --help
+```
+
+### `agy`
+
+Google Anti-Gravity customizations translator
+
+Aliases: `antigravity`
+
+```bash
+pmat agy --help
+```
+
+### `brick-score`
+
+ComputeBrick profiling score (0-100 scale) for trueno/realizar ecosystem
+
+Aliases: `brick`, `computebrick`
+
+```bash
+pmat brick-score --help
+```
+
+### `cache`
+
+Cache strategy management and optimization
+
+```bash
+pmat cache --help
+```
+
+### `ci-local`
+
+Run local CI simulation (quality gates, clippy, tests, cross-compilation)
+
+Aliases: `ci`, `local-ci`
+
+```bash
+pmat ci-local --help
+```
+
+### `comply`
+
+PMAT compliance checking and migration system (runs check by default)
+
+Aliases: `compliance`
+
+```bash
+pmat comply --help
+```
+
+### `config`
+
+Configuration management and settings
+
+```bash
+pmat config --help
+```
+
+### `cuda-tdg`
+
+CUDA-SIMD Technical Debt Gradient (100-point Popper falsification scoring) Analyzes CUDA PTX, SIMD (AVX2/AVX-512/NEON), and WGPU code for defects Integrates Toyota Production System principles with falsificationist methodology
+
+Aliases: `gpu-tdg`, `simd-tdg`
+
+```bash
+pmat cuda-tdg --help
+```
+
+### `debug`
+
+Time-travel debugging commands for execution traces
+
+Aliases: `dbg`
+
+```bash
+pmat debug --help
+```
+
+### `demo-score`
+
+Score demo/book repository quality (0-10 Category G scale)
+
+Aliases: `book-score`, `score-demo`
+
+```bash
+pmat demo-score --help
+```
+
+### `deps-audit`
+
+Audit dependencies for Sovereign AI stack migration
+
+Aliases: `deps`, `audit-deps`
+
+```bash
+pmat deps-audit --help
+```
+
+### `diagnose`
+
+Run self-diagnostics to verify all features are working
+
+Aliases: `diag`, `doctor`
+
+```bash
+pmat diagnose --help
+```
+
+### `embed`
+
+Manage semantic search embeddings for code search
+
+Aliases: `emb`
+
+```bash
+pmat embed --help
+```
+
+### `enforce`
+
+Enforce extreme quality standards using state machine
+
+Aliases: `enf`
+
+```bash
+pmat enforce --help
+```
+
+### `explain`
+
+Explain what a check, metric, or grade means
+
+Aliases: `explain-check`, `what-is`
+
+```bash
+pmat explain --help
+```
+
+### `extract`
+
+Extract function boundaries from a single file (tree-sitter, no index)
+
+Aliases: `ext`
+
+```bash
+pmat extract --help
+```
+
+### `falsify`
+
+Falsify claims in a work item, spec, or ticket against the codebase
+
+Aliases: `falsify-spec`
+
+```bash
+pmat falsify --help
+```
+
+### `five-whys`
+
+Five Whys root cause analysis (Toyota Way methodology) This is the ONLY acceptable debugging method per CLAUDE.md policy
+
+Aliases: `why`, `debug-whys`
+
+```bash
+pmat five-whys --help
+```
+
+### `hooks`
+
+Pre-commit hook management and installation
+
+Aliases: `hook`, `h`
+
+```bash
+pmat hooks --help
+```
+
+### `infra-score`
+
+Infrastructure Score (0-100 + 12 bonus) for CI/CD quality
+
+Aliases: `infra`, `ci-score`
+
+```bash
+pmat infra-score --help
+```
+
+### `init`
+
+Bootstrap an agent-ready workspace: quality hook, MCP registration, skill and root rules file
+
+Aliases: `bootstrap`
+
+```bash
+pmat init --help
+```
+
+### `kaizen`
+
+Autonomous continuous improvement (Toyota Way Kaizen) Scans, fixes, commits, and files GitHub issues for remaining findings
+
+Aliases: `improve`
+
+```bash
+pmat kaizen --help
+```
+
+### `localize`
+
+Fault localization using Spectrum-Based Fault Localization (SBFL) Identify suspicious code locations based on test coverage data
+
+Aliases: `fault`, `fl`
+
+```bash
+pmat localize --help
+```
+
+### `maintain`
+
+Project maintenance commands (cleanup, validation, reports)
+
+Aliases: `maint`, `m`
+
+```bash
+pmat maintain --help
+```
+
+### `mcp`
+
+Connect pmat to an MCP client: every transport, in one place
+
+```bash
+pmat mcp --help
+```
+
+### `memory`
+
+Memory management and optimization
+
+```bash
+pmat memory --help
+```
+
+### `oracle`
+
+PMAT Oracle - PDCA loop for automated quality improvement (Toyota Way) Converges ANY Rust project toward perfect quality using CITL signals
+
+Aliases: `fix`, `pdca`
+
+```bash
+pmat oracle --help
+```
+
+### `org`
+
+[NOT AVAILABLE in the default build] Organizational intelligence — needs --features org-intelligence
+
+Aliases: `organization`
+
+```bash
+pmat org --help
+```
+
+### `perfection-score`
+
+Unified 200-point Perfection Score (master-plan-pmat-work-system.md) Aggregates TDG, Repo Score, Rust Score, Coverage, Mutation, Docs, Performance
+
+Aliases: `perfection`, `perfect`, `ps`
+
+```bash
+pmat perfection-score --help
+```
+
+### `popper-score`
+
+Calculate Popper Falsifiability Score (0-100 scale)
+
+Aliases: `popper`, `falsifiability`
+
+```bash
+pmat popper-score --help
+```
+
+### `predict-quality`
+
+Predict when quality metrics will exceed thresholds (Phase 4 O(1) Quality Gates)
+
+Aliases: `predict`
+
+```bash
+pmat predict-quality --help
+```
+
+### `project-diag`
+
+Rust project diagnostics (20 checks across 5 categories)
+
+Aliases: `pdiag`, `proj-diag`
+
+```bash
+pmat project-diag --help
+```
+
+### `prompt`
+
+AI prompt generation (defect-aware, ticket-based, spec-based)
+
+Aliases: `p`
+
+```bash
+pmat prompt --help
+```
+
+### `qa-work`
+
+QA validation after work completion with Toyota Way quality gates
+
+Aliases: `qa`, `quality`
+
+```bash
+pmat qa-work --help
+```
+
+### `qdd`
+
+Quality-Driven Development (QDD) tool for creating and refactoring code with guaranteed quality
+
+Aliases: `qd`
+
+```bash
+pmat qdd --help
+```
+
+### `quality-gates`
+
+Run configurable quality gates on the current project
+
+Aliases: `gates`, `qg`
+
+```bash
+pmat quality-gates --help
+```
+
+### `query`
+
+Semantic code search with quality annotations (RAG-powered)
+
+Aliases: `q`, `search-code`
+
+```bash
+pmat query --help
+```
+
+### `record-metric`
+
+Record a quality metric observation (Phase 3.4 O(1) Quality Gates - CI/CD)
+
+Aliases: `record`
+
+```bash
+pmat record-metric --help
+```
+
+### `red-team`
+
+Red Team Mode: Automated hallucination detection for commits and code
+
+Aliases: `rt`, `hallucination-detect`
+
+```bash
+pmat red-team --help
+```
+
+### `report`
+
+Generate enhanced analysis reports
+
+Aliases: `r`, `rep`
+
+```bash
+pmat report --help
+```
+
+### `repo-score`
+
+Calculate repository health score (0-100 scale)
+
+Aliases: `health`
+
+```bash
+pmat repo-score --help
+```
+
+### `roadmap`
+
+Roadmap management with PDMT todos and quality gates
+
+Aliases: `road`, `rm`
+
+```bash
+pmat roadmap --help
+```
+
+### `rust-project-score`
+
+Calculate Rust project quality score (0-289 scale; the reported total excludes categories that do not apply to the project)
+
+Aliases: `rust-score`
+
+```bash
+pmat rust-project-score --help
+```
+
+### `score`
+
+Unified quality score — geometric composite (0-100)
+
+```bash
+pmat score --help
+```
+
+### `semantic`
+
+Semantic code search using embeddings
+
+Aliases: `sem`, `find-code`
+
+```bash
+pmat semantic --help
+```
+
+### `serve`
+
+Serve the MCP tool surface over streamable HTTP (`--transport http`)
+
+Aliases: `server`, `api`
+
+```bash
+pmat serve --help
+```
+
+### `show-metrics`
+
+Show quality metrics and trends (Phase 3 O(1) Quality Gates)
+
+Aliases: `metrics`, `trends`
+
+```bash
+pmat show-metrics --help
+```
+
+### `spec`
+
+Specification management and validation
+
+Aliases: `specification`
+
+```bash
+pmat spec --help
+```
+
+### `split`
+
+Analyze and suggest semantic file splits using Louvain community detection
+
+Aliases: `sp`
+
+```bash
+pmat split --help
+```
+
+### `sql`
+
+Direct SQL access to the function index database
+
+```bash
+pmat sql --help
+```
+
+### `stack`
+
+Cross-repo dependency coordination for the sovereign AI stack
+
+Aliases: `stk`
+
+```bash
+pmat stack --help
+```
+
+### `tdg`
+
+Grade technical debt and code quality (TDG - Technical Debt Grading)
+
+Aliases: `grade`, `debt-grade`
+
+```bash
+pmat tdg --help
+```
+
+### `telemetry`
+
+Telemetry and system monitoring
+
+```bash
+pmat telemetry --help
+```
+
+### `test`
+
+Performance testing per SPECIFICATION.md Section 30
+
+```bash
+pmat test --help
+```
+
+### `test-discovery`
+
+Systematic test discovery and fixing
+
+Aliases: `test-fix`, `fix-tests`
+
+```bash
+pmat test-discovery --help
+```
+
+### `test-stability`
+
+Detect flaky and timeout-sensitive tests
+
+Aliases: `test-flaky`, `flaky`
+
+```bash
+pmat test-stability --help
+```
+
+### `validate-docs`
+
+Validate documentation links
+
+Aliases: `docs`, `doc`
+
+```bash
+pmat validate-docs --help
+```
+
+### `validate-readme`
+
+Validate README/documentation for factual accuracy and hallucinations
+
+Aliases: `readme`, `hallucination`
+
+```bash
+pmat validate-readme --help
+```
+
+### `verify`
+
+Pre-flight verification for autonomous agents: run the CI-faithful gate set (format, complexity, satd, clippy, tests) fail-fast before committing
+
+Aliases: `preflight`, `vfy`
+
+```bash
+pmat verify --help
+```
+
+### `work`
+
+Unified GitHub/YAML workflow management
+
+Aliases: `w`
+
+```bash
+pmat work --help
+```

--- a/tests/modules/cli_documentation_sync.rs
+++ b/tests/modules/cli_documentation_sync.rs
@@ -317,80 +317,6 @@ fn test_cli_options_match_documentation() {
     }
 }
 
-/// Top-level commands that `rust-docs/cli-reference.md` does not document yet.
-///
-/// A RATCHET, not an allow-list: this may only ever get SHORTER. It exists because
-/// the honest measurement is 60 undocumented commands out of 71, and a test that
-/// demanded all 60 be written today would simply be disabled tomorrow — which is
-/// how this suite came to assert nothing in the first place (#1228).
-///
-/// Adding a command without documenting it fails the test below. Documenting one
-/// without deleting its line here ALSO fails, so the list cannot rot into a
-/// permanent excuse. Emptying it is the goal; #1228 Step 3 (generate the reference
-/// from the command registry) is how that is meant to happen.
-const UNDOCUMENTED_AT_BASELINE: &[&str] = &[
-    "agent",
-    "agy",
-    "brick-score",
-    "cache",
-    "ci-local",
-    "comply",
-    "config",
-    "cuda-tdg",
-    "debug",
-    "demo-score",
-    "deps-audit",
-    "diagnose",
-    "embed",
-    "enforce",
-    "explain",
-    "extract",
-    "falsify",
-    "five-whys",
-    "hooks",
-    "infra-score",
-    "init",
-    "kaizen",
-    "localize",
-    "maintain",
-    "mcp",
-    "memory",
-    "oracle",
-    "org",
-    "perfection-score",
-    "popper-score",
-    "predict-quality",
-    "project-diag",
-    "prompt",
-    "qa-work",
-    "qdd",
-    "quality-gates",
-    "query",
-    "record-metric",
-    "red-team",
-    "report",
-    "repo-score",
-    "roadmap",
-    "rust-project-score",
-    "score",
-    "semantic",
-    "serve",
-    "show-metrics",
-    "spec",
-    "split",
-    "sql",
-    "stack",
-    "tdg",
-    "telemetry",
-    "test",
-    "test-discovery",
-    "test-stability",
-    "validate-docs",
-    "validate-readme",
-    "verify",
-    "work",
-];
-
 #[test]
 fn test_no_undocumented_commands() {
     // `None` means the document was never shipped (packaged crate); there is
@@ -425,65 +351,21 @@ fn test_no_undocumented_commands() {
         .filter(|c| *c != "help" && !documented_names.contains(c))
         .collect();
 
-    let newly_undocumented: Vec<&&str> = undocumented_now
-        .iter()
-        .filter(|c| !UNDOCUMENTED_AT_BASELINE.contains(c))
-        .collect();
+    // A HARD FAILURE, not a ratchet (operator decision, 2026-09-09). The 60-command
+    // exception list is gone and the debt it recorded is paid: every command has a
+    // section in the reference. A new command without one fails here immediately,
+    // which is the only version of this check that means anything — a list of 60
+    // exceptions nobody was going to shrink is a ratchet in name only.
     assert!(
-        newly_undocumented.is_empty(),
-        "{} new undocumented command(s): {:?}\n\
-         Document them in rust-docs/cli-reference.md as `### `<name>``, or, if that \
-         is genuinely out of scope, add them to UNDOCUMENTED_AT_BASELINE and say why \
-         in the commit message. The list may only shrink.",
-        newly_undocumented.len(),
-        newly_undocumented
-    );
-
-    let stale: Vec<&&str> = UNDOCUMENTED_AT_BASELINE
-        .iter()
-        .filter(|c| !undocumented_now.contains(c))
-        .collect();
-    assert!(
-        stale.is_empty(),
-        "{} entr(y/ies) in UNDOCUMENTED_AT_BASELINE {:?} are now documented or gone \
-         from the CLI. Delete them from the list — a ratchet that keeps satisfied \
-         entries stops measuring anything.",
-        stale.len(),
-        stale
+        undocumented_now.is_empty(),
+        "{} undocumented command(s): {:?}\n\nEvery command needs a `### `<name>`` \
+         section in rust-docs/cli-reference.md. A generated stub carrying the \
+         command's real name and its `--help` summary is enough to pass this; see \
+         the \"Commands not yet hand-documented\" section for the shape.",
+        undocumented_now.len(),
+        undocumented_now
     );
 }
-
-/// Documented examples that name a flag or subcommand the CLI does not have.
-///
-/// A RATCHET, like `UNDOCUMENTED_AT_BASELINE`: it may only ever get SHORTER. The
-/// honest measurement the moment this test could see anything at all was **16 of
-/// 79** examples drifted — the extractor had been reading one line per block and
-/// skipping any block that opened with a comment, which is nearly all of them.
-///
-/// Recorded rather than fixed here because the two are different jobs: deciding
-/// what `demo --web` or `analyze defect-prediction --explain` was MEANT to say
-/// needs someone who knows whether the flag was renamed, dropped, or never
-/// shipped, and guessing would replace drift with fiction. A new drifted example
-/// fails the test immediately; a line here that starts working ALSO fails it, so
-/// the list cannot rot. Emptying it is the goal.
-const DRIFTED_EXAMPLES_AT_BASELINE: &[&str] = &[
-    r#"paiml-mcp-agent-toolkit demo --web --port 8080"#,
-    r#"paiml-mcp-agent-toolkit demo --export markdown -o analysis.md"#,
-    r#"paiml-mcp-agent-toolkit demo --export sarif -o results.sarif"#,
-    r#"paiml-mcp-agent-toolkit scaffold rust \"#,
-    r#"paiml-mcp-agent-toolkit context rust"#,
-    r#"paiml-mcp-agent-toolkit context deno \"#,
-    r#"pmat analyze duplicates --gpu --perf --format json"#,
-    r#"pmat analyze defect-prediction --min-confidence 0.8"#,
-    r#"pmat analyze defect-prediction --explain --format detailed"#,
-    r#"pmat analyze defect-prediction --sarif -o defects.sarif"#,
-    r#"pmat analyze big-o --min-complexity "O(n^2)" --format json"#,
-    r#"pmat analyze makefile --min-severity error --format sarif"#,
-    r#"pmat analyze incremental-coverage --min-coverage 80.0 --fail-on-decrease"#,
-    r#"pmat analyze symbol-table --format ctags --include-private"#,
-    r#"pmat refactor serve --resume --auto-commit "refactor: {file}""#,
-    r#"pmat analyze web-assembly --include-binary --no-include-text"#,
-];
 
 #[test]
 fn test_documentation_examples_are_valid() {
@@ -596,40 +478,14 @@ fn test_documentation_examples_are_valid() {
         "examined 0 documented examples — the extractor matched nothing, which is \
          how this test passed while measuring nothing (#1228)"
     );
-    let new_drift: Vec<&String> = drifted
-        .iter()
-        .filter(|d| {
-            let command = d.lines().next().unwrap_or("").trim();
-            !DRIFTED_EXAMPLES_AT_BASELINE.contains(&command)
-        })
-        .collect();
+    // A HARD FAILURE, not a ratchet (operator decision, 2026-09-09). Every
+    // documented example must name something the CLI actually has.
     assert!(
-        new_drift.is_empty(),
-        "{} NEW drifted example(s) out of {examined} examined:\n{}\n\nFix the \
-         document, or, if the example is right and the CLI is wrong, fix the CLI. \
-         Adding a line to DRIFTED_EXAMPLES_AT_BASELINE needs a reason in the \
-         commit message — the list may only shrink.",
-        new_drift.len(),
-        new_drift
-            .iter()
-            .map(|d| d.as_str())
-            .collect::<Vec<_>>()
-            .join("\n")
-    );
-
-    let fixed: Vec<&&str> = DRIFTED_EXAMPLES_AT_BASELINE
-        .iter()
-        .filter(|baseline| {
-            !drifted
-                .iter()
-                .any(|d| d.lines().next().unwrap_or("").trim() == **baseline)
-        })
-        .collect();
-    assert!(
-        fixed.is_empty(),
-        "{} entr(y/ies) in DRIFTED_EXAMPLES_AT_BASELINE now work: {fixed:?}\nDelete \
-         them from the list — a ratchet that keeps satisfied entries stops \
-         measuring anything.",
-        fixed.len()
+        drifted.is_empty(),
+        "{} of {examined} documented example(s) name something the CLI does not \
+         have:\n{}\n\nFix the document, or, if the example is right and the CLI is \
+         wrong, fix the CLI.",
+        drifted.len(),
+        drifted.join("\n")
     );
 }

--- a/tests/modules/documentation_examples.rs
+++ b/tests/modules/documentation_examples.rs
@@ -167,34 +167,57 @@ fn validate_binary_path(command: &str, expected_binary_path: &str) {
     );
 }
 
+/// Every top-level command the binary actually has, read from `--help`.
+///
+/// #1228: this used to be a hardcoded list of 14 command names. pmat has 71, so
+/// the list was 57 commands out of date and rejected examples for commands that
+/// exist — the same hand-maintained-inventory defect the reference itself had.
+/// Asking the binary removes the second inventory instead of updating it.
+fn known_commands() -> Vec<String> {
+    let output = pmat_command()
+        .arg("--help")
+        .output()
+        .expect("spawn pmat --help");
+    let text = String::from_utf8_lossy(&output.stdout);
+    let mut names = Vec::new();
+    let mut in_commands = false;
+    for line in text.lines() {
+        if line.starts_with("Commands:") {
+            in_commands = true;
+            continue;
+        }
+        if in_commands {
+            if line.trim().is_empty() {
+                break;
+            }
+            if let Some(name) = line.trim_start().split_whitespace().next() {
+                if name.starts_with(|c: char| c.is_ascii_lowercase()) {
+                    names.push(name.to_string());
+                }
+            }
+        }
+    }
+    assert!(
+        !names.is_empty(),
+        "parsed no commands from `pmat --help` — this check would otherwise accept \
+         anything (#1228)"
+    );
+    names
+}
+
 fn validate_command_arguments(parts: &[&str], original_line: &str) {
     if parts.len() <= 1 {
         return;
     }
 
-    let valid_commands = [
-        "generate",
-        "scaffold",
-        "list",
-        "search",
-        "validate",
-        "context",
-        "analyze",
-        "demo",
-        "serve",
-        "refactor",
-        "quality-gate",
-        "diagnose",
-        "report",
-        "enforce",
-        "--help",
-        "--version",
-        "--mode",
-    ];
-
     let first_arg = parts[1];
+    // A global flag rather than a subcommand.
+    if first_arg.starts_with('-') {
+        return;
+    }
+    let known = known_commands();
     assert!(
-        valid_commands.contains(&first_arg),
+        known.iter().any(|c| c == first_arg),
         "Example uses unknown command: {first_arg} in line: {original_line}"
     );
 }

--- a/tests/modules/documentation_examples.rs
+++ b/tests/modules/documentation_examples.rs
@@ -190,7 +190,7 @@ fn known_commands() -> Vec<String> {
             if line.trim().is_empty() {
                 break;
             }
-            if let Some(name) = line.trim_start().split_whitespace().next() {
+            if let Some(name) = line.split_whitespace().next() {
                 if name.starts_with(|c: char| c.is_ascii_lowercase()) {
                     names.push(name.to_string());
                 }


### PR DESCRIPTION
Operator decision on #1228 (2026-09-09): **hard failure, not ratchet**.

A hard failure that leaves the tree red isn't a gate, so the debt is cleared in the same change rather than deferred.

## Undocumented commands: 60 → 0

Every command now has a `### `<name>`` section. The 60 that had none are **generated from the CLI's own `--help`** — name, real summary, aliases, and a `pmat <cmd> --help` example — under a heading that says exactly what they are.

A generated stub is not a hand-written section and doesn't pretend to be: it carries the two things the guard checks and openly still owes argument tables, examples and prose. This is **#1228 step 3 arriving through the back door**, and the section says so — generating the whole reference from the command registry and deleting the markdown-parsing test is still the proper end of the road.

## Drifted examples: 16 → 0

Each named a flag or subcommand the CLI does not have — `demo --web`, `analyze duplicates --gpu`, `analyze defect-prediction --explain`, and thirteen more.

**Removed rather than repaired.** Deciding what `demo --web` was *meant* to say needs someone who knows whether the flag was renamed, dropped, or never shipped; inventing a replacement would swap drift for fiction. A wrong example is worse than no example. If any of those flags should exist, that's a CLI bug and a separate ticket.

## A third hardcoded inventory, found on the way

`documentation_examples.rs` validated examples against **its own list of 14 command names**. pmat has 71 — so it was 57 commands out of date and *rejected examples for commands that exist*. Same hand-maintained-inventory defect as the reference itself, one file away.

It now asks the binary, and asserts it parsed something, so the check cannot silently accept everything.

## Falsified, on a single planted defect with no exception list left to absorb it

```
rename one command's section  -> 1 undocumented command(s): ["agy"]
plant one bad example         -> 1 of 123 documented example(s) name something
                                 the CLI does not have
```

Both exception lists are gone: `grep -c "UNDOCUMENTED_AT_BASELINE\|DRIFTED_EXAMPLES_AT_BASELINE"` → **0**.

`cargo test --lib`: **21302 passed, 0 failed**. Guards: 11 passed. Both ledgers current, ratchets unmoved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqvpQmAsiaKRsScDT7EBuY