### PR TITLE
chore(PMAT-1336): PMAT-1339 is completed — its issue closed when #1340 merged

### DIFF
--- a/docs/roadmaps/roadmap.yaml
+++ b/docs/roadmaps/roadmap.yaml
@@ -6617,11 +6617,11 @@ roadmap:
   github_issue: 1339
   item_type: bug
   title: 'ratchet: a flat 300 s measurement timeout kills the cold clippy metric on a loaded runner — 3 lib tests red on #1337, sized from a workstation figure'
-  status: planned
+  status: completed
   priority: high
   assigned_to: null
   created: 2026-09-12T08:07:34Z
-  updated: 2026-09-12T08:07:34Z
+  updated: 2026-09-12T11:58:01Z
   spec: null
   acceptance_criteria:
   - a metric declaring timeout_secs = 1 whose command sleeps 5 s is reported Unavailable naming a 1 s budget, in about 1 s — and a metric declaring none is still bounded by the 300 s default (a test that fails on the current tree, where timeout_secs is not a field)


### PR DESCRIPTION
`kind:lifecycle` under PMAT-1336. Two lines of `docs/roadmaps/roadmap.yaml`, nothing else.

## Master is red right now

GitHub closed #1339 the moment #1340 merged, because that PR's body says `Closes #1339`. The roadmap item stayed `planned`, so CB-2115 reads an open item naming a closed issue:

```
$ pmat work sync --check-only
   open items 106 · open issues 105 · matched 105 · tolerated 0
   ⚠ ORPHAN-ROADMAP PMAT-1339: #1339 is closed
✗ 1 finding(s): 0 COLLISION, 1 ORPHAN-ROADMAP, 0 ORPHAN-GITHUB, 0 DRIFT
```

That is master red at `e0d9ece8f` with **no commit to blame** — precisely the failure PMAT-1336 exists to close, and precisely the one PMAT-1309 (#1341) is taking off the master push for the *other* direction. This half is not a false red: the item really is wrong, and the fix is this edit.

## The landing commit, named so the claim is checkable

PMAT-1336's third criterion requires each completion to name the merge commit that landed the ticket:

```
e0d9ece8f  Merge pull request #1340 from paiml/PMAT-1339-worker
           fix(PMAT-1339): a ratchet metric declares its own measurement budget;
           300 s is only the default
```

## Why it cannot ride in PMAT-1339's own PR

CB-2113 requires every non-merge commit to name a **non-terminal** roadmap item, so a commit naming `PMAT-1339` while making `PMAT-1339` terminal fails by construction — a ticket cannot complete itself. And a quorum judges a diff against the criteria of the ticket its PR names, so "complete the previous ticket" drew a FAIL every time it was attached to a work ticket (measured: #1330 three FAIL, #1334 one FAIL, #1335 three FAIL). PMAT-1336 is the ticket whose criteria describe this work, which is the whole point of it.

## One thing worth recording

The obvious command is refused, correctly:

```
$ pmat work edit PMAT-1339 -s completed
Error: Invalid transition: Planned → Completed.
       See work-dbc-v1.yaml §work_lifecycle for valid transitions.
```

The item went `planned → inprogress → completed`. The single-step form looks like the right command and is not.

## After

```
$ pmat work sync --check-only
   open items 105 · open issues 105 · matched 105 · tolerated 0
✓ coherent: R ↔ G is a bijection and no matched pair disagrees past the grace window
```

`pmat work validate` exits 0. Diff is `docs/roadmaps/roadmap.yaml`, 2 insertions, 2 deletions — any source change would mean this is not a lifecycle PR (criterion 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
