### PR TITLE
docs(PMAT-1253): drift after the merge — 7 issue titles aligned with their items, 6 releases projected, #1292/#1293 given items; --check-only exits 0

### DIFF
--- a/docs/audits/impl-PMAT-1253-receipt.md
+++ b/docs/audits/impl-PMAT-1253-receipt.md
@@ -177,6 +177,26 @@ The roadmap side, in the same commit: 18 items `completed` with their evidence i
 | the quorum spot-checked 11 of the 74 open/item rows; the other 63 took the fixers' path unreviewed | reversible: an issue can be closed, an item completed |
 | `pv` NotRun, `teamwork` grill NotRun | — (a triage) |
 
+## Post-merge: drift on master
+
+#1291 merged as `6df22b7f0`. The live `--check-only` on master's roadmap then read **15 findings**, not 0:
+
+- **2 ORPHAN-GITHUB: #1292 and #1293.** Both are numbered after #1291 but were created on 2026-09-05 and 2026-08-13, so they were transferred into this repository after the triage. They are real work, and the item fixer gave them items.
+- **6 release DRIFT.** The six paired train items had no `release:` while their issues sit on milestones; the item fixer projected them (§4.1: the sync is the only writer).
+- **7 title DRIFT.** PMAT-1253 and the six train items have titles that differ from the issues they are paired with. The sync never rewrites a title, and PMAT-714 made roadmap titles immutable. The roadmap is authoritative for plan (§5.3), so each issue took its item's title; GitHub keeps the old one in the issue's timeline:
+
+| issue | item | title before |
+|---|---|---|
+| #1253 | PMAT-1253 | goal-mode step 4a: pmat work sync --check-only reaches 0 on master — the fixers, run after |
+| #1202 | PMAT-694 | flake: ci / coverage kills quality_proxy tests whose nested cargo clippy exceeds 600s unde |
+| #1156 | PMAT-695 | build.rs downloads four assets from unpkg.com at build time, two pinned to @latest, into a |
+| #1128 | PMAT-696 | Two Dependabot advisory gates ship; only one is wired, the orphan is RED, and 24 lines of  |
+| #1124 | PMAT-697 | quality_proxy: gates_run claims complexity ran for bash, C and TypeScript, where the heuri |
+| #1137 | PMAT-698 | The #1019 fix deleted the one .pmat-gates.toml section its own default reader consumes, an |
+| #1141 | PMAT-699 | Two root pub mods nothing calls: src/protocol/ (2,047 lines) and src/state/ (3,896 lines)  |
+
+The 60-minute grace window (§5.2) is why the check read coherent at 18:18: the pairings were written at 18:16 and surfaced as drift at 19:16. The retitles bumped the six issues' `updated_at`, which put their release disagreement back inside the window, so the item fixer planned no projection. It ran with `--grace-minutes 0`: projecting a milestone into `release:` is RR-RELEASE's own rule, not a tolerance call. The check itself ran with the default 60 minutes. After the fix, the live `--check-only` exits 0.
+
 ## Machine-readable
 
 orch_model: opus [V]   orch_class: opus   orch_decision: admit   orch_basis: -

--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -4647,7 +4647,7 @@ roadmap:
   priority: high
   assigned_to: null
   created: 2026-09-07T07:56:25Z
-  updated: 2026-09-10T18:16:38Z
+  updated: 2026-09-10T19:40:22.098038771+00:00
   spec: null
   acceptance_criteria: []
   phases: []
@@ -4657,6 +4657,7 @@ roadmap:
   - deferred:3.41.0
   - kind:code
   notes: 'PMAT-1253 (goal-mode §5.1): paired with #1202, the issue this item''s title names first (docs/audits/triage-PMAT-1253-ledger.json).'
+  release: 3.42.0
 - id: PMAT-695
   github_issue: 1156
   item_type: task
@@ -4665,7 +4666,7 @@ roadmap:
   priority: high
   assigned_to: null
   created: 2026-09-07T07:56:26Z
-  updated: 2026-09-10T18:16:38Z
+  updated: 2026-09-10T19:40:22.098038771+00:00
   spec: null
   acceptance_criteria: []
   phases: []
@@ -4675,6 +4676,7 @@ roadmap:
   - deferred:3.41.0
   - kind:code
   notes: 'PMAT-1253 (goal-mode §5.1): paired with #1156, the issue this item''s title names first (docs/audits/triage-PMAT-1253-ledger.json).'
+  release: 3.41.0
 - id: PMAT-696
   github_issue: 1128
   item_type: task
@@ -4683,7 +4685,7 @@ roadmap:
   priority: high
   assigned_to: null
   created: 2026-09-07T07:56:28Z
-  updated: 2026-09-10T18:16:38Z
+  updated: 2026-09-10T19:40:22.098038771+00:00
   spec: null
   acceptance_criteria: []
   phases: []
