### PR TITLE
feat(goal-mode step 1): pmat comply check --checks selects rules by id, and a typo'd id is refused

### DIFF
--- a/docs/audits/quorum-PMAT-718.json
+++ b/docs/audits/quorum-PMAT-718.json
@@ -1,0 +1,250 @@
+{
+  "ticket": "PMAT-718",
+  "pr": 1246,
+  "branch": "PMAT-718-comply-checks-selector",
+  "tool": "agy quorum via paiml-agy-delegate",
+  "width": 3,
+  "judged_head": "a189bfedb",
+  "verdict_counts": {
+    "FAIL": 3,
+    "PASS": 0
+  },
+  "lanes": [
+    {
+      "lane": 1,
+      "conversation_id": "0c727136-ba3b-46c0-a095-0eaddc41a9cc",
+      "verdict": "FAIL",
+      "summary": "Adversarial review of PMAT-718-comply-checks-selector completed.\n\n1. **Gate Behavior:** The `--checks` flag correctly gates. It is not accepted-and-ignored anywhere. `comply report`, `comply ledger`, and the bare `pmat comply` route do not accept `--checks` via clap, safely avoiding the trap.\n2. **CLI Exits:** `pmat comply check --checks CB-21I3` exits 1. `--checks \"\"` and `--checks \" CB-030\"` are properly refused (exit 1). Duplicate valid checks (`--checks CB-030 --checks CB-030`) work and exit 0.\n3. **check_id Correctness:** Evaluated all 166 checks. No IDs are ambiguous (exactly 166 distinct IDs generated). No IDs contain spaces or mismatched colons. \n4. **Flag Interaction:** `select_checks` correctly runs before `retain_blocking_checks` and `summary` tallying. Testing a passing rule on a non-compliant repository successfully exits 0 (as a gate should). A failing selected rule strictly exits 1 and cannot be masked to exit 0.\n5. **Vacuous Tests:** FOUND. The tests `a_selected_check_keeps_its_own_verdict` and `an_empty_selection_selects_everything` are completely vacuous against all four mutants. The PR's claim that mutant (iii) [deselected checks removed] is killed by exactly one test is false; it is killed by three tests (`a_deselected_check_reports_skip_rather_than_disappearing`, `an_unknown_id_is_an_error`, and `a_check_with_no_cb_id_is_selected_by_its_name`). The clap wiring test is a genuine assertion due to formatting constraints isolating string slices.\n6. **Breakages:** No breakages. Callers passing `&[]` are properly evaluating all checks. `comply report` invokes `compute_compliance_report` directly, maintaining the full roster.\n7. **PR Honesty:** Confirmed 166 checks in/out. Verified git history contains only `feat` and `docs` commits with no separate RED commit.\n\nVerdict is FAIL due to the presence of vacuous tests asserting nothing about the change.",
+      "findings": [
+        {
+          "claim": "The flag actually gates and is not decorative",
+          "file": "src/cli/handlers/comply_handlers/check_handlers/check.rs",
+          "fix": "None required",
+          "grounding": "measured",
+          "line": 96
+        },
+        {
+          "claim": "The error is reachable in the CLI and exits 1",
+          "file": "src/cli/handlers/comply_handlers/check_handlers/check.rs",
+          "fix": "None required",
+          "grounding": "measured",
+          "line": 108
+        },
+        {
+          "claim": "Derived IDs are unambiguous and correctly formatted",
+          "file": "src/cli/handlers/comply_handlers/check_handlers/check.rs",
+          "fix": "None required",
+          "grounding": "measured",
+          "line": 74
+        },
+        {
+          "claim": "Selection correctly interacts with --failures-only and --strict",
+          "file": "src/cli/handlers/comply_handlers/check_handlers/check.rs",
+          "fix": "None required",
+          "grounding": "measured",
+          "line": 58
+        },
+        {
+          "claim": "Vacuous tests present: a_selected_check_keeps_its_own_verdict and an_empty_selection_selects_everything survive all 4 mutants. The PR's claim about mutant (iii) is incorrect (killed by 3 tests, not 1).",
+          "file": "src/cli/handlers/comply_handlers/check_handlers/check.rs",
+          "fix": "Remove or improve the vacuous tests to properly assert the behavior under mutation",
+          "grounding": "measured",
+          "line": 1434
+        },
+        {
+          "claim": "Existing callers behave identically and correctly pass &[]",
+          "file": "src/cli/handlers/comply_handlers/command_dispatch.rs",
+          "fix": "None required",
+          "grounding": "measured",
+          "line": 19
+        },
+        {
+          "claim": "The PR body honesty is verified (166 checks in/out, no RED commit)",
+          "file": "src/cli/handlers/comply_handlers/check_handlers/check.rs",
+          "fix": "None required",
+          "grounding": "measured",
+          "line": 1
+        }
+      ],
+      "duration_seconds": 631.3
+    },
+    {
+      "lane": 2,
+      "conversation_id": "f9bef082-8588-46f8-a9eb-9ec227e4a733",
+      "verdict": "FAIL",
+      "summary": "The core logic for `--checks` selection is robust. It properly gates the CLI, correctly computes rule IDs, correctly interacts with existing flags (`--strict`, `--failures-only`), and does not break existing routes like `comply report`. It never silently selects nothing on invalid input (like empty strings or typos). However, the PR body misrepresents the test suite's quality: two of the added tests (`a_selected_check_keeps_its_own_verdict` and `an_empty_selection_selects_everything`) are completely vacuous and pass even if `select_checks` does absolutely nothing. Additionally, the claim that each mutant is killed by exactly one test is false (mutant iii is killed by two). Therefore, the lane fails due to vacuous tests and inaccurate claims about test effectiveness.",
+      "findings": [
+        {
+          "claim": "Does the flag actually gate, or is it decorative?",
+          "file": "src/cli/commands/misc_commands_comply.rs",
+          "fix": "It actually gates. The clap parser only accepts `--checks` on the `comply check` subcommand (line 53). It is not accepted on `comply report` or `comply ledger`. `pmat comply` defaults to `Check` with an empty `checks` vector, which correctly selects all rules. The MCP tool `quality-gate` uses a separate command entirely. There is no path where `--checks` is accepted but ignored.",
+          "grounding": "cited",
+          "line": 53
+        },
+        {
+          "claim": "Is the error reachable in the real CLI, and does the PROCESS exit non-zero?",
+          "file": "src/cli/handlers/comply_handlers/check_handlers/check.rs",
+          "fix": "Yes. The error propagates up from `select_checks` (line 108) to `main` which exits 1. `--checks CB-21I3`, `--checks \"\"`, and `--checks \" CB-030\"` all produce an unknown ID error and exit 1. `--checks CB-030,` also exits 1 due to the empty trailing ID. Duplicate `--checks CB-030 --checks CB-030` parses correctly and works as intended. In no case does it silently select nothing.",
+          "grounding": "measured",
+          "line": 108
+        },
+        {
+          "claim": "`check_id` correctness",
+          "file": "src/cli/handlers/comply_handlers/check_handlers/check.rs",
+          "fix": "The implementation `name.split_once(\": \").map_or(name, |(id, _)| id)` (line 75) is correct. Extracting all unique names from the source reveals NO ambiguous IDs (no duplicates). There are NO names with `: ` where the prefix is a sentence rather than an ID, and NO names with leading/trailing spaces that would break shell matching.",
+          "grounding": "measured",
+          "line": 75
+        },
+        {
+          "claim": "Interaction with the flags already there",
+          "file": "src/cli/handlers/comply_handlers/check_handlers/check.rs",
+          "fix": "Selection correctly runs BEFORE `retain_blocking_checks` (line 58). `summary`/`is_compliant` are correctly re-tallied after selection (lines 59-60). `apply_exit_policy` guarantees that if a selected rule FAILS, `is_compliant` is false, and it will exit 1, even with `--strict`. A passing selected rule on a failing repo exits 0, which is correct (the user gated on a passing rule). No combination can make a failing selected rule produce exit 0.",
+          "grounding": "cited",
+          "line": 58
+        },
+        {
+          "claim": "Vacuous tests",
+          "file": "src/cli/handlers/comply_handlers/check_handlers/check.rs",
+          "fix": "Two tests are completely vacuous: `a_selected_check_keeps_its_own_verdict` and `an_empty_selection_selects_everything` pass under ALL FOUR mutants. The PR's claim that mutants (ii), (iii), (iv) are EACH killed by exactly one test is FALSE: mutant (iii) is killed by TWO tests (Test 1 which asserts length, and Test 5 which panics out-of-bounds on index 1). The clap wiring test (Test 6) correctly asserts on formatting because dropping the delimiter yields a single string `\"\\\"CB-2113,CB-030\\\"\"`, making the `contains(\"\\\"CB-2113\\\"\")` check fail, effectively killing mutant (iv).",
+          "grounding": "measured",
+          "line": 140
+        },
+        {
+          "claim": "What did it break?",
+          "file": "src/cli/command_dispatcher/command_routing.rs",
+          "fix": "Nothing. Callers in tests and the bare `pmat comply` route (line 308) pass an empty array, which safely selects the full roster. `comply report` goes through `handle_report`, which calls `compute_compliance_report` directly without `select_checks`, so it continues to see the full roster unharmed.",
+          "grounding": "cited",
+          "line": 308
+        },
+        {
+          "claim": "The honesty of the PR body",
+          "file": "src/cli/handlers/comply_handlers/check_handlers/check.rs",
+          "fix": "The claims \"166 checks in, 166 checks out\" and that RED was not committed separately are TRUE. The git log contains no separate RED commit, and the diff makes no changes to check definitions or counts. The only overstated claim was the test coverage concerning the mutants.",
+          "grounding": "measured",
+          "line": 0
+        }
+      ],
+      "duration_seconds": 627.0
+    },
+    {
+      "lane": 3,
+      "conversation_id": "638a45fe-95a6-4d51-a4db-32259bce1e61",
+      "verdict": "FAIL",
+      "summary": "The `--checks` flag correctly filters the report and enforces the appropriate exit codes, but fundamentally fails to gate execution. It runs all 166 checks (costing ~12GB memory and significant CPU time) before applying the filter, rendering the flag purely decorative for performance. Additionally, two of the added tests are completely vacuous against the requested mutants.",
+      "findings": [
+        {
+          "claim": "Execution is not gated. `compute_compliance_report` is called before `select_checks`, executing all 166 checks (12GB RAM) before dropping the unselected ones.",
+          "file": "src/cli/handlers/comply_handlers/check_handlers/check.rs",
+          "fix": "Pass the `selected` slice into `compute_compliance_report` to actually bypass the heavy analysis.",
+          "grounding": "measured",
+          "line": 50
+        },
+        {
+          "claim": "Test `a_selected_check_keeps_its_own_verdict` is vacuous. If `select_checks` ignores its argument (mutant i), the test still passes.",
+          "file": "src/cli/handlers/comply_handlers/check_handlers/check.rs",
+          "fix": "Rewrite the test to fail when the logic is broken, or drop it.",
+          "grounding": "asserted",
+          "line": 950
+        },
+        {
+          "claim": "Test `an_empty_selection_selects_everything` is vacuous. It passes against all 4 mutants.",
+          "file": "src/cli/handlers/comply_handlers/check_handlers/check.rs",
+          "fix": "Rewrite the test to fail when the logic is broken, or drop it.",
+          "grounding": "asserted",
+          "line": 961
+        }
+      ],
+      "duration_seconds": 822.7
+    }
+  ],
+  "orchestrator_reverification": [
+    {
+      "finding": "the two control tests are vacuous \u2014 they survive all four mutants",
+      "lanes": [
+        1,
+        2,
+        3
+      ],
+      "verdict": "REFUTED",
+      "reasoning": "A control is SUPPOSED to survive the RED mutants; that is what makes it a control and not a second RED test. The right question is whether it dies under the mutant it exists for. Both do.",
+      "evidence": [
+        "mutant: selection marks SELECTED rules Pass (the 'gate that cannot fail') -> a_selected_check_keeps_its_own_verdict FAILED",
+        "mutant: remove the empty-selection early return -> an_empty_selection_selects_everything FAILED"
+      ],
+      "action": "none; the mutation table in the PR now names these two mutants so the criterion is visible"
+    },
+    {
+      "finding": "the claim 'each mutant is killed by exactly one test' is false",
+      "lanes": [
+        1,
+        2
+      ],
+      "verdict": "CONFIRMED \u2014 but it was my prompt, not the PR",
+      "evidence": "that phrasing appears in the quorum prompt I wrote, not in the PR body or commit message. The lanes correctly refuted it; the PR never asserted it. Mutant (iii) is killed by 2-3 tests.",
+      "action": "the PR's mutation table now names every killing test rather than implying one each"
+    },
+    {
+      "finding": "execution is not gated: all 166 rules run before the filter, ~12GB",
+      "lanes": [
+        3
+      ],
+      "verdict": "CONFIRMED as behaviour, REFRAMED as impact",
+      "evidence": [
+        "local default parallelism: 35.2 GB peak / 3m04s",
+        "local PMAT_COMPLY_JOBS=1 (CI's setting): 12.6 GB peak / 7m31s",
+        "CI run 34352005449 banner: 'comply: 17 group(s), 1 at a time (~4 GB peak; PMAT_COMPLY_JOBS overrides)' and the step COMPLETES on ubuntu-latest",
+        "so peak memory is a function of grouping, which CI already pins; --checks changes neither time nor memory"
+      ],
+      "action": "the PR already disclosed 'selection, not speed'; the numbers are now measured rather than estimated. Lazy evaluation would need every check to declare its id before running, which is a roster refactor, not this ticket."
+    },
+    {
+      "finding": "the flag is decorative / accepted-and-ignored somewhere",
+      "lanes": [
+        1,
+        2
+      ],
+      "verdict": "REFUTED by the lanes themselves",
+      "evidence": "clap accepts --checks only on `comply check`; `comply report`/`comply ledger` do not take it; the bare `pmat comply` route passes vec![] and selects everything",
+      "action": "none"
+    },
+    {
+      "finding": "a failing selected rule could exit 0",
+      "lanes": [
+        1,
+        2
+      ],
+      "verdict": "REFUTED by the lanes themselves",
+      "evidence": "selection runs before retain_blocking_checks; summary and is_compliant are re-tallied after; apply_exit_policy exits 1",
+      "action": "none"
+    },
+    {
+      "finding": "check_id yields ambiguous or malformed ids",
+      "lanes": [
+        1,
+        2
+      ],
+      "verdict": "REFUTED by the lanes themselves",
+      "evidence": "166 checks -> 166 distinct ids, no duplicates, no leading/trailing spaces, no sentence-prefix false positives",
+      "action": "none"
+    }
+  ],
+  "incidental_finding_confirmed_in_production": {
+    "what": "CI run 34352005449 shows the ladder step exiting 1 today ('comply: 5 check(s) failed -> exit 1', '##[error]Process completed with exit code 1') and continue-on-error swallowing it",
+    "why_it_matters": "independent production confirmation of the PMAT-717 finding that 0 ENFORCED is caused by continue-on-error at quality-gate.yml:299, not by the root set",
+    "also": "the same log shows CB-2100 now reporting SIX roots including `gate` \u2014 PMAT-717 is live and working on master"
+  },
+  "gate": {
+    "cmd": "pmat verify --format json",
+    "ok": null,
+    "stages_measured": [
+      "format",
+      "satd",
+      "clippy",
+      "tests"
+    ],
+    "not_measured": [
+      "complexity"
+    ],
+    "note": "complexity declines on a clean tree"
+  }
+}

