### PR TITLE
fix(PMAT-1339): a ratchet metric declares its own measurement budget; 300 s is only the default

### DIFF
--- a/.pmat-ratchet.toml
+++ b/.pmat-ratchet.toml
@@ -57,6 +57,23 @@ baseline = 0
 unit = "count"
 band = 0
 includes_test_files = false
+# This metric's own wall-clock budget, because the 300s default is not a bound
+# on a runaway here — it is a coin toss on the runner. Same commit, same
+# command, two CI hosts:
+#   intel-clean-room-8, run 34676994867: 203s, measured, green (suite 694s)
+#   intel-clean-room-6, run 34680577045: KILLED at the 300s default, and the
+#                                        three metrics_ratchet drive tests
+#                                        failed together with "command exceeded
+#                                        the 300s measurement timeout and was
+#                                        killed" (suite 1287s)
+# The measurement is a COLD full-crate clippy into its own CARGO_TARGET_DIR, run
+# from inside `cargo test --lib`, so its cost is set by how loaded the runner is
+# and how cold target/ratchet-unwrap is, neither of which the command controls.
+# 1800 is ~9x the observed 203s: wide enough that a slow but honest build
+# finishes, narrow enough that a runaway is still cut off inside half an hour.
+# Raising it is not a way of passing — exceeding whichever budget applies is
+# Unavailable, which is a FAIL (INV-2102-4).
+timeout_secs = 1800
 command = '''o=$(CLIPPY_CONF_DIR=. CARGO_TARGET_DIR=target/ratchet-unwrap cargo clippy --quiet --lib --bins --features full --message-format=json -- -D unknown_lints --force-warn clippy::unwrap_used 2>/dev/null) || exit 9
 printf '%s\n' "$o" | grep -qF '"reason":"build-finished","success":true' || exit 9
 printf '%s\n' "$o" | grep -oF '"code":"clippy::unwrap_used"' | wc -l'''

--- a/contracts/comply-ratchet-v1.yaml
+++ b/contracts/comply-ratchet-v1.yaml
@@ -142,6 +142,7 @@ equations:
     - "deleting .pmat-ratchet.toml from a repository that once committed one is a FAILURE, not a Skip"
     - "the lowering pass writes back min(baseline, observed) and never anything larger, never for an unmeasured metric, and preserves the file's comments byte for byte — a job that strips a config's documentation each time it runs is worse than no job"
     - "the lowering pass re-parses what it wrote and verifies it says exactly what was asked, because a plausible-looking wrong number silently becomes the new truth"
+    - "INV-2102-7: every measurement is bounded by the budget the metric declares in `timeout_secs`, defaulting to 300s when it declares none, and exceeding that budget is UNAVAILABLE — which is FAIL by INV-2102-4 — never a pass. The budget is per-metric because one constant has to bound a runaway AND let a legitimately expensive measurement finish, and no single number does both: `unwrap_calls_shipped_code` is a cold full-crate clippy that measured 203s and passed on intel-clean-room-8 (run 34676994867) and was killed at the 300s default on the more loaded intel-clean-room-6 (run 34680577045) — the same commit and the same command, reported as a broken measurement on one host and a clean one on the other. Declaring a wider budget therefore buys time, never a verdict; and the lowering pass must preserve the declaration, since a budget a nightly job silently dropped would re-arm this on the next slow runner with nothing in the diff but a baseline. Held by src/services/metrics_ratchet/drive_tests.rs::a_metric_declares_its_own_budget"
     preconditions:
     - ".pmat-ratchet.toml exists (otherwise CB-2102 Skips: the project declares no baselines), and bash and git are available"
 
@@ -300,3 +301,23 @@ falsification_tests:
     prediction: "the named test fails when this condition holds"
     test: src/services/metrics_ratchet/drive_tests.rs::cb_2102_is_in_the_comply_rule_registry
     if_fails: "P0 — this contract's guarantee does not hold"
+  - id: f_26
+    rule: "INV-2102-7: a metric's declared `timeout_secs` is ignored and every measurement is bounded by the flat default, so the cap that exists to stop a runaway also kills a legitimately slow measurement — and the failure reads as UNAVAILABLE, which is indistinguishable from a rotted command"
+    prediction: "the named test fails when this condition holds"
+    test: src/services/metrics_ratchet/drive_tests.rs::a_metric_declares_its_own_budget
+    if_fails: "P1 — this contract's guarantee does not hold"
+  - id: f_26_control
+    rule: "the control: a metric that declares no budget stops getting the 300s default — a per-metric budget implemented by shortening every measurement would kill the cold clippy metric on every runner instead of only the loaded ones"
+    prediction: "the named test fails when this condition holds"
+    test: src/services/metrics_ratchet/drive_tests.rs::a_metric_without_a_budget_keeps_the_default
+    if_fails: "P0 — this contract's guarantee does not hold"
+  - id: f_27
+    rule: "the lowering pass drops a metric's `timeout_secs`, re-arming the flat-budget defect on the next slow runner with nothing in the nightly job's diff to review but a baseline"
+    prediction: "the named test fails when this condition holds"
+    test: src/services/metrics_ratchet/drive_tests.rs::lowering_preserves_a_timeout_secs_line
+    if_fails: "P1 — this contract's guarantee does not hold"
+  - id: f_28
+    rule: "this repository's own cold full-crate clippy metric stops declaring a budget and goes back to the 300s default, which does not make the gate stricter — it makes it flaky, and a flaky UNAVAILABLE reads as a failed measurement rather than a regression anyone can act on"
+    prediction: "the named test fails when this condition holds"
+    test: src/services/metrics_ratchet/drive_tests.rs::the_committed_unwrap_metric_declares_a_budget
+    if_fails: "P1 — this contract's guarantee does not hold"

