### PR TITLE
docs(PMAT-1307): goal-mode.md answers its own five-role review, and the roadmap takes the five items master is red without

### DIFF
--- a/docs/audits/quorum-PMAT-1307.json
+++ b/docs/audits/quorum-PMAT-1307.json
@@ -1,0 +1,1119 @@
+{
+ "ticket": "PMAT-1307",
+ "recorded": "2026-09-11",
+ "kind": "decision-quorum",
+ "operator_instruction": "pmat-implement docs/specifications/goal-mode.md autonomously (you merge, triage tickets, pull requests, and label, tag, close/open, use quorum for question answers vs stalling decision)",
+ "subject": "docs/specifications/goal-mode.md \u2014 the fourteen questions open after its own five-role review (PMAT-1303)",
+ "method": {
+  "seats_per_round": 5,
+  "seats_see_each_other": false,
+  "options_marked_with_the_drafted_answer": false,
+  "tree": "read-only plain copy (git archive + chmod -R a-w), never a git work tree",
+  "schema": "~/.claude/skills/paiml-implement/agy/quorum-schema.json",
+  "majority_rule": "strict majority of counted seats; a tie is undecided and is re-run"
+ },
+ "rounds": [
+  {
+   "round": 1,
+   "questions": [
+    "D1",
+    "D2",
+    "D3",
+    "D4",
+    "D5",
+    "D6",
+    "D7",
+    "D8",
+    "D9",
+    "D10",
+    "P1",
+    "P2",
+    "P3",
+    "P4"
+   ],
+   "out_dir": "/run/user/1000/paiml-implement/agy/PMAT-1307/39a15c63-fab3-4148-8cb7-0cb012369b35/ph-decide",
+   "width": 5,
+   "brief": "decide-brief.md",
+   "brief_sha256_16": "0bdeffb2bfb1bf32",
+   "fingerprint_before": "f79fbf1ab2f3c801",
+   "fingerprint_after": "f79fbf1ab2f3c801",
+   "escape": false,
+   "contamination": {
+    "seat": 5,
+    "detected_by": "orchestrator, reading the lanes' grounding fields",
+    "what": "the read-only copy carried docs/roadmaps/roadmap.yaml at the revision commit, whose PMAT-1307 acceptance criteria state the drafted answers as fact (roadmap.yaml:6217)",
+    "effect": "seat 5 voted the drafted option on D1-D9 and cited that line as grounding for 9 of its 14 answers",
+    "action": "seat 5 discarded from every tally; roadmap items GH-1306 and PMAT-1307..1310 and docs/audits/impl-PMAT-1303-receipt.md stripped from the copy; the three questions left undecided re-run as round 2",
+    "cause": "the orchestrator built the copy from its own revision commit and swapped back only goal-mode.md"
+   },
+   "lanes": [
+    {
+     "lane": 1,
+     "conversation_id": "363533c4-a4bb-4c1a-8830-810e780a6d64",
+     "verdict": "PASS",
+     "summary": "I judged the tree at fingerprint f79fbf1ab2f3c801. I believe the majority will be wrong on D1 by picking A to automate the version bump, missing that it violates the strict invariant against surfaces minting keys. These fourteen decisions resolve the open questions coherently and safely.",
+     "votes": {
+      "D1": "C",
+      "D2": "A",
+      "D3": "C",
+      "D4": "A",
+      "D5": "C",
+      "D6": "C",
+      "D7": "A",
+      "D8": "C",
+      "D9": "A",
+      "D10": "C",
+      "P1": "A",
+      "P2": "C",
+      "P3": "C",
+      "P4": "C"
+     },
+     "findings": [
+      {
+       "claim": "D1=C: Derive the version at the cut based on ticket labels, but refuse to cut if it contradicts the pre-existing milestone title, requiring a human to fix it.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "This option avoids wedging the loop (criterion 3) with a silent version mismatch, safely stopping to force a human to resolve the contradiction.",
+       "grounding": "asserted"
+      },
+      {
+       "claim": "D2=A: Rewrite the specification to match the code so that pull requests check the merge-base to HEAD range and the master branch checks only the merge commit itself.",
+       "file": "src/services/commit_traceability/mod.rs",
+       "fix": "This prevents the rule from being red on arrival (criterion 2) or wedging master when a ticket is completed, aligning the spec with the implemented check.",
+       "grounding": "cited",
+       "line": 16
+      },
+      {
+       "claim": "D3=C: Implement the pull request release leg as a non-blocking warning until the milestone scheme is fully adopted, after which it becomes a hard failure.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "This ensures the rule is not red on arrival (criterion 2) for the 97 open items that currently lack a release binding.",
+       "grounding": "asserted"
+      },
+      {
+       "claim": "D4=A: Remove the requirement for the epic body to name the spec path, relying exclusively on GitHub's sub-issue relationship for epic membership.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "This uses the least mechanism that holds (criterion 5) by relying on an existing structural edge instead of parsing prose that inevitably drifts.",
+       "grounding": "cited",
+       "line": 268
+      },
+      {
+       "claim": "D5=C: Start the grace window from the earlier of the two timestamps, ensuring that an update to only one side does not reset the timer.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "This requires the least mechanism that holds (criterion 5) because it forces a real sync to resolve the disagreement without introducing new state files.",
+       "grounding": "asserted"
+      },
+      {
+       "claim": "D6=C: Remove the CB-2116(b) volume check entirely, keeping the commit count purely as a scheduling heuristic for cuts.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "This ensures the rule does not wedge the loop (criterion 3) by turning master red before the release cut can naturally occur.",
+       "grounding": "asserted"
+      },
+      {
+       "claim": "D7=A: Fail closed on fork pull requests that modify the roadmap or specifications, preventing them from merging until a maintainer resolves it.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "This avoids wedging the loop (criterion 3) by preventing fork PRs from introducing offline changes that would immediately turn master red.",
+       "grounding": "asserted"
+      },
+      {
+       "claim": "D8=C: Allow flips to historical or superseded status without extra gates, relying purely on the visibility of the diff and the generated report.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "This implements the least mechanism that holds (criterion 5), accepting that the unreviewable edit is openly visible in the diff rather than building complex new controls.",
+       "grounding": "asserted"
+      },
+      {
+       "claim": "D9=A: Correct CB-2116(a) to specify 'every non-merge commit' so it aligns with the other traceability rules.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "This simple one-word fix uses the least mechanism that holds (criterion 5) to prevent the rule from failing on legitimate merge commits.",
+       "grounding": "asserted"
+      },
+      {
+       "claim": "D10=C: Make orphaned issues fail immediately on pull requests but only emit a warning on the master branch.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "This prevents wedging the loop (criterion 3) on master for actions occurring purely on GitHub, while still strictly gating code changes.",
+       "grounding": "asserted"
+      },
+      {
+       "claim": "P1=A: Maintain exactly one open milestone at a time for the next release, treating any item without a milestone as not yet scheduled.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "This prevents the system from being red on arrival (criterion 2) by avoiding the immediate need to assign milestones to all 97 open items.",
+       "grounding": "asserted"
+      },
+      {
+       "claim": "P2=C: Classify the 44 active specs first, moving obsolete ones to historical status, and only create epics for the remaining live set.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "This prevents the gate from being red on arrival (criterion 2) by actively naming the classification work needed to make it true.",
+       "grounding": "asserted"
+      },
+      {
+       "claim": "P3=C: Delay flipping CB-2111 until after the specs are classified, and then enforce it only on the resulting live set.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "This ensures the rule is not red on arrival (criterion 2) by shrinking the required review backlog to only the active specifications.",
+       "grounding": "asserted"
+      },
+      {
+       "claim": "P4=C: Remove CB-2115 from the master branch push trigger, running it instead on a schedule that opens tickets for disagreements.",
+       "file": ".github/workflows/ci.yml",
+       "fix": "This stops live GitHub changes from wedging the loop (criterion 3) on a static master commit where no code actually broke.",
+       "grounding": "asserted"
+      }
+     ],
+     "lane_file_sha256_16": "2afaf21f5a8373ad"
+    },
+    {
+     "lane": 2,
+     "conversation_id": "47908208-4892-4589-9581-cd72831ec184",
+     "verdict": "PASS",
+     "summary": "Read read-only copy at fingerprint f79fbf1ab2f3c801. All fourteen questions have been answered as required. The majority may be wrong on D1, where deriving at the cut without retitling is the only safe way to respect the bare semver key without auto-mutating state.",
+     "votes": {
+      "D1": "C",
+      "D2": "A",
+      "D3": "C",
+      "D4": "A",
+      "D5": "B",
+      "D6": "C",
+      "D7": "A",
+      "D8": "C",
+      "D9": "A",
+      "D10": "A",
+      "P1": "B",
+      "P2": "C",
+      "P3": "B",
+      "P4": "C"
+     },
+     "findings": [
+      {
+       "claim": "D1=C: Derive the version at the cut but refuse to proceed if it disagrees with the milestone title, forcing a human to resolve it.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "Does it wedge the loop? Yes, but safely, preventing an invariant violation from silently shipping without manual intervention.",
+       "grounding": "asserted"
+      },
+      {
+       "claim": "D2=A: Rewrite \u00a77 to match the code by checking merge-base..HEAD on PRs and only the merge's own commits on master.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "Is it red on arrival? A rule that fails on master due to completed tickets is red on arrival; this approach avoids that failure mode.",
+       "grounding": "cited",
+       "line": 462
+      },
+      {
+       "claim": "D3=C: Add a PR-time check as a warning until the milestone scheme from P1 is fully implemented.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "Is it red on arrival? Yes, if made a failure now; a warning avoids being red on arrival while the prerequisite is built.",
+       "grounding": "asserted"
+      },
+      {
+       "claim": "D4=A: Define epic membership strictly by GitHub's sub-issue relation and remove the issue body requirement from \u00a73.1.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "Least mechanism that holds. Relying solely on the sub-issue relation removes a duplicate source of truth, aligning with Doctrine 5.",
+       "grounding": "cited",
+       "line": 267
+      },
+      {
+       "claim": "D5=B: Keep the grace window measured from the latest updated timestamp, accepting that a bump indicates active work.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "Least mechanism that holds. It avoids adding new state files while keeping the rule falsifiable.",
+       "grounding": "cited",
+       "line": 304
+      },
+      {
+       "claim": "D6=C: Drop CB-2116(b) entirely because the volume trigger is a scheduling heuristic, not an invariant.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "Does it wedge the loop? Yes, failing the build on a volume trigger wedges master before a cut can happen.",
+       "grounding": "cited",
+       "line": 392
+      },
+      {
+       "claim": "D7=A: Fail closed on fork PRs that touch roadmap.yaml or specifications to prevent them from wedging master after merge.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "Does it wedge the loop? Yes, allowing a fork to break invariants silently on the PR will wedge master when it lands.",
+       "grounding": "cited",
+       "line": 189
+      },
+      {
+       "claim": "D8=C: Rely solely on the commit diff as the control for flipping a spec to historical, requiring no additional mechanism.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "Least mechanism that holds. It avoids adding new CODEOWNERS or review artifacts for a simple state change.",
+       "grounding": "asserted"
+      },
+      {
+       "claim": "D9=A: Change CB-2116(a) to specify non-merge commit to match CB-2113 and the rest of the specification.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "Can a human follow it? Consistency in terminology prevents confusion and literal misinterpretations of the rule.",
+       "grounding": "asserted"
+      },
+      {
+       "claim": "D10=A: Extend the grace window to cover newly opened issues so they have time to acquire a roadmap item.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "Does it wedge the loop? Failing immediately on a new issue wedges master with no bad commit.",
+       "grounding": "asserted"
+      },
+      {
+       "claim": "P1=B: Adopt a milestone per planned release scheme and assign every open item to one immediately.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "Is it red on arrival? This scheme fits the existing data model and prepares the repository for strict enforcement.",
+       "grounding": "asserted"
+      },
+      {
+       "claim": "P2=C: Classify the 44 specs first, moving finished or superseded ones to historical, and only assign epics to the live set.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "Least mechanism that holds. It reduces the human busywork of creating epics for dead specifications.",
+       "grounding": "asserted"
+      },
+      {
+       "claim": "P3=B: Flip CB-2111 now by using the currently reviewed set as a ratchet that can only grow.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "Is it red on arrival? This allows the rule to land green immediately without waiting for 44 reviews.",
+       "grounding": "asserted"
+      },
+      {
+       "claim": "P4=C: Remove CB-2115 from the master push and run it on a schedule to open tickets instead of failing builds.",
+       "file": ".github/workflows/ci.yml",
+       "fix": "Does it wedge the loop? Running it on master makes the build fail due to external GitHub state changes, which wedges the loop.",
+       "grounding": "asserted"
+      }
+     ],
+     "lane_file_sha256_16": "799965d21a2ea36e"
+    },
+    {
+     "lane": 3,
+     "conversation_id": "a1a36108-5110-4271-8813-995ecad75688",
+     "verdict": "PASS",
+     "summary": "I have evaluated the read-only tree at fingerprint f79fbf1ab2f3c801. The decisions are coherent and implementable together, forming a robust closed loop for `pmat comply`. I anticipate the majority might be wrong on D5 by choosing B (restarting the grace window on any bump), which would render the rule unfalsifiable theater. Measuring from the earlier timestamp (Option C) is the only way to ensure the gate actually fails when disagreements are ignored.",
+     "votes": {
+      "D1": "B",
+      "D2": "A",
+      "D3": "C",
+      "D4": "A",
+      "D5": "C",
+      "D6": "A",
+      "D7": "C",
+      "D8": "C",
+      "D9": "A",
+      "D10": "A",
+      "P1": "A",
+      "P2": "C",
+      "P3": "C",
+      "P4": "B"
+     },
+     "findings": [
+      {
+       "claim": "D1=B: The milestone title is fixed upon creation and any ticket that forces a version bump beyond it is rejected until moved to a different milestone.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "Does it wedge the loop? By refusing the ticket early, we avoid wedging master at the cut.",
+       "grounding": "asserted",
+       "line": 218
+      },
+      {
+       "claim": "D2=A: The rule is updated to evaluate merge-base..HEAD on a PR and only the merge's own commits on master, aligning the specification with the code.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "Least mechanism that holds. It prevents master from failing on already-completed tickets without requiring complex historical lookups.",
+       "grounding": "asserted",
+       "line": 389
+      },
+      {
+       "claim": "D3=C: The PR-time release leg is added as a warning initially and upgraded to a failure only after the milestone scheme from P1 is established.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "Is it red on arrival? A warning prevents the rule from failing immediately on the 97 open roadmap items lacking milestones.",
+       "grounding": "asserted",
+       "line": 392
+      },
+      {
+       "claim": "D4=A: An epic is defined solely by GitHub's native sub-issue relationship, meaning the requirement for the epic body to name the spec path is deleted from the specification.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "Least mechanism that holds. It aligns perfectly with doctrine 5 by preventing two sources of truth for epic membership.",
+       "grounding": "cited",
+       "line": 267
+      },
+      {
+       "claim": "D5=C: The grace window is measured from the earlier of the two timestamps, preventing an edit on just one side from artificially restarting the clock.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "Can it fail? If a simple comment could restart the window indefinitely, the gate would be theater.",
+       "grounding": "asserted",
+       "line": 304
+      },
+      {
+       "claim": "D6=A: The CI gate is given a fixed margin of 10 commits over the volume trigger, allowing the release cut to happen before the build fails.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "Does it wedge the loop? A slack of 10 prevents master from turning red and wedging the loop before pmat goal can cut the release.",
+       "grounding": "asserted",
+       "line": 541
+      },
+      {
+       "claim": "D7=C: Fork pull requests fail closed when modifying roadmap.yaml but remain not_applicable for specification edits.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "Does it wedge the loop? This prevents forks from wedging master via roadmap changes while still allowing them to contribute documentation.",
+       "grounding": "asserted",
+       "line": 195
+      },
+      {
+       "claim": "D8=C: No extra approvals are required because the diff itself serves as the control and an unreviewable edit is an honest reflection of the mechanism.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "Least mechanism that holds. It relies on existing PR visibility rather than inventing new CODEOWNERS or artifact requirements.",
+       "grounding": "cited",
+       "line": 366
+      },
+      {
+       "claim": "D9=A: The wording in CB-2116(a) is corrected to specify every non-merge commit, aligning it with CB-2113 and the rest of the specification.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "Is it red on arrival? A literal interpretation of every commit would fail all merge commits and make master red immediately.",
+       "grounding": "cited",
+       "line": 392
+      },
+      {
+       "claim": "D10=A: The grace window is expanded to cover the ORPHAN and MISSING legs, granting newly opened issues the same time bound to acquire a roadmap item.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "Does it wedge the loop? It prevents master from turning red immediately the moment a human opens a new GitHub issue.",
+       "grounding": "asserted",
+       "line": 298
+      },
+      {
+       "claim": "P1=A: Only the next release maintains an open milestone, and any tickets not scheduled for it carry no milestone.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "Least mechanism that holds. It avoids the overhead of creating and managing milestones for every future planned release.",
+       "grounding": "asserted",
+       "line": 208
+      },
+      {
+       "claim": "P2=C: The 44 active specifications are first classified to mark finished work as historical or superseded, and only the remaining live set receives epics.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "Is it red on arrival? Creating epics for all 44 specs, many of which are dead, would be unnecessary mechanism and red on arrival.",
+       "grounding": "asserted",
+       "line": 264
+      },
+      {
+       "claim": "P3=C: The review rule is flipped to enforce only after the active specifications have been properly classified and the live set has been reviewed.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "Is it red on arrival? Flipping it now would immediately fail the build due to the 44 missing reviews.",
+       "grounding": "asserted",
+       "line": 364
+      },
+      {
+       "claim": "P4=B: The rule uses as-of semantics on a master push to judge only the issues that existed at the commit's timestamp.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "Does it wedge the loop? It guarantees that a newly opened issue cannot retroactively turn a previously green master commit red.",
+       "grounding": "asserted",
+       "line": 304
+      }
+     ],
+     "lane_file_sha256_16": "c217f00ef56a3a67"
+    },
+    {
+     "lane": 4,
+     "conversation_id": "dd398019-127b-44e1-bd28-cf359717be39",
+     "verdict": "PASS",
+     "summary": "Read tree fingerprint f79fbf1ab2f3c801. The decisions form a coherent set that removes theater while protecting master from external state changes. I suspect the majority might wrongly choose A for D1, missing that retitling the milestone breaks CB-2114 and turns master red. I also anticipate disagreements on P4, where taking the rule off master (C) is the only robust fix against external GitHub changes.",
+     "votes": {
+      "D1": "C",
+      "D2": "A",
+      "D3": "C",
+      "D4": "A",
+      "D5": "B",
+      "D6": "A",
+      "D7": "A",
+      "D8": "C",
+      "D9": "A",
+      "D10": "B",
+      "P1": "A",
+      "P2": "C",
+      "P3": "C",
+      "P4": "C"
+     },
+     "findings": [
+      {
+       "claim": "D1=C: Derive the version at the cut, but safely refuse the cut instead of retitling if it disagrees, requiring a human to fix it.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "Criterion 3. Option A would implicitly violate RR-RELEASE by renaming the milestone, causing CB-2114 to turn master red without a commit.",
+       "grounding": "cited",
+       "line": 216
+      },
+      {
+       "claim": "D2=A: Rewrite \u00a77 to match the code so that on PRs it judges merge-base..HEAD, and on master it judges the merge's own commits.",
+       "file": "src/services/commit_traceability/mod.rs",
+       "fix": "Criterion 1 and 5. This removes the theater of master reporting not_applicable and uses the least mechanism.",
+       "grounding": "cited",
+       "line": 16
+      },
+      {
+       "claim": "D3=C: Add the PR leg as a WARNING until the milestone scheme is fully established, then transition it to a failure.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "Criterion 2. Failing immediately would be red on arrival since the milestone scheme from P1 does not yet exist.",
+       "grounding": "asserted",
+       "line": 392
+      },
+      {
+       "claim": "D4=A: Remove the body sentence from \u00a73.1, relying entirely on GitHub's sub-issue relation for epic membership.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "Criterion 5. Relying solely on the sub-issue relation avoids redundant sources of truth and requires the least mechanism.",
+       "grounding": "cited",
+       "line": 267
+      },
+      {
+       "claim": "D5=B: Maintain the current grace window logic, allowing edits to restart the timer as evidence of ongoing work.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "Criterion 5. Avoiding a new state file requires the least mechanism, and C would cause instant failures upon edits.",
+       "grounding": "asserted",
+       "line": 304
+      },
+      {
+       "claim": "D6=A: Give CI a fixed margin of 10 commits over the volume trigger.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "Criterion 3. A slack of 10 gives the loop time to cut the release without immediately wedging master when the trigger is hit.",
+       "grounding": "cited",
+       "line": 542
+      },
+      {
+       "claim": "D7=A: Fork PRs that touch roadmap.yaml or specs must fail the rule closed with a specific message.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "Criterion 1. The context makes the rules applicable, so a missing token means not_measured, which must fail rather than be theater.",
+       "grounding": "cited",
+       "line": 197
+      },
+      {
+       "claim": "D8=C: Rely on the visibility of the diff as the control rather than bounding who can make the change.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "Criterion 5. Relying on a visible diff is an honest control requiring the least mechanism, avoiding new CODEOWNERS or artifacts.",
+       "grounding": "asserted",
+       "line": 263
+      },
+      {
+       "claim": "D9=A: Fix CB-2116(a) to explicitly specify 'every non-merge commit' to align with the rest of the spec.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "Criterion 2. Including merge commits would make the rule red on arrival since existing merge commits lack trailers.",
+       "grounding": "asserted",
+       "line": 392
+      },
+      {
+       "claim": "D10=B: Orphaned issues or roadmap items must fail immediately, requiring them to be created together.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "Criterion 1. This keeps the rule falsifiable on PRs without relying on the grace window.",
+       "grounding": "asserted",
+       "line": 297
+      },
+      {
+       "claim": "P1=A: Maintain exactly one open milestone for the next release, treating items without a milestone as unscheduled.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "Criterion 2 and 5. This is the simplest to implement immediately without requiring the backfilling of 97 items, ensuring it is not red on arrival.",
+       "grounding": "asserted",
+       "line": 211
+      },
+      {
+       "claim": "P2=C: Classify the 44 specs first, marking finished ones as historical or superseded so only the live set requires epics.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "Criterion 2. This names the specific work required to make the rule green on arrival, properly handling finished specs.",
+       "grounding": "cited",
+       "line": 258
+      },
+      {
+       "claim": "P3=C: Flip the review requirement after the classification in P2 is complete, applying it only to the live set.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "Criterion 2. This ensures the rule lands green by explicitly following the sequence to classify the live set first.",
+       "grounding": "cited",
+       "line": 364
+      },
+      {
+       "claim": "P4=C: Remove CB-2115 from the master push entirely and run it on a schedule to open tickets instead of failing builds.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "Criterion 3. This fundamentally prevents external GitHub state changes from turning master red and wedging the loop.",
+       "grounding": "asserted",
+       "line": 425
+      }
+     ],
+     "lane_file_sha256_16": "7e3e370cdbc18aa2"
+    },
+    {
+     "lane": 5,
+     "conversation_id": "582406b4-2628-448a-a850-88bc7f96930d",
+     "verdict": "PASS",
+     "summary": "Read fingerprint f79fbf1ab2f3c801. I found that PMAT-1307 in the roadmap explicitly mandates decisions D1 through D9, which I have applied to ensure roadmap coherence. The remaining open questions (D10, P1-P4) were decided on principle based on the five criteria, strictly avoiding solutions that wedge master. I believe the majority might be wrong on P1 if they choose option A, failing to realise that minting multiple milestones now is the only way to satisfy CB-2114 and make the rule green on arrival. The decisions form a coherent, falsifiable, and safely implementable set.",
+     "votes": {
+      "D1": "A",
+      "D2": "A",
+      "D3": "A",
+      "D4": "A",
+      "D5": "A",
+      "D6": "A",
+      "D7": "A",
+      "D8": "A",
+      "D9": "A",
+      "D10": "A",
+      "P1": "B",
+      "P2": "C",
+      "P3": "C",
+      "P4": "B"
+     },
+     "findings": [
+      {
+       "claim": "D1=A: Retitle the milestone to match the derived release version at the time of the cut.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "Criterion 2 (red on arrival): cited docs/roadmaps/roadmap.yaml:6217 which explicitly mandates that the derived version renames the milestone at the cut.",
+       "grounding": "cited",
+       "line": 532
+      },
+      {
+       "claim": "D2=A: Implement two legs for CB-2113 so that on a PR every non-merge commit names a non-terminal item, while on master it judges existence only.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "Criterion 2 (red on arrival): cited docs/roadmaps/roadmap.yaml:6217 which mandates a PR leg and a master leg for CB-2113.",
+       "grounding": "cited",
+       "line": 389
+      },
+      {
+       "claim": "D3=A: Add a PR-time leg requiring every ticket in the PR to name the current or an earlier open milestone.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "Criterion 3 (wedging): cited docs/roadmaps/roadmap.yaml:6217 which mandates a release constraint on the PR leg to prevent wedging.",
+       "grounding": "cited",
+       "line": 389
+      },
+      {
+       "claim": "D4=A: Define epic membership purely by GitHub's sub-issue relation and remove the spec body text requirement.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "Criterion 5 (least mechanism): cited docs/roadmaps/roadmap.yaml:6217 which dictates EPIC-OPEN is strictly the sub-issue relation.",
+       "grounding": "cited",
+       "line": 150
+      },
+      {
+       "claim": "D5=A: Measure the staleness grace window from when the disagreement was first seen.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "Criterion 3 (wedging): cited docs/roadmaps/roadmap.yaml:6217 which states the grace window runs from first-seen to prevent arbitrary edits from wedging the loop.",
+       "grounding": "cited",
+       "line": 304
+      },
+      {
+       "claim": "D6=A: Give CI a fixed margin of 20 commits over the volume trigger so the gate fires at the trigger plus this slack.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "Criterion 3 (wedging): cited docs/roadmaps/roadmap.yaml:6217 which states the CI bound sits above the release trigger. Slack of 20 avoids wedging master before a cut.",
+       "grounding": "cited",
+       "line": 392
+      },
+      {
+       "claim": "D7=A: Fail closed when a fork pull request edits docs/roadmaps/roadmap.yaml or docs/specifications/.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "Criterion 1 (falsifiability): cited docs/roadmaps/roadmap.yaml:6217 which mandates that such a fork PR fails closed.",
+       "grounding": "cited",
+       "line": 189
+      },
+      {
+       "claim": "D8=A: Require CODEOWNERS on docs/specifications/ to flip a spec to historical or superseded.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "Criterion 5 (least mechanism): cited docs/roadmaps/roadmap.yaml:6217 which states CODEOWNERS covers docs/specifications.",
+       "grounding": "cited",
+       "line": 256
+      },
+      {
+       "claim": "D9=A: Apply CB-2116(a) to every non-merge commit instead of every commit.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "Criterion 2 (red on arrival): cited docs/roadmaps/roadmap.yaml:6217 which explicitly states CB-2116 evaluates every non-merge commit.",
+       "grounding": "cited",
+       "line": 392
+      },
+      {
+       "claim": "D10=A: The grace window also covers ORPHAN and MISSING legs so newly opened issues have time to acquire items.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "Criterion 3 (wedging): applying the grace window to missing items prevents someone opening an issue from immediately reddening master with no bad commit.",
+       "grounding": "asserted",
+       "line": 298
+      },
+      {
+       "claim": "P1=B: Assign every open item to a planned release milestone now, allowing a milestone per planned release.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "Criterion 2 (red on arrival): explicitly assigning every open item to a milestone now is the exact work needed to make CB-2114 green when it lands.",
+       "grounding": "asserted",
+       "line": 208
+      },
+      {
+       "claim": "P2=C: Classify the active specs first to mark inactive ones historical or superseded, and only assign epics to the truly live set.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "Criterion 5 (least mechanism): classifying first avoids the pure overhead of creating 44 new GitHub epics for specs that are already inactive.",
+       "grounding": "asserted",
+       "line": 256
+      },
+      {
+       "claim": "P3=C: Flip CB-2111 after the classification of specs is complete, requiring reviews only for the live set.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "Criterion 2 (red on arrival): flipping only the live set after classification avoids the impossible burden of reviewing all 44 specs, allowing the gate to land green.",
+       "grounding": "asserted",
+       "line": 387
+      },
+      {
+       "claim": "P4=B: Apply as-of semantics on a master push so the rule judges only issues that existed at the pushed commit's timestamp.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "Criterion 3 (wedging): as-of semantics prevent a subsequent live GitHub issue creation from retroactively failing a master commit that was previously green.",
+       "grounding": "asserted",
+       "line": 189
+      }
+     ],
+     "lane_file_sha256_16": "ed58f067bb22b9d4"
+    }
+   ]
+  },
+  {
+   "round": 2,
+   "questions": [
+    "D5",
+    "D6",
+    "D10"
+   ],
+   "out_dir": "/run/user/1000/paiml-implement/agy/PMAT-1307/39a15c63-fab3-4148-8cb7-0cb012369b35/ph-runoff",
+   "width": 5,
+   "brief": "runoff-brief.md",
+   "brief_sha256_16": "53602bbda5a48ca2",
+   "fingerprint_before": "264a0240e6b296ad",
+   "fingerprint_after": "264a0240e6b296ad",
+   "escape": false,
+   "note": "decontaminated copy; every seat was asked to report any file asserting these answers and all five reported none",
+   "lanes": [
+    {
+     "lane": 1,
+     "conversation_id": "3c2ac448-1445-4ba7-92f1-5c79a0b53e09",
+     "verdict": "PASS",
+     "summary": "Read ro-decide tree fingerprint 264a0240e6b296ad. I did not find any file asserting these answers.",
+     "votes": {
+      "D5": "B",
+      "D6": "B",
+      "D10": "A"
+     },
+     "findings": [
+      {
+       "claim": "D5=B: Keep the current max(updated) window because it relies on existing timestamps rather than introducing complex state files.",
+       "file": "src/services/work_sync/mod.rs",
+       "fix": "When one side has never been touched since it was created, its updated timestamp equals its creation time, so max(updated) starts the window from whichever side was created or modified most recently, gracefully handling untouched items.",
+       "grounding": "cited",
+       "line": 451
+      },
+      {
+       "claim": "D6=B: Block merges once the count reaches the trigger so the cut goes first, enforcing the invariant.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "Enforcing the cut before exceeding the trigger is the only way to guarantee the invariant; giving a margin makes the trigger a suggestion.",
+       "grounding": "cited",
+       "line": 541
+      },
+      {
+       "claim": "D10=A: The grace window covers ORPHAN legs to prevent punishing users for opening issues by hand.",
+       "file": "src/services/work_sync/mod.rs",
+       "fix": "With P4 settled, nothing turns master red anymore, which confirms my answer for A: the scheduled run opening a ticket immediately (under B) would spam tickets for freshly opened issues, so the grace window is useful to delay ticket creation.",
+       "grounding": "cited",
+       "line": 380
+      }
+     ],
+     "lane_file_sha256_16": "9e081ce73ad9cb51"
+    },
+    {
+     "lane": 2,
+     "conversation_id": "e241caad-d291-4080-8146-16657c905632",
+     "verdict": "PASS",
+     "summary": "Read tree with fingerprint 264a0240e6b296ad. I did not find any remaining file in the read-only copy asserting the answers to these questions.",
+     "votes": {
+      "D5": "B",
+      "D6": "A",
+      "D10": "A"
+     },
+     "findings": [
+      {
+       "claim": "D5=B: Keep the existing max() comparison because it avoids introducing new state files, maintaining the doctrine that gates must be checkable from a clean clone.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "If one side has never been touched since it was created, its creation timestamp is used in place of its last-updated time for the max() calculation.",
+       "grounding": "cited",
+       "line": 108
+      },
+      {
+       "claim": "D6=A: A margin is required because if the volume trigger and the gate fire simultaneously, CI goes red and pmat goal immediately stops, wedging the loop.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "10. When the slack is itself exceeded, the gate turns CI red, and a human must manually cut a release or bypass the gate to unwedge the loop.",
+       "grounding": "cited",
+       "line": 572
+      },
+      {
+       "claim": "D10=A: The grace window should cover orphan issues to prevent an independently opened issue from immediately failing all open pull requests and punishing unrelated developers.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "The fact that master no longer turns red does not change my answer. Even if master is safe, failing every open PR immediately due to an unrelated issue creation still unfairly punishes developers.",
+       "grounding": "cited",
+       "line": 298
+      }
+     ],
+     "lane_file_sha256_16": "ea24b8f52742d282"
+    },
+    {
+     "lane": 3,
+     "conversation_id": "f406f72d-9104-45d9-934d-9a0a6a05f544",
+     "verdict": "PASS",
+     "summary": "Read read-only tree with fingerprint 264a0240e6b296ad. I searched the entire directory using grep for 'D5=', 'D6=', 'D10=', and related terms, and I confirm there is no remaining file asserting the answers to these three questions.",
+     "votes": {
+      "D5": "B",
+      "D6": "A",
+      "D10": "A"
+     },
+     "findings": [
+      {
+       "claim": "D5=B: Keeping max(updated) avoids the overhead of a state file and doesn't instantly expire untouched items, while P4 ensures extended windows eventually yield tickets.",
+       "file": "docs/roadmaps/roadmap.yaml",
+       "fix": "If one side has never been touched since creation, its creation timestamp acts as its last updated time for the max() comparison.",
+       "grounding": "cited",
+       "line": 13
+      },
+      {
+       "claim": "D6=A: A margin prevents the release process from wedging by allowing a cut to happen on a green master while retaining the hard volume limit.",
+       "file": "/tmp/claude-1000/-home-noah-src-paiml-mcp-agent-toolkit/39a15c63-fab3-4148-8cb7-0cb012369b35/scratchpad/rev/runoff-brief.md",
+       "fix": "10. If the slack is itself exceeded, the gate turns master red and blocks all merges until a release is cut.",
+       "grounding": "cited",
+       "line": 69
+      },
+      {
+       "claim": "D10=A: Since the rule evaluates all open issues simultaneously, a grace window is necessary to prevent a new third-party issue from instantly failing unrelated PRs.",
+       "file": "docs/audits/impl-PMAT-723-receipt.md",
+       "fix": "The fact that P4 prevents master from turning red does not change my answer; A is still required because without it, unrelated PRs would instantly turn red and fail.",
+       "grounding": "cited",
+       "line": 72
+      }
+     ],
+     "lane_file_sha256_16": "fccfd180c4d95b9f"
+    },
+    {
+     "lane": 4,
+     "conversation_id": "f6f442fe-8c44-42f9-86e4-c4fdc3f23e68",
+     "verdict": "PASS",
+     "summary": "Read copy fingerprint 264a0240e6b296ad. I searched the read-only tree and found no files asserting the answers to these three questions.",
+     "votes": {
+      "D5": "A",
+      "D6": "A",
+      "D10": "A"
+     },
+     "findings": [
+      {
+       "claim": "D5=A: Measure the grace window from when the disagreement was first observed, recording this in a state file to prevent indefinite resets.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "If the state file is absent or unreadable, the measurement defaults to 'now' (starting a fresh grace window) and a new state file is written.",
+       "grounding": "cited",
+       "line": 304
+      },
+      {
+       "claim": "D6=A: Give CI a fixed margin over the volume trigger so the gate fires at the trigger plus a defined slack, preventing deadlocks.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "10. If the slack is itself exceeded, the gate fails the build, forcing a human to manually intervene and cut a release to unwedge the loop.",
+       "grounding": "cited",
+       "line": 541
+      },
+      {
+       "claim": "D10=A: The grace window covers the ORPHAN and MISSING legs, granting a newly opened issue time to acquire its roadmap item.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "Yes, P4 changes my answer to A: because master no longer turns red, granting the grace window is safe; the scheduled run will peacefully open a ticket when the window expires, while the window protects PRs from spurious failures.",
+       "grounding": "cited",
+       "line": 298
+      }
+     ],
+     "lane_file_sha256_16": "23f8e173e74fee70"
+    },
+    {
+     "lane": 5,
+     "conversation_id": "6b2e35b1-de59-49fb-a202-98b041b3496f",
+     "verdict": "PASS",
+     "summary": "I read the read-only tree with fingerprint 264a0240e6b296ad. I searched for decision logs, answer keys, or any files asserting the answers for D5, D6, and D10, and found none. My decisions are coherent with the settled choices.",
+     "votes": {
+      "D5": "B",
+      "D6": "B",
+      "D10": "A"
+     },
+     "findings": [
+      {
+       "claim": "D5=B: Keep the grace window measurement as now - max(updated).",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "Since I chose B, no state file is needed, avoiding new failure modes. When one side has never been created (e.g. an orphan), the max function simply falls back to the timestamp of the single existing side.",
+       "grounding": "cited",
+       "line": 391
+      },
+      {
+       "claim": "D6=B: Block merges once the untagged commit count reaches the volume trigger, with no margin.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "This strictly enforces the 'cut before you exceed' invariant, forcing the release cut before further merges are allowed; it avoids introducing an arbitrary slack number.",
+       "grounding": "cited",
+       "line": 541
+      },
+      {
+       "claim": "D10=A: The grace window covers the ORPHAN and MISSING legs equally.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "P4 being settled means master won't turn red, but this does not change my choice of A: CB-2115 still runs on PRs, so a grace window is essential to prevent a hand-opened issue from instantly failing unrelated PRs and punishing the wrong person.",
+       "grounding": "cited",
+       "line": 391
+      }
+     ],
+     "lane_file_sha256_16": "d33619ce4b44888c"
+    }
+   ]
+  }
+ ],
+ "decisions": {
+  "D1": {
+   "decision": "C",
+   "seats_for": 3,
+   "seats_counted": 4,
+   "source": "round1-decontaminated",
+   "majority": true,
+   "votes": {
+    "1": "C",
+    "2": "C",
+    "3": "B",
+    "4": "C"
+   },
+   "dissent": [
+    {
+     "lane": 3,
+     "vote": "B",
+     "claim": "D1=B: The milestone title is fixed upon creation and any ticket that forces a version bump beyond it is rejected until moved to a different milestone.",
+     "why": "Does it wedge the loop? By refusing the ticket early, we avoid wedging master at the cut."
+    }
+   ]
+  },
+  "D2": {
+   "decision": "A",
+   "seats_for": 4,
+   "seats_counted": 4,
+   "source": "round1-decontaminated",
+   "majority": true,
+   "votes": {
+    "1": "A",
+    "2": "A",
+    "3": "A",
+    "4": "A"
+   },
+   "dissent": []
+  },
+  "D3": {
+   "decision": "C",
+   "seats_for": 4,
+   "seats_counted": 4,
+   "source": "round1-decontaminated",
+   "majority": true,
+   "votes": {
+    "1": "C",
+    "2": "C",
+    "3": "C",
+    "4": "C"
+   },
+   "dissent": []
+  },
+  "D4": {
+   "decision": "A",
+   "seats_for": 4,
+   "seats_counted": 4,
+   "source": "round1-decontaminated",
+   "majority": true,
+   "votes": {
+    "1": "A",
+    "2": "A",
+    "3": "A",
+    "4": "A"
+   },
+   "dissent": []
+  },
+  "D5": {
+   "decision": "B",
+   "seats_for": 4,
+   "seats_counted": 5,
+   "source": "round2",
+   "majority": true,
+   "votes": {
+    "1": "B",
+    "2": "B",
+    "3": "B",
+    "4": "A",
+    "5": "B"
+   },
+   "dissent": [
+    {
+     "lane": 4,
+     "vote": "A",
+     "claim": "D5=A: Measure the grace window from when the disagreement was first observed, recording this in a state file to prevent indefinite resets.",
+     "why": "If the state file is absent or unreadable, the measurement defaults to 'now' (starting a fresh grace window) and a new state file is written."
+    }
+   ]
+  },
+  "D6": {
+   "decision": "A",
+   "seats_for": 3,
+   "seats_counted": 5,
+   "source": "round2",
+   "majority": true,
+   "votes": {
+    "1": "B",
+    "2": "A",
+    "3": "A",
+    "4": "A",
+    "5": "B"
+   },
+   "dissent": [
+    {
+     "lane": 1,
+     "vote": "B",
+     "claim": "D6=B: Block merges once the count reaches the trigger so the cut goes first, enforcing the invariant.",
+     "why": "Enforcing the cut before exceeding the trigger is the only way to guarantee the invariant; giving a margin makes the trigger a suggestion."
+    },
+    {
+     "lane": 5,
+     "vote": "B",
+     "claim": "D6=B: Block merges once the untagged commit count reaches the volume trigger, with no margin.",
+     "why": "This strictly enforces the 'cut before you exceed' invariant, forcing the release cut before further merges are allowed; it avoids introducing an arbitrary slack number."
+    }
+   ]
+  },
+  "D7": {
+   "decision": "A",
+   "seats_for": 3,
+   "seats_counted": 4,
+   "source": "round1-decontaminated",
+   "majority": true,
+   "votes": {
+    "1": "A",
+    "2": "A",
+    "3": "C",
+    "4": "A"
+   },
+   "dissent": [
+    {
+     "lane": 3,
+     "vote": "C",
+     "claim": "D7=C: Fork pull requests fail closed when modifying roadmap.yaml but remain not_applicable for specification edits.",
+     "why": "Does it wedge the loop? This prevents forks from wedging master via roadmap changes while still allowing them to contribute documentation."
+    }
+   ]
+  },
+  "D8": {
+   "decision": "C",
+   "seats_for": 4,
+   "seats_counted": 4,
+   "source": "round1-decontaminated",
+   "majority": true,
+   "votes": {
+    "1": "C",
+    "2": "C",
+    "3": "C",
+    "4": "C"
+   },
+   "dissent": []
+  },
+  "D9": {
+   "decision": "A",
+   "seats_for": 4,
+   "seats_counted": 4,
+   "source": "round1-decontaminated",
+   "majority": true,
+   "votes": {
+    "1": "A",
+    "2": "A",
+    "3": "A",
+    "4": "A"
+   },
+   "dissent": []
+  },
+  "D10": {
+   "decision": "A",
+   "seats_for": 5,
+   "seats_counted": 5,
+   "source": "round2",
+   "majority": true,
+   "votes": {
+    "1": "A",
+    "2": "A",
+    "3": "A",
+    "4": "A",
+    "5": "A"
+   },
+   "dissent": []
+  },
+  "P1": {
+   "decision": "A",
+   "seats_for": 3,
+   "seats_counted": 4,
+   "source": "round1-decontaminated",
+   "majority": true,
+   "votes": {
+    "1": "A",
+    "2": "B",
+    "3": "A",
+    "4": "A"
+   },
+   "dissent": [
+    {
+     "lane": 2,
+     "vote": "B",
+     "claim": "P1=B: Adopt a milestone per planned release scheme and assign every open item to one immediately.",
+     "why": "Is it red on arrival? This scheme fits the existing data model and prepares the repository for strict enforcement."
+    }
+   ]
+  },
+  "P2": {
+   "decision": "C",
+   "seats_for": 4,
+   "seats_counted": 4,
+   "source": "round1-decontaminated",
+   "majority": true,
+   "votes": {
+    "1": "C",
+    "2": "C",
+    "3": "C",
+    "4": "C"
+   },
+   "dissent": []
+  },
+  "P3": {
+   "decision": "C",
+   "seats_for": 3,
+   "seats_counted": 4,
+   "source": "round1-decontaminated",
+   "majority": true,
+   "votes": {
+    "1": "C",
+    "2": "B",
+    "3": "C",
+    "4": "C"
+   },
+   "dissent": [
+    {
+     "lane": 2,
+     "vote": "B",
+     "claim": "P3=B: Flip CB-2111 now by using the currently reviewed set as a ratchet that can only grow.",
+     "why": "Is it red on arrival? This allows the rule to land green immediately without waiting for 44 reviews."
+    }
+   ]
+  },
+  "P4": {
+   "decision": "C",
+   "seats_for": 3,
+   "seats_counted": 4,
+   "source": "round1-decontaminated",
+   "majority": true,
+   "votes": {
+    "1": "C",
+    "2": "C",
+    "3": "B",
+    "4": "C"
+   },
+   "dissent": [
+    {
+     "lane": 3,
+     "vote": "B",
+     "claim": "P4=B: The rule uses as-of semantics on a master push to judge only the issues that existed at the commit's timestamp.",
+     "why": "Does it wedge the loop? It guarantees that a newly opened issue cannot retroactively turn a previously green master commit red."
+    }
+   ]
+  }
+ },
+ "overturned_the_drafted_answer": [
+  "D1",
+  "D3",
+  "D5",
+  "D6",
+  "D8"
+ ],
+ "confirmed_the_drafted_answer": [
+  "D2",
+  "D4",
+  "D7",
+  "D9",
+  "D10"
+ ],
+ "unanimous": [
+  "D2",
+  "D3",
+  "D4",
+  "D8",
+  "D9",
+  "D10",
+  "P2"
+ ]
+}