--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -5031,3 +5031,20 @@ roadmap:
   labels:
   - kind:code
   notes: null
+- id: PMAT-718
+  github_issue: null
+  item_type: task
+  title: 'goal-mode step 1 (P1): pmat comply check --checks <CSV> selects rules by id — a deselected rule reports Skip(not selected), never absent, and an unknown id is a hard error because that is how a typo''d gate becomes a green gate'
+  status: planned
+  priority: medium
+  assigned_to: null
+  created: 2026-09-09T12:38:41Z
+  updated: 2026-09-09T12:38:41Z
+  spec: null
+  acceptance_criteria: []
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - kind:code
+  notes: null

--- a/docs/status/unrun-tests-ledger.md
+++ b/docs/status/unrun-tests-ledger.md
@@ -14,7 +14,7 @@ Legs consulted (3):
 - `feature-matrix.yml:feature-tests[mcp-integration]`
 - `feature-matrix.yml:feature-tests[unified-protocol]`
 
-23855 of 27084 lib tests are executed; 3229 are compiled by no leg.
+23861 of 27090 lib tests are executed; 3229 are compiled by no leg.
 
 ## `<unsatisfiable>` — 2200 test(s)
 

--- a/src/cli/command_dispatcher/command_routing.rs
+++ b/src/cli/command_dispatcher/command_routing.rs
@@ -305,6 +305,7 @@ impl CommandDispatcher {
                     failures_only: false,
                     format: crate::cli::commands::ComplyOutputFormat::Text,
                     include_project: vec![],
+                    checks: vec![],
                 });
                 handlers::comply_handlers::handle_comply_command(cmd).await
             }

