### PR TITLE
fix(PMAT-1331): the quality gate returns its failure instead of exiting the process, and the exit-status guard mirrors main

### DIFF
--- a/docs/audits/impl-PMAT-1331-receipt.md
+++ b/docs/audits/impl-PMAT-1331-receipt.md
@@ -1,0 +1,58 @@
+# IMPL-PMAT-1331 — the quality gate returns its failure instead of exiting the process
+
+## Identity
+
+| field | value |
+|---|---|
+| ticket | PMAT-1331 (`kind:code`), found un-quarantining the dispatcher tests (PMAT-1321) |
+| branch | `PMAT-1331-worker`, from master `4e07ede5c` |
+| `gate_cmd` | `cargo fmt --all -- --check && cargo clippy --all-targets -- -D warnings` |
+| model gate | `model=opus class=opus decision=admit basis=file` |
+
+## The ticket's criteria, restated (lanes are briefed with `pmat work status`, a title — #1333)
+
+1. `handle_quality_gate` returns an error instead of calling `process::exit`, and `main` maps it to the same exit code — proven by a CLI test asserting the process exit status is unchanged;
+2. `test_quality_gate_complexity_check` runs without `#[ignore]` and asserts the error;
+3. a count of the remaining `process::exit` call sites is recorded so the next PR can lower it.
+
+## What was wrong, and a correction against myself first
+
+`handle_quality_gate_exit_status` (`quality_gate_part2b.rs`) called `std::process::exit(1)` when a gate failed. A test reaching it **killed the whole test binary** — every test after it never ran, nothing reported a failure — so `test_quality_gate_complexity_check` was `#[ignore]`d.
+
+An earlier attempt on this ticket (#1335, reverted) concluded the conversion was *blocked*: converting to `Err` made the exit-status guard report **101**, and I wrote on the issue that *"there is no CLI error→exit-code mapping — `src/cli/cli_exit*.rs` is not a file."* **That was false.** The mapping is `src/cli_exit.rs`; `src/bin/pmat.rs:182` routes every error through `cli_exit::code_for` → `GeneralError = 1`. I grepped the wrong directory and reported the absence as a fact. A worker had cited the module correctly in its comment and I overruled it. The issue carries the retraction.
+
+The 101 was real but was the **guard's** behaviour: `quality_gate_exit_status_guard_tests.rs` re-execs the test binary, and its child did `outcome.expect("the quality gate must not error out")` — a returned `Err` panicked there. The guard had been written for the `exit(1)` mechanism.
+
+## What lands
+
+- `handle_quality_gate_exit_status` returns `anyhow::Result<()>`: the same `❌ Quality gate FAILED` line, then `Err`. **Undeclared**, so `code_for` maps it to 1 — today's observable code, unchanged. Declaring `ExitCode::QualityGateFailure = 3` is what the enum was built for but would change the status every calling script sees; that is its own decision, not this ticket's.
+- Both callers propagate with `?`; both already returned `Result`.
+- **The guard's child now mirrors `main`**: `Ok` → `GATE_RETURNED`, `Err(e)` → `code_for(&e)`. Its three assertions are untouched — they assert exit 1, and exit 1 is what they still see.
+- `test_quality_gate_complexity_check` runs un-ignored and asserts the returned error contains `Quality gate FAILED` — replacing `is_ok() || is_err()`, a tautology.
+
+## Verification (re-run by the orchestrator)
+
+| what | result |
+|---|---|
+| `cargo test --lib -- quality_gate_exit_status_guard test_quality_gate_complexity_check quality_gate_part2b` | **8 passed, 0 failed** |
+| the three guard cases | still assert **exit 1**, still pass — the shipped exit status is unchanged |
+| `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings` | clean |
+| ratchets | `panic!(` 785, SATD 324 — unmoved |
+| CB-2113 / CB-2115 | ✓ / ✓, 105 ↔ 105 |
+
+**Count (criterion 3):** `std::process::exit(` under `src/cli/handlers/` + `src/cli/analysis_utilities/`, non-comment: master 40, branch 40 — the handler's site is gone (−1) and the guard's child gained the `code_for` exit that mirrors `main` (+1), which is the harness's own exit and is where one belongs. 37 handler sites remain for the next PRs.
+
+## Machine-readable
+
+orch_model: opus [V]   orch_class: opus   orch_decision: admit   orch_basis: -
+fable_binding: true   quota_age_h: absent   quota_mark: U   k_measured_at_set: 601
+
+routes:
+  ph1  class=impl            route=agy-goal w=1.00 basis=absent effort=1[U]  note=paiml-impl-worker, five files, in parallel with PMAT-1314 on a disjoint scope
+  ph2  class=orchestration   route=self  w=100.00  basis=absent              note=re-ran the suite; corrected my own false 'no mapping' claim on the issue first
+
+verification:
+  cmd=cargo-test--lib(guard+complexity_check+part2b)  claimed_exit=0  rerun_exit=0(8-passed)  log_path=/tmp/qr1331.log
+  cmd=guard-asserts-exit-1-unchanged  claimed_exit=-  rerun_exit=0  log_path=/tmp/qr1331.log
+  cmd=cargo-fmt+clippy  claimed_exit=0  rerun_exit=0  log_path=/tmp/qr1331.log
+  cmd=comply-check--checks-CB-2113,CB-2115  claimed_exit=-  rerun_exit=0  log_path=/tmp/qr1331.log

--- a/docs/status/unrun-tests-ledger.md
+++ b/docs/status/unrun-tests-ledger.md
@@ -14,7 +14,7 @@ Legs consulted (3):
 - `feature-matrix.yml:feature-tests[mcp-integration]`
 - `feature-matrix.yml:feature-tests[unified-protocol]`
 
-24212 of 27339 lib tests are executed; 3127 are compiled by no leg.
+24213 of 27340 lib tests are executed; 3127 are compiled by no leg.
 
 ## `<unsatisfiable>` — 2098 test(s)
 
@@ -3280,7 +3280,7 @@ crate::cli::handlers::timeline_mode::coverage_tests::check_feature_availability_
 
 ## Residual — what this walk could not reach
 
-165 `#[ignore]`d test(s) are compiled by some leg and executed by none.
+164 `#[ignore]`d test(s) are compiled by some leg and executed by none.
 `cargo test` prints its own "N ignored" line, so they are declared, not
 hidden, and are not ledgered here.
 

--- a/src/cli/analysis_utilities/quality_gate_exit_status_guard_tests.rs
+++ b/src/cli/analysis_utilities/quality_gate_exit_status_guard_tests.rs
@@ -42,8 +42,8 @@
 //!
 //! | child exit | meaning |
 //! |---|---|
-//! | `1` | the gate called `std::process::exit(1)` — it gated |
-//! | [`GATE_RETURNED`] | the dispatcher returned normally — the gate did **not** gate |
+//! | `1` | the gate returned an `Err` that `main` maps to exit 1 — it gated (#1331: the handler used to call `std::process::exit(1)` directly; now it returns `Err` and this child mirrors `main`'s mapping) |
+//! | [`GATE_RETURNED`] | the dispatcher returned `Ok(())` — the gate did **not** gate |
 //! | anything else | the child never got that far (see [`ChildRun::explain`]) |
 //!
 //! `0` is deliberately not a sentinel: a `--exact` filter that matches no test
@@ -157,10 +157,15 @@ fn run_as_child(argv: Vec<String>) -> ! {
         })
     });
 