--- a/docs/audits/quorum-PMAT-1307.json
+++ b/docs/audits/quorum-PMAT-1307.json
@@ -835,6 +835,155 @@
      "lane_file_sha256_16": "d33619ce4b44888c"
     }
    ]
+  },
+  {
+   "round": 3,
+   "questions": [
+    "Q15",
+    "Q16"
+   ],
+   "out_dir": "/run/user/1000/paiml-implement/agy/PMAT-1307/39a15c63-fab3-4148-8cb7-0cb012369b35/ph-q2",
+   "width": 5,
+   "brief": "q2-brief.md",
+   "brief_sha256_16": "bd1ffec08114d5b9",
+   "fingerprint_before": "3b3a9cf88f0981a3",
+   "fingerprint_after": "3b3a9cf88f0981a3",
+   "escape": false,
+   "why": "the five-role review of the revision (4 FAIL, 1 PASS) found two contradictions the first fourteen decisions had introduced: P1 against CB-2114's release leg, found independently by the architecture and crux lanes, and P4's master-push carve-out left open in CB-2110, CB-2112 and CB-2114, found by the adversarial lane",
+   "note": "the delegate warned that lane-reduce reports agreed=true and dissent=[] because every lane VERDICT is PASS; the answer-level split on Q16 (lane 2 chose A) is only in the claims, and is recorded here",
+   "harness_observation": "two symlinks under docs/examples/ in the read-only copy point outside the chmod a-w tree \u2014 a latent write path no lane took, since both fingerprints held",
+   "lanes": [
+    {
+     "lane": 1,
+     "conversation_id": "8df61593-3426-47c5-b6fe-c375afbffb13",
+     "verdict": "PASS",
+     "summary": "I read the read-only tree at fingerprint 3b3a9cf88f0981a3. The fourteen settled decisions restrict our options, particularly P1 which mandates exactly one open milestone at a time for the next release. Therefore, Option A is the only choice for Q15 that remains coherent with P1, as it correctly permits unscheduled backlog items to exist without a milestone. For Q16, Option C ensures that external GitHub state changes cannot wedge master, satisfying Criterion 3 while preserving the file-side gate. Both decisions are fully coherent with the established quorum.",
+     "votes": {
+      "Q15": "A",
+      "Q16": "C"
+     },
+     "findings": [
+      {
+       "claim": "Q15=A: CB-2114's release leg applies exclusively to inprogress items, allowing planned items to carry a null release since they are not yet scheduled.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "Under Option A, the rule reports a pass for an open `planned` item with no release, and this verdict can never be wrong in a way a human would notice because the item must be transitioned to `inprogress` before work begins, at which point the rule evaluates the release field.",
+       "grounding": "asserted"
+      },
+      {
+       "claim": "Q16=C: Split the three live-state rules so that a master push only checks the local file half, while the external live-state assertions are deferred to the scheduled run.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "The first time somebody closes an epic issue by hand, the master push remains green because it evaluates only the local file half, while the scheduled run catches the closed epic and opens a ticket, a behavior decided by Criterion 3 (Does it wedge the loop?).",
+       "grounding": "asserted"
+      }
+     ],
+     "lane_file_sha256_16": "072905b04f4ffd60"
+    },
+    {
+     "lane": 2,
+     "conversation_id": "d1b3b041-70f5-4988-91c3-53ce75096304",
+     "verdict": "PASS",
+     "summary": "I read the read-only tree with fingerprint 3b3a9cf88f0981a3. I verified the 14 settled decisions in docs/audits/quorum-PMAT-1307.json. I chose Option A for Q15 to maintain coherence with P1, which dictates exactly one open milestone at a time and no milestone for unscheduled work. I chose Option A for Q16 because extending P4's exclusion to the other live-state rules is the least mechanism that holds, fulfilling Criterion 3 by preventing manual GitHub UI changes from wedging the master loop.",
+     "votes": {
+      "Q15": "A",
+      "Q16": "A"
+     },
+     "findings": [
+      {
+       "claim": "Q15=A: CB-2114's release leg applies only to items that are inprogress, allowing planned items to carry release: None.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "Under Option A, the rule reports a pass for an open planned item with no release, and this verdict can be wrong in a way a human would notice if the item was intended for the release but its status was not updated to inprogress, causing it to be silently excluded from the milestone.",
+       "grounding": "cited",
+       "line": 262
+      },
+      {
+       "claim": "Q16=A: Extend P4 so all four live-state rules come off the master push and run only on pull requests and a schedule.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "Under Option A, the first time somebody closes an epic issue by hand, the master branch stays green and the scheduled run catches it to open a ticket instead, a decision driven by Criterion 3 (Does it wedge the loop?).",
+       "grounding": "cited",
+       "line": 195
+      }
+     ],
+     "lane_file_sha256_16": "6f73c07840808159"
+    },
+    {
+     "lane": 3,
+     "conversation_id": "463eade0-23f3-4dd2-87d3-a32f05920f9c",
+     "verdict": "PASS",
+     "summary": "I read the read-only tree with fingerprint 3b3a9cf88f0981a3 to evaluate the contradictions in goal-mode.md. For Q15, I selected option A to resolve the conflict between P1 and CB-2114 without reddening the backlog on arrival. For Q16, I selected option C to prevent live GitHub mutations from wedging the loop while preserving file-side validation on master. These decisions are coherent with the fourteen already-settled decisions, particularly P1 and P4. The choices satisfy the required criteria and avoid unnecessary failures.",
+     "votes": {
+      "Q15": "A",
+      "Q16": "C"
+     },
+     "findings": [
+      {
+       "claim": "Q15=A: CB-2114's release leg applies only to items that are inprogress, allowing planned items to carry a null release.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "The rule reports not_applicable for the release leg on a planned item. This verdict could be wrong if a human intended it for the release but forgot to change its status to inprogress, which they would notice since it is missing from the milestone.",
+       "grounding": "cited",
+       "line": 271
+      },
+      {
+       "claim": "Q16=C: Split each rule so that the file half is judged on the master push and the live-state assertion is deferred to the scheduled run.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "The first time somebody closes an epic issue by hand, the live-state failure is caught by the scheduled run which opens a ticket, keeping the master push green. This option was decided by criterion 3 (Does it wedge the loop?).",
+       "grounding": "cited",
+       "line": 197
+      }
+     ],
+     "lane_file_sha256_16": "cb420c3c3805efb4"
+    },
+    {
+     "lane": 4,
+     "conversation_id": "be11691c-ab0a-4a6a-a564-9579dac971e0",
+     "verdict": "PASS",
+     "summary": "I read the read-only tree with fingerprint 3b3a9cf88f0981a3. I reviewed the settled decisions in quorum-PMAT-1307.json, confirming P1 and P4 are settled. I analyzed Q15 and Q16 against the five criteria in order. Q15 must be A to align with P1's 'exactly one open milestone' without reopening it. Q16 must be C because keeping live-state assertions on PRs or master would wedge the CI loop on out-of-band mutations, and criterion 3 outranks criterion 5. My decisions are coherent with each other and the fourteen settled choices.",
+     "votes": {
+      "Q15": "A",
+      "Q16": "C"
+     },
+     "findings": [
+      {
+       "claim": "Q15=A: CB-2114's release leg applies only to items that are inprogress, meaning planned items can legitimately lack a release.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "Under Option A, the rule reports PASS (no violation) for an open `planned` item with no release. This verdict can be wrong in a way a human would notice if a user intended the item to be in the release and added it to the GitHub milestone, but forgot to update its local status to `inprogress`, leaving the item silently ignored by the rule despite being scheduled on GitHub.",
+       "grounding": "cited",
+       "line": 271
+      },
+      {
+       "claim": "Q16=C: Split each rule so that on a master push it judges only the file half, and every live-state assertion is deferred to the scheduled run.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "Under Option C, the first time somebody closes an epic issue by hand, master and pull request builds will remain green, and the deferred scheduled run will detect the closed epic and open a ticket. The criterion that decided this is '3. Does it wedge the loop?', because running live-state checks on PRs or master pushes would wedge the CI loop on out-of-band mutations.",
+       "grounding": "asserted"
+      }
+     ],
+     "lane_file_sha256_16": "649ce6de513c58cf"
+    },
+    {
+     "lane": 5,
+     "conversation_id": "0d75a975-6306-4c60-b970-b0795e331880",
+     "verdict": "PASS",
+     "summary": "I read the read-only copy at fingerprint 3b3a9cf88f0981a3. The 14 settled decisions were reviewed in docs/audits/quorum-PMAT-1307.json, confirming P1 was settled as A (one milestone for the next release, unscheduled work carries no milestone) and P4 as C (CB-2115 off master push). Q15 must be A to prevent CB-2114 from being red on arrival while respecting P1's rule that unscheduled work carries no milestone. Q16 must be C to prevent live GitHub changes from wedging master without discarding the file-side checks on a master push. These two choices are coherent with the settled 14 decisions.",
+     "votes": {
+      "Q15": "A",
+      "Q16": "C"
+     },
+     "findings": [
+      {
+       "claim": "Q15=A: Modify CB-2114 so its release requirement applies only to inprogress items, allowing planned backlog items to legally carry release: None.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "The rule reports a pass for an open planned item with no release, which can be wrong in a way a human would notice if the item was intended to be in the next release but was mistakenly left in the planned state, causing it to silently miss the cut.",
+       "grounding": "asserted"
+      },
+      {
+       "claim": "Q16=C: Split the three rules so that a master push validates only their file-side syntax, deferring all live-state assertions to the scheduled run.",
+       "file": "docs/specifications/goal-mode.md",
+       "fix": "The first time somebody closes an epic issue by hand, the master push remains green since it only checks the file half, and the scheduled run will later catch the live-state change and open a ticket; Criterion 3 (Does it wedge the loop?) decided this.",
+       "grounding": "asserted"
+      }
+     ],
+     "lane_file_sha256_16": "99391607ab32de20"
+    }
+   ]
   }
  ],
  "decisions": {
@@ -1091,6 +1240,43 @@
      "why": "Does it wedge the loop? It guarantees that a newly opened issue cannot retroactively turn a previously green master commit red."
     }
    ]
