### PR TITLE
fix(PMAT-1314): the eof_drain tests slept 300s, they were never order-dependent — the ticket was wrong and the worker said so

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -9,19 +9,16 @@ retries = 0
 slow-timeout = { period = "60s", terminate-after = 2 }
 fail-fast = false
 test-threads = "num-cpus"
-# PMAT-1314. These two tests PASS under `cargo test --lib` and HANG FOREVER under
-# nextest — measured at 300s with no progress, while the other two tests in the
-# same module pass in milliseconds. nextest gives each test its own process, so
-# whatever they depend on is supplied by another test in a shared process: an
-# order dependency, which is a defect in the tests and not in nextest.
-#
-# They are excluded HERE rather than left to time out, because a lane that ends
-# in `2 timed out` is a lane somebody disables. They are NOT excluded from
-# `cargo test`, which is what every push to master runs, so both are still
-# executed on every merge. scripts/pr-lane-control.sh asserts that this filter
-# names exactly these two, that both still exist in the tree, and that nothing
-# excludes them from the pre-release lane.
-default-filter = 'not (test(=mcp_pmcp::simple_unified_server::eof_drain_tests::eof_does_not_signal_while_a_request_is_in_flight) + test(=mcp_pmcp::simple_unified_server::eof_drain_tests::waits_for_every_outstanding_request))'
+# PMAT-1314. The default-filter that used to sit here excluded two tests
+# (`eof_does_not_signal_while_a_request_is_in_flight`,
+# `waits_for_every_outstanding_request`) that were believed to hang under
+# nextest only, from an order dependency on a shared process. That belief was
+# never verified: both tests hung under plain `cargo test --lib` too, and in
+# isolation — the real cause was `EofSignalingTransport`'s 300s drain backstop
+# being awaited to completion with nothing able to cancel it, which the tests
+# now avoid via a per-instance override. See
+# `src/mcp_pmcp/simple_unified_server.rs` (`drain_backstop` field and the two
+# tests' doc comments). The local fast lane runs everything again.
 
 [profile.coverage]
 # Optimized for coverage runs with instrumentation