--- a/docs/audits/quorum-PMAT-1339.json
+++ b/docs/audits/quorum-PMAT-1339.json
@@ -1,0 +1,144 @@
+{
+  "ticket": "PMAT-1339",
+  "base": "master",
+  "base_resolved": "origin/master",
+  "base_note": "local master differs from origin/master by 115 commit(s); judged against origin/master",
+  "head": "cc00aabed440612a97b78e73ba2c521b241ffe4e",
+  "diff_sha256": "6c9cfed86bf8330782bb6287eb36bf7655bd909ceb1d29506db10d26bc1f9259",
+  "width": 3,
+  "executor": "agy",
+  "prompt_mode": "inline",
+  "prompt_bytes": 32472,
+  "author": {
+    "model": "Opus 5 (1M context)",
+    "family": "claude",
+    "source": "measured"
+  },
+  "agreed": true,
+  "lanes": [
+    {
+      "lane": 1,
+      "status": "SUCCESS",
+      "verdict": "PASS",
+      "summary": "The diff implements PMAT-1339 strictly according to the acceptance criteria. It introduces `timeout_secs` to `MetricBaseline` allowing per-metric configuration for long-running tests like `unwrap_calls_shipped_code` without increasing the flat 300s default for standard metrics. The changes are comprehensively tested (including memoization, default application, budget adherence, and preservation during lowering) and documentation is accurately updated. No criteria are violated.",
+      "findings": [
+        {
+          "claim": "The metric's own wall-clock budget is now used if declared, defaulting to MEASUREMENT_TIMEOUT (300s) otherwise, fulfilling AC1.",
+          "file": "src/services/metrics_ratchet/measure.rs",
+          "grounding": "cited",
+          "line": 383
+        },
+        {
+          "claim": "The lowering pass preserves the `timeout_secs` field byte-for-byte, as verified by `lowering_preserves_a_timeout_secs_line` test, fulfilling AC2.",
+          "file": "src/services/metrics_ratchet/drive_tests.rs",
+          "grounding": "cited",
+          "line": 690
+        },
+        {
+          "claim": "The `unwrap_calls_shipped_code` metric is explicitly assigned a `timeout_secs = 1800` budget with runner statistics in the comments, fulfilling AC3.",
+          "file": ".pmat-ratchet.toml",
+          "grounding": "cited",
+          "line": 76
+        },
+        {
+          "claim": "The `MEASUREMENT_TIMEOUT` documentation is updated to use runner figures instead of the workstation figures, fulfilling AC4.",
+          "file": "src/services/metrics_ratchet/measure.rs",
+          "grounding": "cited",
+          "line": 57
+        }
+      ],
+      "raw_bytes": 4176,
+      "err_bytes": 0,
+      "envelope_status": "SUCCESS",
+      "model": "gemini-3.1-pro-high",
+      "model_measured": "gemini-3.1-pro-high",
+      "model_source": "measured",
+      "family": "gemini"
+    },
+    {
+      "lane": 2,
+      "status": "SUCCESS",
+      "verdict": "PASS",
+      "summary": "The diff perfectly implements the acceptance criteria for PMAT-1339. \n\n- `timeout_secs` is added to `.pmat-ratchet.toml` for the cold clippy metric with the exact notes requested.\n- `MEASUREMENT_TIMEOUT` documentation is updated to describe the default budget and includes the CI runner metrics instead of the workstation metrics.\n- `measure_with_budget` parses and enforces the new `timeout_secs` field, gracefully falling back to the 300s default.\n- The `memo_key` logic prevents false caching by embedding the timeout duration in the memoization key.\n- All four acceptance criteria have dedicated, exact-match tests implemented (`a_metric_declares_its_own_budget`, `lowering_preserves_a_timeout_secs_line`, `the_committed_ratchet_holds_at_head` failure messaging, etc.).\n\nNo gates are weakened. The tests ensure that an override beats a declared budget and that a budget only buys time, not a bypass. The code precisely satisfies the ticket.",
+      "findings": [],
+      "raw_bytes": 3227,
+      "err_bytes": 0,
+      "envelope_status": "SUCCESS",
+      "model": "gemini-3.1-pro-high",
+      "model_measured": "gemini-3.1-pro-high",
+      "model_source": "measured",
+      "family": "gemini"
+    },
+    {
+      "lane": 3,
+      "status": "SUCCESS",
+      "verdict": "PASS",
+      "summary": "The diff implements all acceptance criteria of PMAT-1339 correctly:\n1. `timeout_secs` is properly parsed from the config and falls back to the `MEASUREMENT_TIMEOUT` default of 300s.\n2. `.pmat-ratchet.toml` gives `unwrap_calls_shipped_code` an 1800s budget along with the CI run reasoning.\n3. Tests (`a_metric_declares_its_own_budget`, `a_metric_without_a_budget_keeps_the_default`, etc.) accurately prove that the budgets apply (e.g. 1s kills a 5s task, and the timeout message includes the applied budget).\n4. `the_committed_ratchet_holds_at_head` parses out the correct budget and reports it gracefully.\n5. The rewrite editor `rewrite::apply` preserves the `timeout_secs` config field during lowering, as evidenced by `lowering_preserves_a_timeout_secs_line`.\n6. `MEASUREMENT_TIMEOUT` docstrings accurately reflect the runner metrics instead of the 40s workstation timings.\n\nI found nothing that refutes the ticket's claims.",
+      "findings": [],
+      "raw_bytes": 3140,
+      "err_bytes": 0,
+      "envelope_status": "SUCCESS",
+      "model": "gemini-3.1-pro-high",
+      "model_measured": "gemini-3.1-pro-high",
+      "model_source": "measured",
+      "family": "gemini"
+    }
+  ],
+  "dissent": [],
+  "dedup": [
+    {
+      "file": ".pmat-ratchet.toml",
+      "line": 76,
+      "lanes_agreeing": [
+        1
+      ],
+      "claims": [
+        "The `unwrap_calls_shipped_code` metric is explicitly assigned a `timeout_secs = 1800` budget with runner statistics in the comments, fulfilling AC3."
+      ]
+    },
+    {
+      "file": "src/services/metrics_ratchet/drive_tests.rs",
+      "line": 690,
+      "lanes_agreeing": [
+        1
+      ],
+      "claims": [
+        "The lowering pass preserves the `timeout_secs` field byte-for-byte, as verified by `lowering_preserves_a_timeout_secs_line` test, fulfilling AC2."
+      ]
+    },
+    {
+      "file": "src/services/metrics_ratchet/measure.rs",
+      "line": 57,
+      "lanes_agreeing": [
+        1
+      ],
+      "claims": [
+        "The `MEASUREMENT_TIMEOUT` documentation is updated to use runner figures instead of the workstation figures, fulfilling AC4."
+      ]
+    },
+    {
+      "file": "src/services/metrics_ratchet/measure.rs",
+      "line": 383,
+      "lanes_agreeing": [
+        1
+      ],
+      "claims": [
+        "The metric's own wall-clock budget is now used if declared, defaulting to MEASUREMENT_TIMEOUT (300s) otherwise, fulfilling AC1."
+      ]
+    }
+  ],
+  "uncovered": [],
+  "coverage_source": "lanes",
+  "partial": false,
+  "partial_reasons": [],
+  "auto_merge": {
+    "checked": true,
+    "was_armed": false,
+    "disarmed": false,
+    "note": "auto-merge not armed"
+  },
+  "lint": {
+    "ok": true,
+    "output": "receipt complete: kind=artifact lanes=3 author=Opus 5 (1M context)/claude"
+  }
+}