@@ -4693,6 +4695,7 @@ roadmap:
   - deferred:3.41.0
   - kind:code
   notes: 'PMAT-1253 (goal-mode §5.1): paired with #1128, the issue this item''s title names first (docs/audits/triage-PMAT-1253-ledger.json).'
+  release: 3.41.0
 - id: PMAT-697
   github_issue: 1124
   item_type: task
@@ -4701,7 +4704,7 @@ roadmap:
   priority: high
   assigned_to: null
   created: 2026-09-07T07:56:29Z
-  updated: 2026-09-10T18:16:38Z
+  updated: 2026-09-10T19:40:22.098038771+00:00
   spec: null
   acceptance_criteria: []
   phases: []
@@ -4711,6 +4714,7 @@ roadmap:
   - deferred:3.41.0
   - kind:code
   notes: 'PMAT-1253 (goal-mode §5.1): paired with #1124, the issue this item''s title names first (docs/audits/triage-PMAT-1253-ledger.json).'
+  release: 3.41.0
 - id: PMAT-698
   github_issue: 1137
   item_type: task
@@ -4719,7 +4723,7 @@ roadmap:
   priority: high
   assigned_to: null
   created: 2026-09-07T07:56:30Z
-  updated: 2026-09-10T18:16:38Z
+  updated: 2026-09-10T19:40:22.098038771+00:00
   spec: null
   acceptance_criteria: []
   phases: []
@@ -4729,6 +4733,7 @@ roadmap:
   - deferred:3.41.0
   - kind:code
   notes: 'PMAT-1253 (goal-mode §5.1): paired with #1137, the issue this item''s title names first (docs/audits/triage-PMAT-1253-ledger.json).'
+  release: 3.41.0
 - id: PMAT-699
   github_issue: 1141
   item_type: task
@@ -4737,7 +4742,7 @@ roadmap:
   priority: high
   assigned_to: null
   created: 2026-09-07T07:56:31Z
-  updated: 2026-09-10T18:16:38Z
+  updated: 2026-09-10T19:40:22.098038771+00:00
   spec: null
   acceptance_criteria: []
   phases: []
@@ -4747,6 +4752,7 @@ roadmap:
   - deferred:3.41.0
   - kind:code
   notes: 'PMAT-1253 (goal-mode §5.1): paired with #1141, the issue this item''s title names first (docs/audits/triage-PMAT-1253-ledger.json).'
+  release: 3.41.0
 - id: PMAT-700
   github_issue: null
   item_type: task
@@ -6025,6 +6031,38 @@ roadmap:
   assigned_to: null
   created: 2026-09-10T18:18:21.932438877+00:00
   updated: 2026-09-10T18:18:21.932438877+00:00
+  spec: null
+  acceptance_criteria: []
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels: []
+  notes: null
+- id: GH-1292
+  github_issue: 1292
+  item_type: task
+  title: 'pmat work add re-serialises all of docs/roadmaps/roadmap.yaml (2,531 unrelated lines for one 17-line entry) — a serialization point, #2630 class'
+  status: planned
+  priority: medium
+  assigned_to: null
+  created: 2026-09-10T19:40:22.098038771+00:00
+  updated: 2026-09-10T19:40:22.098038771+00:00
+  spec: null
+  acceptance_criteria: []
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels: []
+  notes: null
+- id: GH-1293
+  github_issue: 1293
+  item_type: task
+  title: 'pmat tdg scores over an incomplete set: 159 files walked, not measured — and the tool will not name them'
+  status: planned
+  priority: medium
+  assigned_to: null
+  created: 2026-09-10T19:40:22.098038771+00:00
+  updated: 2026-09-10T19:40:22.098038771+00:00
   spec: null
   acceptance_criteria: []
   phases: []


### PR DESCRIPTION
Follow-up to #1291 (**PMAT-1253**). After #1291 merged, the live `pmat work sync --check-only` on master read **15 findings**; PMAT-723 cannot add the CB-2115 step until master measures 0.

| finding | cause | fix |
|---|---|---|
| 2 ORPHAN-GITHUB (#1292, #1293) | transferred into this repository after the triage: numbered after #1291, created 2026-09-05 and 2026-08-13 | `github-to-yaml` added their items |
| 6 DRIFT on `release:` | the six paired train items had no `release:`; their issues sit on milestones | `github-to-yaml --grace-minutes 0` projected them (the sync is the only writer, §4.1; the retitles had put the drift back inside the grace window) |
| 7 DRIFT on title | PMAT-1253 and the six train items have titles that differ from their paired issues | each issue took its item's title: the sync never rewrites titles, roadmap titles are immutable (PMAT-714), and the roadmap is authoritative for plan (§5.3); GitHub keeps the old titles in the issue timeline |

These did not show at 18:18, because the 60-minute grace window (§5.2) held the drift until 19:16.

After the fix, the live `--check-only` **exits 0**, `scripts/work-sync-control.sh` passes 4/4, and `pmat work validate` passes. The receipt `docs/audits/impl-PMAT-1253-receipt.md` gains a post-merge section that lists every retitle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
