### PR TITLE
fix(PMAT-1309): CB-2115's grace window covers the orphan legs, and the rule comes off the master push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,10 +225,41 @@ jobs:
       - name: the test suite does not write to the repository (pre-release lane)
         if: github.event_name == 'push'
         run: bash scripts/tests-dont-write-control.sh
-      - name: the closed loop holds (CB-2113) and the roadmap and GitHub agree (CB-2115)
+      - name: the closed loop holds (CB-2113)
         env:
           GH_TOKEN: ${{ github.token }}
-        run: ./target/debug/pmat comply check --checks CB-2113,CB-2115
+        run: ./target/debug/pmat comply check --checks CB-2113
+
+      # PMAT-1309 criterion 2. CB-2115 is guarded OFF the master push, and the
+      # guard is the point of the rule rather than an exemption from it.
+      #
+      # CB-2113 reads the commits in the push. Its verdict is a function of the
+      # diff, so a red one always names a commit someone can fix. CB-2115 reads
+      # GitHub LIVE, so on a push its verdict is a function of what the world
+      # looks like at that instant: master went red at 5af9a0f0d (06:08Z,
+      # 2026-09-11) because five issues had been opened by hand minutes earlier.
+      # Nothing in that push was wrong, no commit was to blame, and the only way
+      # to green master was to write the roadmap items — which is work, not a
+      # revert. A gate that reds the default branch for something no commit did
+      # teaches people to ignore the default branch.
+      #
+      # `!= 'push'` and not `== 'pull_request'`: the rule must also hold on the
+      # merge queue, or the queue is the bypass (the same reasoning as the
+      # `merge_group:` trigger at the top of this file). The scheduled lane that
+      # catches what lands between pull requests is
+      # `.github/workflows/roadmap-coherence-scheduled.yml`, and it opens a
+      # ticket rather than failing a build, because there is no build on a cron
+      # whose failure anybody owns.
+      #
+      # scripts/roadmap-coherence-control.sh arms 17 and 18 hold both halves:
+      # 17 reads THIS file and fails if any push can reach CB-2115, 18 reads the
+      # scheduled workflow and fails if its finding fails the build instead of
+      # opening an issue.
+      - name: the roadmap and GitHub agree (CB-2115) — not on the master push, see below
+        if: github.event_name != 'push'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: ./target/debug/pmat comply check --checks CB-2115
       # CB-2115 joined this step on PMAT-723, in the order goal-mode.md §5.4 sets: the
       # sync reported (PMAT-720), the thirteen items naming #612 were resolved under
       # their own ticket (PMAT-721), the orphans were triaged and fixed by the sync's

--- a/.github/workflows/roadmap-coherence-scheduled.yml
+++ b/.github/workflows/roadmap-coherence-scheduled.yml
@@ -1,0 +1,78 @@
+# PMAT-1309 criterion 2 — the other half of taking CB-2115 off the master push.
+#
+# CB-2115 reads GitHub live, so its verdict on a push to master is a function of
+# what the world looks like at that instant rather than of the diff. Master went
+# red at 5af9a0f0d (06:08Z, 2026-09-11) because five issues had been opened by
+# hand minutes earlier: nothing in the push was wrong and no commit was to blame.
+# `.github/workflows/ci.yml` now guards that step with `github.event_name !=
+# 'push'`, which closes the false-red — and opens a real hole, because an issue
+# opened by hand between two pull requests is then seen by nothing.
+#
+# This workflow is that hole's floor. It asks the same question on a cron and
+# reports the answer as a TICKET, never as a red build: there is no build here
+# whose failure anybody owns, and a permanently-red scheduled workflow is a
+# notification people turn off. The finding lands where the fix is tracked.
+#
+# Held by scripts/roadmap-coherence-control.sh arm 18, which fails if the check
+# step loses `continue-on-error` (the finding would fail the build again) or if
+# the issue-opening step disappears (the finding would reach nobody).
+name: roadmap coherence (scheduled)
+
+on:
+  schedule:
+    # Daily, offset from quality-gate (06:17) so the two do not contend for a
+    # runner. The window CB-2115 tolerates is 60 minutes, so a daily cadence
+    # sees every issue this lane exists to catch: anything opened by hand is
+    # hours old by the time this runs.
+    - cron: "37 5 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: roadmap-coherence-scheduled
+  cancel-in-progress: false
+
+jobs:
+  roadmap-coherence:
+    name: the roadmap and GitHub agree (CB-2115)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: build pmat from this tree
+        run: cargo build --bin pmat --locked
+
+      # continue-on-error is the whole design, not a workaround: a finding here
+      # must open a ticket INSTEAD OF failing the build (PMAT-1309 criterion 2).
+      # The step's own outcome is still recorded, which is what the next step
+      # branches on.
+      - name: CB-2115 against live GitHub
+        id: check
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -o pipefail
+          ./target/debug/pmat comply check --checks CB-2115 2>&1 | tee cb2115.out
+
+      - name: Open or refresh the ticket
+        if: steps.check.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          title="CB-2115: the roadmap and GitHub have drifted apart"
+          body="$(printf 'Found by the scheduled roadmap-coherence lane (PMAT-1309 criterion 2, goal-mode.md §3.3 and §5.2).\n\nThis is a TICKET and not a red build on purpose: CB-2115 reads GitHub live, so its verdict is not a function of any commit. Fix it with `pmat work sync --direction github-to-yaml` for an issue with no item, or by closing the item for an item naming a closed issue.\n\n```\n%s\n```\n\nRun: %s/%s/actions/runs/%s' "$(cat cb2115.out)" "$GITHUB_SERVER_URL" "$GITHUB_REPOSITORY" "$GITHUB_RUN_ID")"
+          n=$(gh issue list --state open --search "\"$title\" in:title" --json number --jq '.[0].number // empty')
+          if [ -n "$n" ]; then gh issue comment "$n" --body "$body"; else gh issue create --title "$title" --body "$body"; fi
+
+      - name: Say so when it is clean
+        if: steps.check.outcome == 'success'
+        run: |
+          echo "CB-2115 clean: every open issue has an open item and every open item an open issue."

--- a/.github/workflows/roadmap-coherence-scheduled.yml
+++ b/.github/workflows/roadmap-coherence-scheduled.yml
@@ -40,6 +40,13 @@ jobs:
       contents: read
       issues: write
     steps:
+      # @v7 is not a typo for @v4, and this is the second reader to ask. It is
+      # what 37 other steps in .github/workflows already pin, actions/checkout
+      # v7.0.1 is real, and `gh api repos/actions/checkout/git/ref/tags/v7`
+      # resolves to 3d3c42e5aac5ba805825da76410c181273ba90b1. The confusion is
+      # understandable: v4.4.0, v5.1.0, v6.1.0 and v7.0.1 were all published
+      # within 26 minutes of each other on 2026-07-20, so a memory of "v4 is
+      # the latest" is recent enough to feel current and is wrong.
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
@@ -53,6 +60,14 @@ jobs:
       # must open a ticket INSTEAD OF failing the build (PMAT-1309 criterion 2).
       # The step's own outcome is still recorded, which is what the next step
       # branches on.
+      #
+      # It covers THIS step and deliberately not the ones above it, because a
+      # finding and a broken lane are opposite things. A finding means the lane
+      # worked: the roadmap and GitHub really have drifted, nobody's build is at
+      # fault, and the answer is a ticket. A checkout or a build that fails means
+      # the lane did not run at all — nothing was measured, and a green tick over
+      # an unasked question is the failure mode this whole ticket is about. That
+      # one is supposed to go red and page someone.
       - name: CB-2115 against live GitHub
         id: check
         continue-on-error: true