--- a/docs/audits/impl-PMAT-1314-receipt.md
+++ b/docs/audits/impl-PMAT-1314-receipt.md
@@ -1,0 +1,65 @@
+# IMPL-PMAT-1314 — two tests that "hung under nextest" were sleeping for 300 seconds, and the ticket blamed the wrong thing
+
+## Identity
+
+| field | value |
+|---|---|
+| ticket | PMAT-1314 (`kind:code`), filed from the Pareto lane work (PMAT-1313) |
+| branch | `PMAT-1314-worker`, from master `4e07ede5c` |
+| `gate_cmd` | `cargo fmt --all -- --check && cargo clippy --all-targets -- -D warnings` |
+| model gate | `model=opus class=opus decision=admit basis=file` |
+
+## The ticket's criteria, restated (lanes are briefed with a title — #1333)
+
+1. the root cause is named — what the test depends on that another test supplies — rather than worked around with a longer timeout;
+2. both tests pass under `cargo nextest run --lib` in isolation;
+3. the `default-filter` in `.config/nextest.toml` is removed in the same PR and `pr-lane-control.sh` arm 3 is updated or retired with it.
+
+## The diagnosis was wrong, and the worker refused to propagate it
+
+The ticket — written by me — said `eof_does_not_signal_while_a_request_is_in_flight` and `waits_for_every_outstanding_request` pass under `cargo test`, hang under nextest, and are therefore **order-dependent**: passing only in a process another test has warmed.
+
+The worker measured it and found otherwise, and I confirmed on master before accepting:
+
+```
+$ cargo test --lib -- …eof_drain_tests::waits_for_every_outstanding_request --exact
+test result: ok. 1 passed …    wall=384s
+```
+
+**It passes in complete isolation under plain `cargo test` — after 384 seconds.** `EofSignalingTransport` runs an unconditional, uncancellable `tokio::time::sleep(Self::DRAIN_BACKSTOP)` — 300 s — on its terminal-receive-error path (`simple_unified_server.rs:~240-256`). Production never waits it out: an outer `select!` drops the future. The tests provide no such thing. So `cargo test` sat through five minutes and reported `ok`; nextest's 120 s slow-timeout killed it and reported a hang. **Neither runner was wrong about what it saw. The framing was.** The issue carries the correction.
+
+Criterion 1 as written asked for "what the test depends on that another test supplies". Nothing did. The honest answer to criterion 1 is the mechanism above, with its line numbers.
+
+## What lands
+
+- The two tests override the drain backstop for their own run, so the terminal-error path completes without the 300 s wait. Production's constant is unchanged.
+- `.config/nextest.toml` loses its `default-filter`; the local fast lane runs everything.
+- `scripts/pr-lane-control.sh`: arm 3 now asserts the config carries **no** `default-filter`, arm 4 refuses a fixture that reintroduces one, and the two double-exclusion arms are retired with this ticket named. 8 arms.
+
+## Verification (re-run by the orchestrator)
+
+| what | result |
+|---|---|
+| RED: the acceptance command on the unmodified tree | `timeout` exit **124** (killed at the wrapper) |
+| RED, cross-checked on master under plain `cargo test` | passes after **384 s** — the sleep, not a hang |
+| GREEN: `cargo nextest run --lib -E 'test(eof_drain_tests)'` | **4 passed in 0.040 s** |
+| `cargo test --lib -- eof_drain_tests` | passes |
+| `scripts/pr-lane-control.sh` | **8/8 arms** |
+| `cargo fmt --all -- --check`, clippy `-D warnings` | clean |
+| ratchets | 785 / 324 — unmoved |
+| CB-2113 / CB-2115 | ✓ / ✓, 105 ↔ 105 |
+
+## Machine-readable
+
+orch_model: opus [V]   orch_class: opus   orch_decision: admit   orch_basis: -
+fable_binding: true   quota_age_h: absent   quota_mark: U   k_measured_at_set: 601
+
+routes:
+  ph1  class=impl            route=agy-goal w=1.00 basis=absent effort=1[U]  note=paiml-impl-worker, three files, in parallel with PMAT-1331 on a disjoint scope; it refuted the ticket's diagnosis and was right
+  ph2  class=orchestration   route=self  w=100.00  basis=absent              note=confirmed the 384s on master before accepting; corrected the issue
+
+verification:
+  cmd=cargo-test--exact(master,one-hanger)  claimed_exit=-  rerun_exit=0(384s)  log_path=/tmp/qr1314.log
+  cmd=cargo-nextest-eof_drain_tests(fixed)  claimed_exit=0  rerun_exit=0(4-passed-0.040s)  log_path=/tmp/qr1314.log
+  cmd=pr-lane-control(8-arms)  claimed_exit=0  rerun_exit=0  log_path=/tmp/qr1314.log
+  cmd=comply-check--checks-CB-2113,CB-2115  claimed_exit=-  rerun_exit=0  log_path=/tmp/qr1314.log

--- a/scripts/pr-lane-control.sh
+++ b/scripts/pr-lane-control.sh
@@ -4,19 +4,24 @@
 #
 #   arm 1 GREEN  ci.yml does NOT enable nextest, and says in the file why not
 #   arm 2 RED    a workflow that enables nextest without lifting the thread cap is refused
-#   arm 3 GREEN  the fast lane's exclusion names exactly two tests
-#   arm 4 GREEN  both named tests still exist in the tree
-#   arm 5 RED    an exclusion naming a test that does not exist is refused
-#   arm 6 GREEN  nothing excludes those two from the pre-release lane
-#   arm 7 RED    a Makefile that skips one of them from `cargo test` is refused
-#   arm 8 GREEN  the coverage ratchet file is tracked, parses, and is where ci.yml says
-#   arm 9 RED    the gate's own arithmetic fails a floor above a fixture's coverage
-#   arm 10 GREEN the gate's own arithmetic passes a floor at the fixture's coverage
-#   arm 11 RED   the gate refuses an lcov with no line records
+#   arm 3 GREEN  .config/nextest.toml carries no default-filter (the fast lane runs everything)
+#   arm 4 RED    a config that reintroduces a default-filter is refused
+#   arm 5 GREEN  the coverage ratchet file is tracked, parses, and is where ci.yml says
+#   arm 6 RED    the gate's own arithmetic fails a floor above a fixture's coverage
+#   arm 7 GREEN  the gate's own arithmetic passes a floor at the fixture's coverage
+#   arm 8 RED    the gate refuses an lcov with no line records
 #
-# Arms 2, 5 and 7 are the ones that matter: without them this script asserts that
+# Arms 2 and 4 are the ones that matter: without them this script asserts that
 # a file contains the string somebody just wrote into it, which is theater. Each
 # builds a fixture carrying the defect and requires the predicate to REFUSE it.