--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -6613,3 +6613,24 @@ roadmap:
   labels:
   - kind:lifecycle
   notes: 'CB-2113 requires every commit to name a NON-TERMINAL item, so a commit marking PMAT-X completed while naming PMAT-X fails it: a ticket cannot complete itself. The completion must ride in another PR — but a quorum judges a diff against the criteria of the ticket that PR names, and complete the previous ticket is in no ticket''s criteria, so it is flagged out-of-scope every time however well justified. Measured three times in one session: PR 1330 three FAIL, 1334 one FAIL, 1335 three FAIL, each naming the same cross-ticket status change. Not doing it is worse: GitHub closes the issue on merge and the item goes ORPHAN-ROADMAP under CB-2115, reddening master with no commit to blame. The repository already solved the identical problem for triage by giving it its own ticket (PMAT-1332); this is that, for lifecycle.'
+- id: PMAT-1339
+  github_issue: 1339
+  item_type: bug
+  title: 'ratchet: a flat 300 s measurement timeout kills the cold clippy metric on a loaded runner — 3 lib tests red on #1337, sized from a workstation figure'
+  status: planned
+  priority: high
+  assigned_to: null
+  created: 2026-09-12T08:07:34Z
+  updated: 2026-09-12T08:07:34Z
+  spec: null
+  acceptance_criteria:
+  - a metric declaring timeout_secs = 1 whose command sleeps 5 s is reported Unavailable naming a 1 s budget, in about 1 s — and a metric declaring none is still bounded by the 300 s default (a test that fails on the current tree, where timeout_secs is not a field)
+  - 'pmat comply ratchet --lower preserves a timeout_secs line: the rewrite editor round-trips the committed file byte-for-byte apart from the baselines it lowers'
+  - .pmat-ratchet.toml gives unwrap_calls_shipped_code a budget with the two CI runs recorded beside it, and the_committed_ratchet_holds_at_head reads it (the failure message names the budget it applied)
+  - the MEASUREMENT_TIMEOUT doc comment no longer carries the ~40 s workstation figure; it carries the runner figures (203 s green on intel-clean-room-8 run 34676994867; killed at 300 s on intel-clean-room-6 run 34680577045)
+  phases: []
+  subtasks: []
+  estimated_effort: null
+  labels:
+  - kind:code
+  notes: 'Introduced by #1327 (PMAT-1324): MEASUREMENT_TIMEOUT is one flat 300 s for every metric, sized from a ~40 s workstation figure. unwrap_calls_shipped_code is a cold cargo clippy of the whole crate into its own target dir, run inside cargo test --lib; on intel-clean-room-8 it took 203 s (green), on intel-clean-room-6 (suite 1287 s vs 694 s) it was killed at 300 s and three drive tests failed together, serialised on the build-directory lock. A cap that bounds a runaway must not bound a legitimate slow build: the metric declares its own budget.'