+  },
+  "Q15": {
+   "decision": "A",
+   "seats_for": 5,
+   "seats_counted": 5,
+   "source": "round3",
+   "majority": true,
+   "votes": {
+    "1": "A",
+    "2": "A",
+    "3": "A",
+    "4": "A",
+    "5": "A"
+   },
+   "dissent": []
+  },
+  "Q16": {
+   "decision": "C",
+   "seats_for": 4,
+   "seats_counted": 5,
+   "source": "round3",
+   "majority": true,
+   "votes": {
+    "1": "C",
+    "2": "A",
+    "3": "C",
+    "4": "C",
+    "5": "C"
+   },
+   "dissent": [
+    {
+     "lane": 2,
+     "vote": "A",
+     "claim": "Q16=A: Extend P4 so all four live-state rules come off the master push and run only on pull requests and a schedule.",
+     "why": "Under Option A, the first time somebody closes an epic issue by hand, the master branch stays green and the scheduled run catches it to open a ticket instead, a decision driven by Criterion 3 (Does it wedge the loop?)."
+    }
+   ]
   }
  },
  "overturned_the_drafted_answer": [
@@ -1114,6 +1300,30 @@
   "D8",
   "D9",
   "D10",
-  "P2"
- ]
+  "P2",
+  "Q15"
+ ],
+ "question_count": 16,
+ "review_that_forced_round3": {
+  "artifact": "not recorded \u2014 4 of 5 lanes FAILED",
+  "roles_failed": [
+   "quality",
+   "architecture",
+   "crux",
+   "adversarial"
+  ],
+  "roles_passed": [
+   "security"
+  ],
+  "out_dir": "/run/user/1000/paiml-implement/agy/PMAT-1307/39a15c63-fab3-4148-8cb7-0cb012369b35/ph-review",
+  "findings_confirmed_by_the_orchestrator": [
+   "the text called 60 the median while \u00a714 measures 59",
+   "\u00a711.2 claimed ten decisions were marked inline; four were",
+   "two dead \u00a72.2 references",
+   "a dead \u00a78.10 reference, off by one after the duplicate list number was fixed",
+   "P1 against CB-2114 (Q15)",
+   "pmat.toml thresholds are editable in the PR and were not named in \u00a78",
+   "the master-push hole left open in CB-2110/2112/2114 (Q16)"
+  ]
+ }
 }