--- a/docs/audits/quorum-PMAT-1309.json
+++ b/docs/audits/quorum-PMAT-1309.json
@@ -1,0 +1,78 @@
+{
+  "ticket": "PMAT-1309",
+  "base": "master",
+  "base_resolved": "origin/master",
+  "base_note": "local master differs from origin/master by 121 commit(s); judged against origin/master",
+  "head": "052d181f07f9efd7d18f041269bfccf1cbafe8dd",
+  "diff_sha256": "60af9ff7150b53375abca5802f4bac8d5c161399699a493b2cbea17a7fe1033c",
+  "width": 3,
+  "executor": "agy",
+  "prompt_mode": "inline",
+  "prompt_bytes": 67000,
+  "author": {
+    "model": "Opus 5 (1M context)",
+    "family": "claude",
+    "source": "measured"
+  },
+  "agreed": true,
+  "lanes": [
+    {
+      "lane": 1,
+      "status": "SUCCESS",
+      "verdict": "PASS",
+      "summary": "I have reviewed the diff against the requirements for PMAT-1309 and found no issues. The implementation perfectly aligns with the ticket, the specification, and the acceptance criteria.\n\nHere is a summary of the verification:\n1. **The grace window covers the ORPHAN and MISSING legs**: \n   - `src/services/work_sync/mod.rs` successfully implements logic to tolerate `OrphanRoadmap` (`NoIssue` only) and `OrphanGithub` if their age is within the `grace_minutes` window.\n   - The age is accurately measured from the issue's `createdAt` and the item's `created` timestamps, properly falling back to `updatedAt`/`updated` when they are unavailable or unparseable.\n   - Tolerated findings are correctly logged in `tolerated_notes` and do not fail the CI check, resolving the problem of the master branch going red when an issue is manually opened. \n   - Tolerated findings are appropriately added to `tolerated_orphans` and correctly included in the `plan` so `pmat work sync` will still process them.\n\n2. **The rule comes off the master push**:\n   - `.github/workflows/ci.yml` successfully guards the execution of `CB-2115` with `if: github.event_name != 'push'`, removing it from the master push while preserving its presence on pull requests and merge queues.\n\n3. **Scheduled workflow opens tickets rather than failing the build**:\n   - `.github/workflows/roadmap-coherence-scheduled.yml` is introduced to cover the gap left by removing the check from the master push.\n   - It runs on a daily schedule, executes with `continue-on-error: true`, and strictly opens or updates an issue on failure using `gh issue create` / `gh issue comment`, adhering to the exact specification without failing the build.\n\n4. **Rigorous validation**:\n   - `scripts/roadmap-coherence-control.sh` comprehensively guards these new behaviors. Arms 12 to 15 correctly verify that fresh orphans are tolerated and older ones fail. Arm 17 enforces that no step in `ci.yml` runs `CB-2115` on a push. Arm 18 ensures that the scheduled workflow maintains `continue-on-error: true` and the issue reporting logic.\n   - `src/cli/handlers/comply_handlers/check_handlers/check_roadmap_coherence_tests.rs` and `src/services/work_sync/tests.rs` include robust unit tests for the age calculations, formatting of `tolerated_notes`, and `plan` integration.\n\nThe change does exactly what the ticket asks for, and nothing it forbids. No gates are improperly weakened, and all receipt claims are backed by the diff.",
+      "findings": [],
+      "raw_bytes": 6255,
+      "err_bytes": 0,
+      "envelope_status": "SUCCESS",
+      "model": "gemini-3.1-pro-high",
+      "model_measured": "gemini-3.1-pro-high",
+      "model_source": "measured",
+      "family": "gemini"
+    },
+    {
+      "lane": 2,
+      "status": "SUCCESS",
+      "verdict": "PASS",
+      "summary": "The diff successfully implements the requirements of PMAT-1309. The grace window is extended to cover both the ORPHAN-GITHUB and ORPHAN-ROADMAP legs by verifying timestamps (`created` for items, and `created_at` falling back to `updated_at` for issues). Instances within the grace window are appropriately categorized as tolerated and still planned by the fixer. Furthermore, it successfully removes the CB-2115 check from the master push by conditioning its execution in `ci.yml`, and introduces a new scheduled workflow to handle live checking by creating issues rather than failing the build. Comprehensive bash and rust tests are provided to ensure this behavior holds. No extra unrequested changes were included.",
+      "findings": [],
+      "raw_bytes": 2686,
+      "err_bytes": 0,
+      "envelope_status": "SUCCESS",
+      "model": "gemini-3.1-pro-high",
+      "model_measured": "gemini-3.1-pro-high",
+      "model_source": "measured",
+      "family": "gemini"
+    },
+    {
+      "lane": 3,
+      "status": "SUCCESS",
+      "verdict": "PASS",
+      "summary": "The diff successfully implements both requirements of PMAT-1309. It introduces a `created_at` / `created` age check for issues and roadmap items to tolerate orphans (ORPHAN and MISSING legs) inside the grace window. It properly delegates these tolerated orphans to `tolerated_orphans` so that `pmat work sync` can still fix them immediately. Additionally, it takes the CB-2115 check off the master push in `ci.yml` (using `if: github.event_name != 'push'`) and adds a scheduled workflow (`roadmap-coherence-scheduled.yml`) that opens a ticket rather than failing the build when discrepancies are found. The bash control scripts and Rust tests have been thoroughly updated to verify this new logic.",
+      "findings": [],
+      "raw_bytes": 3546,
+      "err_bytes": 0,
+      "envelope_status": "SUCCESS",
+      "model": "gemini-3.1-pro-high",
+      "model_measured": "gemini-3.1-pro-high",
+      "model_source": "measured",
+      "family": "gemini"
+    }
+  ],
+  "dissent": [],
+  "dedup": [],
+  "uncovered": [],
+  "coverage_source": "lanes",
+  "partial": false,
+  "partial_reasons": [],
+  "auto_merge": {
+    "checked": true,
+    "was_armed": false,
+    "disarmed": false,
+    "note": "auto-merge not armed"
+  },
+  "lint": {
+    "ok": true,
+    "output": "receipt complete: kind=artifact lanes=3 author=Opus 5 (1M context)/claude"
+  }
+}

--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -6254,7 +6254,7 @@ roadmap:
   updated: 2026-09-11T06:16:11Z
   spec: null
   acceptance_criteria:
-  - 'the staleness grace window covers the ORPHAN and MISSING legs as well as a field disagreement: an issue opened less than staleness_grace_minutes ago is not_measured rather than a finding, and so is an item added without its issue'
+  - 'the staleness grace window covers the ORPHAN and MISSING legs as well as a field disagreement: an issue opened less than staleness_grace_minutes ago is tolerated (the rule PASSES and prints the count, goal-mode.md §5.2, quorum 5 of 5) rather than a finding, and so is an item added without its issue; past the window each is a finding'
   - CB-2115 no longer runs on a push to master; it runs on pull requests, and on a schedule whose finding OPENS A TICKET instead of failing the build
   - the window stays at now - max(item.updated, issue.updated_at); no first-seen state file is added, and a control arm proves a timestamp bump restarts it, which is the accepted cost recorded in goal-mode.md §5.2
   - scripts/roadmap-coherence-control.sh carries an arm for a freshly opened orphan issue inside the window, one for the same issue past it, and one proving the master-push path is gone