--- a/docs/status/unrun-tests-ledger.md
+++ b/docs/status/unrun-tests-ledger.md
@@ -14,7 +14,7 @@ Legs consulted (3):
 - `feature-matrix.yml:feature-tests[mcp-integration]`
 - `feature-matrix.yml:feature-tests[unified-protocol]`
 
-24207 of 27334 lib tests are executed; 3127 are compiled by no leg.
+24212 of 27339 lib tests are executed; 3127 are compiled by no leg.
 
 ## `<unsatisfiable>` — 2098 test(s)
 

--- a/src/services/metrics_ratchet/config.rs
+++ b/src/services/metrics_ratchet/config.rs
@@ -122,6 +122,27 @@ pub struct MetricBaseline {
     /// never a zero (CRUX-12, #1152).
     #[serde(default)]
     pub analyzer: Option<String>,
+    /// Wall-clock budget, in seconds, for ONE measurement of this metric.
+    /// `None` means the 300s default in [`super::measure`].
+    ///
+    /// A per-metric budget exists because one flat number has to serve two
+    /// jobs that pull in opposite directions: bounding a runaway (the
+    /// fork-bomb of GH #1324, which must be cut off quickly) and letting an
+    /// expensive but legitimate measurement finish. A single constant sized
+    /// for the first kills the second, and it cannot be sized from the
+    /// machine that wrote it down: `unwrap_calls_shipped_code` here is a cold
+    /// full-crate clippy into its own target dir, which took 203s and passed
+    /// on intel-clean-room-8 (run 34676994867) and was killed at the 300s
+    /// default on the slower intel-clean-room-6 (run 34680577045) — same
+    /// commit, same command, opposite verdicts, and the second one reported a
+    /// timeout rather than a regression.
+    ///
+    /// So the budget is declared next to the command whose cost it describes,
+    /// by whoever can justify it, rather than inferred from whichever runner
+    /// happened to measure fastest. Exceeding it is still `Unavailable`, never
+    /// a pass: a generous budget buys time, it never buys a verdict.
+    #[serde(default)]
+    pub timeout_secs: Option<u64>,
 }
 
 /// Declarations that make the `.pmat-metrics.toml` audit total.

--- a/src/services/metrics_ratchet/config_tests.rs
+++ b/src/services/metrics_ratchet/config_tests.rs
@@ -33,6 +33,7 @@ fn unwrap_metric(band: u64) -> BTreeMap<String, MetricBaseline> {
             justification: None,
             zero_is_reachable: false,
             analyzer: None,
+            timeout_secs: None,
         },
     );
     m

--- a/src/services/metrics_ratchet/drive_tests.rs
+++ b/src/services/metrics_ratchet/drive_tests.rs
@@ -178,6 +178,7 @@ fn baseline(v: i64, justification: Option<&str>) -> MetricBaseline {
         justification: justification.map(str::to_string),
         zero_is_reachable: false,
         analyzer: None,
+        timeout_secs: None,
     }
 }
 