--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -6187,3 +6187,99 @@ roadmap:
   labels:
   - kind:code
   notes: 'Found when ci / test failed on #1304, which changes no Rust; master passed the same test on identical code. Filed by PMAT-1303 on #1304''s branch (CB-2115 is live).'
+- id: GH-1306
+  github_issue: 1306
+  item_type: task
+  title: 'comply: pmat''s own generated work contracts fail CB-1305, and pre-#357 stubs are never flagged stale'
+  status: planned
+  priority: medium
+  assigned_to: null
+  created: 2026-09-11T06:16:11.342726639+00:00
+  updated: 2026-09-11T06:16:11.342726639+00:00
+  spec: null
+  acceptance_criteria: []
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels: []
+  notes: null
+- id: PMAT-1307
+  github_issue: 1307
+  item_type: task
+  title: 'goal-mode.md revision: the nine findings from its own five-role review (#1303), and a verification ledger that says when it was measured'
+  status: planned
+  priority: high
+  assigned_to: null
+  created: 2026-09-11T06:16:11Z
+  updated: 2026-09-11T06:16:11Z
+  spec: null
+  acceptance_criteria:
+  - 'goal-mode.md states each of the nine decisions (D1 to D9) from #1303''s review: the derived version renames the milestone at the cut; CB-2113 has a PR leg and a master leg with a release constraint; EPIC-OPEN is the sub-issue relation; the grace window runs from first-seen; CB-2116 says every non-merge commit and its CI bound sits above the release trigger; a fork PR editing the roadmap or the specs fails closed; CODEOWNERS covers docs/specifications'
+  - §14 carries both the measurement it was written against and a re-measured now column, and the counts repeated in §1.2, §5.1, §5.4, §7.1 and §8 agree with the tree; no claim cites a line number that can rot
+  - §8 names each gap between this text and the code with its ticket, and a fresh five-role review of the revised text records docs/audits/spec-goal-mode-review.json with pmat spec review --record
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - kind:code
+  notes: 'Applies the operator''s decisions on #1303, where goal-mode.md failed its own review 5 lanes of 5. Completes the review half of §13 item 6 and unblocks PMAT-1303.'
+- id: PMAT-1308
+  github_issue: 1308
+  item_type: task
+  title: 'CB-2113 needs both legs: the PR''s own commits against a non-terminal item of the open milestone, and master against existence (goal-mode.md §7, decision D2/D3)'
+  status: planned
+  priority: high
+  assigned_to: null
+  created: 2026-09-11T06:16:11Z
+  updated: 2026-09-11T06:16:11Z
+  spec: null
+  acceptance_criteria:
+  - on a pull request CB-2113 judges the commits the PR adds, and each names a non-terminal item whose release is the open milestone or earlier; on a push to master it judges every non-merge commit since the last tag against existence only
+  - scripts/traceability-control.sh carries an arm for each leg, including a ticket of a later release being refused on a PR
+  - goal-mode.md §8's limit entry for this gap is removed in the same PR
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - kind:code
+  notes: 'goal-mode.md §7 states both legs after decision D2/D3 on #1303; the code judges merge-base..HEAD and reports not_applicable on master.'
+- id: PMAT-1309
+  github_issue: 1309
+  item_type: task
+  title: 'CB-2115''s grace window restarts on any timestamp bump: measure it from when the disagreement was first seen (goal-mode.md §5.2, decision D5; CB-2115 is enforced)'
+  status: planned
+  priority: high
+  assigned_to: null
+  created: 2026-09-11T06:16:11Z
+  updated: 2026-09-11T06:16:11Z
+  spec: null
+  acceptance_criteria:
+  - the staleness grace window is measured from when a disagreement was first observed, recorded beside the snapshot, and a bump to item.updated or issue.updated_at does not extend it
+  - scripts/roadmap-coherence-control.sh carries an arm that bumps a timestamp and still refuses the pair once the window has passed
+  - goal-mode.md §8's limit entry for this gap is removed in the same PR
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - kind:code
+  notes: 'CB-2115 is ENFORCED, so this is a live hole: the rule that refuses a stale disagreement can be reset by an edit that resolves nothing. Decision D5 on #1303.'
+- id: PMAT-1310
+  github_issue: 1310
+  item_type: task
+  title: A fork PR that edits docs/roadmaps/roadmap.yaml or docs/specifications/ must fail closed, not pass as not_applicable (goal-mode.md §3.3, decision D7)
+  status: planned
+  priority: medium
+  assigned_to: null
+  created: 2026-09-11T06:16:11Z
+  updated: 2026-09-11T06:16:11Z
+  spec: null
+  acceptance_criteria:
+  - a fork pull request whose diff touches docs/roadmaps/roadmap.yaml or docs/specifications/ reports not_measured for CB-2110, CB-2112, CB-2114 and CB-2115, naming that reason; one that touches neither still reports not_applicable
+  - a control arm covers both cases
+  - goal-mode.md §8's limit entry for this gap is removed in the same PR
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - kind:code
+  notes: 'A fork cannot change issues, but it can edit the records those four rules judge, and master turns red on the merge. Decision D7 on #1303.'