--- a/docs/specifications/goal-mode.md
+++ b/docs/specifications/goal-mode.md
@@ -368,8 +368,21 @@ same verdict a matched pair inside the window gets. It is emphatically not `not_
 which §3.3 maps to FAIL: the sync that would mint its item cannot have run yet, and a rule
 that turns master red the instant anyone opens an issue is a rule someone disables. The same holds for an item added without its
 issue. Past the window it is a finding, and `pmat work sync` is the fixer. (Decided by
-quorum 2026-09-11, 5 of 5 seats — one of the two unanimous decisions of the sixteen.) The code
-covers the field-disagreement leg only; extending it to ORPHAN and MISSING is PMAT-1309.
+quorum 2026-09-11, 5 of 5 seats — one of the two unanimous decisions of the sixteen.)
+
+The code does all three legs (PMAT-1309). `work_sync::check` tolerates an open item that
+names no issue and an open issue that no item names whenever that record's own age is inside
+the window: from the item's `created`, falling back to `updated`, and from the issue's
+`created_at`, falling back to `updated_at` — which is all a snapshot written before the field
+existed carries, and which answers "was this opened a minute ago?" only by coincidence. Each
+toleration is counted in `tolerated` AND named in the line the rule prints, because one count
+cannot tell a drifted field from a young orphan and a PASS that silently swallowed a real
+orphan would be worse than the red build this tolerance replaces. The window is a tolerance in
+the VERDICT only: `plan` still lists a tolerated orphan, so `pmat work sync` mints the issue
+for an item written a minute ago instead of refusing every item younger than an hour. The
+other three `ORPHAN-ROADMAP` reasons — the issue is closed, absent, or labelled `no-roadmap` —
+are never behind the window, because none of them is a freshness problem: a closed issue does
+not become un-closed by being recent.
 
 ### 5.3 `RR-COHERENCE` — which side wins
 
@@ -581,10 +594,9 @@ refuses `skipped` by design. The gate is right; the input cannot be used by any 
    measure **master**, not merely the PR — see §7. Setting it is a ruleset change on
    `13878864`; until it is made, CB-2113 measures the PR's commits only and says so in
    its output rather than pretending to cover master.
-5. **Four rules describe more than the code does today**, each with its ticket: CB-2113's
+5. **Three rules describe more than the code does today**, each with its ticket: CB-2113's
    master leg reports `not_applicable` there for now and its release leg is unwritten
-   (PMAT-1308), CB-2115's grace window covers the field-disagreement leg only and the rule
-   still runs on a master push (PMAT-1309), the fork carve-out above is not yet implemented
+   (PMAT-1308), the fork carve-out above is not yet implemented
    (PMAT-1310), and CB-2114 still binds every open item rather than the `inprogress` ones
    while CB-2110/2112/2114 still assert live state on a master push (PMAT-1312), and the
    cut's sweep-and-move of §10.3 is a description of `pmat goal`, which does not exist

--- a/docs/status/unrun-tests-ledger.md
+++ b/docs/status/unrun-tests-ledger.md
@@ -14,7 +14,7 @@ Legs consulted (3):
 - `feature-matrix.yml:feature-tests[mcp-integration]`
 - `feature-matrix.yml:feature-tests[unified-protocol]`
 
-24212 of 27339 lib tests are executed; 3127 are compiled by no leg.
+24225 of 27352 lib tests are executed; 3127 are compiled by no leg.
 
 ## `<unsatisfiable>` — 2098 test(s)
 

--- a/scripts/roadmap-coherence-control.sh
+++ b/scripts/roadmap-coherence-control.sh
@@ -28,6 +28,7 @@
 #   arm 15 RED   the same item created 6 hours ago                           exit 1, Fail, ORPHAN-ROADMAP PMAT-002
 #   arm 16 GREEN the accepted cost: bumping `updated` restarts the window      exit 0, Pass — a DELIBERATE weakness, see the arm
 #   arm 17 CI    CB-2115 is unreachable on a push to master (.github/workflows/ci.yml)
+#   arm 18 CI    the scheduled lane OPENS A TICKET rather than failing the build
 #
 # Each arm asserts BOTH the process exit code and the CB-2115 entry in the JSON
 # report: the exit code is what CI acts on, the entry is what proves the verdict
@@ -367,6 +368,15 @@ cb2115_steps="$(awk '
   /^jobs:[ \t]*$/ { injobs = 1; next }
   injobs && /^[^ \t#]/ { flush(); injobs = 0 }
   injobs != 1 { next }
+  # A comment is not a step. ci.yml DISCUSSES CB-2115 in prose — the withheld
+  # `#     run: ... --checks CB-2112,CB-2113,CB-2114,CB-2115` at the end of the
+  # traceability job, and the paragraph explaining why the live rule is guarded.
+  # Accumulated into the preceding step those words make an unrelated, unguarded
+  # step (the CB-2113 one) read as a CB-2115 step with no guard, which is a false
+  # RED — and the mirror case, a real step followed by a comment naming a guard,
+  # would be a false GREEN. Measured: without this rule the arm reported the
+  # traceability job twice, once FAILED and once GREEN, on the same file.
+  /^[ \t]*#/ { next }
   /^  [A-Za-z0-9_.-]+:[ \t]*$/ { flush(); job = $1; sub(/:$/, "", job); jobif = ""; stepif = ""; step = ""; next }
   /^      - / { flush(); step = ""; stepif = "" }
   { step = step " " $0
@@ -402,4 +412,58 @@ EOF
   echo "roadmap-coherence-control: arm 17 GREEN — no push to master can reach CB-2115 in ci.yml"
 fi
 
-echo "roadmap-coherence-control: all 17 arms behaved — CB-2115 can fail, can pass, says why, tolerates only what is fresh, and refuses its own bypasses"
+
+# ── arm 18: the scheduled lane reports a finding as a TICKET, not a red build ──
+# Arm 17 takes CB-2115 off the master push. That closes a false red and opens a
+# real hole: an issue opened by hand between two pull requests is then seen by
+# nothing. Criterion 2 of PMAT-1309 fills it with a scheduled run "whose finding
+# OPENS A TICKET instead of failing the build", and this arm is what makes that
+# clause falsifiable rather than aspirational. Three things must all hold, and
+# each has its own way of rotting:
+#
+#   (a) SOME workflow runs `pmat comply check` naming CB-2115 under a `schedule:`
+#       trigger — else the hole is simply open.
+#   (b) that step carries `continue-on-error: true` — else the finding fails the
+#       build after all, which is the outcome the criterion rules out, and a
+#       permanently-red cron is a notification people turn off.
+#   (c) some later step runs `gh issue create` — else the finding reaches nobody
+#       and the run is a green tick over a real drift, the worst of the three.
+#
+# Falsified before it was believed: with (b) deleted the arm prints FAILED naming
+# continue-on-error; with (c)'s step deleted it prints FAILED naming gh issue
+# create; with the whole workflow deleted it prints FAILED naming the schedule.
+wfdir="$(cd "$(dirname "$0")/.." && pwd)/.github/workflows"
+arm18_file=""
+for f in "$wfdir"/*.yml "$wfdir"/*.yaml; do
+  [ -f "$f" ] || continue
+  grep -q 'schedule:' "$f" || continue
+  grep -q 'CB-2115' "$f" || continue
+  grep -qE 'comply[[:space:]]+check' "$f" || continue
+  arm18_file="$f"
+  break
+done
+
+if [ -z "$arm18_file" ]; then
+  echo "roadmap-coherence-control: ARM 18 FAILED — no workflow under .github/workflows runs \`pmat comply check\` with CB-2115 on a \`schedule:\`" >&2
+  echo "  Arm 17 takes CB-2115 off the master push; without a scheduled lane an issue opened between two pull requests is seen by nothing (PMAT-1309 criterion 2)." >&2
+  exit 1
+fi
+arm18_name="$(basename "$arm18_file")"
+
+# (b) the step that runs the check must not fail the build.
+if ! grep -qE '^[[:space:]]*continue-on-error:[[:space:]]*true' "$arm18_file"; then
+  echo "roadmap-coherence-control: ARM 18 FAILED — $arm18_name runs CB-2115 on a schedule but no step carries \`continue-on-error: true\`, so a finding FAILS THE BUILD" >&2
+  echo "  Criterion 2 requires the scheduled finding to open a ticket INSTEAD OF failing the build (goal-mode.md §3.3, §5.2)." >&2
+  exit 1
+fi
+
+# (c) and it must reach a human.
+if ! grep -q 'gh issue create' "$arm18_file"; then
+  echo "roadmap-coherence-control: ARM 18 FAILED — $arm18_name never runs \`gh issue create\`, so a scheduled finding reaches nobody" >&2
+  echo "  A green tick over a real drift is worse than the red build this lane replaced." >&2
+  exit 1
+fi
+
+echo "roadmap-coherence-control: arm 18 GREEN — $arm18_name asks CB-2115 on a schedule, does not fail the build on a finding, and opens a ticket"
+
+echo "roadmap-coherence-control: all 18 arms behaved — CB-2115 can fail, can pass, says why, tolerates only what is fresh, refuses its own bypasses, and reports out of band what it no longer reds master for"

--- a/scripts/roadmap-coherence-control.sh
+++ b/scripts/roadmap-coherence-control.sh
@@ -22,12 +22,25 @@
 #   arm 9  N/M   the roadmap was committed and then deleted                   exit 1, Fail, not_measured: "committed and is now gone"
 #   arm 10 N/M   a snapshot path committed in .pmat.yaml (the bypass token)   exit 1, Fail, not_measured: names .pmat.yaml and --github-snapshot
 #   arm 11 RED   grace_minutes: 10 makes a 30-minute-old disagreement a DRIFT exit 1, Fail — then the same pair passes without the option
+#   arm 12 GREEN an orphan issue OPENED 5 minutes ago, grace 60               exit 0, Pass, tolerated 1, names #2
+#   arm 13 RED   the same orphan issue opened 6 hours ago                     exit 1, Fail, ORPHAN-GITHUB #2 — and again with updated_at bumped to now
+#   arm 14 GREEN an item with no github_issue, created 5 minutes ago          exit 0, Pass, tolerated 1, names PMAT-002
+#   arm 15 RED   the same item created 6 hours ago                           exit 1, Fail, ORPHAN-ROADMAP PMAT-002
+#   arm 16 GREEN the accepted cost: bumping `updated` restarts the window      exit 0, Pass — a DELIBERATE weakness, see the arm
+#   arm 17 CI    CB-2115 is unreachable on a push to master (.github/workflows/ci.yml)
 #
 # Each arm asserts BOTH the process exit code and the CB-2115 entry in the JSON
 # report: the exit code is what CI acts on, the entry is what proves the verdict
 # came from this rule and not from another one. A missing entry is
 # under-discovery and fails the control (exit 2) — "we found no CB-2115 row"
 # must never render as "CB-2115 passed".
+#
+# Arms 12-15 are PMAT-1309: the window covers the two freshness legs of §5.1 as
+# well as the field disagreement. Each is a PAIR — the same fixture inside and
+# outside the window — so an implementation that tolerated everything, or
+# nothing, fails one half of every pair. Arm 13's second half proves the ORPHAN
+# leg measures `created_at`, not `updated_at`: an issue open for six hours and
+# relabelled a second ago is still an orphan.
 #
 # Arm 6 is the one that proves §5.2's tolerance is a bound in TIME: the same
 # disagreement as arm 5 passes only because one side moved inside the window.
@@ -64,6 +77,8 @@ report="$work/report.json"
 # inside and outside the window. Nothing built from them is an artifact.
 old="$(date -u -d '2 days ago' +%Y-%m-%dT%H:%M:%SZ)"   # bashrs disable-line=DET002
 now="$(date -u +%Y-%m-%dT%H:%M:%SZ)"                   # bashrs disable-line=DET002
+fresh="$(date -u -d '5 minutes ago' +%Y-%m-%dT%H:%M:%SZ)" # bashrs disable-line=DET002
+sixh="$(date -u -d '6 hours ago' +%Y-%m-%dT%H:%M:%SZ)"    # bashrs disable-line=DET002
 
 # The fixture is a git repository with NO remote, so nothing here can fall back
 # to a live `gh` call: the rule reads the snapshot the `.pmat.yaml` names or
@@ -89,6 +104,16 @@ item() {
 issue() {
   jq -cn --argjson n "$1" --arg t "$2" --arg s "$3" --argjson l "$4" --arg u "$5" \
     '{number:$n, title:$t, state:$s, labels:$l, updated_at:$u}'
+}
+# item_created <id> <title> <status> <issue|null> <updated> <created>
+# `created` is the field the ORPHAN leg of the window measures from (§5.2).
+item_created() {
+  printf '  - id: %s\n    title: %s\n    status: %s\n    github_issue: %s\n    updated: %s\n    created: %s\n' "$1" "$2" "$3" "$4" "$5" "$6"
+}
+# issue_created <number> <title> <open|closed> <labels-json-array> <updated_at> <created_at>
+issue_created() {
+  jq -cn --argjson n "$1" --arg t "$2" --arg s "$3" --argjson l "$4" --arg u "$5" --arg c "$6" \
+    '{number:$n, title:$t, state:$s, labels:$l, updated_at:$u, created_at:$c}'
 }
 # write_snapshot <issue-json>...   (GRACE, if set, becomes the only .pmat.yaml option)
 write_snapshot() {
@@ -246,4 +271,135 @@ run_gate
 [ "$STATUS" = "Pass" ] || fail_arm 11 "CB-2115 must be Pass under the default grace"
 echo "roadmap-coherence-control: arm 11 RED  — grace_minutes: 10 refused the 30-minute DRIFT that the default tolerates (exit 1, then 0)"
 
-echo "roadmap-coherence-control: all 11 arms behaved — CB-2115 can fail, can pass, says why, and refuses its own bypasses"
+# ── arm 12: GREEN — an issue OPENED 5 minutes ago that no item names ───────────
+# The case that reddened master at 5af9a0f0d, 06:08Z, 2026-09-11: five issues
+# opened by hand, no roadmap item yet, no commit to blame. Inside the window it
+# is tolerated, and the PASS must still NAME it — a pass that silently swallows
+# an orphan is worse than the red build it replaces.
+write_roadmap "$(item PMAT-001 'planned work' planned 1 "$old")"
+write_snapshot "$(issue 1 'planned work' open '[]' "$old")" \
+               "$(issue_created 2 'opened by hand' open '[]' "$fresh" "$fresh")"
+run_gate
+[ "$RC" -eq 0 ] || fail_arm 12 "an issue opened 5 minutes ago is inside the grace window and must exit 0 (§5.2, PMAT-1309)"
+[ "$STATUS" = "Pass" ] || fail_arm 12 "CB-2115 must be Pass while the window is open"
+needs 12 "tolerated 1" "#2"
+echo "roadmap-coherence-control: arm 12 GREEN — ORPHAN-GITHUB #2, opened 5 minutes ago, tolerated AND named (exit 0)"
+
+# ── arm 13: RED — the same orphan issue, opened 6 hours ago ────────────────────
+write_snapshot "$(issue 1 'planned work' open '[]' "$old")" \
+               "$(issue_created 2 'opened by hand' open '[]' "$sixh" "$sixh")"
+run_gate
+[ "$RC" -eq 1 ] || fail_arm 13 "an orphan issue past the window must exit 1 — age is the only difference from arm 12"
+[ "$STATUS" = "Fail" ] || fail_arm 13 "CB-2115 must be Fail on an ORPHAN-GITHUB past the window"
+needs 13 "ORPHAN-GITHUB" "#2"
+# ...and a bump to `updated_at` does NOT restart it: the ORPHAN leg measures when
+# the issue was OPENED. An issue open for six hours and relabelled a second ago
+# is an orphan, not a new issue.
+write_snapshot "$(issue 1 'planned work' open '[]' "$old")" \
+               "$(issue_created 2 'opened by hand' open '[]' "$now" "$sixh")"
+run_gate
+[ "$RC" -eq 1 ] || fail_arm 13 "created_at, not updated_at: touching a 6-hour-old orphan must not buy it a new window"
+needs 13 "ORPHAN-GITHUB" "#2"
+echo "roadmap-coherence-control: arm 13 RED   — ORPHAN-GITHUB #2 opened 6 hours ago refused, and still refused after updated_at is bumped to now (exit 1, twice)"
+
+# ── arm 14: GREEN — an item written 5 minutes ago whose issue is not minted ────
+write_roadmap "$(item PMAT-001 'planned work' planned 1 "$old")" \
+              "$(item_created PMAT-002 'brand new' planned null "$fresh" "$fresh")"
+write_snapshot "$(issue 1 'planned work' open '[]' "$old")"
+run_gate
+[ "$RC" -eq 0 ] || fail_arm 14 "an item created 5 minutes ago has not had time to be minted (§5.2, PMAT-1309)"
+[ "$STATUS" = "Pass" ] || fail_arm 14 "CB-2115 must be Pass while the window is open"
+needs 14 "tolerated 1" "PMAT-002"
+echo "roadmap-coherence-control: arm 14 GREEN — PMAT-002, written 5 minutes ago with no issue, tolerated AND named (exit 0)"
+
+# ── arm 15: RED — the same item, written 6 hours ago ───────────────────────────
+write_roadmap "$(item PMAT-001 'planned work' planned 1 "$old")" \
+              "$(item_created PMAT-002 'not so new' planned null "$sixh" "$sixh")"
+write_snapshot "$(issue 1 'planned work' open '[]' "$old")"
+run_gate
+[ "$RC" -eq 1 ] || fail_arm 15 "an item with no issue past the window must exit 1 — age is the only difference from arm 14"
+[ "$STATUS" = "Fail" ] || fail_arm 15 "CB-2115 must be Fail on an ORPHAN-ROADMAP past the window"
+needs 15 "ORPHAN-ROADMAP" "PMAT-002" "no issue"
+echo "roadmap-coherence-control: arm 15 RED   — ORPHAN-ROADMAP PMAT-002, written 6 hours ago, refused (exit 1)"
+
+# ── arm 16: GREEN — THE ACCEPTED COST, encoded on purpose ─────────────────────
+# A two-day-old disagreement is a DRIFT (arm 5). Touch either side and the window
+# starts again, so the same disagreement passes. This arm asserts that it PASSES.
+#
+# THIS IS A DELIBERATE WEAKNESS, NOT A BUG TO FIX. goal-mode.md §5.2 records the
+# trade and the vote (quorum 2026-09-11, 4 of 5 seats): measuring from when a
+# sync FIRST SAW the disagreement needs a first-seen record that must be written,
+# committed, read back and kept honest across every clone and every CI runner,
+# and a gate whose verdict depends on a state file cannot be judged from a clean
+# clone. The cost taken is a window a touch can restart. If you are here because
+# this arm offends you, change the SPEC first — do not delete the arm.
+write_roadmap "$(item PMAT-001 'old title' planned 1 "$now")"
+write_snapshot "$(issue 1 'new title' open '[]' "$old")"
+run_gate
+[ "$RC" -eq 0 ] || fail_arm 16 "bumping the item's updated restarts the window — the accepted cost of having no first-seen state (§5.2)"
+[ "$STATUS" = "Pass" ] || fail_arm 16 "CB-2115 must be Pass once a side has been touched"
+needs 16 "tolerated 1"
+echo "roadmap-coherence-control: arm 16 GREEN — a timestamp bump restarts the window; DELIBERATE (§5.2's accepted cost, quorum 4 of 5) — do not 'fix' this arm"
+
+# ── arm 17: CB-2115 is unreachable on a push to master ────────────────────────
+# Criterion 2 of PMAT-1309: CB-2115 reads GitHub LIVE, so its verdict on master
+# changes while master does not — an issue opened by hand turns a green commit
+# red with no diff to blame. It runs on pull requests, where a human can fix what
+# the diff caused, and on a schedule, where a finding opens a ticket. This arm
+# reads the workflow, not the rule: every job in .github/workflows/ci.yml whose
+# steps run `pmat comply check` naming CB-2115 must be guarded so a push cannot
+# reach it. A job with no guard at all is reachable on a push to master and fails
+# here. If CB-2115 has left ci.yml entirely the arm says so and checks no
+# further — the pull-request and schedule legs then live in another workflow,
+# which this arm does not read.
+ci="$(cd "$(dirname "$0")/.." && pwd)/.github/workflows/ci.yml"
+if [ ! -f "$ci" ]; then
+  echo "roadmap-coherence-control: ARM 17 FAILED — no $ci to read" >&2
+  exit 1
+fi
+# One record per CB-2115 step: "<job>\t<every guard expression in that job and step>".
+cb2115_steps="$(awk '
+  function flush() {
+    if (job != "" && step ~ /comply[ \t]+check/ && step ~ /CB-2115/) {
+      printf "%s\t%s %s\n", job, jobif, stepif
+    }
+  }
+  /^jobs:[ \t]*$/ { injobs = 1; next }
+  injobs && /^[^ \t#]/ { flush(); injobs = 0 }
+  injobs != 1 { next }
+  /^  [A-Za-z0-9_.-]+:[ \t]*$/ { flush(); job = $1; sub(/:$/, "", job); jobif = ""; stepif = ""; step = ""; next }
+  /^      - / { flush(); step = ""; stepif = "" }
+  { step = step " " $0
+    if ($0 ~ /github\.event_name/) {
+      if ($0 ~ /^    if:/) { jobif = jobif " " $0 } else { stepif = stepif " " $0 }
+    }
+  }
+  END { flush() }
+' "$ci")"
+
+if [ -z "$cb2115_steps" ]; then
+  echo "roadmap-coherence-control: arm 17 N/A   — no step in ci.yml runs pmat comply check with CB-2115; the pull-request and schedule legs are elsewhere and this arm does not read them"
+else
+  arm17_bad=0
+  while IFS=$'\t' read -r job guard; do
+    [ -n "$job" ] || continue
+    ok=0
+    case "$guard" in
+      *"github.event_name == 'push'"*) ok=0 ;;
+      *"github.event_name != 'push'"*|*"github.event_name == 'pull_request'"*|*"github.event_name == 'schedule'"*) ok=1 ;;
+    esac
+    if [ "$ok" -eq 1 ]; then
+      echo "roadmap-coherence-control: arm 17       — job '$job' runs CB-2115 behind:$guard"
+    else
+      arm17_bad=1
+      echo "roadmap-coherence-control: ARM 17 FAILED — job '$job' in .github/workflows/ci.yml runs \`pmat comply check\` with CB-2115 and a push to master reaches it (guard found: '${guard# }')" >&2
+      echo "  CB-2115 reads GitHub live: on master its verdict changes with no diff to blame (5af9a0f0d, 06:08Z 2026-09-11). Guard the step or the job with github.event_name (goal-mode.md §3.3, §5.2; PMAT-1309 criterion 2)." >&2
+    fi
+  done <<EOF
+$cb2115_steps
+EOF
+  [ "$arm17_bad" -eq 0 ] || exit 1
+  echo "roadmap-coherence-control: arm 17 GREEN — no push to master can reach CB-2115 in ci.yml"
+fi
+
+echo "roadmap-coherence-control: all 17 arms behaved — CB-2115 can fail, can pass, says why, tolerates only what is fresh, and refuses its own bypasses"

--- a/src/cli/handlers/comply_handlers/check_handlers/check_roadmap_coherence.rs
+++ b/src/cli/handlers/comply_handlers/check_handlers/check_roadmap_coherence.rs
@@ -1,11 +1,16 @@
 /// CB-2115: Roadmap Coherence (goal-mode.md §5.1, §5.2, §5.4; invariant D).
 ///
 /// The open roadmap items and the open, unlabelled GitHub issues are in
-/// bijection (§5.1, tolerance zero: COLLISION, ORPHAN-ROADMAP, ORPHAN-GITHUB)
-/// and no matched pair has disagreed past the grace window (§5.2, a bound in
-/// time: DRIFT). The judgement is the step-3 engine, `work_sync::check`; the
-/// inputs and their early verdicts are `roadmap_inputs`. `grace_minutes` is
-/// read from `.pmat.yaml` `comply.checks.cb-2115.options`.
+/// bijection (§5.1: COLLISION, ORPHAN-ROADMAP, ORPHAN-GITHUB) and no matched
+/// pair has disagreed past the grace window (§5.2, a bound in time: DRIFT).
+/// The judgement is the step-3 engine, `work_sync::check`; the inputs and their
+/// early verdicts are `roadmap_inputs`. `grace_minutes` is read from
+/// `.pmat.yaml` `comply.checks.cb-2115.options`.
+///
+/// The window covers the two freshness legs as well (PMAT-1309): an issue
+/// opened, or an item written, less than `grace_minutes` ago is tolerated, and
+/// the PASS NAMES every toleration. A pass that swallowed a real orphan in a
+/// bare count would be worse than the red build this tolerance replaces.
 pub(crate) fn check_roadmap_coherence(
     project_path: &Path,
     comply_config: &crate::models::comply_config::ComplyConfig,
@@ -38,8 +43,16 @@ pub(crate) fn check_roadmap_coherence(
     let settings = crate::services::work_sync::Settings::new(chrono::Utc::now(), grace_minutes);
     let report = crate::services::work_sync::check(&inputs.roadmap, &inputs.snapshot, &settings);
     let n = report.findings.len();
+    let tolerated = if report.tolerated_notes.is_empty() {
+        String::new()
+    } else {
+        format!(
+            " — {}",
+            first_eight(report.tolerated_notes.iter().cloned(), report.tolerated)
+        )
+    };
     let pass = format!(
-        "{} open item(s) and {} open issue(s) are in bijection: matched {}, tolerated {} inside the {}-minute grace window (goal-mode.md §5); snapshot: {} taken {}",
+        "{} open item(s) and {} open issue(s) are in bijection: matched {}, tolerated {} inside the {}-minute grace window (goal-mode.md §5){tolerated}; snapshot: {} taken {}",
         report.open_items, report.open_issues, report.matched, report.tolerated, grace_minutes, inputs.source, inputs.taken_at
     );
     let fail = format!(

--- a/src/cli/handlers/comply_handlers/check_handlers/check_roadmap_coherence_tests.rs
+++ b/src/cli/handlers/comply_handlers/check_handlers/check_roadmap_coherence_tests.rs
@@ -36,6 +36,13 @@ mod tests_roadmap_coherence {
         format!("  - id: {id}\n    title: {title}\n    status: {status}\n    github_issue: {issue}\n    updated: {updated}\n")
     }
 
+    /// An item that also carries a `created` timestamp — the field the ORPHAN
+    /// leg of the grace window measures from (§5.2, PMAT-1309).
+    fn item_created(id: &str, title: &str, issue: Option<u64>, created: &str) -> String {
+        let issue = issue.map_or("null".to_string(), |n| n.to_string());
+        format!("  - id: {id}\n    title: {title}\n    status: planned\n    github_issue: {issue}\n    created: {created}\n    updated: {created}\n")
+    }
+
     fn issue(number: u64, title: &str, state: &str, labels: &[&str], updated_at: &str) -> serde_json::Value {
         serde_json::json!({"number": number, "title": title, "state": state, "labels": labels, "updated_at": updated_at})
     }
@@ -296,6 +303,60 @@ mod tests_roadmap_coherence {
         })
         .expect("`comply check --github-snapshot FILE` must parse");
         assert!(parsed.contains("fixtures/x.json"), "the path must survive parsing: {parsed}");
+    }
+
+    #[test]
+    fn a_freshly_opened_orphan_issue_passes_and_the_message_names_it() {
+        // The case that reddened master at 5af9a0f0d 06:08Z on 2026-09-11: an
+        // issue opened by hand, seconds old, with no roadmap item yet. Inside
+        // the window it is tolerated — and the PASS must still NAME it, or the
+        // rule would be silently swallowing a real orphan (§5.2, PMAT-1309).
+        let dir = project(Some("paiml/fixture"), &item("PMAT-001", "planned work", "planned", Some(1), &days_ago(2)));
+        snapshot(
+            dir.path(),
+            vec![
+                issue(1, "planned work", "open", &[], &days_ago(2)),
+                issue(2, "stray", "open", &[], &minutes_ago(1)),
+            ],
+            None,
+        );
+        let c = run(dir.path());
+        assert_eq!(c.status, CheckStatus::Pass, "{}", c.message);
+        assert!(c.message.contains("tolerated 1"), "{}", c.message);
+        assert!(c.message.contains("#2"), "a tolerated orphan must be named, not swallowed: {}", c.message);
+    }
+
+    #[test]
+    fn an_item_added_a_minute_ago_with_no_issue_is_tolerated() {
+        // The mirror: the item is written before its issue is minted.
+        let items = format!(
+            "{}{}",
+            item("PMAT-001", "planned work", "planned", Some(1), &days_ago(2)),
+            item_created("PMAT-002", "brand new", None, &minutes_ago(1))
+        );
+        let dir = project(Some("paiml/fixture"), &items);
+        snapshot(dir.path(), vec![issue(1, "planned work", "open", &[], &days_ago(2))], None);
+        let c = run(dir.path());
+        assert_eq!(c.status, CheckStatus::Pass, "{}", c.message);
+        assert!(c.message.contains("tolerated 1"), "{}", c.message);
+        assert!(c.message.contains("PMAT-002"), "{}", c.message);
+    }
+
+    #[test]
+    fn the_same_item_past_the_window_is_a_finding() {
+        // The control for the two tests above: age is the only difference.
+        let items = format!(
+            "{}{}",
+            item("PMAT-001", "planned work", "planned", Some(1), &days_ago(2)),
+            item_created("PMAT-002", "not so new", None, &days_ago(2))
+        );
+        let dir = project(Some("paiml/fixture"), &items);
+        snapshot(dir.path(), vec![issue(1, "planned work", "open", &[], &days_ago(2))], None);
+        let c = run(dir.path());
+        assert_eq!(c.status, CheckStatus::Fail, "{}", c.message);
+        for needle in ["ORPHAN-ROADMAP", "PMAT-002", "no issue"] {
+            assert!(c.message.contains(needle), "message must name {needle}: {}", c.message);
+        }
     }
 
     #[test]

--- a/src/cli/handlers/work_handlers/core_handlers/sync.rs
+++ b/src/cli/handlers/work_handlers/core_handlers/sync.rs
@@ -429,10 +429,13 @@ mod tests {
     #[test]
     fn report_json_carries_the_verdict_and_the_classes() {
         let mut r = crate::models::roadmap::Roadmap::new(Some("paiml/pmat".to_string()));
-        r.roadmap.push(crate::models::roadmap::RoadmapItem::new(
-            "A".to_string(),
-            "alpha".to_string(),
-        ));
+        let mut a = crate::models::roadmap::RoadmapItem::new("A".to_string(), "alpha".to_string());
+        // Past the 60-minute grace window, or the missing issue is a TOLERATED
+        // freshness case rather than the ORPHAN-ROADMAP this test is about
+        // (goal-mode.md §5.2, PMAT-1309).
+        a.created = (Utc::now() - chrono::Duration::hours(2)).to_rfc3339();
+        a.updated = a.created.clone();
+        r.roadmap.push(a);
         let s = GithubSnapshot::from_json(&snap("")).expect("snapshot");
         let report = engine::check(&r, &s, &Settings::new(Utc::now(), 60));
         let doc: serde_json::Value =

--- a/src/services/spec_epic/tests.rs
+++ b/src/services/spec_epic/tests.rs
@@ -29,6 +29,7 @@ fn issue(
         state_reason: None,
         labels: labels.iter().map(|l| (*l).to_string()).collect(),
         milestone: None,
+        created_at: None,
         updated_at: Utc::now(),
         sub_issues,
     }

--- a/src/services/work_sync/github.rs
+++ b/src/services/work_sync/github.rs
@@ -72,7 +72,7 @@ pub fn fetch_snapshot(repo: &str) -> Result<GithubSnapshot> {
         "--limit",
         &ISSUE_CAP.to_string(),
         "--json",
-        "number,title,state,stateReason,labels,milestone,updatedAt",
+        "number,title,state,stateReason,labels,milestone,createdAt,updatedAt",
     ])?;
     refuse_truncation(
         issues.as_array().map(Vec::len).unwrap_or(0),
@@ -211,6 +211,10 @@ pub fn parse_snapshot(
                 })
                 .unwrap_or_default(),
             milestone: v["milestone"]["title"].as_str().map(str::to_string),
+            created_at: v["createdAt"]
+                .as_str()
+                .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
+                .map(|d| d.with_timezone(&Utc)),
             updated_at,
             sub_issues: None,
         });

--- a/src/services/work_sync/linkage_tests.rs
+++ b/src/services/work_sync/linkage_tests.rs
@@ -29,6 +29,7 @@ fn issue(
         state_reason: None,
         labels: labels.iter().map(|s| s.to_string()).collect(),
         milestone: milestone.map(str::to_string),
+        created_at: None,
         updated_at: Utc::now(),
         sub_issues: None,
     }

--- a/src/services/work_sync/mod.rs
+++ b/src/services/work_sync/mod.rs
@@ -23,6 +23,24 @@
 //! issue.updated_at)` exceeds the grace window. A bound in time, not a count —
 //! "up to 3 may disagree" means three items may be wrong forever.
 //!
+//! **That window covers the two freshness legs of §5.1 as well** (PMAT-1309):
+//! an issue opened less than the window ago that no item names, and an open
+//! item written less than the window ago that names no issue, are TOLERATED —
+//! counted, reported by name, and not findings. Neither is evidence that the
+//! two sides disagree; both are evidence that the sync which would join them
+//! has not run yet, and a rule that reds the default branch the instant anyone
+//! opens an issue (`5af9a0f0d`, 06:08Z, 2026-09-11 — five issues, no diff to
+//! blame) is a rule someone disables. The other three `ORPHAN-ROADMAP` reasons
+//! are NOT freshness problems and are never behind the window: a closed issue
+//! does not become un-closed by being recent.
+//!
+//! The window is still `now − max(item.updated, issue.updated_at)` for a field
+//! disagreement, and `now − created` (falling back to the update stamp) for the
+//! two freshness legs. No first-seen state is written anywhere: a gate whose
+//! verdict depends on a state file cannot be judged from a clean clone (§5.2,
+//! quorum 4 of 5). The cost is a window that any timestamp bump restarts, and
+//! that cost is recorded and accepted, not hidden.
+//!
 //! "Open" here is every non-terminal status — `planned`, `inprogress`, `blocked`
 //! and `review` — because a `blocked` item with no issue is exactly as invisible
 //! to GitHub as a `planned` one. The specification names the first two; the enum
@@ -73,6 +91,13 @@ pub struct IssueSnapshot {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub milestone: Option<String>,
     pub updated_at: DateTime<Utc>,
+    /// When the issue was opened. `None` on a snapshot written before the field
+    /// existed, and then the freshness leg falls back to `updated_at` —
+    /// measured, never assumed: `updated_at` answers "was this opened a minute
+    /// ago?" only by coincidence, and stops answering it the moment anyone
+    /// comments on the issue.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<DateTime<Utc>>,
     /// How many sub-issues the issue has — GitHub's native relation, the only
     /// epic membership goal-mode.md §4.3 accepts. The live reader measures it
     /// for issues labelled `epic`; `None` is "not measured", never zero
@@ -85,6 +110,13 @@ impl IssueSnapshot {
     /// Member of **G** (§5.1): open and not labelled `no-roadmap`.
     pub fn in_universe(&self) -> bool {
         self.state == IssueState::Open && !self.labels.iter().any(|l| l == NO_ROADMAP_LABEL)
+    }
+
+    /// How many minutes ago the issue was opened, by [`IssueSnapshot::created_at`]
+    /// when the snapshot carries one and by `updated_at` when it does not
+    /// (§5.2, PMAT-1309).
+    pub fn age_minutes(&self, now: DateTime<Utc>) -> i64 {
+        (now - self.created_at.unwrap_or(self.updated_at)).num_minutes()
     }
 
     /// Labelled `epic` (§4.3) — open or closed; the epic leg judges the state.
@@ -300,8 +332,22 @@ pub struct SyncReport {
     pub open_issues: usize,
     /// Pairs (open item, open issue) with exactly one owner.
     pub matched: usize,
-    /// Field disagreements inside the grace window: counted, not findings.
+    /// Everything the grace window tolerated — field disagreements AND the two
+    /// freshness legs (§5.2, PMAT-1309): counted, not findings.
     pub tolerated: usize,
+    /// One line per toleration, in the same order, so a PASS can NAME what it
+    /// tolerated. A single count cannot tell "a field drifted" from "an orphan
+    /// issue is young", and a pass that silently swallowed a real orphan is the
+    /// failure this rule exists to prevent. `tolerated == tolerated_notes.len()`
+    /// always.
+    #[serde(default)]
+    pub tolerated_notes: Vec<String>,
+    /// The orphans the window tolerated, as findings. Not part of the verdict —
+    /// they are still the FIXER's work, so `plan` reads them: the window moves
+    /// what the gate says, never what `pmat work sync` does, or no item added
+    /// in the last hour could ever be minted.
+    #[serde(default)]
+    pub tolerated_orphans: Vec<Finding>,
     pub findings: Vec<Finding>,
 }
 
@@ -320,6 +366,46 @@ impl SyncReport {
 /// Member of **R** (§5.1): every non-terminal status.
 pub fn is_open(item: &RoadmapItem) -> bool {
     !matches!(item.status, ItemStatus::Completed | ItemStatus::Cancelled)
+}
+
+/// How many minutes ago the item was written, from `created` and falling back
+/// to `updated` when `created` does not parse (§5.2, PMAT-1309).
+///
+/// `i64::MAX` when neither parses: a timestamp the engine cannot read must never
+/// buy an item a grace window it did not earn (the same rule the DRIFT leg
+/// applies, and `an_unparseable_item_timestamp_never_hides_drift` pins).
+fn item_age_minutes(item: &RoadmapItem, now: DateTime<Utc>) -> i64 {
+    let parse = |s: &str| {
+        DateTime::parse_from_rfc3339(s)
+            .ok()
+            .map(|d| d.with_timezone(&Utc))
+    };
+    match parse(&item.created).or_else(|| parse(&item.updated)) {
+        Some(dt) => (now - dt).num_minutes(),
+        None => i64::MAX,
+    }
+}
+
+/// The line a tolerated finding contributes to the report's `tolerated_notes`.
+fn tolerated_note(finding: &Finding, age_minutes: i64, grace_minutes: i64) -> String {
+    format!(
+        "{} ({age_minutes} min old, inside the {grace_minutes}-minute grace window)",
+        finding.render()
+    )
+}
+
+/// Count one toleration, note it by name, and keep it on the fixer's list.
+fn record_toleration(
+    report: &mut SyncReport,
+    finding: Finding,
+    age_minutes: i64,
+    grace_minutes: i64,
+) {
+    report.tolerated += 1;
+    report
+        .tolerated_notes
+        .push(tolerated_note(&finding, age_minutes, grace_minutes));
+    report.tolerated_orphans.push(finding);
 }
 
 /// Judge the roadmap against the snapshot. Pure; deterministic order.
@@ -368,7 +454,10 @@ pub fn check(roadmap: &Roadmap, snapshot: &GithubSnapshot, settings: &Settings) 
     });
     report.findings.extend(collisions);
 
-    let mut orphan_roadmap = Vec::new();
+    let grace_minutes = settings.grace.num_minutes();
+    // (finding, Some(age) when the window tolerates it). Only `NoIssue` can be
+    // tolerated: the other three reasons are not freshness problems.
+    let mut orphan_roadmap: Vec<(Finding, Option<i64>)> = Vec::new();
     let mut matched_pairs = Vec::new(); // (item, issue)
 
     for item in &open_items {
@@ -377,66 +466,93 @@ pub fn check(roadmap: &Roadmap, snapshot: &GithubSnapshot, settings: &Settings) 
         }
         match item.github_issue {
             None => {
-                orphan_roadmap.push(Finding::OrphanRoadmap {
-                    id: item.id.clone(),
-                    title: item.title.clone(),
-                    github_issue: None,
-                    reason: OrphanReason::NoIssue,
-                });
+                let age = item_age_minutes(item, settings.now);
+                orphan_roadmap.push((
+                    Finding::OrphanRoadmap {
+                        id: item.id.clone(),
+                        title: item.title.clone(),
+                        github_issue: None,
+                        reason: OrphanReason::NoIssue,
+                    },
+                    (age < grace_minutes).then_some(age),
+                ));
             }
             Some(n) => {
                 if let Some(issue) = snapshot.issue(n) {
                     if issue.state == IssueState::Closed {
-                        orphan_roadmap.push(Finding::OrphanRoadmap {
-                            id: item.id.clone(),
-                            title: item.title.clone(),
-                            github_issue: Some(n),
-                            reason: OrphanReason::IssueClosed,
-                        });
+                        orphan_roadmap.push((
+                            Finding::OrphanRoadmap {
+                                id: item.id.clone(),
+                                title: item.title.clone(),
+                                github_issue: Some(n),
+                                reason: OrphanReason::IssueClosed,
+                            },
+                            None,
+                        ));
                     } else if !issue.in_universe() {
-                        orphan_roadmap.push(Finding::OrphanRoadmap {
-                            id: item.id.clone(),
-                            title: item.title.clone(),
-                            github_issue: Some(n),
-                            reason: OrphanReason::IssueExcluded,
-                        });
+                        orphan_roadmap.push((
+                            Finding::OrphanRoadmap {
+                                id: item.id.clone(),
+                                title: item.title.clone(),
+                                github_issue: Some(n),
+                                reason: OrphanReason::IssueExcluded,
+                            },
+                            None,
+                        ));
                     } else {
                         matched_pairs.push((item, issue));
                     }
                 } else {
-                    orphan_roadmap.push(Finding::OrphanRoadmap {
-                        id: item.id.clone(),
-                        title: item.title.clone(),
-                        github_issue: Some(n),
-                        reason: OrphanReason::IssueAbsent,
-                    });
+                    orphan_roadmap.push((
+                        Finding::OrphanRoadmap {
+                            id: item.id.clone(),
+                            title: item.title.clone(),
+                            github_issue: Some(n),
+                            reason: OrphanReason::IssueAbsent,
+                        },
+                        None,
+                    ));
                 }
             }
         }
     }
-    orphan_roadmap.sort_by_key(|f| match f {
+    orphan_roadmap.sort_by_key(|(f, _)| match f {
         Finding::OrphanRoadmap { id, .. } => id.clone(),
         _ => String::new(),
     });
-    report.findings.extend(orphan_roadmap);
+    for (finding, tolerated) in orphan_roadmap {
+        match tolerated {
+            Some(age) => record_toleration(&mut report, finding, age, grace_minutes),
+            None => report.findings.push(finding),
+        }
+    }
 
     report.matched = matched_pairs.len();
 
-    let mut orphan_github = Vec::new();
+    let mut orphan_github: Vec<(Finding, Option<i64>)> = Vec::new();
     for issue in &g_issues {
         if !named_issues.contains_key(&issue.number) {
-            orphan_github.push(Finding::OrphanGithub {
-                number: issue.number,
-                title: issue.title.clone(),
-                milestone: issue.milestone.clone(),
-            });
+            let age = issue.age_minutes(settings.now);
+            orphan_github.push((
+                Finding::OrphanGithub {
+                    number: issue.number,
+                    title: issue.title.clone(),
+                    milestone: issue.milestone.clone(),
+                },
+                (age < grace_minutes).then_some(age),
+            ));
         }
     }
-    orphan_github.sort_by_key(|f| match f {
+    orphan_github.sort_by_key(|(f, _)| match f {
         Finding::OrphanGithub { number, .. } => *number,
         _ => 0,
     });
-    report.findings.extend(orphan_github);
+    for (finding, tolerated) in orphan_github {
+        match tolerated {
+            Some(age) => record_toleration(&mut report, finding, age, grace_minutes),
+            None => report.findings.push(finding),
+        }
+    }
 
     let mut drift_findings = Vec::new();
     for (item, issue) in matched_pairs {
@@ -458,12 +574,36 @@ pub fn check(roadmap: &Roadmap, snapshot: &GithubSnapshot, settings: &Settings) 
                 Err(_) => i64::MAX,
             };
 
-            if age_minutes < settings.grace.num_minutes() {
+            if age_minutes < grace_minutes {
                 if title_differs {
                     report.tolerated += 1;
+                    report.tolerated_notes.push(tolerated_note(
+                        &Finding::Drift {
+                            id: item.id.clone(),
+                            number: issue.number,
+                            field: DriftField::Title,
+                            roadmap: item.title.clone(),
+                            github: issue.title.clone(),
+                            age_minutes,
+                        },
+                        age_minutes,
+                        grace_minutes,
+                    ));
                 }
                 if release_differs {
                     report.tolerated += 1;
+                    report.tolerated_notes.push(tolerated_note(
+                        &Finding::Drift {
+                            id: item.id.clone(),
+                            number: issue.number,
+                            field: DriftField::Release,
+                            roadmap: item.release.clone().unwrap_or_default(),
+                            github: issue.milestone.clone().unwrap_or_default(),
+                            age_minutes,
+                        },
+                        age_minutes,
+                        grace_minutes,
+                    ));
                 }
             } else {
                 if title_differs {
@@ -563,7 +703,15 @@ pub fn plan(
     direction: Direction,
 ) -> Vec<Action> {
     let mut actions = Vec::new();
-    for finding in &report.findings {
+    // The tolerated orphans are the fixer's work as much as the findings are
+    // (PMAT-1309): the grace window is a tolerance in the VERDICT, and an item
+    // written a minute ago is exactly the item `--direction yaml-to-github` is
+    // run to mint.
+    for finding in report
+        .findings
+        .iter()
+        .chain(report.tolerated_orphans.iter())
+    {
         match finding {
             Finding::Collision { ids, number } => {
                 for id in ids {

--- a/src/services/work_sync/tests.rs
+++ b/src/services/work_sync/tests.rs
@@ -795,3 +795,172 @@ fn apply_on_an_unknown_id_changes_nothing() {
     assert_eq!(n, 0);
     assert_eq!(r, before);
 }
+
+// ── §5.2 the window covers the ORPHAN legs too (PMAT-1309) ───────────────────
+//
+// An issue opened seconds ago, and an item added seconds ago, are not evidence
+// that the roadmap and GitHub disagree — they are evidence that the sync that
+// would have joined them has not run yet. CB-2115 turned master red at
+// 5af9a0f0d for exactly that, with no commit to blame. Inside the window each
+// is TOLERATED (the rule passes and counts it); past it each is a finding.
+
+#[test]
+fn a_freshly_opened_orphan_issue_is_tolerated() {
+    // #5 was opened at t0 and the clock is 30 minutes later: inside the default
+    // 60-minute window, so the bijection is not yet expected to hold.
+    let report = check(
+        &roadmap(vec![]),
+        &snapshot(vec![issue(5, "opened by hand", IssueState::Open)]),
+        &later(30),
+    );
+    assert!(
+        report.is_coherent(),
+        "an issue opened 30 minutes ago is inside the window: {report:?}"
+    );
+    assert_eq!(report.tolerated, 1, "{report:?}");
+    assert_eq!(
+        report.open_issues, 1,
+        "it is still counted in G: {report:?}"
+    );
+}
+
+#[test]
+fn an_orphan_issue_past_the_window_is_a_finding() {
+    // The control for the test above: the same issue, one minute past the
+    // window, is the ORPHAN-GITHUB it always was.
+    let report = check(
+        &roadmap(vec![]),
+        &snapshot(vec![issue(5, "opened by hand", IssueState::Open)]),
+        &later(61),
+    );
+    assert_eq!(
+        report.findings,
+        vec![Finding::OrphanGithub {
+            number: 5,
+            title: "opened by hand".to_string(),
+            milestone: None,
+        }]
+    );
+    assert_eq!(report.tolerated, 0, "{report:?}");
+}
+
+#[test]
+fn a_roadmap_item_with_no_issue_is_tolerated_inside_the_window() {
+    // The mirror case: the item was written 30 minutes ago and its issue has
+    // not been minted yet.
+    let report = check(
+        &roadmap(vec![open("A", "alpha", None)]),
+        &snapshot(vec![]),
+        &later(30),
+    );
+    assert!(report.is_coherent(), "{report:?}");
+    assert_eq!(report.tolerated, 1, "{report:?}");
+}
+
+#[test]
+fn a_roadmap_item_with_no_issue_past_the_window_is_a_finding() {
+    let report = check(
+        &roadmap(vec![open("A", "alpha", None)]),
+        &snapshot(vec![]),
+        &later(61),
+    );
+    assert_eq!(
+        report.findings,
+        vec![Finding::OrphanRoadmap {
+            id: "A".to_string(),
+            title: "alpha".to_string(),
+            github_issue: None,
+            reason: OrphanReason::NoIssue,
+        }]
+    );
+    assert_eq!(report.tolerated, 0, "{report:?}");
+}
+
+#[test]
+fn a_closed_issue_is_a_finding_however_recent() {
+    // The window is a freshness tolerance, and only NoIssue and ORPHAN-GITHUB
+    // are freshness problems. A closed issue does not become un-closed by being
+    // recent, an absent one does not appear, and a no-roadmap label does not
+    // fall off — all three stay findings at age zero. This test dies if someone
+    // later puts them behind the window.
+    let mut excluded = issue(9, "bump deps", IssueState::Open);
+    excluded.labels.push(NO_ROADMAP_LABEL.to_string());
+    let r = roadmap(vec![
+        open("A", "alpha", Some(7)),
+        open("B", "beta", Some(77)),
+        open("C", "gamma", Some(9)),
+    ]);
+    let s = snapshot(vec![issue(7, "alpha", IssueState::Closed), excluded]);
+    let report = check(&r, &s, &now());
+    assert_eq!(
+        classes(&report),
+        vec!["ORPHAN-ROADMAP", "ORPHAN-ROADMAP", "ORPHAN-ROADMAP"],
+        "{report:?}"
+    );
+    let reasons: Vec<OrphanReason> = report
+        .findings
+        .iter()
+        .filter_map(|f| match f {
+            Finding::OrphanRoadmap { reason, .. } => Some(*reason),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        reasons,
+        vec![
+            OrphanReason::IssueClosed,
+            OrphanReason::IssueAbsent,
+            OrphanReason::IssueExcluded
+        ],
+        "{report:?}"
+    );
+    assert_eq!(report.tolerated, 0, "none of these is a freshness problem");
+}
+
+#[test]
+fn the_tolerated_count_includes_a_tolerated_orphan() {
+    // A fresh orphan on each side plus a field disagreement: the count the rule
+    // prints is every toleration, not only the field ones. A PASS that swallowed
+    // an orphan without counting it is the failure this rule exists to prevent.
+    let r = roadmap(vec![open("A", "alpha", None), open("B", "beta", Some(1))]);
+    let s = snapshot(vec![
+        issue(1, "beta (renamed)", IssueState::Open),
+        issue(5, "opened by hand", IssueState::Open),
+    ]);
+    let report = check(&r, &s, &later(30));
+    assert!(report.is_coherent(), "{report:?}");
+    assert_eq!(
+        report.tolerated, 3,
+        "one item with no issue, one orphan issue, one title drift: {report:?}"
+    );
+}
+
+#[test]
+fn a_tolerated_orphan_is_still_the_fixers_work() {
+    // The window moves the GATE's verdict, never the fixer's work list: `pmat
+    // work sync` must still mint the issue for an item added a minute ago, or
+    // no new item could ever be minted until it had aged an hour.
+    let r = roadmap(vec![open("A", "alpha", None)]);
+    let s = snapshot(vec![issue(5, "opened by hand", IssueState::Open)]);
+    let report = check(&r, &s, &later(30));
+    assert!(
+        report.is_coherent(),
+        "tolerated, so the gate passes: {report:?}"
+    );
+    let actions = plan(&r, &s, &report, Direction::Full);
+    assert_eq!(
+        actions,
+        vec![
+            Action::CreateIssue {
+                id: "A".to_string(),
+                title: "alpha".to_string(),
+            },
+            Action::CreateItem {
+                number: 5,
+                title: "opened by hand".to_string(),
+                release: None,
+            },
+        ],
+        "a tolerated orphan is still an orphan the fixer closes"
+    );
+}

--- a/src/services/work_sync/tests.rs
+++ b/src/services/work_sync/tests.rs
@@ -39,6 +39,7 @@ fn issue(number: u64, title: &str, state: IssueState) -> IssueSnapshot {
         state_reason: None,
         labels: Vec::new(),
         milestone: None,
+        created_at: None,
         updated_at: t0(),
         sub_issues: None,
     }
@@ -98,8 +99,11 @@ fn a_bijection_with_agreeing_fields_is_coherent() {
 
 #[test]
 fn an_open_item_with_no_issue_is_an_orphan_roadmap() {
+    // Past the grace window, so this is the classification and not the
+    // freshness question `a_roadmap_item_with_no_issue_is_tolerated_inside_the_window`
+    // asks (PMAT-1309: the fixture used to be judged at age zero).
     let r = roadmap(vec![open("A", "alpha", None)]);
-    let report = check(&r, &snapshot(vec![]), &now());
+    let report = check(&r, &snapshot(vec![]), &later(61));
     assert_eq!(
         report.findings,
         vec![Finding::OrphanRoadmap {
@@ -161,7 +165,7 @@ fn blocked_and_review_items_are_open() {
         item("B", "blocked", ItemStatus::Blocked, None),
         item("R", "review", ItemStatus::Review, None),
     ]);
-    let report = check(&r, &snapshot(vec![]), &now());
+    let report = check(&r, &snapshot(vec![]), &later(61));
     assert_eq!(report.open_items, 2);
     assert_eq!(report.count("ORPHAN-ROADMAP"), 2, "{report:?}");
 }
@@ -170,7 +174,7 @@ fn blocked_and_review_items_are_open() {
 fn an_open_issue_no_item_names_is_an_orphan_github() {
     let mut nine = issue(9, "nine", IssueState::Open);
     nine.milestone = Some("3.42.0".to_string());
-    let report = check(&roadmap(vec![]), &snapshot(vec![nine]), &now());
+    let report = check(&roadmap(vec![]), &snapshot(vec![nine]), &later(61));
     assert_eq!(
         report.findings,
         vec![Finding::OrphanGithub {
@@ -245,7 +249,7 @@ fn a_closed_issue_no_item_names_is_not_an_orphan() {
 fn an_open_issue_named_only_by_a_completed_item_is_an_orphan_github() {
     let r = roadmap(vec![item("C", "five", ItemStatus::Completed, Some(5))]);
     let s = snapshot(vec![issue(5, "five", IssueState::Open)]);
-    let report = check(&r, &s, &now());
+    let report = check(&r, &s, &later(61));
     assert_eq!(classes(&report), vec!["ORPHAN-GITHUB"], "{report:?}");
 }
 
@@ -439,6 +443,7 @@ fn findings_are_ordered_by_class_then_key() {
 fn a_snapshot_round_trips_through_json() {
     let mut one = issue(1, "alpha", IssueState::Closed);
     one.state_reason = Some(CloseReason::NotPlanned);
+    one.created_at = Some(at(-100));
     one.labels.push("bug".to_string());
     one.milestone = Some("3.42.0".to_string());
     let mut s = snapshot(vec![one]);
@@ -962,5 +967,80 @@ fn a_tolerated_orphan_is_still_the_fixers_work() {
             },
         ],
         "a tolerated orphan is still an orphan the fixer closes"
+    );
+}
+
+#[test]
+fn an_issue_created_long_ago_but_touched_now_is_a_finding() {
+    // The freshness leg asks when the issue was OPENED, not when it was last
+    // commented on: `created_at` is read when the snapshot carries one. Under
+    // `updated_at` alone this orphan — open for seventeen hours, relabelled a
+    // minute ago — would read as brand new and be tolerated forever.
+    let mut touched = issue(5, "an old orphan", IssueState::Open);
+    touched.created_at = Some(at(-1000));
+    touched.updated_at = at(59);
+    let report = check(&roadmap(vec![]), &snapshot(vec![touched]), &later(60));
+    assert_eq!(
+        report.findings,
+        vec![Finding::OrphanGithub {
+            number: 5,
+            title: "an old orphan".to_string(),
+            milestone: None,
+        }],
+        "{report:?}"
+    );
+    assert_eq!(report.tolerated, 0);
+}
+
+#[test]
+fn a_snapshot_without_created_at_falls_back_to_the_update_stamp() {
+    // A snapshot written before the field existed carries `created_at: None`
+    // (`#[serde(default)]`), and then the update stamp is the only evidence
+    // there is. Measured, not assumed: the fallback is exercised here.
+    let mut old_format = issue(5, "opened by hand", IssueState::Open);
+    old_format.created_at = None;
+    old_format.updated_at = at(55);
+    let report = check(&roadmap(vec![]), &snapshot(vec![old_format]), &later(60));
+    assert!(report.is_coherent(), "{report:?}");
+    assert_eq!(report.tolerated, 1);
+    assert!(
+        GithubSnapshot::from_json(
+            r#"{"repo":"paiml/pmat","taken_at":"2026-09-09T12:00:00Z","issues":[{"number":5,"title":"t","state":"open","updated_at":"2026-09-09T12:00:00Z"}]}"#
+        )
+        .expect("a snapshot with no created_at still parses")
+        .issues[0]
+            .created_at
+            .is_none()
+    );
+}
+
+#[test]
+fn the_tolerated_notes_name_every_toleration() {
+    // The count and the names agree, always, and each name says WHICH kind of
+    // toleration it is — a single number cannot tell "a field drifted" from
+    // "an orphan issue is young", and the rule's PASS prints these lines.
+    let r = roadmap(vec![open("A", "alpha", None), open("B", "beta", Some(1))]);
+    let s = snapshot(vec![
+        issue(1, "beta (renamed)", IssueState::Open),
+        issue(5, "opened by hand", IssueState::Open),
+    ]);
+    let report = check(&r, &s, &later(30));
+    assert_eq!(report.tolerated, report.tolerated_notes.len(), "{report:?}");
+    let notes = report.tolerated_notes.join(" | ");
+    for needle in [
+        "ORPHAN-ROADMAP A: no issue",
+        "ORPHAN-GITHUB #5: opened by hand",
+        "DRIFT B <-> #1 title",
+        "30 min old, inside the 60-minute grace window",
+    ] {
+        assert!(
+            notes.contains(needle),
+            "the notes must name {needle}: {notes}"
+        );
+    }
+    assert_eq!(
+        report.tolerated_orphans.len(),
+        2,
+        "a tolerated DRIFT is not the fixer's work, the two orphans are: {report:?}"
     );
 }


### PR DESCRIPTION
Closes #1309.

## Why master went red for something no commit did

CB-2115 asserts a live bijection between `docs/roadmaps/roadmap.yaml` and this repo's GitHub issues. On 2026-09-11 at 06:08Z it turned master red at `5af9a0f0d`: five issues had been opened **by hand** minutes earlier, no roadmap item existed yet, and no commit was to blame. Nothing in that push was wrong, and the only way to green master was to write the items — which is work, not a revert.

CB-2113 reads the commits in the push, so a red one always names a commit someone can fix. CB-2115 reads GitHub **live**, so on a push its verdict is a function of what the world looks like at that instant. A gate that reds the default branch for something no commit did teaches people to ignore the default branch.

Two changes, both from the quorum recorded in `docs/audits/quorum-PMAT-1307.json`.

## 1. The grace window covers all three legs (D10, 5 of 5 — one of only two unanimous decisions of sixteen)

`work_sync::check` already tolerated a **field disagreement** inside `staleness_grace_minutes`. It now also tolerates:

- an **open issue that no item names**, when the issue's own age is inside the window — from `created_at`, falling back to `updated_at`. The fallback is not cosmetic: a snapshot written before the field existed carries only `updated_at`, which answers *"was this opened a minute ago?"* only by coincidence, so the field is now fetched live (`createdAt`) and defaulted in the snapshot type.
- an **open item that names no issue**, from the item's `created`, falling back to `updated`.

The other three `ORPHAN-ROADMAP` reasons — issue closed, absent, or labelled `no-roadmap` — are **never** behind the window. None is a freshness problem: a closed issue does not become un-closed by being recent. `a_closed_issue_is_a_finding_however_recent` fails if anyone later puts them there.

Two properties the diff is careful about:

- **A PASS that swallowed a real orphan would be worse than the red build it replaces.** One `tolerated` count cannot tell a drifted field from a young orphan, so `SyncReport` gains `tolerated_notes` — one rendered line per toleration, `tolerated == tolerated_notes.len()` — and the CB-2115 PASS names every one of them.
- **The window is a tolerance in the VERDICT only.** `plan()` still lists a tolerated orphan, so `pmat work sync` mints the issue for an item written a minute ago rather than silently refusing every item younger than an hour — which would have broken the PMAT-721/#1291 flow.

No first-seen state file, per D5 (4 of 5): a gate whose verdict depends on a state file cannot be judged from a clean clone. The cost is that a timestamp bump restarts the window; that is **deliberate**, recorded in §5.2, and pinned by control arm 16 with its own "do not fix this arm" line.

## 2. CB-2115 comes off the master push (P4, 3 of 4)

`ci.yml` splits the step. CB-2113 keeps running on every event. CB-2115 is guarded `github.event_name != 'push'` — not `== 'pull_request'`, because the rule must also hold on the merge queue or the queue is the bypass, the same reasoning as this file's `merge_group:` trigger.

That closes a false red and opens a real hole: an issue opened by hand **between** two pull requests is then seen by nothing. `.github/workflows/roadmap-coherence-scheduled.yml` is that hole's floor — a daily cron that asks the same question and reports the answer as a **ticket**, never a red build. The check step carries `continue-on-error: true` and a later step opens or refreshes exactly one issue. There is no build on a cron whose failure anybody owns, and a permanently-red scheduled workflow is a notification people turn off.

## Controls — 18 arms, every new one falsified

`scripts/roadmap-coherence-control.sh` gains arms 12–18. Arms 12–15 are **pairs** — the same fixture inside and outside the window — so an implementation that tolerated everything fails as surely as one that tolerated nothing.

| mutant | result |
|---|---|
| `continue-on-error` deleted | ARM 18 FAILED — *"so a finding FAILS THE BUILD"* |
| `gh issue create` removed | ARM 18 FAILED — *"a scheduled finding reaches nobody"* |
| scheduled workflow deleted | ARM 18 FAILED — *"no workflow … on a `schedule:`"* |
| ci.yml guard deleted | ARM 17 FAILED — *"a push to master reaches it (guard found: '')"* |
| guard weakened to `== 'push'` | ARM 17 FAILED — *"guard found: '… == 'push''"* |

### A parser defect this tree exposed

Arm 17's awk accumulated every line of a job into the current step, **comments included**. `ci.yml` discusses CB-2115 in prose — including the withheld `#     run: … --checks CB-2112,CB-2113,CB-2114,CB-2115` — so that prose made an unrelated, unguarded step (the CB-2113 one) read as a CB-2115 step with no guard. Measured: the arm reported the `traceability` job **twice on one file, once FAILED and once GREEN**.

The mirror case is worse: a real unguarded step followed by a comment naming a guard would have read GREEN. Comment lines are now skipped.

This is why the falsification above was redone. With the defect present, the first four mutant runs were **indistinguishable from the restored one** — all exiting 1 at arm 17, before arm 18 ever ran. Four identical exit codes across four different mutations is what caught it.

## Verification

| check | result |
|---|---|
| `cargo test --lib -- work_sync roadmap_coherence` (orchestrator re-run) | **77 passed, 0 failed** |
| `roadmap-coherence-control.sh` | 18/18, exit 0 |
| `work-sync-control.sh` | 4/4, exit 0 — 6615 lines round-tripped byte-for-byte |
| `cargo clippy --lib --bins --features full -- -D warnings` | exit 0 |
| `panic!(` in `src/*.rs` | 785, unmoved |
| new `.unwrap()` in the diff | 0 |
| `analyze unrun-tests --executed '' --check-ledger` | exit 0 |

The acceptance command in the worker's brief was **malformed** and the worker caught it: `cargo test --lib A B -- …` takes one positional TESTNAME and exits 1 with `unexpected argument` before any test runs — identically on a green and a red tree, so it measured nothing. Corrected to `cargo test --lib -- A B --test-threads=4`.

Two forced out-of-scope edits, both mechanical and both reviewed: `spec_epic/tests.rs` builds `IssueSnapshot` with an exhaustive literal (one `created_at: None`), and `sync.rs`'s `report_json_carries_the_verdict_and_the_classes` built its fixture with `RoadmapItem::new` (i.e. `created = now`), which this change now tolerates — the fixture is aged two hours so the test still asserts what it is about.

## Spec

`goal-mode.md` §5.2's *"The code covers the field-disagreement leg only; extending it to ORPHAN and MISSING is PMAT-1309"* is now false and is replaced by what the code does. §8's limit list drops from four rules to three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