+#
+# PMAT-1314 retired the former arms 5, 6 and 7 (which asserted that the fast
+# lane's now-deleted default-filter named exactly two tests that exist, and
+# that nothing double-excluded them from the pre-release lane). Those two
+# tests hung from a real drain-backstop bug, not an order dependency; once
+# fixed, there is nothing left to exclude and nothing left for those arms to
+# check. See `.config/nextest.toml` and
+# `src/mcp_pmcp/simple_unified_server.rs`.
 #
 # Usage: bash scripts/pr-lane-control.sh
 set -uo pipefail
@@ -35,20 +40,8 @@ nextest_is_off_and_explained() {  # $1 = workflow file
     && grep -qF 'NEXTEST_TEST_THREADS=4' "$1" \
     && grep -qF 'PMAT-1315' "$1"
 }
-excluded_tests() {        # $1 = nextest config; prints one test path per line
-  grep -oE 'test\(=[^)]+\)' "$1" | sed 's/^test(=//; s/)$//'
-}
-test_exists() {           # $1 = full test path; true iff its fn is in the tree
-  local fn=${1##*::}
-  grep -rqE "fn ${fn}\(" src --include='*.rs'
-}
-not_skipped_in_slow_lane() {  # $1 = file that may carry cargo-test skips
-  local t
-  while read -r t; do
-    [ -n "$t" ] || continue
-    grep -qE -- "--skip[= ]+${t##*::}" "$1" && return 1
-  done < <(excluded_tests "$NT")
-  return 0
+nextest_has_no_default_filter() {  # $1 = nextest config
+  ! grep -qE '^default-filter' "$1"
 }
 
 # ── arm 1 ─────────────────────────────────────────────────────────────────────
@@ -65,50 +58,29 @@ fi
 echo "pr-lane-control: arm 2 RED   — enabling nextest under the thread cap is refused"
 
 # ── arm 3 ─────────────────────────────────────────────────────────────────────
-N=$(excluded_tests "$NT" | grep -c . )
-[ "$N" -eq 2 ] || fail_arm 3 "the fast lane's exclusion must name exactly two tests, found $N"
-echo "pr-lane-control: arm 3 GREEN — the exclusion names exactly 2 tests"
+nextest_has_no_default_filter "$NT" \
+  || fail_arm 3 "the local fast lane must not carry a default-filter — PMAT-1314 fixed the two tests' real defect (an uncancellable 300s drain backstop) instead of hiding them"
+echo "pr-lane-control: arm 3 GREEN — no default-filter, the fast lane runs everything"
 
-# ── arm 4 ─────────────────────────────────────────────────────────────────────
-while read -r t; do
-  [ -n "$t" ] || continue
-  test_exists "$t" || fail_arm 4 "excluded test does not exist in the tree: $t (a filter naming a renamed test excludes nothing, silently)"
-done < <(excluded_tests "$NT")
-echo "pr-lane-control: arm 4 GREEN — every excluded test exists"
-
-# ── arm 5 (falsifier) ─────────────────────────────────────────────────────────
-if test_exists "a::b::this_test_was_renamed_or_deleted_and_the_filter_was_not"; then
-  fail_arm 5 "the existence predicate must refuse a test that is not in the tree"
+# ── arm 4 (falsifier) ─────────────────────────────────────────────────────────
+printf '[profile.default]\ndefault-filter = "not test(=some::excluded::test)"\n' > "$T/with-filter.toml"
+if nextest_has_no_default_filter "$T/with-filter.toml"; then
+  fail_arm 4 "a config that reintroduces a default-filter must be refused"
 fi
-echo "pr-lane-control: arm 5 RED   — an exclusion naming a missing test is refused"
+echo "pr-lane-control: arm 4 RED   — a config reintroducing a default-filter is refused"
 
-# ── arm 6 ─────────────────────────────────────────────────────────────────────
-for f in Makefile "$WF"; do
-  not_skipped_in_slow_lane "$f" \
-    || fail_arm 6 "$f skips a test the fast lane already excludes — then NOTHING runs it"
-done
-echo "pr-lane-control: arm 6 GREEN — the pre-release lane still runs both"
-
-# ── arm 7 (falsifier) ─────────────────────────────────────────────────────────
-first=$(excluded_tests "$NT" | head -1); first=${first##*::}
-printf 'test-x:\n\tcargo test --lib -- --skip %s\n' "$first" > "$T/Makefile"
-if not_skipped_in_slow_lane "$T/Makefile"; then
-  fail_arm 7 "a Makefile that also skips an excluded test must be refused"
-fi
-echo "pr-lane-control: arm 7 RED   — double-exclusion is refused"
-
-# ── arms 8–11: the coverage ratchet ──────────────────────────────────────────
+# ── arms 5–8: the coverage ratchet ──────────────────────────────────────────
 # ci.yml sets coverage_min and coverage_baseline_file; sovereign-ci.yml's
 # `Enforce coverage floor` step reads lcov DA records and fails below
 # max(min, baseline). None of that is visible from this repository, so these arms
 # reproduce the step's arithmetic on a fixture and require it to answer both ways.
 BL=$(grep -oE "coverage_baseline_file: '[^']+'" "$WF" | sed "s/.*: '//; s/'$//")
-[ -n "$BL" ] || fail_arm 8 "ci.yml must name coverage_baseline_file"
+[ -n "$BL" ] || fail_arm 5 "ci.yml must name coverage_baseline_file"
 git ls-files --error-unmatch "$BL" >/dev/null 2>&1 \
-  || fail_arm 8 "$BL must be TRACKED — .pmat/ is gitignored, so a baseline there never reaches CI and the ratchet is coverage_min alone"
+  || fail_arm 5 "$BL must be TRACKED — .pmat/ is gitignored, so a baseline there never reaches CI and the ratchet is coverage_min alone"
 BASE=$(tr -dc '0-9.' < "$BL" | head -c 16)
-[ -n "$BASE" ] || fail_arm 8 "$BL must hold a number"
-echo "pr-lane-control: arm 8 GREEN — the ratchet file $BL is tracked and reads $BASE"
+[ -n "$BASE" ] || fail_arm 5 "$BL must hold a number"
+echo "pr-lane-control: arm 5 GREEN — the ratchet file $BL is tracked and reads $BASE"
 
 # the gate's arithmetic, as sovereign-ci.yml writes it: covered = DA records with hits>0
 gate_pct() { awk -F'[:,]' '/^DA:/ { t++; if ($3 > 0) c++ } END { if (t==0) print "EMPTY"; else printf "%.2f", (c/t)*100 }' "$1"; }
@@ -117,13 +89,13 @@ gate_verdict() {  # $1 lcov, $2 floor → 0 pass, 1 fail (mirrors: exit 1 iff pc
   awk -v p="$p" -v f="$2" 'BEGIN { exit (p < f) ? 1 : 0 }'
 }
 printf 'SF:a.rs\nDA:1,1\nDA:2,1\nDA:3,1\nDA:4,0\nend_of_record\n' > "$T/fixture.lcov"   # 75.00%
-if gate_verdict "$T/fixture.lcov" 80; then fail_arm 9 "a 75% fixture must FAIL an 80 floor"; fi
-echo "pr-lane-control: arm 9 RED   — 75% under an 80 floor is refused"
-gate_verdict "$T/fixture.lcov" 75 || fail_arm 10 "a 75% fixture must PASS a 75 floor"
-echo "pr-lane-control: arm 10 GREEN — 75% at a 75 floor passes"
+if gate_verdict "$T/fixture.lcov" 80; then fail_arm 6 "a 75% fixture must FAIL an 80 floor"; fi
+echo "pr-lane-control: arm 6 RED   — 75% under an 80 floor is refused"
+gate_verdict "$T/fixture.lcov" 75 || fail_arm 7 "a 75% fixture must PASS a 75 floor"
+echo "pr-lane-control: arm 7 GREEN — 75% at a 75 floor passes"
 : > "$T/empty.lcov"
-if gate_verdict "$T/empty.lcov" 0; then fail_arm 11 "an lcov with no DA records must be refused even at floor 0"; fi
-echo "pr-lane-control: arm 11 RED   — empty coverage data is refused"
+if gate_verdict "$T/empty.lcov" 0; then fail_arm 8 "an lcov with no DA records must be refused even at floor 0"; fi
+echo "pr-lane-control: arm 8 RED   — empty coverage data is refused"
 
 [ "$FAIL" -eq 0 ] || { echo "pr-lane-control: FAILED"; exit 1; }
-echo "pr-lane-control: all 11 arms behaved — nextest is off with its measurement recorded, the local fast lane excludes exactly two named tests that exist, and cargo test still runs them"
+echo "pr-lane-control: all 8 arms behaved — nextest is off with its measurement recorded, the local fast lane carries no default-filter, and cargo test runs everything"

--- a/src/mcp_pmcp/simple_unified_server.rs
+++ b/src/mcp_pmcp/simple_unified_server.rs
@@ -85,6 +85,18 @@ struct EofSignalingTransport<T: Transport> {
     /// Why the session ended, recorded on the first receive error and held
     /// until `in_flight` drains to zero.
     pending_end: Option<String>,
+    /// How long `receive()` will withhold EOF while a request is unanswered.
+    ///
+    /// A per-instance field rather than only [`Self::DRAIN_BACKSTOP`] used
+    /// directly: production always gets the full backstop (set in [`Self::new`]),
+    /// but a unit test that calls `receive()` and awaits it to completion —
+    /// with no outer `select!` to cancel it, unlike the real actor (see
+    /// `handle_terminal_receive_error`) — pays this wait in full every time.
+    /// `eof_drain_tests` overrides it to a few milliseconds so the worst-case
+    /// path it deliberately exercises does not cost 300 real seconds per test
+    /// (PMAT-1314; this, not test order, is why the two tests that observe
+    /// EOF with a request still in flight used to hang under every runner).
+    drain_backstop: std::time::Duration,
 }
 
 impl<T: Transport> EofSignalingTransport<T> {
@@ -101,12 +113,13 @@ impl<T: Transport> EofSignalingTransport<T> {
                 session_end_tx: Some(tx),
                 in_flight: 0,
                 pending_end: None,
+                drain_backstop: Self::DRAIN_BACKSTOP,
             },
             rx,
         )
     }
 
-    /// How long `receive()` will withhold EOF while a request is unanswered.
+    /// The production value of [`Self::drain_backstop`].
     ///
     /// Only a backstop: the actor's biased outbound arm normally wins in
     /// microseconds. It exists so a handler that never answers degrades to the
@@ -236,7 +249,7 @@ impl<T: Transport> EofSignalingTransport<T> {
             // truncation rather than wedging the process forever; a hang is
             // worse for a user than a lost response. The normal path never
             // waits: the outbound arm wins in microseconds.
-            tokio::time::sleep(Self::DRAIN_BACKSTOP).await;
+            tokio::time::sleep(self.drain_backstop).await;
         }
 
         self.signal_if_drained();
@@ -570,10 +583,19 @@ mod eof_drain_tests {
 
     /// The regression: EOF observed while a request is still being handled
     /// must NOT end the session, or that response is truncated.
+    ///
+    /// PMAT-1314: this test deliberately awaits the withheld `receive()` call
+    /// to completion, with no outer `select!` to cancel it — unlike the real
+    /// actor, nothing here can decrement `in_flight` while that call is
+    /// suspended, so it always pays the full `drain_backstop` fallback. Set
+    /// to a few milliseconds here rather than production's 300s (used to
+    /// hang for the full 300s under EVERY runner, `cargo test` included, not
+    /// just `nextest` — the tests were never order-dependent).
     #[tokio::test]
     async fn eof_does_not_signal_while_a_request_is_in_flight() {
         let (mut transport, mut session_end) =
             EofSignalingTransport::new(ScriptedTransport::new(vec![Some(a_request()), None]));
+        transport.drain_backstop = std::time::Duration::from_millis(5);
 
         assert!(transport.receive().await.is_ok(), "request should arrive");
         assert!(transport.receive().await.is_err(), "then EOF");
@@ -608,6 +630,10 @@ mod eof_drain_tests {
     }
 
     /// Several requests may be consumed before EOF; all must be answered.
+    ///
+    /// PMAT-1314: same `drain_backstop` override as
+    /// `eof_does_not_signal_while_a_request_is_in_flight`, for the same
+    /// reason — see that test's doc comment.
     #[tokio::test]
     async fn waits_for_every_outstanding_request() {
         let (mut transport, mut session_end) =
@@ -616,6 +642,7 @@ mod eof_drain_tests {
                 Some(a_request()),
                 None,
             ]));
+        transport.drain_backstop = std::time::Duration::from_millis(5);
 
         transport.receive().await.unwrap();
         transport.receive().await.unwrap();


### PR DESCRIPTION
See `docs/audits/impl-PMAT-1314-receipt.md` — the ticket, what landed, every claim re-run by the orchestrator, and the corrections recorded against the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