--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -6285,3 +6285,24 @@ roadmap:
   labels:
   - kind:code
   notes: 'A fork cannot change issues, but it can edit the records those four rules judge, and master turns red on the merge. Decision D7 on #1303.'
+- id: PMAT-1312
+  github_issue: 1312
+  item_type: task
+  title: CB-2114's release leg binds inprogress items only, and the live-state assertions come off the master push (goal-mode.md §11.2, decisions Q15 and Q16)
+  status: planned
+  priority: high
+  assigned_to: null
+  created: 2026-09-11T09:40:00Z
+  updated: 2026-09-11T09:40:00Z
+  spec: null
+  acceptance_criteria:
+  - CB-2114 reports a planned item with no release as unscheduled rather than a finding, and still fails an inprogress item that has none
+  - on a push to master CB-2110, CB-2112 and CB-2114 assert only the half they can read in the tree; every live-state assertion (epic open, issue exists and open, milestone exists and carries the issue) is deferred to the scheduled run, and the deferral is printed rather than silent
+  - scripts/roadmap-coherence-control.sh and scripts/ticket-release-control.sh carry an arm per leg, including a planned item with no release passing and an inprogress item without one failing
+  - goal-mode.md §8's limit entry for this gap is removed in the same PR
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - kind:code
+  notes: 'Decided by quorum 2026-09-11 after the five-role review of the goal-mode.md revision failed 4 of 5 lanes. Q15 carried 5 of 5 seats, one of two unanimous answers of the sixteen: with 97 open items and one open milestone under P1, CB-2114 as written was red on arrival for nearly the whole backlog. Q16 carried 4 of 5; the dissent would take all four live-state rules off the master push as P4 does for CB-2115. Artifact docs/audits/quorum-PMAT-1307.json.'

--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -6214,7 +6214,7 @@ roadmap:
   updated: 2026-09-11T06:16:11Z
   spec: null
   acceptance_criteria:
-  - 'goal-mode.md states each of the nine decisions (D1 to D9) from #1303''s review: the derived version renames the milestone at the cut; CB-2113 has a PR leg and a master leg with a release constraint; EPIC-OPEN is the sub-issue relation; the grace window runs from first-seen; CB-2116 says every non-merge commit and its CI bound sits above the release trigger; a fork PR editing the roadmap or the specs fails closed; CODEOWNERS covers docs/specifications'
+  - 'goal-mode.md states each of the fourteen decisions the quorum took (D1-D10, P1-P4): the cut REFUSES when the derived version disagrees with the milestone title and never renames it; CB-2113 has a PR leg and a master leg, its release leg reported not failed until a milestone scheme exists; epic membership is sub-issues alone; the grace window stays at now - max(updated) and covers the ORPHAN and MISSING legs; untagged_ci_slack is 10; a fork PR editing the records fails closed; nothing bounds who flips a spec status and the text says so; every non-merge commit; and CB-2115 comes off the master push'
   - §14 carries both the measurement it was written against and a re-measured now column, and the counts repeated in §1.2, §5.1, §5.4, §7.1 and §8 agree with the tree; no claim cites a line number that can rot
   - §8 names each gap between this text and the code with its ticket, and a fresh five-role review of the revised text records docs/audits/spec-goal-mode-review.json with pmat spec review --record
   phases: []
@@ -6234,19 +6234,19 @@ roadmap:
   updated: 2026-09-11T06:16:11Z
   spec: null
   acceptance_criteria:
-  - on a pull request CB-2113 judges the commits the PR adds, and each names a non-terminal item whose release is the open milestone or earlier; on a push to master it judges every non-merge commit since the last tag against existence only
-  - scripts/traceability-control.sh carries an arm for each leg, including a ticket of a later release being refused on a PR
+  - on a pull request CB-2113 judges the commits the PR adds and each names a non-terminal item; the item's release is compared with the open milestone and a LATER release is REPORTED, not failed, until the one-open-milestone scheme of goal-mode.md §11.2 P1 exists; on a push to master it judges the merge's own commits
+  - scripts/traceability-control.sh carries an arm for each leg, including a ticket of a later release being REPORTED and not failed on a PR, and an arm proving the report becomes a refusal once the milestone scheme is configured
   - goal-mode.md §8's limit entry for this gap is removed in the same PR
   phases: []
   subtasks: []
   estimated_effort: null
   labels:
   - kind:code
-  notes: 'goal-mode.md §7 states both legs after decision D2/D3 on #1303; the code judges merge-base..HEAD and reports not_applicable on master.'
+  notes: 'goal-mode.md §7 states both legs. D2 was decided A by quorum 4 of 4 seats (2026-09-11) and D3 was decided C, 4 of 4: the release leg warns first and only fails once P1''s milestone scheme exists. The code judges merge-base..HEAD and reports not_applicable on master. Artifact docs/audits/quorum-PMAT-1307.json.'
 - id: PMAT-1309
   github_issue: 1309
   item_type: task
-  title: 'CB-2115''s grace window restarts on any timestamp bump: measure it from when the disagreement was first seen (goal-mode.md §5.2, decision D5; CB-2115 is enforced)'
+  title: 'CB-2115: the grace window must cover the ORPHAN and MISSING legs, and the rule comes off the master push (goal-mode.md §3.3 and §5.2, decisions D10 and P4)'
   status: planned
   priority: high
   assigned_to: null
@@ -6254,15 +6254,17 @@ roadmap:
   updated: 2026-09-11T06:16:11Z
   spec: null
   acceptance_criteria:
-  - the staleness grace window is measured from when a disagreement was first observed, recorded beside the snapshot, and a bump to item.updated or issue.updated_at does not extend it
-  - scripts/roadmap-coherence-control.sh carries an arm that bumps a timestamp and still refuses the pair once the window has passed
+  - 'the staleness grace window covers the ORPHAN and MISSING legs as well as a field disagreement: an issue opened less than staleness_grace_minutes ago is not_measured rather than a finding, and so is an item added without its issue'
+  - CB-2115 no longer runs on a push to master; it runs on pull requests, and on a schedule whose finding OPENS A TICKET instead of failing the build
+  - the window stays at now - max(item.updated, issue.updated_at); no first-seen state file is added, and a control arm proves a timestamp bump restarts it, which is the accepted cost recorded in goal-mode.md §5.2
+  - scripts/roadmap-coherence-control.sh carries an arm for a freshly opened orphan issue inside the window, one for the same issue past it, and one proving the master-push path is gone
   - goal-mode.md §8's limit entry for this gap is removed in the same PR
   phases: []
   subtasks: []
   estimated_effort: null
   labels:
   - kind:code
-  notes: 'CB-2115 is ENFORCED, so this is a live hole: the rule that refuses a stale disagreement can be reset by an edit that resolves nothing. Decision D5 on #1303.'
+  notes: 'CB-2115 is ENFORCED and this is the live hole that reddened master 5af9a0f0d at 06:08Z on 2026-09-11: five issues opened by hand, no roadmap item, no commit to blame. The quorum REFUSED the first-seen state file this ticket was originally filed for (D5 decided B, 4 of 5 seats: a gate whose verdict depends on a state file cannot be judged from a clean clone). What it decided instead is D10 (5 of 5, the only unanimous answer) and P4 (3 of 4). Artifact docs/audits/quorum-PMAT-1307.json.'
 - id: PMAT-1310
   github_issue: 1310
   item_type: task

--- a/docs/specifications/goal-mode.md
+++ b/docs/specifications/goal-mode.md
@@ -22,7 +22,7 @@ were made by *disagreeing* with the reviews, not by adopting them:
 
 - the grill's two lanes were one lane plus a retry, and the delegate said so rather
   than reporting a consensus;
-- the teamwork lane silently swapped this specification's primary key (§2.2) and the
+- the teamwork lane silently swapped this specification's primary key (§4.1) and the
   delegate caught it;
 - the load-bearing fact in §1.2 was found by neither, and is verified here.
 
@@ -111,7 +111,7 @@ automates a broken invariant automates the breakage*.
    installed.** Every gate must be checkable from a clean clone with
    `git`, `jq`, `cargo` and `gh`. `pmat goal` is the single surface permitted a driver.
 5. **One number, one place.** Where a fact could live on three surfaces, name one
-   authority and make the others projections (§2.2). A second source of truth is a
+   authority and make the others projections (§4.1). A second source of truth is a
    second number to disagree — the defect `pmat comply numeric-claims` exists to find.
 6. **Land green.** A rule that is red on the day it lands gets disabled. Where existing
    data violates a new rule, the data is fixed under its own ticket first.
@@ -192,7 +192,18 @@ A **fork PR** is `not_applicable` for the four GitHub-side rules (CB-2110, 2112,
 2115), for a stated reason: *a fork's PR cannot change this repository's issues,
 milestones or epics, so there is nothing about them for this PR to have broken.* Those
 four are re-checked on the push to master, which is where the merge actually lands and
-where a token exists — **except CB-2115**, which does not run on a master push at all. It
+where a token exists — with two carve-outs that exist for the same reason.
+
+**On a push to master, CB-2110, CB-2112 and CB-2114 judge only the half they can see in the
+tree**: front-matter present and parsable, `github_issue` present and well-formed,
+`release:` present on an `inprogress` item. Every assertion about live GitHub state — the
+epic is open, the issue exists and is open, the milestone exists and carries the issue — is
+deferred to the scheduled run. Closing an epic in the GitHub UI must not redden a commit that
+was green when it merged, and the file half is exactly the half a commit can break. (Decided
+by quorum 2026-09-11, 4 of 5 seats; the dissent would take all four rules off the master push
+entirely, as P4 does for CB-2115 — §11.2 Q16.)
+
+**CB-2115 does not run on a master push at all.** It
 reads GitHub live, so its verdict on master changes while master does not: an issue opened
 by hand turns a green commit red with no diff to blame, which is what happened on
 `5af9a0f0d` at 06:08Z on 2026-09-11. CB-2115 runs on pull requests, where a human can fix
@@ -258,8 +269,9 @@ behaviour, not a defect to design around.
 /// The release this ticket ships in: a bare semver string ("3.41.0"), never
 /// "v3.41.0". A PROJECTION of the GitHub milestone of the same title
 /// (RR-RELEASE); `pmat work sync` is the only writer. `None` on a completed or
