### PR TITLE
docs(PMAT-1336): lifecycle gets its own ticket — a ticket cannot complete itself, and no other ticket's criteria cover doing it

### DIFF
--- a/docs/audits/quorum-PMAT-1336.json
+++ b/docs/audits/quorum-PMAT-1336.json
@@ -1,0 +1,71 @@
+{
+  "ticket": "PMAT-1336",
+  "base": "master",
+  "base_resolved": "origin/master",
+  "base_note": "local master differs from origin/master by 112 commit(s); judged against origin/master",
+  "head": "fe04f49855e3a304e5809b82cc1ff28d59d62fa7",
+  "diff_sha256": "49c40d49bdeed79aa038901d6cd9713dfda43cde7073a4aa5c1f3cad75e6b87c",
+  "width": 3,
+  "executor": "agy",
+  "prompt_mode": "inline",
+  "prompt_bytes": 5048,
+  "author": {
+    "model": "Opus 5 (1M context)",
+    "family": "claude",
+    "source": "measured"
+  },
+  "agreed": true,
+  "lanes": [
+    {
+      "lane": 1,
+      "status": "SUCCESS",
+      "verdict": "PASS",
+      "summary": "The diff perfectly executes the intent of PMAT-1336. By modifying only `docs/roadmaps/roadmap.yaml`, it marks previously merged tickets (PMAT-1329 and PMAT-1332) as `completed`, resolving the CB-2113 Catch-22 that prevents tickets from completing themselves. Adding PMAT-1336 to the roadmap as `inprogress` is necessary to satisfy the first acceptance criterion (maintaining a bijection between non-terminal roadmap items and open GitHub issues). There are no out-of-scope changes, weakened gates, or unbacked claims.",
+      "findings": [],
+      "raw_bytes": 2077,
+      "err_bytes": 0,
+      "envelope_status": "SUCCESS",
+      "model": "gemini-3.1-pro-high",
+      "model_measured": "gemini-3.1-pro-high",
+      "family": "gemini"
+    },
+    {
+      "lane": 2,
+      "status": "SUCCESS",
+      "verdict": "PASS",
+      "summary": "The diff correctly implements PMAT-1336 by creating the lifecycle ticket itself and using its authority to mark PMAT-1329 and PMAT-1332 as completed. This perfectly adheres to the ticket's stated purpose of providing a valid scope for cross-ticket completions, it respects the constraint to only modify roadmap.yaml, and it does not violate any acceptance criteria.",
+      "findings": [],
+      "raw_bytes": 2866,
+      "err_bytes": 0,
+      "envelope_status": "SUCCESS",
+      "model": "gemini-3.1-pro-high",
+      "model_measured": "gemini-3.1-pro-high",
+      "family": "gemini"
+    },
+    {
+      "lane": 3,
+      "status": "SUCCESS",
+      "verdict": "PASS",
+      "summary": "The diff strictly conforms to the acceptance criteria of PMAT-1336. It limits its changes to the whitelisted 'docs/roadmaps/roadmap.yaml' file and successfully transitions PMAT-1329 and PMAT-1332 to a terminal 'completed' state, acting as the designated lifecycle ticket. There are no source changes or other forbidden modifications that refute the ticket's requirements.",
+      "findings": [],
+      "raw_bytes": 1773,
+      "err_bytes": 0,
+      "envelope_status": "SUCCESS",
+      "model": "gemini-3.1-pro-high",
+      "model_measured": "gemini-3.1-pro-high",
+      "family": "gemini"
+    }
+  ],
+  "dissent": [],
+  "dedup": [],
+  "uncovered": [],
+  "coverage_source": "lanes",
+  "partial": false,
+  "partial_reasons": [],
+  "auto_merge": {
+    "checked": true,
+    "was_armed": false,
+    "disarmed": false,
+    "note": "auto-merge not armed"
+  }
+}

--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -6516,11 +6516,11 @@ roadmap:
   github_issue: 1329
   item_type: bug
   title: 'cargo test --lib mutates a TRACKED file: the dispatcher tests append duplicate ✅ COMPLETED markers to docs/execution/roadmap.md on every run'
-  status: inprogress
+  status: completed
   priority: high
   assigned_to: null
   created: 2026-09-11T18:20:00Z
-  updated: 2026-09-12T01:11:45Z
+  updated: 2026-09-12T04:02:54Z
   spec: null
   acceptance_criteria:
   - 'the full cargo test --lib leaves git status --porcelain EXACTLY as it found it — tracked and untracked, whole tree — proven by a check that runs the suite rather than by reading the tests. Corrected from empty to unchanged: this repository legitimately carries untracked scratch a developer has every right to have, so empty would fail on their desk and teach them to skip the check, while unchanged is stricter for the question the ticket asks because a NEW untracked file registers too'
@@ -6556,11 +6556,11 @@ roadmap:
   github_issue: 1332
   item_type: task
   title: 'triage: four orphan issues from the PMAT-1313 cycle need roadmap items (kind:triage)'