@@ -265,6 +266,7 @@ fn lowering_a_metric_with_no_baseline_line_is_an_error() {
 /// nothing today. `cargo test --lib` is reached.
 #[test]
 fn the_committed_ratchet_holds_at_head() {
+    let cfg = RatchetConfig::load(repo_root()).expect("the ratchet file parses");
     let report = run(repo_root()).expect("the repository's own ratchet file must load");
     if report.outcome != Outcome::Ok {
         let mut lines = report.holes.clone();
@@ -274,9 +276,32 @@ fn the_committed_ratchet_holds_at_head() {
                 .metrics
                 .iter()
                 .filter(|m| m.outcome == Outcome::Fail)
-                .map(|m| format!("{}: {}", m.metric, m.detail)),
+                .map(|m| {
+                    format!(
+                        "{}: {} [{}]",
+                        m.metric,
+                        m.detail,
+                        budget_of(&cfg, &m.metric)
+                    )
+                }),
         );
         panic!("{RATCHET_FILE} is red at HEAD:\n  {}", lines.join("\n  "));
+    }
+}
+
+/// Which wall-clock budget a metric was measured under, for the failure above.
+///
+/// A timed-out measurement and a regression are both `Fail` here, and they need
+/// opposite responses — one is "the runner was slow, the budget is wrong", the
+/// other is "the tree got worse". Naming the budget that applied is what lets a
+/// reader tell them apart without opening the config, which is the whole reason
+/// PMAT-1339 exists: the 300s default appeared in the failure text of three
+/// tests on intel-clean-room-6 (run 34680577045) while nothing in the message
+/// said where the 300 came from or that it could be changed.
+fn budget_of(cfg: &RatchetConfig, id: &str) -> String {
+    match cfg.metric.get(id).and_then(|m| m.timeout_secs) {
+        Some(secs) => format!("budget {secs}s, declared by the metric"),
+        None => "budget 300s, the default for a metric that declares none".to_string(),
     }
 }
 
@@ -590,4 +615,121 @@ fn a_metric_declares_its_own_budget() {
          waited out the command (or the 300s default) instead"
     );
     let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// The control for the test above, in two parts: the default must still be
+/// exactly 300s for a metric that declares nothing, and it must apply to a
+/// metric that declares nothing even while another declares a budget. Without
+/// this, the budget test above is satisfied by a change that shortens EVERY
+/// measurement — which would kill the cold clippy metric on every runner
+/// instead of only the loaded ones.
+#[test]
+fn a_metric_without_a_budget_keeps_the_default() {
+    assert_eq!(
+        measure::resolve_timeout(None),
+        std::time::Duration::from_secs(300),
+        "a metric that declares no budget must still get the 300s default"
+    );
+    assert_eq!(
+        measure::resolve_timeout(Some(1800)),
+        std::time::Duration::from_secs(1800),
+        "a declared budget is applied verbatim, in seconds"
+    );
+
+    let dir = scratch("budget-default");
+    let m = metric_from_toml("printf 4", "");
+    assert_eq!(
+        m.timeout_secs, None,
+        "a metric that names no budget deserialises to None, not to some default number"
+    );
+    assert_eq!(measure::measure_metric(&dir, &m), Measurement::Value(4));
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// The test-only override must keep WINNING over a declared budget. It is the
+/// only reason the kill paths are testable at all — no test can wait out 300s,
+/// still less the 1800s a metric may legitimately declare — so a declared
+/// budget that outranked it would not slow those tests down, it would make
+/// them unrunnable and they would be deleted.
+#[test]
+fn a_test_override_beats_a_declared_budget() {
+    let dir = scratch("budget-override");
+    let m = metric_from_toml("sleep 30 && printf 1", "timeout_secs = 3600");
+
+    measure::set_test_timeout_override_ms(Some(50));
+    let resolved = measure::resolve_timeout(m.timeout_secs);
+    let started = std::time::Instant::now();
+    let got = measure::measure_metric(&dir, &m);
+    let elapsed = started.elapsed();
+    measure::set_test_timeout_override_ms(None);
+
+    assert_eq!(
+        resolved,
+        std::time::Duration::from_millis(50),
+        "the thread-local override must outrank the metric's own declaration"
+    );
+    assert!(
+        matches!(got, Measurement::Unavailable(_)),
+        "the 50ms override did not fire against a 3600s declaration: {got:?}"
+    );
+    assert!(
+        elapsed < std::time::Duration::from_secs(3),
+        "the 50ms override did not fire: the measurement took {elapsed:?}"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// INV-2102-7's write-back half. The lowering editor is line-oriented and
+/// passes through every key it does not rewrite — but "passes through" is a
+/// property of the current implementation, not a promise, and a budget silently
+/// dropped by a scheduled nightly job would re-arm the exact defect PMAT-1339
+/// closes on the next slow runner, with nothing in the diff to review but a
+/// baseline. So it is asserted byte for byte.
+#[test]
+fn lowering_preserves_a_timeout_secs_line() {
+    let with_budget = SAMPLE.replace(
+        "[metric.u]\n",
+        "[metric.u]\n# the budget this metric's cost needs\ntimeout_secs = 1800\n",
+    );
+    let mut want = BTreeMap::new();
+    want.insert("u".to_string(), 97i64);
+    let out = rewrite::apply(&with_budget, &want).expect("rewrite succeeds");
+
+    assert_eq!(
+        out,
+        with_budget
+            .replace("baseline = 100", "baseline = 97")
+            .replace("justification = \"a reason that no longer applies\"\n", ""),
+        "the lowering pass must change the baseline, drop the justification, and touch \
+         nothing else"
+    );
+
+    let parsed = RatchetConfig::parse(&out).expect("the rewritten file re-parses");
+    assert_eq!(
+        parsed.metric["u"].timeout_secs,
+        Some(1800),
+        "the rewritten file lost the metric's measurement budget"
+    );
+}
+
+/// The committed declaration. This repository's compiler-derived metric costs
+/// far more than the 300s default on a loaded runner (203s green on
+/// intel-clean-room-8 run 34676994867; killed at 300s on intel-clean-room-6 run
+/// 34680577045), so deleting this line does not make the gate stricter — it
+/// makes it flaky, and a flaky UNAVAILABLE reads as a failed measurement rather
+/// than as a regression anybody can act on.
+#[test]
+fn the_committed_unwrap_metric_declares_a_budget() {
+    let cfg = RatchetConfig::load(repo_root()).expect("the ratchet file parses");
+    let m = cfg
+        .metric
+        .get("unwrap_calls_shipped_code")
+        .expect("the compiler-derived unwrap metric is committed");
+    assert_eq!(
+        m.timeout_secs,
+        Some(1800),
+        "the cold full-crate clippy metric must declare its own budget: the 300s default \
+         killed it on intel-clean-room-6 (run 34680577045) at the same commit that measured \
+         203s on intel-clean-room-8 (run 34676994867)"
+    );
 }

--- a/src/services/metrics_ratchet/drive_tests.rs
+++ b/src/services/metrics_ratchet/drive_tests.rs
@@ -538,3 +538,56 @@ fn zero_is_still_reachable_when_it_is_declared_or_already_the_baseline() {
         Measurement::Value(7)
     );
 }
+
+// ── the per-metric measurement budget ───────────────────────────────────────
+
+/// A metric fixture built by DESERIALISING its TOML rather than by a struct
+/// literal, so `extra` can carry a key this build may not yet know about —
+/// which is what lets the budget tests below be written against the file
+/// format a human edits rather than against the shape of the struct.
+fn metric_from_toml(command: &str, extra: &str) -> MetricBaseline {
+    let text = format!(
+        "baseline = 1\n\
+         unit = \"count\"\n\
+         band = 0\n\
+         includes_test_files = false\n\
+         command = '{command}'\n\
+         description = \"a fixture\"\n\
+         {extra}\n"
+    );
+    toml::from_str(&text).expect("the metric fixture parses")
+}
+
+/// The defect PMAT-1339 names. One flat 300s budget bounds a runaway AND a
+/// legitimately slow measurement, and the two cannot be told apart by a number
+/// chosen for a workstation: this repo's compiler-derived metric took 203s on
+/// intel-clean-room-8 (run 34676994867) and was killed at 300s on the slower
+/// intel-clean-room-6 (run 34680577045). So the budget belongs to the metric.
+///
+/// Read in reverse here: a metric that declares ONE second must be killed after
+/// about one second, not after the five its command asks for, and the message
+/// must name the second — a budget the operator cannot see in the failure is a
+/// budget they cannot correct.
+#[test]
+fn a_metric_declares_its_own_budget() {
+    let dir = scratch("budget-declared");
+    let m = metric_from_toml("sleep 5 && printf 1", "timeout_secs = 1");
+
+    let started = std::time::Instant::now();
+    let got = measure::measure_metric(&dir, &m);
+    let elapsed = started.elapsed();
+
+    let Measurement::Unavailable(why) = &got else {
+        unreachable!("a 1s budget against a 5s command produced {got:?}")
+    };
+    assert!(
+        why.contains("1s measurement timeout"),
+        "the message must name the budget it applied, got: {why}"
+    );
+    assert!(
+        elapsed < std::time::Duration::from_secs(3),
+        "the declared 1s budget was not applied: the measurement took {elapsed:?}, so it \
+         waited out the command (or the 300s default) instead"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/src/services/metrics_ratchet/kernel_tests.rs
+++ b/src/services/metrics_ratchet/kernel_tests.rs
@@ -237,6 +237,7 @@ fn baseline(value: i64) -> MetricBaseline {
         justification: None,
         zero_is_reachable: false,
         analyzer: None,
+        timeout_secs: None,
     }
 }
 

--- a/src/services/metrics_ratchet/measure.rs
+++ b/src/services/metrics_ratchet/measure.rs
@@ -48,13 +48,27 @@ const RATCHET_DEPTH_ENV: &str = "PMAT_RATCHET_DEPTH";
 /// value that still lets the depth-0 case through.
 const RATCHET_MAX_DEPTH: u32 = 1;
 
-/// How long a single metric's command may run before [`measure_now`] kills it
-/// and reports `Unavailable`. A ratchet measurement is a `grep`/`git grep`
-/// pipeline or, at the expensive end, a single `cargo` invocation over an
-/// already-built tree (this repo's own compiler-derived metric is ~40s); 300s
-/// is generous enough to absorb a cold cache or a slow CI runner without ever
-/// being generous enough to let a runaway process (recursive or otherwise)
-/// sit unbounded.
+/// The DEFAULT budget: how long a metric that declares no
+/// [`MetricBaseline::timeout_secs`] of its own may run before [`measure_now`]
+/// kills it and reports `Unavailable`.
+///
+/// It is a default rather than the rule because one number cannot do both
+/// jobs. Most ratchet measurements are a `grep`/`git grep` pipeline and finish
+/// in under a second, so 300s bounds a runaway (recursive or otherwise)
+/// without ever being close to legitimate. At the expensive end sits a COLD
+/// `cargo clippy` over the whole crate, and there 300s is not a bound on a
+/// runaway at all — it is a coin toss on the runner. This repository's
+/// `unwrap_calls_shipped_code` measured 203s and passed on intel-clean-room-8
+/// (run 34676994867) and was killed at this default on the more loaded
+/// intel-clean-room-6 (run 34680577045): the same commit and the same command,
+/// reported as a broken measurement on one machine and a clean one on the
+/// other.
+///
+/// A metric whose legitimate cost can exceed this declares `timeout_secs` in
+/// `.pmat-ratchet.toml`, next to the command whose cost it describes. What a
+/// larger budget never buys is a verdict: exceeding whichever budget applies is
+/// still `Unavailable`, because "we could not measure it" must never read as
+/// "it did not regress" (`INV-2102-4`).
 const MEASUREMENT_TIMEOUT: Duration = Duration::from_secs(300);
 
 /// How often [`measure_now`]'s wait loop polls the child for completion.
@@ -114,7 +128,7 @@ pub fn measure_all(
 pub fn measure_metric(project_path: &Path, metric: &MetricBaseline) -> Measurement {
     let raw = match metric.analyzer.as_deref() {
         Some(name) => measure_analyzer(project_path, name),
-        None => measure(project_path, &metric.command),
+        None => measure_with_budget(project_path, &metric.command, metric.timeout_secs),
     };
     guard_zero(raw, metric)
 }
@@ -190,6 +204,20 @@ pub fn guard_zero(raw: Measurement, metric: &MetricBaseline) -> Measurement {
 /// upward, greets as the largest improvement in the project's history and the
 /// lowering job then makes permanent.
 pub fn measure(project_path: &Path, command: &str) -> Measurement {
+    measure_with_budget(project_path, command, None)
+}
+
+/// [`measure`], with the metric's own wall-clock budget in seconds.
+///
+/// `None` means the [`MEASUREMENT_TIMEOUT`] default; see
+/// [`MetricBaseline::timeout_secs`] for why the budget travels with the metric
+/// rather than living in one constant.
+pub fn measure_with_budget(
+    project_path: &Path,
+    command: &str,
+    timeout_secs: Option<u64>,
+) -> Measurement {
+    let timeout = resolve_timeout(timeout_secs);
     #[cfg(test)]
     if is_own_repo(project_path) {
         // Take the map lock only long enough to hand out this command's cell,
@@ -202,13 +230,29 @@ pub fn measure(project_path: &Path, command: &str) -> Measurement {
             let mut map = REPO_MEASUREMENTS
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
-            std::sync::Arc::clone(map.entry(command.to_owned()).or_default())
+            std::sync::Arc::clone(map.entry(memo_key(command, timeout)).or_default())
         };
         return cell
-            .get_or_init(|| measure_now(project_path, command))
+            .get_or_init(|| measure_now(project_path, command, timeout))
             .clone();
     }
-    measure_now(project_path, command)
+    measure_now(project_path, command, timeout)
+}
+
+/// The memo key: the command text AND the budget it was measured under.
+///
+/// The budget has to be in the key. A command killed at 1s and the same command
+/// given 1800s are two different measurements — one `Unavailable`, one a count —
+/// and a memo keyed on the text alone would hand the first caller's verdict to
+/// the second, making a result depend on which test won a race. Keying on the
+/// pair keeps the whole point of the memo (six callers, one cold clippy) for
+/// every caller that agrees about the budget, which is every production caller
+/// of a given metric, and separates only those that do not. `\u{1f}` (ASCII
+/// unit separator) cannot appear in a `u64` rendering, so the two fields cannot
+/// be confused for one another.
+#[cfg(test)]
+fn memo_key(command: &str, timeout: Duration) -> String {
+    format!("{}\u{1f}{command}", timeout.as_millis())
 }
 
 /// Test-only memo for measurements taken against THIS repository.
@@ -220,8 +264,11 @@ pub fn measure(project_path: &Path, command: &str) -> Measurement {
 /// roughly four minutes measuring the same unchanged tree six times, on each of
 /// the eight feature legs CI runs.
 ///
-/// Keyed on the command text, which IS the metric's identity here: two metrics
-/// sharing a command must measure the same thing, or one of them is misdeclared.
+/// Keyed on the command text AND the budget it ran under (see [`memo_key`]).
+/// The text alone IS the metric's identity here — two metrics sharing a command
+/// must measure the same thing, or one of them is misdeclared — but a command
+/// killed at 1s and the same command given 1800s are not the same measurement,
+/// so the budget joins the key rather than being averaged over by the memo.
 ///
 /// Scoped to this repository on purpose. Fixture-driven tests build a temp dir,
 /// measure it, mutate it and measure again — caching those would make a test
@@ -250,7 +297,7 @@ fn is_own_repo(project_path: &Path) -> bool {
 }
 
 // Test-only, thread-local overrides for `current_depth` and
-// `measurement_timeout`.
+// `resolve_timeout`.
 //
 // `cargo test` runs many tests concurrently as OS threads inside one
 // process, and `std::env::set_var` is process-global — a test that wants to
@@ -279,7 +326,8 @@ pub(crate) fn set_test_depth_override(depth: Option<u32>) {
 }
 
 /// Make every measurement on the CALLING THREAD use `ms` milliseconds instead
-/// of [`MEASUREMENT_TIMEOUT`], without touching the real process environment.
+/// of the budget it would otherwise get — the metric's own `timeout_secs`, or
+/// [`MEASUREMENT_TIMEOUT`] — without touching the real process environment.
 /// `None` clears the override. `#[cfg(test)]` only.
 #[cfg(test)]
 pub(crate) fn set_test_timeout_override_ms(ms: Option<u64>) {
@@ -317,19 +365,27 @@ fn truncate_command(command: &str) -> String {
     }
 }
 
-/// The wall-clock budget for one measurement. Overridable only under
-/// `#[cfg(test)]`, and only via the thread-local set by
-/// [`set_test_timeout_override_ms`], so a test can assert the kill path
-/// without waiting out [`MEASUREMENT_TIMEOUT`] and without affecting any
-/// other test's measurements.
-fn measurement_timeout() -> Duration {
+/// The wall-clock budget for one measurement, in precedence order: the
+/// `#[cfg(test)]` thread-local override, then the metric's own declared
+/// `timeout_secs`, then [`MEASUREMENT_TIMEOUT`].
+///
+/// The override is first on purpose and must stay first. It is how the kill
+/// paths are tested at all — a test asserting that a runaway is killed cannot
+/// wait out 300s, still less the 1800s a metric may legitimately declare — so a
+/// declared budget that outranked it would make those tests unrunnable rather
+/// than merely slow. It is set only by this module's own tests, only on the
+/// calling thread, and no production path can reach it.
+pub(crate) fn resolve_timeout(declared_secs: Option<u64>) -> Duration {
     #[cfg(test)]
     {
         if let Some(ms) = TEST_TIMEOUT_OVERRIDE_MS.with(std::cell::Cell::get) {
             return Duration::from_millis(ms);
         }
     }
-    MEASUREMENT_TIMEOUT
+    match declared_secs {
+        Some(secs) => Duration::from_secs(secs),
+        None => MEASUREMENT_TIMEOUT,
+    }
 }
 
 /// Drain one of the child's pipes on its own thread, delivering the bytes
@@ -452,7 +508,7 @@ fn kill_process_tree(child: &mut Child) {
 /// process group now holds this recycled id" — worse than the hang it
 /// replaces. The bound (not a signal) is what protects this arm; see the
 /// comment at the success-arm drain below for the full argument.
-fn measure_now(project_path: &Path, command: &str) -> Measurement {
+fn measure_now(project_path: &Path, command: &str, timeout: Duration) -> Measurement {
     if command.trim().is_empty() {
         return Measurement::Unavailable(
             "the metric declares no command, so its baseline cannot be reproduced".into(),
@@ -516,7 +572,6 @@ fn measure_now(project_path: &Path, command: &str) -> Measurement {
     let out_rx = drain_on_thread(child.stdout.take());
     let err_rx = drain_on_thread(child.stderr.take());
 
-    let timeout = measurement_timeout();
     let deadline = Instant::now() + timeout;
     let status = loop {
         match child.try_wait() {


### PR DESCRIPTION
Closes #1339.

## The defect

`MEASUREMENT_TIMEOUT` is one flat 300 s for every ratchet metric, and its doc comment sized it from a workstation figure: *"this repo's own compiler-derived metric is ~40s"*. The metric in question, `unwrap_calls_shipped_code`, is a **cold full-crate `cargo clippy --lib --bins --features full`** into its own target directory, run from inside `cargo test --lib`. On a runner it is nowhere near 40 s:

| runner | run | metric | suite | outcome |
|---|---|---|---|---|
| intel-clean-room-8 | [34676994867](https://github.com/paiml/paiml-mcp-agent-toolkit/actions/runs/34676994867) | 203 s | 694 s | green |
| intel-clean-room-6 | [34680577045](https://github.com/paiml/paiml-mcp-agent-toolkit/actions/runs/34680577045) | killed at 300 s | 1287 s | 3 tests red |

So the cap that exists to bound a runaway — the fork-bomb case `RATCHET_DEPTH_ENV` guards, which once reached a load average of 3,026 — was also bounding a legitimate slow build. `unmeasurable is not compliant` is the correct verdict for a metric that did not measure; the defect is that it did not measure.

**This is not only #1337's problem.** PR #1338's `ci / test` failed the same way at 08:26Z today, on a 1413 s suite: the same three tests, the same `exceeded the 300s measurement timeout`. Two PRs whose diffs are unrelated to the ratchet are both red on it.

## The fix

A metric declares its own budget. `MetricBaseline` gains `timeout_secs: Option<u64>`; `None` still means 300 s. Precedence is **test override → declared → default**, so the existing kill-path tests still avoid waiting five minutes. `.pmat-ratchet.toml` gives `unwrap_calls_shipped_code` `timeout_secs = 1800` — ~9x the observed 203 s, still a bound.

Raising the flat constant was the alternative and is wrong: it would relax the runaway guard for every cheap `git grep` metric in order to accommodate one expensive one.

### The memoisation question

`measure` memoises on the command text. A command killed at 1 s and the same command given 1800 s are different results, so the text alone is no longer the identity. The cache is now keyed on `(command, budget)` rather than bypassed, which keeps the six-callers-one-cold-clippy win for every caller that agrees on the budget — that is every production caller of a given metric — and separates only those that disagree.

### What the failure now says

`the_committed_ratchet_holds_at_head` appends `[budget Ns, declared by the metric]` or `[budget 300s, the default]` per failing metric. A timed-out measurement and a real regression are both `Fail` and need opposite responses; the message now tells them apart.

### Contract

`contracts/comply-ratchet-v1.yaml` gains **INV-2102-7** — a measurement is bounded by the metric's declared budget, default 300 s, and exceeding it is UNAVAILABLE, never a pass — plus falsification entries naming the tests that hold it, in INV-2102-6's style.

## RED before GREEN

Every test was run on the pre-fix tree and its failure recorded:

- `a_metric_declares_its_own_budget` — pre-fix, 5.02 s: *"a 1s budget against a 5s command produced Value(1)"*. The declared 1 s was ignored and the command ran to completion under the 300 s default.
- `the_committed_unwrap_metric_declares_a_budget` — pre-fix: `left: None, right: Some(1800)`.
- The remaining three cannot compile pre-fix: 11 errors, `no field timeout_secs on MetricBaseline`, `cannot find function resolve_timeout`.

## Verification

| check | result |
|---|---|
| `cargo test --lib metrics_ratchet` (orchestrator re-run) | **75 passed, 0 failed** |
| `cargo clippy --lib --bins --features full -- -D warnings` | exit 0 |
| `panic!(` in `src/*.rs` | 785, unmoved |
| SATD markers | 324, unmoved |
| new `.unwrap()` in the diff | 0 |
| `analyze unrun-tests --executed '' --check-ledger` | exit 0 |

The ledger was rendered from a binary proven to carry this change — `strings pmat \| grep -c timeout_secs` is 4 here and 0 on installed master, control literal `zero_is_reachable` 3 in both. Both agent worktrees share `/mnt/nvme-raid0/targets/paiml-mcp-agent-toolkit`, so `debug/pmat` is whichever tree built last and the path alone proves nothing. The obvious literal to check, `[budget Ns, declared by the metric]`, is behind `cfg(test)` and absent from `--bin pmat` whichever tree built it — it would have read exactly like the change being missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