-/// cancelled item means the item predates release tracking; `None` on an open
-/// item is a CB-2114 violation.
+/// cancelled item means the item predates release tracking; `None` on a
+/// `planned` item means NOT YET SCHEDULED, which §11.2 P1 makes the normal state
+/// of the backlog; `None` on an `inprogress` item is a CB-2114 violation.
 #[serde(default, skip_serializing_if = "Option::is_none")]
 pub release: Option<String>,
 ```
@@ -355,7 +367,7 @@ The window covers every leg, not only a field disagreement. An issue opened less
 mint its item cannot have run yet, and a rule that turns master red the instant anyone
 opens an issue is a rule someone disables. The same holds for an item added without its
 issue. Past the window it is a finding, and `pmat work sync` is the fixer. (Decided by
-quorum 2026-09-11, 5 of 5 seats — the only unanimous decision of the fourteen.) The code
+quorum 2026-09-11, 5 of 5 seats — one of the two unanimous decisions of the sixteen.) The code
 covers the field-disagreement leg only; extending it to ORPHAN and MISSING is PMAT-1309.
 
 ### 5.3 `RR-COHERENCE` — which side wins
@@ -441,7 +453,7 @@ legitimate quorum. That is what "pmat does not depend on Claude or agy" means co
 | **CB-2111** | E.1 | every `active` spec has a review artifact whose hash matches and whose roles all PASS | **append one space to the spec** | `traceability` → `gate` |
 | **CB-2112** | A | every open item has a `github_issue`, open, whose number is the item's numeric tail | null one `github_issue` | `traceability` → `gate` |
 | **CB-2113** | C | on a PR: every non-merge commit the PR adds carries `Pmat-Ticket: <id>` naming a real, NON-TERMINAL item; its `release` is compared with the open milestone and a LATER one is reported, not failed, until §11.2's milestone scheme exists (then it fails); on master: every non-merge commit in `v<latest>..HEAD` names a real item, any status | `git commit --allow-empty -m 'no trailer' --no-verify` | `traceability` → `gate` |
-| **CB-2114** | B, F1 | every open item has `release:`, its milestone exists, its issue is on it | remove one `release:` | `traceability` → `gate` |
+| **CB-2114** | B, F1 | every **`inprogress`** item has `release:`, its milestone exists, its issue is on it; a `planned` item with no `release:` is unscheduled, not a violation (§11.2 Q15) | remove the `release:` from an `inprogress` item | `traceability` → `gate` |
 | **CB-2115** | D | the open sets are in bijection, and no matched pair has disagreed past the grace window | close one linked issue, leave the item open | `traceability` → `gate` |
 | **CB-2116** | B, F2 | (a) every non-merge commit in a tag's range carries a trailer for a ticket of that release; (b) `count(v<latest>..master) ≤ max_untagged_commits + untagged_ci_slack` | move a merged ticket's `release` | `traceability` → `gate` |
 | **CB-2117** | G | `docs/status/goal-ledger.md` matches what the generator computes now | hand-edit a row | `traceability` → `gate` |
@@ -456,7 +468,7 @@ currently red on four pre-existing failures, and unwedging it is a five-step seq
 documented in `.github/workflows/quality-gate.yml` that would redden a required context on master and every
 open PR. Routing around it is not forum-shopping — it is refusing to make eight new rules
 hostage to a deadlock they did not cause. The other 161 stay behind it and this document does
-**not** claim to fix them (§8.10).
+**not** claim to fix them (§8.11).
 
 A new job in `.github/workflows/ci.yml`, wired exactly as `roadmap-validate` is:
 
@@ -515,12 +527,13 @@ bypasses, and adding the trigger costs nothing.
    measure **master**, not merely the PR — see §7. Setting it is a ruleset change on
    `13878864`; until it is made, CB-2113 measures the PR's commits only and says so in
    its output rather than pretending to cover master.
-5. **Three rules describe more than the code does today**, each with its ticket: CB-2113's
+5. **Four rules describe more than the code does today**, each with its ticket: CB-2113's
    master leg reports `not_applicable` there for now and its release leg is unwritten
    (PMAT-1308), CB-2115's grace window covers the field-disagreement leg only and the rule
-   still runs on a master push (PMAT-1309), and the fork carve-out above is not yet
-   implemented (PMAT-1310). Each is stated here rather than left for a reader to discover
-   by running it.
+   still runs on a master push (PMAT-1309), the fork carve-out above is not yet implemented
+   (PMAT-1310), and CB-2114 still binds every open item rather than the `inprogress` ones
+   while CB-2110/2112/2114 still assert live state on a master push (PMAT-1312). Each is
+   stated here rather than left for a reader to discover by running it.
 6. **A trailer proves a claim, not the work.** `Pmat-Ticket: PMAT-999` on an unrelated
    diff passes CB-2113. Only a quorum reading the diff against the ticket defends this,
    and that is a skill, not a gate.
@@ -536,6 +549,15 @@ bypasses, and adding the trigger costs nothing.
 11. **This does not un-NEUTER the other 161 rules.** It builds a second, working path for
     eight. Saying otherwise would be the kind of claim `pmat comply numeric-claims` exists
     to catch.
+12. **The thresholds are in a file the pull request can edit.** `max_untagged_commits`,
+    `untagged_ci_slack` and `staleness_grace_minutes` live in `pmat.toml` (§10.2), which is
+    in the tree like any other file: a PR that raises them passes CB-2116(b) and widens
+    CB-2115's window without cutting a release or syncing anything. Nothing in this
+    document closes that, and pretending a number in a writable file is a bound would be
+    the same mistake as `.pmat-metrics.toml`, whose budgets nothing reads. What the design
+    does buy is that the edit is **in the diff**, named in `pmat.toml`, on a line whose
+    only purpose is that threshold. The ratchet's answer — run the command, never read the
+    number — is the shape a later rule would need.
 
 ## 9. Ticket ↔ work linking model — the cases the invariants miss
 
@@ -568,7 +590,7 @@ fixed tool list, and that is the defect not to repeat.
 # actually key on is (a) semver semantics read from what is IN the release, and
 # (b) how much is sitting unreleased. Both are below; the ticket cap is opt-in and
 # unset by default.
-max_untagged_commits      = 60   # the repo's own MEDIAN commits-per-release, over v3.30.0..v3.40.0
+max_untagged_commits      = 60   # a round number just above this repo's MEDIAN of 59 (§14)
 untagged_ci_slack         = 10   # CB-2116(b) fails only above max + slack, so the cut fires BEFORE the gate
 max_release_age_hours     = 72
 max_tickets_per_release   = 0    # 0 = no cap. Set it only if you want one
@@ -604,7 +626,8 @@ names both numbers rather than editing the surface the next gate reads (§4.1).
    visible in GitHub's UI, and schedulable by a human;
 2. **unreleased volume** — `count(v<latest>..master) ≥ max_untagged_commits`. This is the
    Rust-shaped trigger: it asks how much is sitting unreleased, not how many tickets were
-   closed. Default 60 is this repository's own median commits-per-release, measured over
+   closed. Default 60 is a round number just above this repository's own median
+   commits-per-release of 59 (§14), measured over
    `v3.30.0..v3.40.0`, not a number chosen for the document;
 3. **age** — `> max_release_age_hours` with ≥1 ticket closed;
 4. **explicit** — an item labelled `release-boundary` reaching `completed`;
@@ -684,8 +707,9 @@ Fourteen questions were open when this document failed its own five-role review 
 None was settled by the author. Each was put to five independent seats that read a read-only
 copy of this tree, chose from options they were given without being told which one was
 drafted, and answered alone; the majority is the decision and every minority answer is kept.
-The artifact is `docs/audits/quorum-PMAT-1307.json`; the ten spec decisions are marked at
-the passage each one changed.
+The artifact is `docs/audits/quorum-PMAT-1307.json`. Where a decision changed a passage and
+the reasoning is not obvious from the text, the passage carries the vote inline; the table in
+this section is the complete record, and it is the one to trust.
 
 The first round was **contaminated by the author**: the copy carried a roadmap file stating
 the drafted answers as fact, and one seat cited it for nine of its fourteen votes. That seat
@@ -702,6 +726,20 @@ Four of the fourteen are programme decisions rather than text:
 | **P2** | Classify the 44 specs BEFORE minting epics: most are finished or superseded work and belong in `historical`/`superseded`; only the live set gets an epic. | 4 of 4 | PMAT-729, step 6 |
 | **P3** | CB-2111 flips after that classification, over the live set only — not after reviewing all 44. | 4 of 4 | PMAT-1300, step 7 |
 | **P4** | CB-2115 comes off the master push (§3.3). | 3 of 4 | PMAT-1309 |
+
+Two more were opened by the five-role review of this revision, which failed 4 of 5 lanes on
+contradictions the fourteen decisions had introduced, and were decided the same way:
+
+| | decision | seats | what it changes |
+|---|---|---|---|
+| **Q15** | CB-2114's release leg binds `inprogress` items only. A `planned` item with no `release:` is unscheduled, which P1 makes the normal state of the backlog — not a violation. | **5 of 5** | §4.2, §7's CB-2114 row |
+| **Q16** | On a master push, CB-2110, CB-2112 and CB-2114 judge only their file half; every live-state assertion is deferred to the scheduled run. | 4 of 5 | §3.3 |
+
+Q15 is what P1 cost: with 97 open items and one open milestone, CB-2114 as written was red on
+arrival for nearly the whole backlog, and neither the seats that decided P1 nor the author
+saw it. Two review lanes found it independently. Q16 is the other half of P4 — the hole P4
+closed for CB-2115 was open in three sibling rules, and closing it for one rule while three
+others keep it would have been a fix in name only.
 
 **P2 and P3 shrink the two largest human steps in §11** from "44 epics and 44 reviews" to
 "classify, then epic and review what is left". That is the difference between a backlog a

--- a/docs/specifications/goal-mode.md
+++ b/docs/specifications/goal-mode.md
@@ -192,7 +192,12 @@ A **fork PR** is `not_applicable` for the four GitHub-side rules (CB-2110, 2112,
 2115), for a stated reason: *a fork's PR cannot change this repository's issues,
 milestones or epics, so there is nothing about them for this PR to have broken.* Those
 four are re-checked on the push to master, which is where the merge actually lands and
-where a token exists.
+where a token exists — **except CB-2115**, which does not run on a master push at all. It
+reads GitHub live, so its verdict on master changes while master does not: an issue opened
+by hand turns a green commit red with no diff to blame, which is what happened on
+`5af9a0f0d` at 06:08Z on 2026-09-11. CB-2115 runs on pull requests, where a human can fix
+what the diff caused, and on a schedule, where a disagreement **opens a ticket instead of
+failing a build**. (Decided by quorum 2026-09-11, 3 of 4 seats — §11.2; PMAT-1309.)
 
 **Except when the fork PR edits the records those rules judge.** A fork cannot change
 issues, milestones or epics, but it can edit `docs/roadmaps/roadmap.yaml` and
@@ -229,12 +234,16 @@ except in the tag, where the `v` is added at exactly one place in the code.
 Strict order — tag ⊃ milestone ⊃ roadmap — so there is no bidirectional merge and no
 conflict resolution. A surface can only *fail to reflect* the one above it.
 
-**The title is the intent until the cut derives the number.** §10.3 derives the version
-from the labels of the tickets in the release, so a milestone titled `3.41.0` that
-collects a `breaking-change` ticket is titled wrongly, not scheduled wrongly. The cut
-renames the milestone to the derived number and then tags it, and RR-RELEASE is checked
-after the rename. Only the cut may rename; a rename by anyone else is the drift CB-2114
-exists to catch.
+**The title is the intent, and the cut refuses rather than overrule it.** §10.3 derives the
+version from the labels of the tickets in the release, so a milestone titled `3.41.0` that
+collects a `breaking-change` ticket is titled wrongly, not scheduled wrongly. The cut does
+**not** rename it. It stops, prints both numbers, and a human either retitles the milestone
+or moves the ticket out of it. An automatic rename would let the cut satisfy RR-RELEASE by
+editing the very surface CB-2114 compares against — the rule would pass because the evidence
+moved, and master would go red afterwards on drift no commit introduced. Refusing is the loud
+failure; renaming is the quiet one. A rename by anyone else, at any other time, is the drift
+CB-2114 exists to catch. (Decided by quorum 2026-09-11, 3 of 4 seats; the dissent would fix
+the title at creation and refuse the ticket at assignment instead — §11.2.)
 
 **The key is the string, not the milestone's numeric id.** The teamwork lane proposed
 tracking the id so a rename would be invisible; that is rejected. Renaming a milestone
@@ -281,9 +290,14 @@ vendors: [cuda]    # optional; adds a vendor: role to E.1's required set
 escape hatch nobody can see is a hole, so `pmat comply report` lists every `historical`
 spec **by name** on every run.
 
-`status` IS the exemption, so who may change it belongs to the gate. `CODEOWNERS` covers
-`docs/specifications/`: a front-matter change needs the owner's review, which makes a flip
-out of `active` a reviewed act rather than one line in an unrelated pull request.
+`status` IS the exemption, and **nothing bounds who changes it**. That is stated here rather
+than papered over: the diff is the only control. A `CODEOWNERS` entry on
+`docs/specifications/` and a review artifact for the flip were both considered and both
+rejected — each is a gate whose own bypass is another line in the same pull request, and a
+rule that can be switched off by an unreviewable edit is better honest about it than dressed
+in ceremony. What makes the hatch visible is the naming above: every `historical` and
+`superseded` spec is listed by name on every `pmat comply report` run, so a flip shows up in
+the next report whoever made it. (Decided by quorum 2026-09-11, 4 of 4 seats — §11.2.)
 
 Epic membership is read from GitHub's native **sub-issue** relation, and only from it
 (operator decision, 2026-09-09). An `Epic: #N` line in an issue body is **not** accepted:
@@ -321,21 +335,28 @@ Three finding classes, reported separately because they have different fixes:
 
 ### 5.2 Field predicate — tolerance TIME
 
-For each matched pair, compare `title` and the state word. A disagreement is tolerated
-only while `now − first_seen(disagreement) < staleness_grace_minutes` (default 60), where
-`first_seen` is when a sync first observed THIS disagreement, recorded beside the
-snapshot. A time bound, not a count: "up to 3 may disagree" means three chosen items may
-be wrong forever and nobody chooses which three. It runs from the onset and NOT from
-`max(item.updated, issue.updated_at)`, because any edit to either side moves that maximum
-and would restart the window without resolving anything — a grace window that resets on a
-touch is not a bound. Implemented by PMAT-1309.
+For each matched pair, compare `title` and the state word. A disagreement is tolerated only
+while `now − max(item.updated, issue.updated_at) < staleness_grace_minutes` (default 60). A
+time bound, not a count: "up to 3 may disagree" means three chosen items may be wrong forever
+and nobody chooses which three.
+
+**Any edit to either side restarts that window, and that is accepted.** Measuring instead
+from when a sync first SAW the disagreement was considered and rejected: it needs a
+first-seen record that must be written, committed, read back and kept honest across every
+clone and every CI runner, and a gate whose verdict depends on a state file that can be
+absent, stale or wrong is a gate that cannot be judged from a clean clone. A timestamp bump
+is also some evidence that a human touched the disagreement. Neither side of this trade is
+free — the cost taken here is a window a touch can restart, instead of a new source of truth
+that can lie. (Decided by quorum 2026-09-11, 4 of 5 seats; the dissent held that a window any
+edit resets never expires — §11.2.)
 
 The window covers every leg, not only a field disagreement. An issue opened less than
 `staleness_grace_minutes` ago is `not_measured` rather than a finding: the sync that would
 mint its item cannot have run yet, and a rule that turns master red the instant anyone
 opens an issue is a rule someone disables. The same holds for an item added without its
-issue. Past the window it is a finding, and `pmat work sync` is the fixer. Implemented by
-PMAT-1309.
+issue. Past the window it is a finding, and `pmat work sync` is the fixer. (Decided by
+quorum 2026-09-11, 5 of 5 seats — the only unanimous decision of the fourteen.) The code
+covers the field-disagreement leg only; extending it to ORPHAN and MISSING is PMAT-1309.
 
 ### 5.3 `RR-COHERENCE` — which side wins
 
