### PR TITLE
fix(PMAT-1319): the AST phase runs when a cache-dependent analysis needs it — no more green report of nothing

### DIFF
--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -6472,3 +6472,23 @@ roadmap:
   labels:
   - kind:code
   notes: 'Found climbing to 95% (PMAT-1317). command_routing.rs, the one place every pmat subcommand passes through, reads 3.3% covered; its 11 routing tests and 86 siblings sit in an include! hub attached only under cfg(pmat_broken_tests) with the comment TEMPORARILY DISABLED: File splitting broke syntax. Lifting the hub alone: 98 x CommandDispatcher not in scope, 14 x crate::demo missing, 2 x new WorkCommands fields — stale imports and API drift, not syntax. A routing arm can be mis-wired today and nothing fails.'
+- id: PMAT-1324
+  github_issue: 1324
+  item_type: bug
+  title: 'pmat comply check runs .pmat-ratchet.toml measurement commands with no recursion guard: fork bomb when a measurement calls pmat comply'
+  status: planned
+  priority: critical
+  assigned_to: null
+  created: 2026-09-11T14:21:00Z
+  updated: 2026-09-11T14:21:00Z
+  spec: null
+  acceptance_criteria:
+  - a measurement command that invokes pmat comply is refused or bounded — the recursion is detected rather than run, and the refusal names the offending entry
+  - every measurement command runs under a timeout and a depth limit, both set in one place and both proven by a test that plants a self-referential measurement and asserts the process count stays bounded
+  - the guard is proven on the reproduction from the issue rather than asserted from the code
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - kind:code
+  notes: 'Filed by the operator 2026-09-11 after pmat 3.40.0 took Lambda-Vector to a 1-minute load average of 3,026 on 48 cores with 9,740 processes. Path: pmat comply ratchet -> measurement -> pmat comply check -> check_metrics_ratchet -> the same measurement, fanning out by the number of ratchet entries at every level. Named files: check_metrics_ratchet.rs:69, metrics_ratchet/measure.rs:210 (Command::new bash), check_builders_ratchet.rs:10. Triaged as critical: it is a denial of service against the developer''s own machine, reachable from a documented workflow (ratcheting a comply check''s own finding count).'

--- a/docs/status/unrun-tests-ledger.md
+++ b/docs/status/unrun-tests-ledger.md
@@ -14,7 +14,7 @@ Legs consulted (3):
 - `feature-matrix.yml:feature-tests[mcp-integration]`
 - `feature-matrix.yml:feature-tests[unified-protocol]`
 
-24103 of 27327 lib tests are executed; 3224 are compiled by no leg.
+24104 of 27328 lib tests are executed; 3224 are compiled by no leg.
 
 ## `<unsatisfiable>` — 2195 test(s)
 