--- a/src/cli/command_structure/executor/tests.rs
+++ b/src/cli/command_structure/executor/tests.rs
@@ -260,6 +260,7 @@ mod tests {
                 failures_only: false,
                 format: crate::cli::commands::ComplyOutputFormat::Text,
                 include_project: vec![],
+                checks: vec![],
             }),
         };
 

--- a/src/cli/commands/misc_commands_comply.rs
+++ b/src/cli/commands/misc_commands_comply.rs
@@ -37,6 +37,20 @@ pub enum ComplyCommands {
         /// Additional project paths to include in cross-stack health checks
         #[arg(long, value_name = "PATH")]
         include_project: Vec<PathBuf>,
+
+        /// Run only these rules, by id (e.g. `CB-2113,CB-030`).
+        ///
+        /// PMAT-718 (goal-mode.md §7.2 P1). A CI job that gates on one rule
+        /// needs to ask for that rule; without this it must run all 166 and
+        /// grep the output, which is a gate on a substring.
+        ///
+        /// A deselected rule reports Skip("not selected"), it does not vanish:
+        /// an absent check and a skipped check must not look alike.
+        ///
+        /// An id matching no rule is an ERROR. Selecting nothing on a typo is
+        /// how `CB-21I3` becomes a green gate.
+        #[arg(long, value_name = "IDS", value_delimiter = ',')]
+        checks: Vec<String>,
     },
 
     /// Migrate project to latest PMAT standards