-  status: inprogress
+  status: completed
   priority: high
   assigned_to: null
   created: 2026-09-11T18:45:00Z
-  updated: 2026-09-11T18:45:00Z
+  updated: 2026-09-12T04:02:54Z
   spec: null
   acceptance_criteria:
   - every orphan issue named in the ticket has a roadmap item whose github_issue matches, whose title matches the issue, and whose notes record the analysis rather than proposing a diff
@@ -6593,3 +6593,23 @@ roadmap:
   labels:
   - kind:code
   notes: 'Measured on PR #1327 (PMAT-1324): four rounds. Rounds 1-3 each found a real bug, which is the quorum working. Round 4 found nothing but scope — 3 of 3 FAIL, every lane calling the wall-clock timeout unrequested, while the ticket''s own acceptance criterion 2 reads every measurement command runs under a timeout and a depth limit and the issue names no timeout as part of the defect. The lanes reasoned correctly from what they were given: a title. Writing the receipt unblocked it, but that makes correct review contingent on the author having written their own account first, which is the one thing a reviewer should not have to take on trust for what was this ticket for.'
+- id: PMAT-1336
+  github_issue: 1336
+  item_type: task
+  title: 'lifecycle: a ticket cannot complete itself, and no other ticket''s criteria cover doing it for them (kind:lifecycle)'
+  status: inprogress
+  priority: high
+  assigned_to: null
+  created: 2026-09-12T05:21:15Z
+  updated: 2026-09-12T05:21:15Z
+  spec: null
+  acceptance_criteria:
+  - every roadmap item whose issue is closed is terminal and every non-terminal item's issue is open — pmat work sync --check-only reports a bijection with zero findings against live GitHub
+  - the branch touches only docs/roadmaps/roadmap.yaml and docs/audits; any source change means it is not a lifecycle PR
+  - each completion names in the commit message the merge commit that landed the ticket, so the claim is checkable rather than asserted
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - kind:lifecycle
+  notes: 'CB-2113 requires every commit to name a NON-TERMINAL item, so a commit marking PMAT-X completed while naming PMAT-X fails it: a ticket cannot complete itself. The completion must ride in another PR — but a quorum judges a diff against the criteria of the ticket that PR names, and complete the previous ticket is in no ticket''s criteria, so it is flagged out-of-scope every time however well justified. Measured three times in one session: PR 1330 three FAIL, 1334 one FAIL, 1335 three FAIL, each naming the same cross-ticket status change. Not doing it is worse: GitHub closes the issue on merge and the item goes ORPHAN-ROADMAP under CB-2115, reddening master with no commit to blame. The repository already solved the identical problem for triage by giving it its own ticket (PMAT-1332); this is that, for lifecycle.'


### PR DESCRIPTION
**kind:lifecycle** — roadmap bookkeeping only. One file, no source change.

## Why this needed its own ticket

CB-2113 requires every non-merge commit to name a **non-terminal** roadmap item, so a commit marking PMAT-X completed while naming `Pmat-Ticket: PMAT-X` names a terminal item and fails the rule: **a ticket cannot complete itself.** The completion must ride in another PR.

But a quorum judges a diff against the acceptance criteria of the ticket that PR names — and *"complete the previous ticket"* is in no ticket's criteria. So it is flagged as out-of-scope **every time**, however well justified. Measured three times in one session: **#1330** (3 FAIL), **#1334** (1 FAIL), **#1335** (3 FAIL), each naming the same cross-ticket status change.

Not doing it is worse: GitHub closes the issue when the PR merges, leaving the item non-terminal against a closed issue — **ORPHAN-ROADMAP under CB-2115** — and master goes red with no commit to blame.

This repository already solved the identical problem for triage by giving it its own ticket (#1332). **#1336** is that, for lifecycle, with criteria a lifecycle PR can actually satisfy.

## What lands

| ticket | merged as | issue |
|---|---|---|
| PMAT-1329 | `d49871e50` (#1334) | closed by GitHub on merge |
| PMAT-1332 | `e80d79c2a` (#1328) | closed under the operator's own words |

Each completion names its merge commit, so the claim is checkable rather than asserted.

## PMAT-1331's finding, for the record

This branch began as an attempt at #1331. Converting `handle_quality_gate_exit_status`'s `process::exit(1)` into a returned `Err` compiles, un-ignores `test_quality_gate_complexity_check`, makes it pass — **and moves the observable exit status from 1 to 101**, which `quality_gate_exit_status_guard_tests.rs` caught in all three of its cases (`child exit: Some(101)`). There is no CLI error→exit-code mapping; that mapping is the prerequisite, and it is now what #1331 asks for first. The attempt is reverted and the finding lives on the issue, so no PR is needed for it.

Verified against live GitHub: **CB-2113 ✓, CB-2115 ✓ (105 items ↔ 105 issues, 0 tolerated)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