-    // Still here ⇒ the gate did not exit. Surface a dispatch error rather than
-    // reporting it as "the gate declined to gate".
-    outcome.expect("the quality gate must not error out");
-    std::process::exit(GATE_RETURNED);
+    // Mirror `src/bin/pmat.rs`: an `Err` is mapped through `cli_exit::code_for`
+    // to a process exit code (#1331 — the handler no longer calls
+    // `std::process::exit` itself, so the child must reproduce `main`'s
+    // mapping to observe the same code the shipped binary would produce).
+    // `Ok(())` means the gate did not gate.
+    match outcome {
+        Ok(()) => std::process::exit(GATE_RETURNED),
+        Err(e) => std::process::exit(i32::from(crate::cli_exit::code_for(&e))),
+    }
 }
 
 // ── the parent half ─────────────────────────────────────────────────────────

--- a/src/cli/analysis_utilities/quality_gate_part2b.rs
+++ b/src/cli/analysis_utilities/quality_gate_part2b.rs
@@ -96,11 +96,24 @@ pub fn gate_exits_on_violation(report_only: bool) -> bool {
 ///
 /// `exit_on_violation` is the resolved policy from `gate_exits_on_violation`,
 /// not a flag the user typed: it is `true` unless `--report-only` was passed.
-fn handle_quality_gate_exit_status(exit_on_violation: bool, passed: bool) {
+///
+/// Returns `Err` rather than calling `std::process::exit` (#1331): a handler
+/// that terminates the process is unreachable to every caller that is not a
+/// live CLI binary — in particular to `#[tokio::test]`s that call the
+/// dispatcher in-process, which it killed outright. `src/bin/pmat.rs` routes
+/// every `Err` the dispatcher returns through `pmat::cli_exit::code_for`,
+/// which maps an undeclared error to `ExitCode::GeneralError = 1` — the same
+/// code this used to produce via `process::exit(1)`, so the shipped binary's
+/// observable behaviour is unchanged. This deliberately does NOT attach an
+/// `ExitCoded` (e.g. `ExitCode::QualityGateFailure = 3`): doing so would
+/// change the exit status from today's 1, which is a separate decision this
+/// ticket does not make.
+fn handle_quality_gate_exit_status(exit_on_violation: bool, passed: bool) -> Result<()> {
     if exit_on_violation && !passed {
         eprintln!("\n❌ Quality gate FAILED");
-        std::process::exit(1);
+        return Err(anyhow::anyhow!("Quality gate FAILED"));
     }
+    Ok(())
 }
 
 /// Persist all quality gate violations to SQLite for `pmat sql` queryability.
@@ -266,21 +279,31 @@ mod part2b_pure_tests {
         print_quality_gate_final_status(&r, &v);
     }
 
-    // ── handle_quality_gate_exit_status: no-exit branches only ──
-    // (The `std::process::exit(1)` branch would terminate the test process,
-    // so we only drive the three non-exiting combos.)
+    // ── handle_quality_gate_exit_status: all three combos, now that a failing
+    // verdict returns `Err` instead of calling `std::process::exit` (#1331).
 
     #[test]
     fn test_handle_quality_gate_exit_status_not_fail_on_violation_noop() {
-        // exit_on_violation=false (`--report-only`): never exits, pass or fail.
-        handle_quality_gate_exit_status(false, false);
-        handle_quality_gate_exit_status(false, true);
+        // exit_on_violation=false (`--report-only`): never fails, pass or fail.
+        handle_quality_gate_exit_status(false, false).expect("report-only never fails");
+        handle_quality_gate_exit_status(false, true).expect("report-only never fails");
     }
 
     #[test]
     fn test_handle_quality_gate_exit_status_passed_fail_on_violation_noop() {
-        // exit_on_violation=true + passed=true: no exit.
-        handle_quality_gate_exit_status(true, true);
+        // exit_on_violation=true + passed=true: no failure.
+        handle_quality_gate_exit_status(true, true).expect("a passing gate is Ok");
+    }
+
+    #[test]
+    fn test_handle_quality_gate_exit_status_failing_gate_returns_err() {
+        // exit_on_violation=true + passed=false: the one failing combo.
+        let err = handle_quality_gate_exit_status(true, false)
+            .expect_err("a failing gate with exit_on_violation must return Err");
+        assert!(
+            err.to_string().contains("Quality gate FAILED"),
+            "{err}"
+        );
     }
 
     // ── the exit-status policy, resolved from the parser ─────────────────

--- a/src/cli/analysis_utilities/quality_gate_project.rs
+++ b/src/cli/analysis_utilities/quality_gate_project.rs
@@ -290,7 +290,7 @@ async fn handle_project_quality_gate(
     print_quality_gate_final_status(&results, &violations);
 
     // Handle exit status
-    handle_quality_gate_exit_status(exit_on_violation, results.passed);
+    handle_quality_gate_exit_status(exit_on_violation, results.passed)?;
 
     Ok(())
 }

--- a/src/cli/analysis_utilities/quality_gate_single_file.rs
+++ b/src/cli/analysis_utilities/quality_gate_single_file.rs
@@ -61,7 +61,7 @@ async fn handle_single_file_quality_gate(
     output_single_file_results(&single_file, &results, &violations, format, output).await?;
 
     // Handle exit status
-    handle_quality_gate_exit_status(exit_on_violation, results.passed);
+    handle_quality_gate_exit_status(exit_on_violation, results.passed)?;
 
     Ok(())
 }

--- a/src/cli/command_dispatcher/tests_scaffold_quality_gate.rs
+++ b/src/cli/command_dispatcher/tests_scaffold_quality_gate.rs
@@ -152,12 +152,6 @@
     }
 
     #[tokio::test]
-    // This test is correct; the handler is what must change (#1331):
-    // `exit_on_violation=true` reaches `handle_quality_gate`'s real
-    // `std::process::exit(1)` path (an empty temp dir is reported as an
-    // "unmeasured gate" violation), so this call terminates the whole test
-    // binary rather than returning the `Result` this test wants to assert on.
-    #[ignore = "reaches handle_quality_gate's process::exit(1), which kills the test binary — see #1331"]
     async fn test_quality_gate_complexity_check() {
         use tempfile::TempDir;
         let temp_dir = TempDir::new().expect("internal error");
@@ -175,7 +169,8 @@
             false,
         )
         .await;
-        assert!(result.is_ok() || result.is_err());
+        let err = result.expect_err("an unmeasured gate with exit_on_violation is a failure");
+        assert!(err.to_string().contains("Quality gate FAILED"), "{err}");
     }
 
     #[tokio::test]


### PR DESCRIPTION
See `docs/audits/impl-PMAT-1331-receipt.md` — the ticket, what landed, every claim re-run by the orchestrator, and the corrections recorded against the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