--- a/src/cli/handlers/comply_handlers/check_handlers/check.rs
+++ b/src/cli/handlers/comply_handlers/check_handlers/check.rs
@@ -50,8 +50,14 @@ pub(crate) async fn handle_check(
     strict: bool,
     failures_only: bool,
     format: ComplyOutputFormat,
+    selected: &[String],
 ) -> Result<()> {
     let mut report = compute_compliance_report(project_path)?;
+    // PMAT-718: before `failures_only`, so a deselected rule cannot be retained
+    // as a failure, and before the summary is re-tallied.
+    select_checks(&mut report.checks, selected)?;
+    report.summary = CheckSummary::tally(&report.checks);
+    report.is_compliant = report.checks.iter().all(|c| c.status != CheckStatus::Fail);
     if failures_only {
         retain_blocking_checks(&mut report, strict);
     }
@@ -59,6 +65,62 @@ pub(crate) async fn handle_check(
     output_compliance_report(&report, format, project_path)?;
 
     apply_exit_policy(&report, strict)
+}
+
+/// The id a rule is selected by: the `CB-NNN` prefix of its name, or the whole
+/// name for a check that has no CB id (`Version Currency`, `Git Hooks`, …).
+///
+/// PMAT-718 (goal-mode.md §7.2, prerequisite P1).
+pub(crate) fn check_id(name: &str) -> &str {
+    name.split_once(": ").map_or(name, |(id, _)| id)
+}
+
+/// Restrict a report to the ids in `selected`.
+///
+/// PMAT-718 (goal-mode.md §7.2, prerequisite P1). An EMPTY selection means "no
+/// `--checks` was given" and selects everything, so every existing caller is
+/// unaffected.
+///
+/// Two properties the spec requires, and neither is decoration:
+///
+/// * a DESELECTED check reports `Skip`, never disappears. An absent check and a
+///   skipped check must not look alike, or a shrinking roster reads as a
+///   shrinking problem — `3 checks, 0 fail` and `166 checks, 0 fail` are not
+///   the same claim;
+/// * an UNKNOWN id is an ERROR. Silently selecting nothing is how a typo'd gate
+///   becomes a green gate — the job asks for `CB-2113`, gets `CB-21I3`, selects
+///   no rule, and every remaining check skips into a pass.
+///
+/// Matching is on the id, so `--checks CB-030` selects `CB-030: O(1) Hooks`;
+/// a check with no CB id is selected by its whole name.
+pub(crate) fn select_checks(checks: &mut [ComplianceCheck], selected: &[String]) -> Result<()> {
+    if selected.is_empty() {
+        return Ok(());
+    }
+
+    let known: std::collections::HashSet<&str> = checks.iter().map(|c| check_id(&c.name)).collect();
+    let unknown: Vec<&str> = selected
+        .iter()
+        .map(String::as_str)
+        .filter(|id| !known.contains(id))
+        .collect();
+    if !unknown.is_empty() {
+        anyhow::bail!(
+            "--checks names {} no rule provides: {}. \
+             Refusing rather than selecting nothing: a typo that silently selects \
+             no rule turns this command into a gate that cannot fail.",
+            if unknown.len() == 1 { "an id" } else { "ids" },
+            unknown.join(", ")
+        );
+    }
+
+    for c in checks.iter_mut() {
+        if !selected.iter().any(|id| id == check_id(&c.name)) {
+            c.status = CheckStatus::Skip;
+            c.message = "not selected (--checks)".to_string();
+        }
+    }
+    Ok(())
 }
 
 /// Reject an input no compliance verdict can honestly be given for.
@@ -828,6 +890,128 @@ mod build_compliance_report_tests {
         let checks = vec![check("a", CheckStatus::Pass), check("b", CheckStatus::Fail)];
         let report = build_compliance_report(checks, "1.0.0", VersionSource::PinnedByProject);
         assert!(!report.is_compliant);
+    }
+
+    // ── PMAT-718 / goal-mode.md §7.2 P1: `comply check --checks <CSV>`.
+
+    #[test]
+    fn a_deselected_check_is_skipped_not_dropped() {
+        // The roster must keep its size. A check that vanishes when it is not
+        // selected makes "3 checks, 0 fail" indistinguishable from
+        // "166 checks, 0 fail" — a shrinking roster reading as a shrinking
+        // problem is the whole failure mode this guards.
+        let mut checks = vec![
+            check("CB-2113: Traceability", CheckStatus::Pass),
+            check("CB-030: O(1) Hooks", CheckStatus::Pass),
+        ];
+        select_checks(&mut checks, &["CB-2113".to_string()]).expect("known id");
+
+        assert_eq!(checks.len(), 2, "a deselected check must not disappear");
+        let deselected = &checks[1];
+        assert_eq!(
+            deselected.status,
+            CheckStatus::Skip,
+            "a deselected check must report Skip, not its unrun verdict"
+        );
+        assert!(
+            deselected.message.contains("not selected"),
+            "a Skip must say WHY it skipped, or it is indistinguishable from a \
+             rule that had nothing to look at: {}",
+            deselected.message
+        );
+    }
+
+    #[test]
+    fn an_unknown_id_is_an_error() {
+        // How a typo'd gate becomes a green gate: the job asks for CB-2113,
+        // gets CB-21I3, selects nothing, and every check skips into a pass.
+        let mut checks = vec![check("CB-2113: Traceability", CheckStatus::Pass)];
+        let err = select_checks(&mut checks, &["CB-21I3".to_string()])
+            .expect_err("an id matching no check must be refused, never ignored");
+        assert!(
+            err.to_string().contains("CB-21I3"),
+            "the error must name the id that matched nothing: {err}"
+        );
+    }
+
+    #[test]
+    fn a_selected_check_keeps_its_own_verdict() {
+        // Control. Selection must not become "pass everything": the selected
+        // rule's real status survives untouched.
+        let mut checks = vec![
+            check("CB-2113: Traceability", CheckStatus::Fail),
+            check("CB-030: O(1) Hooks", CheckStatus::Pass),
+        ];
+        select_checks(&mut checks, &["CB-2113".to_string()]).expect("known id");
+        assert_eq!(checks[0].status, CheckStatus::Fail);
+    }
+
+    #[test]
+    fn an_empty_selection_selects_everything() {
+        // Control. `--checks` absent must be byte-identical to today, or every
+        // existing caller silently starts skipping its whole roster.
+        let mut checks = vec![
+            check("CB-2113: Traceability", CheckStatus::Fail),
+            check("Git Hooks", CheckStatus::Pass),
+        ];
+        select_checks(&mut checks, &[]).expect("no selection");
+        assert_eq!(checks[0].status, CheckStatus::Fail);
+        assert_eq!(checks[1].status, CheckStatus::Pass);
+    }
+
+    #[test]
+    fn a_check_with_no_cb_id_is_selected_by_its_name() {
+        // Not every check is a CB rule: `Git Hooks`, `Version Currency` and
+        // friends have no id, so their name IS the id.
+        let mut checks = vec![
+            check("Git Hooks", CheckStatus::Pass),
+            check("CB-030: O(1) Hooks", CheckStatus::Pass),
+        ];
+        select_checks(&mut checks, &["Git Hooks".to_string()]).expect("known id");
+        assert_eq!(checks[0].status, CheckStatus::Pass);
+        assert_eq!(checks[1].status, CheckStatus::Skip);
+    }
+
+    /// The wiring, not the logic. `select_checks` being right proves nothing if
+    /// no argv reaches it — the repo has shipped a correct gate nothing invoked
+    /// more than once. Parsed through the production route, `Cli::try_parse_from`.
+    ///
+    /// Lib target on purpose: CI runs `cargo test --lib` only, so a guard in
+    /// `tests/` would never execute (see
+    /// `analysis_utilities/quality_gate_exit_status_guard_tests.rs`).
+    #[test]
+    fn the_checks_argument_reaches_the_command_as_a_split_list() {
+        use crate::cli::commands::ComplyCommands;
+        let parsed = crate::cli::commands::on_big_stack(|| {
+            use clap::Parser;
+            crate::cli::Cli::try_parse_from([
+                "pmat",
+                "comply",
+                "check",
+                "--checks",
+                "CB-2113,CB-030",
+            ])
+            .map(|cli| format!("{:?}", cli.command))
+            .map_err(|e| e.to_string())
+        })
+        .expect("`comply check --checks CB-2113,CB-030` must parse");
+
+        assert!(
+            parsed.contains("CB-2113") && parsed.contains("CB-030"),
+            "both ids must survive parsing: {parsed}"
+        );
+        assert!(
+            parsed.contains("\"CB-2113\"") && parsed.contains("\"CB-030\""),
+            "the CSV must be SPLIT on commas, not carried as one string — \
+             without value_delimiter the whole list is a single unknown id and \
+             every run errors: {parsed}"
+        );
+
+        // And the field is actually on the Check variant.
+        let _ = |c: ComplyCommands| match c {
+            ComplyCommands::Check { checks, .. } => checks,
+            _ => vec![],
+        };
     }
 
     #[test]

--- a/src/cli/handlers/comply_handlers/check_handlers/check_empty_project_guard_tests.rs
+++ b/src/cli/handlers/comply_handlers/check_handlers/check_empty_project_guard_tests.rs
@@ -22,7 +22,7 @@ mod comply_check_empty_project_guard_tests {
     async fn comply_check_refuses_a_directory_with_no_project_in_it() {
         let dir = tempfile::tempdir().expect("tempdir");
 
-        let err = super::handle_check(dir.path(), false, false, ComplyOutputFormat::Text)
+        let err = super::handle_check(dir.path(), false, false, ComplyOutputFormat::Text, &[])
             .await
             .expect_err("an empty directory must not be reported as COMPLIANT");
 

--- a/src/cli/handlers/comply_handlers/check_handlers/check_path_guard_tests.rs
+++ b/src/cli/handlers/comply_handlers/check_handlers/check_path_guard_tests.rs
@@ -19,7 +19,7 @@ mod comply_check_path_guard_tests {
     #[tokio::test]
     async fn comply_check_rejects_a_missing_project_path() {
         let path = missing_path();
-        let err = super::handle_check(&path, false, false, ComplyOutputFormat::Text)
+        let err = super::handle_check(&path, false, false, ComplyOutputFormat::Text, &[])
             .await
             .expect_err("a missing project path must not produce a compliance report");
         let msg = format!("{err:#}");
@@ -42,7 +42,7 @@ mod comply_check_path_guard_tests {
         // The old code's first filesystem call was a `create_dir_all` under the
         // path it had not checked.
         let path = missing_path();
-        let _ = super::handle_check(&path, false, false, ComplyOutputFormat::Text).await;
+        let _ = super::handle_check(&path, false, false, ComplyOutputFormat::Text, &[]).await;
         assert!(
             !path.join(".pmat").exists(),
             "comply check must not materialise a config dir under a nonexistent path"

--- a/src/cli/handlers/comply_handlers/command_dispatch.rs
+++ b/src/cli/handlers/comply_handlers/command_dispatch.rs
@@ -13,8 +13,9 @@ pub async fn handle_comply_command(command: ComplyCommands) -> Result<()> {
             failures_only,
             format,
             include_project,
+            checks,
         } => {
-            let result = handle_check(&path, strict, failures_only, format).await;
+            let result = handle_check(&path, strict, failures_only, format, &checks).await;
             if !include_project.is_empty() {
                 if let Err(e) = check_file_health_multi(&path, &include_project) {
                     eprintln!("Cross-stack health check warning: {}", e);


### PR DESCRIPTION
Step 1 of `docs/specifications/goal-mode.md` §11 — prerequisite **P1**. PMAT-718.

> **Reviewed by a 3/3 agy quorum.** All three lanes validated the core and FAILed on the test suite. One finding refuted with measurements, one confirmed against a claim I made in the prompt rather than in the PR, one reframed. Artifact: `docs/audits/quorum-PMAT-718.json`.

## Why the job needs it

Step 2 wires a single rule (CB-2113) into the `gate` job that step 0 just made visible. A job that gates on one rule has to be able to **ask for that rule**; today it must run all 166 and grep the output, which is a gate on a substring.

```console
$ pmat comply check --checks CB-2113,CB-030
```

## Two properties, neither decorative

**A deselected rule reports `Skip`, it does not vanish.** Measured: 166 checks in, 166 out — 1 selected, 165 `Skip("not selected (--checks)")`.

> `{"total": 166, "pass": 1, "warn": 0, "fail": 0, "skip": 165}`

An absent check and a skipped check must not look alike. `3 checks, 0 fail` and `166 checks, 0 fail` are not the same claim.

**An id no rule provides is a hard error**, exit 1, naming the id:

```console
$ pmat comply check --checks CB-21I3 ; echo $?
Error: --checks names an id no rule provides: CB-21I3. Refusing rather than
selecting nothing: a typo that silently selects no rule turns this command
into a gate that cannot fail.
1
```

That refusal *is* the flag's reason to exist. Select-nothing-and-exit-0 is how a typo'd gate becomes a green gate.

## Shape

Selection runs **before** `--failures-only`, so a deselected rule cannot be retained as a failure; `summary` and `is_compliant` are re-tallied **after** it. Matching is on the id — the `CB-NNN` prefix — and a check with no CB id (`Git Hooks`, `Version Currency`) is selected by its whole name. An empty selection means no `--checks` was given and selects everything.

## Mutation table

Every mutant, and **every** test that kills it — the quorum was right that "one test each" would have been a false summary:

| mutant | killed by |
|---|---|
| `select_checks` ignores its argument | the 3 RED tests |
| unknown ids ignored | `an_unknown_id_is_an_error` |
| deselected checks removed from the vec rather than skipped | `a_deselected_check_is_skipped_not_dropped`, `an_unknown_id_is_an_error`, `a_check_with_no_cb_id_is_selected_by_its_name` |
| `value_delimiter = ','` dropped | `the_checks_argument_reaches_the_command_as_a_split_list` |
| **selection marks SELECTED rules `Pass`** | `a_selected_check_keeps_its_own_verdict` |
| **the empty-selection early return removed** | `an_empty_selection_selects_everything` |

The last two rows answer the quorum's one substantive test finding — all three lanes called those two "vacuous because they survive all four mutants". A control is *supposed* to survive the RED mutants; that is what makes it a control rather than a second RED test. Both die under the mutant they exist for, measured above. The first guards against selection becoming "pass everything" — a gate that cannot fail. The second guards every existing caller: without the early return they all silently start skipping their whole roster.

## What the lanes independently confirmed

- `--checks` is accepted **only** on `comply check`; `comply report` and `comply ledger` do not take it, and the bare `pmat comply` route passes an empty selection. No accepted-and-ignored path.
- 166 checks → 166 **distinct** ids. No ambiguity, no leading/trailing spaces, no sentence-prefix false positives.
- No combination — `--strict`, `--failures-only`, any selection — lets a **failing selected rule** exit 0.
- `--checks ""`, `--checks "CB-030,"` and `--checks " CB-030"` are each refused with exit 1 rather than silently selecting nothing.

## Cost: selection, not speed — now measured

Every rule still runs and is deselected afterwards. The first draft of this PR said "177s either way" from memory; the real numbers:

| | peak RSS | wall |
|---|---|---|
| default parallelism | 35.2 GB | 3m04s |
| `PMAT_COMPLY_JOBS=1` (what CI pins) | 12.6 GB | 7m31s |

A lane read this as a CI hazard. It is not: comply already prints `17 group(s), 1 at a time (~4 GB peak; PMAT_COMPLY_JOBS overrides)` and the step completes on `ubuntu-latest` today. `--checks` changes neither number. Making selection skip execution needs every check to declare its id *before* it runs — a roster refactor, not this ticket.

## Two things I am not hiding

- **RED is not a separate commit.** The commit that should have carried it was refused by the format hook, and I had piped the command through `tail`, which swallowed the non-zero exit — so RED and GREEN landed together in `a189bfe`. The RED evidence is real (3 named failures before the implementation) but the commit boundary is not there to check it against.
- **A claim the lanes refuted was mine, in their prompt.** I told them the PR claims "each mutant is killed by exactly one named test". It never did — but the summary was heading that way, and the table above is the correction.

## Incidental, from CI run 34352005449

The `Ladder gate — pmat comply` step **exits 1 on master today** (`comply: 5 check(s) failed -> exit 1`, `##[error]Process completed with exit code 1`) and `continue-on-error` swallows it. That is independent production confirmation of PMAT-717's finding about where `0 ENFORCED` comes from. The same log shows CB-2100 reporting **six** roots including `gate` — step 0 is live and working.

Ledger re-rendered on a clean tree: +6 executed, exactly this PR's 6 new lib tests.

`pmat verify`: format/satd/clippy/tests green; `ok:null` only because `complexity` declines on a clean tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)