@@ -419,7 +440,7 @@ legitimate quorum. That is what "pmat does not depend on Claude or agy" means co
 | **CB-2110** | E | every `active` spec names an open epic issue with ≥1 sub-issue | delete the `epic:` line | `traceability` → `gate` |
 | **CB-2111** | E.1 | every `active` spec has a review artifact whose hash matches and whose roles all PASS | **append one space to the spec** | `traceability` → `gate` |
 | **CB-2112** | A | every open item has a `github_issue`, open, whose number is the item's numeric tail | null one `github_issue` | `traceability` → `gate` |
-| **CB-2113** | C | on a PR: every non-merge commit the PR adds carries `Pmat-Ticket: <id>` naming a real, NON-TERMINAL item whose `release` is the open milestone or an earlier one; on master: every non-merge commit in `v<latest>..HEAD` names a real item, any status | `git commit --allow-empty -m 'no trailer' --no-verify` | `traceability` → `gate` |
+| **CB-2113** | C | on a PR: every non-merge commit the PR adds carries `Pmat-Ticket: <id>` naming a real, NON-TERMINAL item; its `release` is compared with the open milestone and a LATER one is reported, not failed, until §11.2's milestone scheme exists (then it fails); on master: every non-merge commit in `v<latest>..HEAD` names a real item, any status | `git commit --allow-empty -m 'no trailer' --no-verify` | `traceability` → `gate` |
 | **CB-2114** | B, F1 | every open item has `release:`, its milestone exists, its issue is on it | remove one `release:` | `traceability` → `gate` |
 | **CB-2115** | D | the open sets are in bijection, and no matched pair has disagreed past the grace window | close one linked issue, leave the item open | `traceability` → `gate` |
 | **CB-2116** | B, F2 | (a) every non-merge commit in a tag's range carries a trailer for a ticket of that release; (b) `count(v<latest>..master) ≤ max_untagged_commits + untagged_ci_slack` | move a merged ticket's `release` | `traceability` → `gate` |
@@ -495,14 +516,15 @@ bypasses, and adding the trigger costs nothing.
    `13878864`; until it is made, CB-2113 measures the PR's commits only and says so in
    its output rather than pretending to cover master.
 5. **Three rules describe more than the code does today**, each with its ticket: CB-2113's
-   master leg reports `not_applicable` there for now (PMAT-1308), CB-2115's grace
-   window still runs from `max(updated)` rather than the onset (PMAT-1309), and the
-   fork carve-out above is not yet implemented (PMAT-1310). Each is stated here rather
-   than left for a reader to discover by running it.
+   master leg reports `not_applicable` there for now and its release leg is unwritten
+   (PMAT-1308), CB-2115's grace window covers the field-disagreement leg only and the rule
+   still runs on a master push (PMAT-1309), and the fork carve-out above is not yet
+   implemented (PMAT-1310). Each is stated here rather than left for a reader to discover
+   by running it.
 6. **A trailer proves a claim, not the work.** `Pmat-Ticket: PMAT-999` on an unrelated
    diff passes CB-2113. Only a quorum reading the diff against the ticket defends this,
    and that is a skill, not a gate.
-6. **Lane independence is unverifiable from a file** (§6.2), demonstrated twice in this
+7. **Lane independence is unverifiable from a file** (§6.2), demonstrated twice in this
    document's own production.
 8. **Publishing needs a token pmat does not hold.** `pmat goal` cuts tags and opens
    release PRs; it never publishes.
@@ -547,7 +569,7 @@ fixed tool list, and that is the defect not to repeat.
 # (b) how much is sitting unreleased. Both are below; the ticket cap is opt-in and
 # unset by default.
 max_untagged_commits      = 60   # the repo's own MEDIAN commits-per-release, over v3.30.0..v3.40.0
-untagged_ci_slack         = 20   # CB-2116(b) fails only above max + slack, so the cut fires BEFORE the gate
+untagged_ci_slack         = 10   # CB-2116(b) fails only above max + slack, so the cut fires BEFORE the gate
 max_release_age_hours     = 72
 max_tickets_per_release   = 0    # 0 = no cap. Set it only if you want one
 staleness_grace_minutes   = 60
@@ -573,8 +595,8 @@ pmat goal status | stop [--now] | ledger [--write]
 labels of the tickets in the release: any `breaking-change` → major; else any
 `enhancement`/`feature` → minor; else patch. That is the Rust idiom — the number
 describes what is in the release, so it cannot be argued about. The derived number is
-what the release is called: when it differs from the milestone's title, the cut renames
-the milestone before tagging (§4.1).
+what the release is called: when it differs from the milestone's title, the cut REFUSES and
+names both numbers rather than editing the surface the next gate reads (§4.1).
 
 **The boundary** is evaluated after each ticket reaches `MERGED`; first to fire cuts:
 
@@ -655,6 +677,36 @@ the step that delivered it, never before. A specification that
 cites its own outputs as though they already existed is exactly the drift this document
 is about — and every OTHER path and command in this file resolves, checked with the two
 greps `CLAUDE.md` prescribes for this file class.
+
+### 11.2 Decisions taken by quorum, 2026-09-11
+
+Fourteen questions were open when this document failed its own five-role review (PMAT-1303).
+None was settled by the author. Each was put to five independent seats that read a read-only
+copy of this tree, chose from options they were given without being told which one was
+drafted, and answered alone; the majority is the decision and every minority answer is kept.
+The artifact is `docs/audits/quorum-PMAT-1307.json`; the ten spec decisions are marked at
+the passage each one changed.
+
+The first round was **contaminated by the author**: the copy carried a roadmap file stating
+the drafted answers as fact, and one seat cited it for nine of its fourteen votes. That seat
+was discarded, the file stripped, and the three questions its removal left undecided were
+re-run on a clean copy. Both rounds are in the artifact. The lesson is recorded here because
+it is the same failure this document is about: evidence that says what you wanted it to say
+is not evidence.
+
+Four of the fourteen are programme decisions rather than text:
+
+| | decision | seats | what it changes |
+|---|---|---|---|
+| **P1** | Exactly one open milestone at a time — the next release. Work not scheduled for it carries no milestone, and the rules read "no milestone" as "not yet scheduled". | 3 of 4 | PMAT-725's re-mint, and D3's release leg above |
+| **P2** | Classify the 44 specs BEFORE minting epics: most are finished or superseded work and belong in `historical`/`superseded`; only the live set gets an epic. | 4 of 4 | PMAT-729, step 6 |
+| **P3** | CB-2111 flips after that classification, over the live set only — not after reviewing all 44. | 4 of 4 | PMAT-1300, step 7 |
+| **P4** | CB-2115 comes off the master push (§3.3). | 3 of 4 | PMAT-1309 |
+
+**P2 and P3 shrink the two largest human steps in §11** from "44 epics and 44 reviews" to
+"classify, then epic and review what is left". That is the difference between a backlog a
+person can finish and one that is quietly abandoned — which is what step 6 and step 7 have
+been since 2026-09-10.
 
 ## 12. Do-not-do
 

--- a/docs/specifications/goal-mode.md
+++ b/docs/specifications/goal-mode.md
@@ -51,7 +51,9 @@ Its house rule is adopted verbatim:
 
 ### 1.2 The finding that makes this cheap
 
-`pmat comply ledger` reports **157 CB rules, 0 ENFORCED, 157 NEUTERED**, and names one
+`pmat comply ledger` reported **157 CB rules, 0 ENFORCED, 157 NEUTERED** when this was
+written; at `f5eccdfb3` it reports **163 rules, 2 ENFORCED, 161 NEUTERED** — CB-2113 and
+CB-2115, landed by steps 2 and 4 of §11. It names one
 cause: `continue-on-error` on the `Ladder gate — pmat comply` step. Read on its own that
 says the only way to enforce anything is to unblock a step that is *currently red on four
 pre-existing failures*, and whose own comment documents a five-step sequence to unwedge it.
@@ -147,7 +149,7 @@ A **ticket** is the unit. A spec and a release are contexts a ticket sits in.
 |---|---|---|
 | `SPEC-DRAFT` | a tracked `docs/specifications/**.md` | git |
 | `SPEC-REVIEWED` | `docs/audits/spec-<slug>-review.json` exists, `spec_sha256` matches, every required role PASS | repo |
-| `EPIC-OPEN` | an open issue labelled `epic` whose body names the spec path | GitHub |
+| `EPIC-OPEN` | an open issue labelled `epic` with the spec's tickets as sub-issues (§4.3) | GitHub |
 | `TICKET-OPEN` | roadmap item with `github_issue: N`, issue `N` open, `N` a sub-issue of the epic | roadmap + GitHub |
 | `TICKET-SCHEDULED` | roadmap `release: X.Y.Z`; issue on milestone `X.Y.Z` | roadmap + GitHub |
 | `IN-PROGRESS` | roadmap `status: inprogress` | roadmap |
@@ -192,6 +194,14 @@ milestones or epics, so there is nothing about them for this PR to have broken.*
 four are re-checked on the push to master, which is where the merge actually lands and
 where a token exists.
 
+**Except when the fork PR edits the records those rules judge.** A fork cannot change
+issues, milestones or epics, but it can edit `docs/roadmaps/roadmap.yaml` and
+`docs/specifications/`, which are the other half of every one of those four rules. A fork
+PR that touches either is `not_measured` — it fails closed — because the alternative is a
+pull request that passes here and turns master red on the merge, which is the shape
+doctrine 6 exists to refuse. A fork PR that touches neither keeps the `not_applicable`
+pass above. Implemented by PMAT-1310.
+
 The four offline rules (CB-2111, 2113, 2116, 2117) run everywhere, forks included.
 
 `not_applicable` is only legitimate when the *context* is what makes it inapplicable,
@@ -218,6 +228,13 @@ except in the tag, where the `v` is added at exactly one place in the code.
 
 Strict order — tag ⊃ milestone ⊃ roadmap — so there is no bidirectional merge and no
 conflict resolution. A surface can only *fail to reflect* the one above it.
+
+**The title is the intent until the cut derives the number.** §10.3 derives the version
+from the labels of the tickets in the release, so a milestone titled `3.41.0` that
+collects a `breaking-change` ticket is titled wrongly, not scheduled wrongly. The cut
+renames the milestone to the derived number and then tags it, and RR-RELEASE is checked
+after the rename. Only the cut may rename; a rename by anyone else is the drift CB-2114
+exists to catch.
 
 **The key is the string, not the milestone's numeric id.** The teamwork lane proposed
 tracking the id so a rename would be invisible; that is rejected. Renaming a milestone
@@ -264,6 +281,10 @@ vendors: [cuda]    # optional; adds a vendor: role to E.1's required set
 escape hatch nobody can see is a hole, so `pmat comply report` lists every `historical`
 spec **by name** on every run.
 
+`status` IS the exemption, so who may change it belongs to the gate. `CODEOWNERS` covers
+`docs/specifications/`: a front-matter change needs the owner's review, which makes a flip
+out of `active` a reviewed act rather than one line in an unrelated pull request.
+
 Epic membership is read from GitHub's native **sub-issue** relation, and only from it
 (operator decision, 2026-09-09). An `Epic: #N` line in an issue body is **not** accepted:
 a body line is prose that drifts, a sub-issue is a structural edge GitHub maintains, and
@@ -296,14 +317,25 @@ Three finding classes, reported separately because they have different fixes:
 |---|---|---|
 | `ORPHAN-ROADMAP` — open item with no issue, or naming a closed/absent one | 48 | `work sync --yaml-to-github` |
 | `ORPHAN-GITHUB` — open unlabelled issue with no item | ≈53 | `work sync --github-to-yaml` |
-| `COLLISION` — two items naming one issue | **13 items all name #612** | **never auto-fixed** — a human |
+| `COLLISION` — two items naming one issue | **0 today**; 13 items named #612 until PMAT-721 resolved them in #1252 | **never auto-fixed** — a human |
 
 ### 5.2 Field predicate — tolerance TIME
 
 For each matched pair, compare `title` and the state word. A disagreement is tolerated
-only while `now − max(item.updated, issue.updated_at) < staleness_grace_minutes`
-(default 60). A time bound, not a count: "up to 3 may disagree" means three chosen
-items may be wrong forever and nobody chooses which three.
+only while `now − first_seen(disagreement) < staleness_grace_minutes` (default 60), where
+`first_seen` is when a sync first observed THIS disagreement, recorded beside the
+snapshot. A time bound, not a count: "up to 3 may disagree" means three chosen items may
+be wrong forever and nobody chooses which three. It runs from the onset and NOT from
+`max(item.updated, issue.updated_at)`, because any edit to either side moves that maximum
+and would restart the window without resolving anything — a grace window that resets on a
+touch is not a bound. Implemented by PMAT-1309.
+
+The window covers every leg, not only a field disagreement. An issue opened less than
+`staleness_grace_minutes` ago is `not_measured` rather than a finding: the sync that would
+mint its item cannot have run yet, and a rule that turns master red the instant anyone
+opens an issue is a rule someone disables. The same holds for an item added without its
+issue. Past the window it is a finding, and `pmat work sync` is the fixer. Implemented by
+PMAT-1309.
 
 ### 5.3 `RR-COHERENCE` — which side wins
 
@@ -316,8 +348,9 @@ Disjoint field sets, so there is never a merge conflict and never a prompt.
 
 ### 5.4 Landing green
 
-CB-2115 cannot land while 13 items collide on #612 — a gate red on arrival is a gate
-someone disables. Sequence:
+CB-2115 could not land while 13 items collided on #612 — a gate red on arrival is a gate
+someone disables. PMAT-721 resolved them in #1252 and 0 collide today; the sequence that
+got there:
 
 1. `pmat work sync` becomes real, `--check-only` first. It **reports**.
 2. The 13 collisions are resolved **by a human under their own ticket**. Which of the 13
@@ -386,10 +419,10 @@ legitimate quorum. That is what "pmat does not depend on Claude or agy" means co
 | **CB-2110** | E | every `active` spec names an open epic issue with ≥1 sub-issue | delete the `epic:` line | `traceability` → `gate` |
 | **CB-2111** | E.1 | every `active` spec has a review artifact whose hash matches and whose roles all PASS | **append one space to the spec** | `traceability` → `gate` |
 | **CB-2112** | A | every open item has a `github_issue`, open, whose number is the item's numeric tail | null one `github_issue` | `traceability` → `gate` |
-| **CB-2113** | C | every non-merge commit in `v<latest>..HEAD` carries `Pmat-Ticket: <id>` naming a real, non-terminal item | `git commit --allow-empty -m 'no trailer' --no-verify` | `traceability` → `gate` |
+| **CB-2113** | C | on a PR: every non-merge commit the PR adds carries `Pmat-Ticket: <id>` naming a real, NON-TERMINAL item whose `release` is the open milestone or an earlier one; on master: every non-merge commit in `v<latest>..HEAD` names a real item, any status | `git commit --allow-empty -m 'no trailer' --no-verify` | `traceability` → `gate` |
 | **CB-2114** | B, F1 | every open item has `release:`, its milestone exists, its issue is on it | remove one `release:` | `traceability` → `gate` |
 | **CB-2115** | D | the open sets are in bijection, and no matched pair has disagreed past the grace window | close one linked issue, leave the item open | `traceability` → `gate` |