--- a/src/services/deep_context/analyzer_core/spawn.rs
+++ b/src/services/deep_context/analyzer_core/spawn.rs
@@ -3,7 +3,7 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use tracing::debug;
+use tracing::{debug, info};
 
 use crate::services::cache::{CacheConfig, SessionCacheManager};
 use crate::services::deep_context::analyzer_core::types::{
@@ -11,6 +11,27 @@ use crate::services::deep_context::analyzer_core::types::{
 };
 use crate::services::deep_context::AnalysisType;
 use crate::services::deep_context::DeepContextAnalyzer;
+
+/// Whether `analysis_type`'s function cannot produce a real result unless the
+/// AST phase has already run — either because it reads a process-global
+/// `*_UNIFIED_CACHE` DashMap that ONLY the AST phase fills (`analyze_single_file_complexity`
+/// in `analysis_functions/metrics_complexity.rs` maps every file to `None` on a
+/// cache miss, so `Complexity` silently reports zero files rather than erroring —
+/// see #1319), or because it accepts a `prebuilt_context: Option<Arc<ProjectContext>>`
+/// that lets it reuse the AST phase's parse instead of a slower from-scratch one
+/// (`analyze_provability_with_context`, `analyze_dag_with_context` in
+/// `analysis_functions/metrics_analyses.rs` — `Provability` and `Dag`).
+///
+/// `DeadCode` and `BigO` parse independently and never touch a `*_UNIFIED_CACHE`
+/// or a `prebuilt_context`. `TechnicalDebtGradient` never spawns a task at all
+/// (`spawn_analysis_task` maps it to `Ok(())` — it is computed later in
+/// `correlate_defects`), so it is excluded too.
+fn needs_ast_cache(analysis_type: &AnalysisType) -> bool {
+    matches!(
+        analysis_type,
+        AnalysisType::Complexity | AnalysisType::Provability | AnalysisType::Dag
+    )
+}
 
 impl DeepContextAnalyzer {
     #[provable_contracts_macros::contract("pmat-core.yaml", equation = "path_exists")]
@@ -30,7 +51,24 @@ impl DeepContextAnalyzer {
         // instead of redundantly calling syn::parse_file() (~3 GB savings).
         let mut prebuilt_context: Option<Arc<crate::services::context::ProjectContext>> = None;
 
-        if self.config.include_analyses.contains(&AnalysisType::Ast) {
+        let ast_requested = self.config.include_analyses.contains(&AnalysisType::Ast);
+        let run_ast = ast_requested || self.config.include_analyses.iter().any(needs_ast_cache);
+
+        if run_ast {
+            if !ast_requested {
+                if let Some(dependent) = self
+                    .config
+                    .include_analyses
+                    .iter()
+                    .find(|t| needs_ast_cache(t))
+                {
+                    info!(
+                        "AST phase added implicitly: {:?} reads a cache only the AST phase fills",
+                        dependent
+                    );
+                }
+            }
+
             let file_classifier_config = self.config.file_classifier_config.clone();
             let path = project_path.to_path_buf();
             let ast_result = tokio::spawn(async move {
@@ -70,8 +108,14 @@ impl DeepContextAnalyzer {
                 }));
             }
 
-            self.integrate_analysis_result(&mut results, ast_result);
-            analysis_progress.inc(1);
+            // Only integrate the AST result into `results.ast_contexts` when the
+            // caller actually asked for Ast — an implicitly-added AST phase fills
+            // the caches and `prebuilt_context` above, but must not hand the
+            // caller `ast_contexts` it never requested (#1319).
+            if ast_requested {
+                self.integrate_analysis_result(&mut results, ast_result);
+                analysis_progress.inc(1);
+            }
         }
 
         // Phase 2: Spawn remaining analyses in parallel (they benefit from populated caches)

--- a/src/services/deep_context/analyzer_formatting/analysis_sections_tests.rs
+++ b/src/services/deep_context/analyzer_formatting/analysis_sections_tests.rs
@@ -95,14 +95,15 @@ async fn complexity_hotspots_name_the_fixtures_most_complex_function_first() {
     );
 }
 
-/// Found while covering this file: `include_analyses: [Complexity]` WITHOUT
-/// `Ast` yields `Some(report)` with ZERO files — the complexity phase reads a
-/// process-global cache the AST phase fills, and an empty cache is not an
-/// error. The CLI cannot reach this (`--include` is refused as unimplemented),
-/// but a library caller can, and gets a green report of nothing. Pinned here
-/// so a fix — an error, or an implicit AST phase — changes a test.
+/// PMAT-1319: `include_analyses: [Complexity]` WITHOUT `Ast` used to yield
+/// `Some(report)` with ZERO files — the complexity phase reads a process-global
+/// cache only the AST phase fills, and an empty cache was not treated as an
+/// error. `execute_parallel_analyses_with_progress` now runs the AST phase
+/// implicitly whenever a cache-dependent phase (Complexity, Provability, Dag)
+/// is requested without Ast, so the cache is populated either way — but the
+/// caller must not receive `ast_contexts` it never asked for.
 #[tokio::test]
-async fn complexity_without_ast_is_an_empty_report_that_claims_success() {
+async fn complexity_without_ast_still_finds_the_fixtures_functions() {
     let (_dir, _analyzer, context) = analyzed(vec![AnalysisType::Complexity]).await;
     let report = context
         .analyses
@@ -111,9 +112,26 @@ async fn complexity_without_ast_is_an_empty_report_that_claims_success() {
         .expect("the phase ran and returned Ok");
     assert_eq!(
         report.files.len(),
-        0,
-        "PMAT-1319: if this now finds the file, the cold-cache trap is fixed — retire this test \
-         and drop the Ast from the other tests' requests"
+        1,
+        "the implicit AST phase fills the cache, so the one fixture file is found"
+    );
+    let names: Vec<&str> = report
+        .files
+        .iter()
+        .flat_map(|f| f.functions.iter())
+        .map(|f| f.name.as_str())
+        .collect();
+    assert!(
+        names.contains(&"tangled"),
+        "tangled must be present; got {names:?}"
+    );
+    assert!(
+        names.contains(&"plain"),
+        "plain must be present; got {names:?}"
+    );
+    assert!(
+        context.analyses.ast_contexts.is_empty(),
+        "Ast was not requested, so the implicit AST phase must not leak ast_contexts to the caller"
     );
 }
 

--- a/src/services/deep_context/scope_wiring_tests.rs
+++ b/src/services/deep_context/scope_wiring_tests.rs
@@ -163,3 +163,35 @@ async fn an_empty_include_pattern_list_still_means_every_file() {
         .expect("analysis");
     assert_eq!(context.file_tree.total_files, 2);
 }
+
+/// PMAT-1319: `config()` requests `Complexity + Satd` without `Ast` — the
+/// implicit AST phase must still fill the process-global cache Complexity
+/// reads, so this fixture's own `complexity_report` is a real report and not
+/// the empty-but-Ok result the defect produced.
+#[tokio::test]
+async fn complexity_report_is_real_without_ast_in_the_request() {
+    let dir = fixture();
+    let context = DeepContextAnalyzer::new(config(vec![]))
+        .analyze_project(&dir.path().to_path_buf())
+        .await
+        .expect("analysis");
+    let report = context
+        .analyses
+        .complexity_report
+        .as_ref()
+        .expect("Complexity was requested");
+    assert!(
+        !report.files.is_empty(),
+        "the implicit AST phase must populate the cache Complexity reads"
+    );
+    let names: Vec<&str> = report
+        .files
+        .iter()
+        .flat_map(|f| f.functions.iter())
+        .map(|f| f.name.as_str())
+        .collect();
+    assert!(
+        names.contains(&"tangled"),
+        "tangled must be present; got {names:?}"
+    );
+}


### PR DESCRIPTION
**Stacked on #1316** (its `analysis_sections_tests.rs` is where the pinned test lives). Merge #1316 first; until then this PR's diff against master carries both.

Closes #1319. Implemented in parallel with #1320 by a `paiml-impl-worker` on a disjoint path scope; every claim below was re-run by the orchestrator.

## The defect

`DeepContextAnalyzer` with `include_analyses: vec![AnalysisType::Complexity]` and no `Ast` returns **`Ok(context)` with `complexity_report: Some(report)` whose `files` is empty** — for a fixture with two functions. `analyze_single_file_complexity` reads process-global `*_UNIFIED_CACHE` maps that only the AST phase fills; with `Ast` absent, phase 1 is skipped, every file misses the cache, and `aggregate_results(vec![])` is a green report of nothing.

## The fix

`spawn.rs` runs the AST phase when any cache-dependent analysis is requested, whether or not the caller asked for `Ast`. The dependency set lives in one place — `fn needs_ast_cache` — with a doc comment that names each member **and each non-member with its reason**:

- **needs it**: `Complexity` (reads `*_UNIFIED_CACHE`), `Provability`, `Dag` (take the AST phase's `prebuilt_context`)
- **does not**: `DeadCode`, `BigO` (parse independently), `TechnicalDebtGradient` (spawns no task at all — computed later in `correlate_defects`)

The AST result is still only *integrated* into `results.ast_contexts` when the caller asked for `Ast`, so an implicit run is not leaked to a caller that did not request it. `info!` says when it happens.

## Verification (re-run by the orchestrator, not taken from the worker)

- **GREEN**: `cargo test --lib -- analysis_sections_tests scope_wiring_tests` → **8 passed, 0 failed**
- **RED**: with `spawn.rs` alone reverted, `complexity_without_ast_still_finds_the_fixtures_functions` **FAILS** — the test dies on exactly the change it is about
- the pinned test from #1316 is **inverted**, as its own message instructed, and now asserts the fixture's `tangled` and `plain` are found *and* that `ast_contexts` stays `None`
- a new test in `scope_wiring_tests.rs` proves that file's own fixture — which requests `Complexity + Satd` without `Ast` — now yields a real report
- `cargo fmt --all -- --check` and `cargo clippy --all-targets -- -D warnings`: clean
- ratchets unmoved: `panic!(` 785, SATD comment markers 324

🤖 Generated with [Claude Code](https://claude.com/claude-code)