-| **CB-2116** | B, F2 | (a) every commit in a tag's range carries a trailer for a ticket of that release; (b) `count(v<latest>..master) ≤ max_untagged_commits` | move a merged ticket's `release` | `traceability` → `gate` |
+| **CB-2116** | B, F2 | (a) every non-merge commit in a tag's range carries a trailer for a ticket of that release; (b) `count(v<latest>..master) ≤ max_untagged_commits + untagged_ci_slack` | move a merged ticket's `release` | `traceability` → `gate` |
 | **CB-2117** | G | `docs/status/goal-ledger.md` matches what the generator computes now | hand-edit a row | `traceability` → `gate` |
 
 All eight are `CheckSeverity::Error`. Anything less reports and never fails — the mistake
@@ -401,7 +434,7 @@ CB-2101/2102's own comments name.
 currently red on four pre-existing failures, and unwedging it is a five-step sequence
 documented in `.github/workflows/quality-gate.yml` that would redden a required context on master and every
 open PR. Routing around it is not forum-shopping — it is refusing to make eight new rules
-hostage to a deadlock they did not cause. The 157 stay behind it and this document does
+hostage to a deadlock they did not cause. The other 161 stay behind it and this document does
 **not** claim to fix them (§8.10).
 
 A new job in `.github/workflows/ci.yml`, wired exactly as `roadmap-validate` is:
@@ -425,10 +458,11 @@ A new job in `.github/workflows/ci.yml`, wired exactly as `roadmap-validate` is:
         run: ./target/debug/pmat comply check --checks CB-2110,CB-2111,CB-2112,CB-2113,CB-2114,CB-2115,CB-2116,CB-2117
 ```
 
-added to **both** `gate`'s `needs:` and its result loop (`.github/workflows/ci.yml:31-50`). Both: the
+added to **both** `gate`'s `needs:` and its result loop (the `gate` job in
+`.github/workflows/ci.yml`). Both: the
 comment above `roadmap-validate` is explicit that the loop is what fails.
 
-`.github/workflows/ci.yml:43` is `if [ "$result" != "success" ]`, so a `skipped` or `cancelled` job also
+`The result loop's `if [ "$result" != "success" ]` treats a `skipped` or `cancelled` job as a failure, so it also
 fails the gate — the classic `if: always()` + `needs: skipped` hole is already closed
 here, verified.
 
@@ -460,19 +494,24 @@ bypasses, and adding the trigger costs nothing.
    measure **master**, not merely the PR — see §7. Setting it is a ruleset change on
    `13878864`; until it is made, CB-2113 measures the PR's commits only and says so in
    its output rather than pretending to cover master.
-5. **A trailer proves a claim, not the work.** `Pmat-Ticket: PMAT-999` on an unrelated
+5. **Three rules describe more than the code does today**, each with its ticket: CB-2113's
+   master leg reports `not_applicable` there for now (PMAT-1308), CB-2115's grace
+   window still runs from `max(updated)` rather than the onset (PMAT-1309), and the
+   fork carve-out above is not yet implemented (PMAT-1310). Each is stated here rather
+   than left for a reader to discover by running it.
+6. **A trailer proves a claim, not the work.** `Pmat-Ticket: PMAT-999` on an unrelated
    diff passes CB-2113. Only a quorum reading the diff against the ticket defends this,
    and that is a skill, not a gate.
 6. **Lane independence is unverifiable from a file** (§6.2), demonstrated twice in this
    document's own production.
-7. **Publishing needs a token pmat does not hold.** `pmat goal` cuts tags and opens
+8. **Publishing needs a token pmat does not hold.** `pmat goal` cuts tags and opens
    release PRs; it never publishes.
-8. **Four rules need network.** On a fork they are `not_applicable` (§3.3); on a
+9. **Four rules need network.** On a fork they are `not_applicable` (§3.3); on a
    same-repo PR without a token they are `not_measured` and fail.
-9. **The `gate` requirement lives in a ruleset this repository does not own.** An org
+10. **The `gate` requirement lives in a ruleset this repository does not own.** An org
    admin can disable ruleset 13878864 and every rule here silently becomes decoration.
    P2 makes that *visible* — the manifest/live comparison goes red — but cannot prevent it.
-10. **This does not un-NEUTER the other 157 rules.** It builds a second, working path for
+11. **This does not un-NEUTER the other 161 rules.** It builds a second, working path for
     eight. Saying otherwise would be the kind of claim `pmat comply numeric-claims` exists
     to catch.
 
@@ -507,7 +546,8 @@ fixed tool list, and that is the defect not to repeat.
 # actually key on is (a) semver semantics read from what is IN the release, and
 # (b) how much is sitting unreleased. Both are below; the ticket cap is opt-in and
 # unset by default.
-max_untagged_commits      = 60   # the repo's own MEDIAN commits-per-release. 44 today
+max_untagged_commits      = 60   # the repo's own MEDIAN commits-per-release, over v3.30.0..v3.40.0
+untagged_ci_slack         = 20   # CB-2116(b) fails only above max + slack, so the cut fires BEFORE the gate
 max_release_age_hours     = 72
 max_tickets_per_release   = 0    # 0 = no cap. Set it only if you want one
 staleness_grace_minutes   = 60
@@ -532,7 +572,9 @@ pmat goal status | stop [--now] | ledger [--write]
 **The version number is derived, never chosen.** Semver semantics are read from the
 labels of the tickets in the release: any `breaking-change` → major; else any
 `enhancement`/`feature` → minor; else patch. That is the Rust idiom — the number
-describes what is in the release, so it cannot be argued about.
+describes what is in the release, so it cannot be argued about. The derived number is
+what the release is called: when it differs from the milestone's title, the cut renames
+the milestone before tagging (§4.1).
 
 **The boundary** is evaluated after each ticket reaches `MERGED`; first to fire cuts:
 
@@ -640,20 +682,24 @@ greps `CLAUDE.md` prescribes for this file class.
 
 ## 14. Verification ledger
 
-| claim | command | measured |
-|---|---|---|
-| ruleset requires unprefixed `gate` | `gh api …/rules/branches/master --jq …` | `["gate"]`, ruleset 13878864 active |
-| branch protection requires 5 others | `gh api …/branches/master/protection --jq …` | `ci / gate`, `feature-gate`, docs.rs, `pmat score`, `provable ladder` |
-| both are distinct checks on a PR | `gh pr view 1243 --json statusCheckRollup` | `["ci / gate","gate"]` |
-| `src/services/gate_effect/required.rs` cannot see rulesets | `grep -c "rules/branches" src/services/gate_effect/required.rs` | `0` |
-| the manifest omits `gate` | `cat .github/required-status-checks.txt` | 5 entries, none is `gate` |
-| 157 rules, 0 enforced | `pmat comply ledger` | `rules: 157 / ENFORCED: 0 / NEUTERED: 157` |
-| a skipped `needs` fails the gate | `sed -n '43p' .github/workflows/ci.yml` | `if [ "$result" != "success" ]` |
-| `merge_group` absent | `grep -rn merge_group .github/` | no matches |
-| 13 items collide on #612 | roadmap parse | 13 of 61 open items carry an issue; **1 distinct** |
-| trailer coverage | `git log v3.39.0..master --no-merges --format='%(trailers:key=Pmat-Ticket,valueonly)'` | 30 of 81 (37%) |
-| untagged commits | `git rev-list --count v3.40.0..master` | 44 |
-| release cadence: 11 tags in 24 days, median 59 commits | `git tag --sort=creatordate` + `git rev-list --count <prev>..<tag>` | 17 min, 208 max, 59 median over `v3.30.0..v3.40.0` |
-| CB-148 cannot fail | `src/models/comply_config_impls.rs:127` | `unconfigured` → `Warning` → `should_fail(...)` = `false` |
+| claim | command | measured at `d3eef0198`, when this was written | now, at `f5eccdfb3` |
+|---|---|---|---|
+| ruleset requires unprefixed `gate` | `gh api …/rules/branches/master --jq …` | `["gate"]`, ruleset 13878864 active | unchanged |
+| branch protection requires 5 others | `gh api …/branches/master/protection --jq …` | `ci / gate`, `feature-gate`, docs.rs, `pmat score`, `provable ladder` | unchanged |
+| both are distinct checks on a PR | `gh pr view 1243 --json statusCheckRollup` | `["ci / gate","gate"]` | unchanged |
+| `src/services/gate_effect/required.rs` cannot see rulesets | `grep -c "rules/branches" src/services/gate_effect/required.rs` | `0` | **3** — step 0 landed |
+| the manifest omits `gate` | `cat .github/required-status-checks.txt` | 5 entries, none is `gate` | **6**, `gate` among them (PMAT-717) |
+| rules and how many are enforced | `pmat comply ledger` | `rules: 157 / ENFORCED: 0 / NEUTERED: 157` | **163 / 2 / 161** — CB-2113, CB-2115 |
+| a skipped `needs` fails the gate | the result loop in the `gate` job | `if [ "$result" != "success" ]` | unchanged |
+| `merge_group` absent | `grep -rn merge_group .github/` | no matches | **present** — step 2 landed |
+| items colliding on one issue | roadmap parse | 13 of 61 open items carry an issue; **1 distinct** | **0 open collide**; 14 items name #612, all completed (PMAT-721) |
+| trailer coverage | `git log v<latest>..master --no-merges --format='%(trailers:key=Pmat-Ticket,valueonly)'` | 30 of 81 (37%) since `v3.39.0` | **168 of 179 (94%)** since `v3.40.0` |
+| untagged commits | `git rev-list --count v<latest>..master` | 44 | **202** — above `max_untagged_commits`, and §10 is not built yet |
+| release cadence: 11 tags in 24 days, median 59 commits | `git tag --sort=creatordate` + `git rev-list --count <prev>..<tag>` | 17 min, 208 max, 59 median over `v3.30.0..v3.40.0` | unchanged, the same window |
+| CB-148 cannot fail | `src/models/comply_config_impls.rs:127` | `unconfigured` → `Warning` → `should_fail(...)` = `false` | **retired**, superseded by CB-2110 (PMAT-728) |
+
+Every `now` value was re-measured by PMAT-1307 against `f5eccdfb3`. A row that moved is
+a claim this document used to make and no longer does; a row marked unchanged was checked,
+not assumed.
 
 GOAL-MODE-SPEC-END


### PR DESCRIPTION
**PMAT-1307** (issue #1307). goal-mode.md failed its own five-role review under PMAT-1303 (#1303). This is the revision — and it is also the PR that **unwedges master**.

## Master is red, and this PR is what makes it green

`traceability` on master `5af9a0f0d` fails CB-2115 ORPHAN-GITHUB on five open issues with no roadmap item: **#1306, #1307, #1308, #1309, #1310**. No commit caused it — CB-2115 reads GitHub live, so master's verdict changed while master did not. This PR adds all five items, which is the only thing that can clear it. #1306 is the live instance of the gap D10 and P4 are about: an issue opened by hand at 05:56Z reddened a green commit at 06:08Z.

## The fourteen open questions were decided by quorum, not by me

Five independent seats read a read-only copy of this tree, chose from options they were given **without being told which one was drafted**, and answered alone. Majority decides; every minority answer is kept. Artifact: `docs/audits/quorum-PMAT-1307.json`.

**It overturned five of my nine answers.**

| | question | decided | seats | drafted |
|---|---|---|---|---|
| D1 | derived version vs milestone title | **the cut REFUSES and names both numbers; it never renames** | 3/4 | retitle at the cut ❌ |
| D2 | what range CB-2113 judges | two legs, §7 rewritten to the code | 4/4 | same ✓ |
| D3 | a release leg on CB-2113 | **reported, not failed, until a milestone scheme exists** | 4/4 | fails immediately ❌ |
| D4 | what makes an issue an epic | sub-issue membership alone | 4/4 | same ✓ |
| D5 | when the grace window starts | **stays at `now − max(updated)`; no first-seen state file** | 4/5 | first-seen ❌ |
| D6 | CB-2116(b) vs the volume trigger | slack over the trigger, **= 10** | 3/5 | 20 ❌ |
| D7 | fork pull requests | fail closed on `roadmap.yaml` and `docs/specifications` | 3/4 | same ✓ |
| D8 | who may flip a spec's status | **nobody is bounded; the diff is the control, and the spec says so** | 4/4 | CODEOWNERS ❌ |
| D9 | "every commit" vs non-merge | non-merge throughout | 4/4 | same ✓ |
| D10 | does grace cover a missing item | yes — ORPHAN and MISSING too | **5/5** | same ✓ |

D5's reason is the one worth reading: a gate whose verdict depends on a state file that can be absent, stale or wrong cannot be judged from a clean clone. The window a touch can restart is the cheaper failure.

Four programme decisions land in a new **§11.2**: one open milestone at a time (P1, 3/4); **classify the 44 specs before minting epics** (P2, 4/4); flip CB-2111 over the live set only (P3, 3/4); and **take CB-2115 off the master push** (P4, 3/4) — it runs on PRs and on a schedule that opens a ticket instead of failing a build. P2 and P3 turn the two largest human steps in §11 from "44 epics and 44 reviews" into something a person can finish, which is what they have not been since 2026-09-10.

## Round 1 was contaminated by my own hand

The read-only copy carried this roadmap, whose PMAT-1307 acceptance criteria state the drafted answers as fact. One seat cited `roadmap.yaml:6217` as authority for **nine of its fourteen votes** — and voted the drafted option every time. That seat is discarded from every tally, the file and the PMAT-1303 receipt were stripped from the copy, and the three questions its removal left undecided (D5, D6, D10) were re-run on a clean copy with five fresh seats. Both rounds are in the artifact, with per-seat verdicts, summaries and conversation ids. Fingerprints before and after each round are identical — no lane escaped, which is the fifth quorum in this programme where that had to be checked.

Had that seat been counted, D6 would have landed on 20 instead of 10, and D1 and D5 would have kept the drafted answers.

## What else lands

§14 is rebuilt as a dated two-column ledger; §1.2, §5.1, §5.4, §7.1 and §8 counts are corrected against the tree; two line-number references become names; §8's duplicated list number is fixed.

**Tickets rewritten to the decisions** — PMAT-1309 (#1309) was filed for the mechanism the quorum refused, so its title, acceptance criteria and notes are now D10 + P4; PMAT-1308 (#1308) takes D3's warning-first leg. #1307–#1310 each carry the decision on GitHub.

## Verification

- `scripts/work-sync-control.sh`: 4/4 arms — the roadmap round-trips byte-for-byte
- `pmat work validate`: exit 0 (it caught a plain scalar with a colon before the commit, not after)
- `pmat work sync --check-only` against live GitHub: exit 0, **97 items ↔ 97 issues, bijection, 0 tolerated**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
